### PR TITLE
Add Filter For DropDown Detail

### DIFF
--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -202,7 +202,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
 				}
                                 $evts[] = array(
 					'id'    => $evt->ID(),
-					'text'  => apply_filters('FHEE__EE_Event_Registrations___get_table_filters__event_name', $evt->get( 'EVT_name' ), $event),
+					'text'  => apply_filters('FHEE__EE_Event_Registrations___get_table_filters__event_name', $evt->get( 'EVT_name' ), $evt),
 					'class' => $evt->is_expired() ? 'ee-expired-event' : '',
 				);
 				if ( $evt->ID() === $current_EVT_ID && $evt->is_expired() ) {

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -209,6 +209,11 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
 					$checked = '';
 				}
 			}
+			$evts = apply_filters( 
+				'FHEE__Event_Registrations__get_event_filter_toggle_html', 
+				$evts
+			);
+			
 			$event_filter = '<div class="ee-event-filter">';
 			$event_filter .= EEH_Form_Fields::select_input( 'event_id', $evts, $current_EVT_ID );
 			$event_filter .= '<span class="ee-event-filter-toggle">';

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -200,20 +200,15 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
 				if ( ! $evt->get_count_of_all_registrations() ) {
 					continue;
 				}
-				$evts[] = array(
+                                $evts[] = array(
 					'id'    => $evt->ID(),
-					'text'  => $evt->get( 'EVT_name' ),
+					'text'  => apply_filters('FHEE__EE_Event_Registrations___get_table_filters__event_name', $evt->get( 'EVT_name' ), $event),
 					'class' => $evt->is_expired() ? 'ee-expired-event' : '',
 				);
 				if ( $evt->ID() === $current_EVT_ID && $evt->is_expired() ) {
 					$checked = '';
 				}
 			}
-			$evts = apply_filters( 
-				'FHEE__Event_Registrations__get_event_filter_toggle_html', 
-				$evts
-			);
-			
 			$event_filter = '<div class="ee-event-filter">';
 			$event_filter .= EEH_Form_Fields::select_input( 'event_id', $evts, $current_EVT_ID );
 			$event_filter .= '<span class="ee-event-filter-toggle">';


### PR DESCRIPTION
Problem - Company uses manual event checkin. And company has many events with the same name. Trial and error is not the ideal way to identify the correct event. 

The proposed filter, FHEE__Event_Registrations__get_event_filter_toggle_html, allows us to modify the text output of the selector drop down to include other distinguishing information. 

For example, we can add the event start date after the event name, making events distinguishable:

	function jv_ee_add_date_to_text( $evts ) {

	foreach ($evts as $key => $e){

		global $wpdb; 
		$start_date = $wpdb->get_var( $wpdb->prepare(' SELECT `DTT_EVT_start` FROM `wp_2_esp_datetime` WHERE `EVT_ID` = %d ', $e['id'] ) );
		$start_date = date("m/d/Y", strtotime($start_date));

		$evts[$key]['text'] = $e['text'].' - '.$start_date;

	}

	return $evts;

	}
	add_filter( 'FHEE__Event_Registrations__get_event_filter_toggle_html', 'jv_ee_add_date_to_text', 10, 3 );


**Thanks for your pull request!**

Please answer the following questions in order to expedite its acceptance.

####What problem does this work solve, or what benefit does it have?

####Why do you think these changes are needed in Event Espresso core instead of being put in an add-on? 
> Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on

####Why do you think this is the best implementation?

####Does this include unit tests? Or how can it be tested?
> Automated tests not only demonstrate the code works, but also help in ongoing maintenance. So pull requests with automated tests are preferred.

##Please indicate
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
