### PR TITLE
Add filter to transaction list table action links

### DIFF
--- a/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
+++ b/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
@@ -280,14 +280,15 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table {
 		$send_pay_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'send_payment_reminder', 'TXN_ID'=>$item->ID() ), TXN_ADMIN_URL );
 
         //Build row actions
-        $view_lnk = '
+        $actionlinks = array();
+        $actionlinks['view_lnk'] = '
 		<li>
 			<a href="'.$view_lnk_url.'" title="' . __( 'View Transaction Details', 'event_espresso' ) . '" class="tiny-text">
 				<span class="dashicons dashicons-cart"></span>
 			</a>
 		</li>';
 
-         $dl_invoice_lnk = '
+        $actionlinks['dl_invoice_lnk'] = '
 		<li>
 			<a title="' . __( 'Download Transaction Invoice', 'event_espresso' ) . '" target="_blank" href="'.$dl_invoice_lnk_url.'" class="tiny-text">
 				<span class="ee-icon ee-icon-PDF-file-type ee-icon-size-16"></span>
@@ -296,33 +297,34 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table {
 
 
       		//only show payment reminder link if the message type is active.
-      		$EEMSG = EE_Registry::instance()->load_lib('messages');
-      		$active_mts = $EEMSG->get_active_message_types();
-      		if ( in_array( 'payment_reminder', $active_mts ) ) {
-	       $send_pay_lnk = '
+		$EEMSG = EE_Registry::instance()->load_lib('messages');
+		$active_mts = $EEMSG->get_active_message_types();
+		if ( in_array( 'payment_reminder', $active_mts ) ) {
+			$actionlinks['send_pay_lnk'] = '
 		<li>
 			<a href="'.$send_pay_lnk_url.'" title="' . __( 'Send Payment Reminder', 'event_espresso' ) . '" class="tiny-text">
 				<span class="dashicons dashicons-email-alt"></span>
 			</a>
 		</li>';
-		$send_pay_lnk = $item->get('STS_ID') != EEM_Transaction::complete_status_code && $item->get('STS_ID') != EEM_Transaction::overpaid_status_code ? $send_pay_lnk : '';
+			$actionlinks['send_pay_lnk'] = $item->get('STS_ID') != EEM_Transaction::complete_status_code && $item->get('STS_ID') != EEM_Transaction::overpaid_status_code ? $actionlinks['send_pay_lnk'] : '';
 		} else {
-			$send_pay_lnk = '';
+			$actionlinks['send_pay_lnk'] = '';
 		}
 
-	        $view_reg_lnk = '
+		$actionlinks['view_reg_lnk'] = '
 		<li>
 			<a href="'.$view_reg_lnk_url.'" title="' . __( 'View Registration Details', 'event_espresso' ) . '" class="tiny-text">
 				<span class="dashicons dashicons-clipboard"></span>
 			</a>
 		</li>';
 
-			$actions = '
-		<ul class="txn-overview-actions-ul">' .
-		$view_lnk . $dl_invoice_lnk . $send_pay_lnk . $view_reg_lnk . '
-		</ul>';
+		$actionlinks = apply_filters( 'FHEE__Admin_Transactions_List_Table__column_actions__action_links', $actionlinks, $item );
 
-			return $actions;
+		$actions = '<ul class="txn-overview-actions-ul">' . "\n\t";
+		$actions .= implode( "\n\t", $actionlinks );
+		$actions .= "\n</ul>\t";
+
+		return $actions;
     }
 
 


### PR DESCRIPTION
This commit modifies the transactions list table to run the action links through a filter so that they can be easily extended.

I've tried to follow existing code style and filter naming patterns, and used the same procedure that is used in `Events_Admin_List_Table`. However, I chose to use an associative array with action ids so that each action could be reliably identified when the filter is used. This allows me to modify an existing action like below without relying on URL parameters, CSS classes or other identifying elements which might change from version to version.

``````
add_filter( 'FHEE__Admin_Transactions_List_Table__column_actions__action_links', 'modify_transactions_list_table_actions', 10, 2 );
function modify_transactions_list_table_actions( $actions, $item ) {
    $registration = $item->primary_registration();
    $actions['dl_invoice_lnk'] = '
    <li>
        <a title="' . __( 'Download Transaction Invoice', 'event_espresso' ) . '" target="_blank" href="' . $registration->invoice_url() . '" class="tiny-text">
            <span class="ee-icon ee-icon-PDF-file-type ee-icon-size-16"></span>
        </a>
    </li>';

    return $actions;
}```
``````
