### PR TITLE
Styling changes to question group

### DIFF
--- a/admin_pages/registration_form/assets/espresso_registration_form_admin.css
+++ b/admin_pages/registration_form/assets/espresso_registration_form_admin.css
@@ -34,8 +34,6 @@
 
 .question-group-questions-container {
     background: white;
-    width: 100%;
-    clear: both;
     border: 1px solid #e5e5e5;
     -webkit-box-shadow: 0 1px 1px rgba(0,0,0,.04);
     box-shadow: 0 1px 1px rgba(0,0,0,.04);
@@ -61,7 +59,6 @@
     border-bottom: 1px solid #eee;
     padding: 6px 8px !important;
     margin: 0 !important;
-    /*line-height: 1.4;*/
 }
 .question-group-questions.inside {
     padding: 0 !important;
@@ -110,6 +107,17 @@
     width: 25em !important;
 }
 
+#post-body-content > div {
+    max-width: 48.5%;
+    width: auto !important;
+    float: left;
+    clear: none;
+}
+
+#post-body-content > div:last-child {
+    float: right !important;
+}
+
 table.question-options-table td, table.question-options-table th{
 	padding:1em 10px 0 3px; line-height: 1em;
 }
@@ -136,5 +144,13 @@ table.question-options-table td:last-child {
     }
     #update_question_group_event_form textarea {
         width: 100% !important;
+    }
+}
+@media screen and (max-width:1400px) {
+    #post-body-content > div {
+        max-width: 100% !important;
+        width: 100% !important;
+        clear: both !important;
+        float: none !important;
     }
 }

--- a/caffeinated/admin/extend/registration_form/templates/question_groups_main_meta_box.template.php
+++ b/caffeinated/admin/extend/registration_form/templates/question_groups_main_meta_box.template.php
@@ -23,7 +23,7 @@ $disabled = ! empty( $QSG_system ) ? ' disabled="disabled"' : '';
 $id =  ! empty( $QST_system ) ? '_disabled' : '';
 ?>
 
-<div class="edit-group padding">
+<div id="group-details" class="edit-group padding">
 	<table class="form-table">
 		<tbody>
 		
@@ -112,7 +112,7 @@ $id =  ! empty( $QST_system ) ? '_disabled' : '';
 	</table>
 </div>
 
-<div class="edit-group padding question-group-questions-container postbox">
+<div id="group-questions" class="edit-group padding question-group-questions-container postbox">
     <div class="handlediv" title="Click to toggle"><br></div>
     <h2 class="handle"><?php _e('Questions','event_espresso');?></h2>
 	<div class="form-table question-group-questions inside">


### PR DESCRIPTION
The drag-and-drop questions in question groups have been restyled so that they are more obviously an interactive component. CSS changes also include a fix for when header tags are being used in question text.
