### PR TITLE
Added markup around ticket info

### DIFF
--- a/modules/single_page_checkout/templates/registration_page_attendee_information.template.php
+++ b/modules/single_page_checkout/templates/registration_page_attendee_information.template.php
@@ -54,8 +54,8 @@ if ( $event_queue['total_items'] > 0 ) {
 					<tr>
 						<td>
 						<?php
-							echo $item['ticket']->name();
-							echo $item['ticket']->description() ? '<br/>' . $item['ticket']->description() : '';
+							echo '<span class="spco-ticket-info-name">' . $item['ticket']->name() . '</span>';
+							echo $item['ticket']->description() ? '<br/><span class="spco-ticket-info-description">' . $item['ticket']->description() . '</span>' : '';
 						?>
 						</td>
 						<td class="jst-cntr"><?php echo $ticket_count[ $item['ticket']->ID() ];?></td>


### PR DESCRIPTION
Possible UI Fix/Bug or feature.
There was no way to differentiate between the ticket name and description on checkout so added span elements around them with approriate class-names. Allows for targeting with CSS and/or Javscript.

I'm hoping you can consider this a quickfix and merge it into next version :) 
