### PR TITLE
deserialize in prepare_for_get

### DIFF
--- a/core/db_models/fields/EE_Serialized_Text_Field.php
+++ b/core/db_models/fields/EE_Serialized_Text_Field.php
@@ -42,6 +42,22 @@ class EE_Serialized_Text_Field extends EE_Text_Field_Base{
 			return $data;
 		}
 	}
+	/**
+	 * Value provided should definetely be a serialized string. We should unserialize into an array
+	 * @param string $value_found_in_db_for_model_object
+	 * @return array
+	 */
+	function prepare_for_get($value_of_field_on_model_object) {
+		$data = maybe_unserialize($value_of_field_on_model_object);
+		//it's possible that this still has serialized data if its the session.  WP has a bug, http://core.trac.wordpress.org/ticket/26118 that doesnt' unserialize this automatically.
+		$token = 'C';
+		$data = is_string($data) ? trim($data) : $data;
+		if ( is_string($data) && strlen($data) > 1 && $data[0] == $token  && preg_match( "/^{$token}:[0-9]+:/s", $data ) ) {
+			return unserialize($data);
+		} else {
+			return $data;
+		}
+	}
 	
 	/**
 	 * Gets a string representation of the array


### PR DESCRIPTION
A object->get('serialized_field') on a serialzed field containting an encoded array should return the array instead of the encoded string