### PR TITLE
ADDED filters to the Price and Quantity table headers.

### DIFF
--- a/modules/ticket_selector/templates/ticket_selector_chart.template.php
+++ b/modules/ticket_selector/templates/ticket_selector_chart.template.php
@@ -13,9 +13,33 @@ $template_settings =  isset ( EE_Registry::instance()->CFG->template_settings->E
 					<span class="ee-icon ee-icon-tickets"></span><?php echo apply_filters( 'FHEE__ticket_selector_chart_template__table_header_available_tickets', __( 'Available Tickets', 'event_espresso' )); ?>
 				</th>
 				<?php if ( apply_filters( 'FHEE__ticket_selector_chart_template__display_ticket_price_details', TRUE )) { ?>
-				<th scope="col" width="22.5%"><?php _e( 'Price', 'event_espresso' ); ?> </th>
+				<th scope="col" width="22.5%">
+					<?php
+						/**
+						 * Filters the text printed for the header of the price column in the ticket selector table
+						 *
+						 * @since 4.7.2
+						 *
+						 * @param string 'Price' The translatable text to display in the table header for price
+						 * @param int $EVT_ID The Event ID
+						 */
+						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_price', __( 'Price', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+					?>
+				</th>
 				<?php } ?>
-				<th scope="col" width="17.5%" class="cntr"><?php _e( 'Qty*', 'event_espresso' ); ?></th>
+				<th scope="col" width="17.5%" class="cntr">
+					<?php
+						/**
+						* Filters the text printed for the header of the quantity column in the ticket selector table
+						*
+						* @since 4.7.2
+						*
+						* @param string 'Qty*' The translatable text to display in the table header for the Quantity of tickets
+						* @param int $EVT_ID The Event ID
+						*/
+						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_qty', _e( 'Qty*', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+					?>
+				</th>
 			</tr>
 		</thead>
 		<tbody>


### PR DESCRIPTION
This enables people to easily modify the content of these table headers and matches the pattern with the 'Available Tickets' header that already contains a filter.

Also, the event ID is passed to the filters. This enables, for example, a plugin/theme to be able to see if this event only allows people to select 1 ticket, in which case the radio button is displayed and in such a case the 'Qty' heading becomes superfluous. Same deal with 'Price' if the event is Free.