### PR TITLE
Rework count_checkins_not_checkedout() for clarity

### DIFF
--- a/core/db_classes/EE_Registration.class.php
+++ b/core/db_classes/EE_Registration.class.php
@@ -951,12 +951,23 @@ class EE_Registration extends EE_Soft_Delete_Base_Class implements EEI_Registrat
 
 
 	/**
-	 * Returns the number of current Check-ins this registration is checked into for any of the datetimes the registration is for.  Note, this is ONLY checked in (does not include checkedout)
+	 * Returns the number of current Check-ins this registration is checked into for any of the datetimes the registration is for.
 	 * @return int
 	 */
 	public function count_checkins_not_checkedout() {
-		return $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
-	}
+		$check_ins = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
+		$check_outs = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 0 ) ) );
+		
+		return $check_ins - $check_outs;
+    	}
+	
+	/**
+	 * Returns the number of times this registration has had CHK_in set to 1
+	 * @return int
+    	 */
+	public function count_checkins_only() {
+        	return $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
+    	}
 
 
 

--- a/core/db_classes/EE_Registration.class.php
+++ b/core/db_classes/EE_Registration.class.php
@@ -948,26 +948,24 @@ class EE_Registration extends EE_Soft_Delete_Base_Class implements EEI_Registrat
 		return $this->get_model()->count_related( $this, 'Checkin' );
 	}
 
-
+	 /**
+	 * Returns the number of current Check-ins this registration is checked into (CHK_in = 1) that do not have a balancing checkout (CHK_out = 0)
+	 * @return int
+	 */
+	 public function count_active_checkins_only() {
+	 	$check_ins = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
+	 	$check_outs = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 0 ) ) );
+	 	return $check_ins - $check_outs;
+	 }
 
 	/**
-	 * Returns the number of current Check-ins this registration is checked into for any of the datetimes the registration is for.
+	 * Returns the number of current Check-ins this registration is checked into for any of the datetimes the registration is for.  Note, this is ONLY checked in (does not include checkedout)
 	 * @return int
 	 */
 	public function count_checkins_not_checkedout() {
-		$check_ins = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
-		$check_outs = $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 0 ) ) );
-		
-		return $check_ins - $check_outs;
-    	}
-	
-	/**
-	 * Returns the number of times this registration has had CHK_in set to 1
-	 * @return int
-    	 */
-	public function count_checkins_only() {
-        	return $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
-    	}
+		return $this->get_model()->count_related( $this, 'Checkin', array( array( 'CHK_in' => 1 ) ) );
+	}
+
 
 
 


### PR DESCRIPTION
Whenever you check someone into or out of a datetime, it adds a row to `esp_checkin`. Misclicks can cause an attendee to be checked in, which are then checked out to be corrected. If the attendee is checked in again later, their check-in count is now 2 according to `count_checkins_not_checkedout()`.

This changes `count_checkins_not_checkedout()` to return a count of the number of datetimes that this registration is currently checked into to allow for accurate attendance reporting and ticket use display.
`count_checkins_only()` contains the function that `count_checkins_not_checkedout()` had, with a more appropriate name.
This is less specific than `verify_can_checkin_against_TKT_uses` as it isn't tied to a datetime and can be used with just a `REG_ID`.
Using this change, checking if `count_checkins_not_checkedout()` equals `$ticket->uses()` can accurately return a boolean of fully attended or not, allowing for extended functionality like certificates of attendance.