### PR TITLE
Fix "Add New Contact" page to allow adding contacts

### DIFF
--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -107,6 +107,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT {
 					'contact_list_export'=>  __("Export Data", "event_espresso"),
 				),
 			'publishbox' => array(
+				'add_attendee' => __("Add Contact Record", 'event_espresso'),
 				'edit_attendee' => __("Update Contact Record", 'event_espresso')
 				),
 			'hide_add_button_on_cpt_route' => array(
@@ -454,7 +455,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT {
 					'order' => 15,
 					'persistent' => FALSE
 					),
-				'metaboxes' => array_merge( $this->_default_espresso_metaboxes, array('_publish_post_box' ) ),
+				'metaboxes' => array_merge( $this->_default_espresso_metaboxes, array('_publish_post_box', 'attendee_editor_metaboxes' ) ),
 				'require_nonce' => FALSE
 				),
 

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -107,7 +107,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT {
 					'contact_list_export'=>  __("Export Data", "event_espresso"),
 				),
 			'publishbox' => array(
-				'add_attendee' => __("Add Contact Record", 'event_espresso'),
+				'add_new_attendee' => __("Add Contact Record", 'event_espresso'),
 				'edit_attendee' => __("Update Contact Record", 'event_espresso')
 				),
 			'hide_add_button_on_cpt_route' => array(


### PR DESCRIPTION
Required for a plugin we are writing.  Currently the ?page=espresso_registrations&action=add_new_attendee action raises a PHP error and is missing the side widget for adding email address etc.