### PR TITLE
use receipt's base.css when printing too

### DIFF
--- a/modules/gateways/Invoice/lib/templates/invoice_header.template.php
+++ b/modules/gateways/Invoice/lib/templates/invoice_header.template.php
@@ -4,7 +4,7 @@
 <title>[organization]<?php __(' Invoice #', 'event_espresso'); ?>[registration_code]<?php __(' for ', 'event_espresso'); ?>[name]</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <!-- Base Stylesheet do not change or remove -->
-<link rel="stylesheet" type="text/css" href="[base_url]base.css" media="screen" />
+<link rel="stylesheet" type="text/css" href="[base_url]base.css" media="screen, print" />
 <!-- Print Style Sheet -->
 <link rel="stylesheet" type="text/css" href="[base_url]css/print/<?php echo str_replace('.css', '',$invoice_css); ?>_print.css" media="print" />
 <!-- Primary Style Sheet -->


### PR DESCRIPTION
The receipt/invoice base.css file is loaded with the screen media context but not the print context. Printing the receipt or invoice does not preserve the nice formatting shown in a browser.

I've set it to `screen, print` just to make the commit minimal. But it could probably just as well be set to `all`.
