### PR TITLE
add action for removing filters

### DIFF
--- a/modules/event_single/EED_Event_Single.module.php
+++ b/modules/event_single/EED_Event_Single.module.php
@@ -315,6 +315,7 @@ class EED_Event_Single  extends EED_Module {
 		remove_filter( 'the_content', array( 'EED_Event_Single', 'event_datetimes' ), 110 );
 		remove_filter( 'the_content', array( 'EED_Event_Single', 'event_tickets' ), 120 );
 		remove_filter( 'the_content', array( 'EED_Event_Single', 'event_venues' ), 130 );
+		do_action( 'AHEE__EED_Event_Single__use_filterable_display_order__after_remove_filters' );
 		// we're not returning the $content directly because the template we are loading uses the_content (or the_excerpt)
 		return $content;
 	}


### PR DESCRIPTION
EED_Event_Single::use_filterable_display_order calls an action allowing modifying the filter order, but doesn't call an action to allow cleaning up afterwards.
This adds the action to clean up.

EED_Events_Archive::use_filterable_display_order already calls an action allowing cleanup.