### PR TITLE
Convert Exception to EE_Error for sites messing with `plugin_dir_url`

### DIFF
--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -383,24 +383,21 @@ class Registry
             );
         }
         if (filter_var($url_base, FILTER_VALIDATE_URL) === false) {
-            $message = printf(
-                esc_html__(
-                    'The url given for %1$s assets is invalid.  The url provided was: "%2$s". This usually happens when another plugin or theme on a site is using the "%3$s" filter or has an invalid url set for the "%4$s" constant',
-                    'event_espresso'
-                ),
-                'Event Espresso',
-                $url_base,
-                'plugins_url',
-                'WP_PLUGIN_URL'
-            );
-            if ( WP_DEBUG ) {
-                throw new InvalidArgumentException(
-                    $message
-                );
-            }
             if (is_admin()) {
                 EE_Error::add_error(
-                    $message
+                    sprintf(
+                        esc_html__(
+                            'The url given for %1$s assets is invalid.  The url provided was: "%2$s". This usually happens when another plugin or theme on a site is using the "%3$s" filter or has an invalid url set for the "%4$s" constant',
+                            'event_espresso'
+                        ),
+                        'Event Espresso',
+                        $url_base,
+                        'plugins_url',
+                        'WP_PLUGIN_URL'
+                    ),
+                    __FILE__,
+                    __FUNCTION__,
+                    __LINE__
                 );
             }
             return;


### PR DESCRIPTION
See https://events.codebasehq.com/projects/event-espresso/tickets/11493 for context.

When `WP_DEBUG` is true, this will still throw an exception.  When not true, an `EE_Error` notice will be created instead (and only display in the admin).

Here's what the notice appears like:

![New notice](https://www.evernote.com/l/AAMtf_rf33ZNbYqThBhJtgKjMf35wcXoUT4B/image.png)

## To Test

You can add the following code to some plugin (I just added it temporarily to the beginning fo the `espresso.php` file) to cause the conditions for the notice appearing:

```
add_filter('plugins_url', function($url) {
    return preg_replace_callback(
        '!(https?://[^/|"]+)([^"]+)?!',
        function($matches) {
            if (isset($matches[0]) && $matches[0] === site_url()) {
                return "/";
            } elseif (isset($matches[0]) && strpos($matches[0], site_url()) !== false) {
                return $matches[2];
            } else {
                return $matches[0];
            }
        },
        $url
    );
});
```

* [x] Using the above code, ensure that the error notice appears when `WP_DEBUG` is not defined or set to `false` and an exception is thrown when `WP_DEBUG` is defined and `true`.

Also please provide feedback (reviewer and tester) for actual content of notice.
