### PR TITLE
don't show tax details on receipt when tax is zero

### DIFF
--- a/modules/gateways/Invoice/lib/templates/receipt_body.template.php
+++ b/modules/gateways/Invoice/lib/templates/receipt_body.template.php
@@ -170,8 +170,8 @@ $tax_total_line_item;
 
 		<?php }?>
 		</div>
+		<?php if ($tax_total_line_item && $tax_total_line_item->get_total_tax() && $tax_total_line_item->children()){?>
 		<div class="taxes">
-			<?php if ($tax_total_line_item && $tax_total_line_item->children()){?>
 				<h3 class="section-title"><?php _e("Taxes",'event_espresso')?></h3>
 				<table class="invoice-amount">
 
@@ -201,9 +201,9 @@ $tax_total_line_item;
 					</tbody>
 
 				</table>
-			<?php }?>
 			<p><?php _e("* taxable items", "event_espresso");?></p>
 		</div>
+		<?php }?>
 		<div class="grand-total-dv">
 		<h2 class="grand-total"><?php printf(__("Grand Total: %s", "event_espresso"),EEH_Template::format_currency($total_cost));?></h2>
 		</div>


### PR DESCRIPTION
This hides the taxes element completely on receipts where tax totals zero. Maybe there are use-cases where you want to show zero tax, but I thought I'd send the PR anyway. Just close it if you want to leave it in place.
