### PR TITLE
Fix broken boolean indicator for whether the pricing metabox is being loaded for an event being created or not. (fixes #297)

### DIFF
--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -996,7 +996,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $event                 = $this->_adminpage_obj->get_cpt_model_obj();
         //set is_creating_event property.
         $EVT_ID                   = $event->ID();
-        $this->_is_creating_event = absint($EVT_ID) === 0;
+        $this->_is_creating_event = empty($this->_req_data['post']);
         //default main template args
         $main_template_args = array(
             'event_datetime_help_link' => EEH_Template::get_help_tab_link(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
See #297 for original report.  Turns out the problem isn't actually with the documentation but due to a change in behaviour for how the `_is_creating_event` property is being set in `espresso_events_Pricing_Hooks::pricing_metabox`.  I'm not sure exactly the root cause but it looks like at some point in either the evolution of WP or the evolution of EE, a post (and thus an event) ALWAYS has an initial ID on page load of the editor regardless of context (I'm guessing at some point the post_id started getting generated a lot earlier).  This in turn meant that `$this->_is_ creating_event` would always be `false`.

The fix for this simply involves checking for `post` in the request and if its empty, we're creating a event.  This will be backward compatible with older versions of WP (if older versions of WP we support were not affected by this bug).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Using the plugin [here](https://github.com/eventespresso/event-espresso-core/blob/master/docs/T--Tutorials/modifying-defaults-for-events.md#modifying-the-defaults-on-creating-a-new-event), I:

* [x] verified creating an event was filtered.
* [x] verified editing an event was left untouched.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
