### PR TITLE
Bugfix for [ESPRESSO_EVENTS order_by="venue_title"]

### DIFF
--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -270,7 +270,7 @@ class EEH_Event_Query {
 					break;
 
 				case 'venue_title' :
-					$SQL .= ', EE_Venue_TBL.post_title AS venue_title' ;
+					$SQL .= ', Venue.post_title AS venue_title' ;
 					break;
 
 				case 'city' :


### PR DESCRIPTION
Sorting the event list by venue_title doesn not work (tested with 4.4.5 but seems to also be the case in master branch). The shortcode [ESPRESSO_EVENTS order_by="venue_title"] returns an empty list.

In line 273 you're referencing with the alias EE_Venue_TBL, but that alias is never defined. I guess it's supposed to be "Venue", which is defined in the join in line 431.
