### PR TITLE
ADDED a filter to allow the complete removal of the maximum tickets purchased footnote

### DIFF
--- a/modules/ticket_selector/templates/ticket_selector_chart.template.php
+++ b/modules/ticket_selector/templates/ticket_selector_chart.template.php
@@ -434,7 +434,7 @@ foreach ( $tickets as $TKT_ID => $ticket ) {
 	<input type="hidden" name="tkt-slctr-max-atndz-<?php echo $EVT_ID; ?>" value="<?php echo $max_atndz; ?>" />
 	<input type="hidden" name="tkt-slctr-event-id" value="<?php echo $EVT_ID; ?>" />
 
-<?php if ( $max_atndz > 0 ) { ?>
+<?php if ( $max_atndz > 0 && apply_filters( 'FHEE__ticket_selector_chart_template__maximum_tickets_purchased_display_footnote', true, $max_atndz, $EVT_ID ) ) { ?>
 	<p class="smaller-text lt-grey-text">* <?php echo apply_filters( 'FHEE__ticket_selector_chart_template__maximum_tickets_purchased_footnote', sprintf( __( 'Please note that a maximum number of %d tickets can be purchased for this event per order.', 'event_espresso' ), $max_atndz ));?></p>
 <?php } ?>
 


### PR DESCRIPTION
Currently the existing filter only allows you to change just the message shown in the footnote. (This also needs to be changed a little as it's always plural even if the max is 1, but that can be a separate PR).

If you simply return an empty string to the existing filter, you get a paragraph tag with just a '*' character. This is unnecessary. It's possible to hide this via CSS, but having a filter to show or hide this footnote is cleaner.