### PR TITLE
Remove last invalid param from `wp_register_style` call ...

### DIFF
--- a/core/libraries/form_sections/inputs/EE_Datepicker_Input.php
+++ b/core/libraries/form_sections/inputs/EE_Datepicker_Input.php
@@ -33,7 +33,7 @@ class EE_Datepicker_Input extends EE_Form_Input_Base{
 	 */
 	public static function enqueue_styles_and_scripts() {
 		// load css
-		wp_register_style( 'espresso-ui-theme', EE_GLOBAL_ASSETS_URL . 'css/espresso-ui-theme/jquery-ui-1.10.3.custom.min.css', array(), EVENT_ESPRESSO_VERSION, TRUE );
+		wp_register_style( 'espresso-ui-theme', EE_GLOBAL_ASSETS_URL . 'css/espresso-ui-theme/jquery-ui-1.10.3.custom.min.css', array(), EVENT_ESPRESSO_VERSION );
 		wp_enqueue_style( 'espresso-ui-theme');
 	}
 


### PR DESCRIPTION
...that breaks JQueryUI css inclusion.

Ref : https://eventespresso.com/topic/jquery-ui-css-not-included-correctly-when-using-datepicker/

**Thanks for your pull request!**

Please answer the following questions in order to expedite its acceptance.

####What problem does this work solve, or what benefit does it have?

See support post above. JQuery UI CSS media type is set to '1' (invalid) when datepicker is used in registration form.

####Why do you think these changes are needed in Event Espresso core instead of being put in an add-on? 

Fix the broken styles.

####Why do you think this is the best implementation?

Fixes the bug.

####Does this include unit tests? Or how can it be tested?

Not got time to fix your code AND write your tests for a paid product, sorry.

##Please indicate
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [NA] User input is adequately validated and sanitized
* [NA] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
