### PR TITLE
ADDED filters for the Price and Qty. table headers in the ticket selector

### DIFF
--- a/modules/ticket_selector/templates/ticket_selector_chart.template.php
+++ b/modules/ticket_selector/templates/ticket_selector_chart.template.php
@@ -10,12 +10,36 @@ $template_settings =  isset ( EE_Registry::instance()->CFG->template_settings->E
 		<thead>
 			<tr>
 				<th scope="col" class="ee-ticket-selector-ticket-details-th">
-					<?php echo apply_filters( 'FHEE__ticket_selector_chart_template__table_header_available_tickets', __( 'Available Tickets', 'event_espresso' )); ?> <span class="ee-icon ee-icon-tickets"></span>
+					<?php echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_available_tickets', __( 'Available Tickets', 'event_espresso' ) ), 'event_espresso' ); ?> <span class="ee-icon ee-icon-tickets"></span>
 				</th>
 				<?php if ( apply_filters( 'FHEE__ticket_selector_chart_template__display_ticket_price_details', TRUE )) { ?>
-				<th scope="col" class="ee-ticket-selector-ticket-price-th"><?php _e( 'Price', 'event_espresso' ); ?> </th>
+				<th scope="col" width="22.5%">
+					<?php
+						/**
+						 * Filters the text printed for the header of the price column in the ticket selector table
+						 *
+						 * @since 4.7.2
+						 *
+						 * @param string 'Price' The translatable text to display in the table header for price
+						 * @param int $EVT_ID The Event ID
+						 */
+						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_price', __( 'Price', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+					?>
+				</th>
 				<?php } ?>
-				<th scope="col" class="ee-ticket-selector-ticket-qty-th"><?php _e( 'Qty*', 'event_espresso' ); ?></th>
+				<th scope="col" width="17.5%" class="cntr">
+					<?php
+						/**
+						* Filters the text printed for the header of the quantity column in the ticket selector table
+						*
+						* @since 4.7.2
+						*
+						* @param string 'Qty*' The translatable text to display in the table header for the Quantity of tickets
+						* @param int $EVT_ID The Event ID
+						*/
+						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_qty', __( 'Qty*', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+					?>
+				</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/modules/ticket_selector/templates/ticket_selector_chart.template.php
+++ b/modules/ticket_selector/templates/ticket_selector_chart.template.php
@@ -10,7 +10,7 @@ $template_settings =  isset ( EE_Registry::instance()->CFG->template_settings->E
 		<thead>
 			<tr>
 				<th scope="col" class="ee-ticket-selector-ticket-details-th">
-					<?php echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_available_tickets', __( 'Available Tickets', 'event_espresso' ) ), 'event_espresso' ); ?> <span class="ee-icon ee-icon-tickets"></span>
+					<?php echo esc_html( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_available_tickets', __( 'Available Tickets', 'event_espresso' ) ), 'event_espresso' ); ?> <span class="ee-icon ee-icon-tickets"></span>
 				</th>
 				<?php if ( apply_filters( 'FHEE__ticket_selector_chart_template__display_ticket_price_details', TRUE )) { ?>
 				<th scope="col" width="22.5%">
@@ -23,7 +23,7 @@ $template_settings =  isset ( EE_Registry::instance()->CFG->template_settings->E
 						 * @param string 'Price' The translatable text to display in the table header for price
 						 * @param int $EVT_ID The Event ID
 						 */
-						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_price', __( 'Price', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+						echo esc_html( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_price', __( 'Price', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
 					?>
 				</th>
 				<?php } ?>
@@ -37,7 +37,7 @@ $template_settings =  isset ( EE_Registry::instance()->CFG->template_settings->E
 						* @param string 'Qty*' The translatable text to display in the table header for the Quantity of tickets
 						* @param int $EVT_ID The Event ID
 						*/
-						echo esc_html__( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_qty', __( 'Qty*', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
+						echo esc_html( apply_filters( 'FHEE__ticket_selector_chart_template__table_header_qty', __( 'Qty*', 'event_espresso' ), $EVT_ID ), 'event_espresso' );
 					?>
 				</th>
 			</tr>


### PR DESCRIPTION
 to match the pre-existing FHEE__ticket_selector_chart_template__table_header_available_tickets

ADDED esc_html call to the pre-existing FHEE__ticket_selector_chart_template__table_header_available_tickets filter for consistency and security

The new filters receive the Event ID which allows plugins/themes to see if these headings need to exist at all (or changed them based on the available tickets).

This replaces the previous pull request https://github.com/eventespresso/event-espresso-core/pull/83 -- I'm so sorry I made a bit of a mess with that. Not only did I not have the most recent master (even though I simply forked the repo), I also has _e() in the filter rather than __() which meant the extra text was doubled up. Brilliant.

Noticed that in your cherry-picked commit that you'd also added esc_html__ to the pre-existing available tickets header, so I've added that in here too, so it should _hopefully_ just be a straight up replacement for thr  FET-8343-add-filters-to-ticket-selector-table-header branch that you'd created. Again, sorry about that mess. Won't happen again.