### PR TITLE
Added filter for the fputcsv2 function

### DIFF
--- a/core/db_classes/EE_CSV.class.php
+++ b/core/db_classes/EE_CSV.class.php
@@ -546,6 +546,8 @@
 
 		$delimiter_esc = preg_quote($delimiter, '/');
 		$enclosure_esc = preg_quote($enclosure, '/');
+		//Allow user to filter the csv delimiter for other countries csv standards
+		$delimiter = apply_filters( 'FHEE__EE_CSV__fputcsv2__delimiter', $delimiter );
 
 		$output = array();
 		foreach ($row as $field_value) {


### PR DESCRIPTION
Allows user to return a different character for the delimiter in the csv function. Many countries do not use , but rather ;

Signed-off-by: Jonathan de Jong <jonathan@tigerton.se>