### PR TITLE
Switch to wp_add_inline_script from wp_localize_script for eejs.data api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,11 @@ jobs:
       env: WP_MULTISITE=1
     - php: 5.6
       env: WP_MULTISITE=1
-    # wp 4.2 builds
+    # wp 4.5 builds
     - php: 5.6
-      env: WP_VERSION=4.2
+      env: WP_VERSION=4.5
     - php: 5.6
-      env: WP_VERSION=4.2 WP_MULTISITE=1
+      env: WP_VERSION=4.5 WP_MULTISITE=1
     - php: nightly
     - stage: javascript-tests
       script:

--- a/core/espresso_definitions.php
+++ b/core/espresso_definitions.php
@@ -1,7 +1,7 @@
 <?php
 // define versions
 define('EVENT_ESPRESSO_VERSION', espresso_version());
-define('EE_MIN_WP_VER_REQUIRED', '4.2');
+define('EE_MIN_WP_VER_REQUIRED', '4.5');
 define('EE_MIN_WP_VER_RECOMMENDED', '4.9');
 define('EE_MIN_PHP_VER_RECOMMENDED', '5.6.32');
 define('EE_SUPPORT_EMAIL', 'support@eventespresso.com');

--- a/tests/includes/EE_REST_TestCase.php
+++ b/tests/includes/EE_REST_TestCase.php
@@ -25,6 +25,13 @@ abstract class EE_REST_TestCase extends EE_UnitTestCase
                 'Test being run on a version of WP that does not have the REST framework installed'
             );
         }
+
+        if (! function_exists('rest_validate_value_from_schema')) {
+            $this->markTestSkipped(
+                'Test being run on a version of WP that does not have the `rest_validate_value_from_schema` function available.'
+            );
+        }
+
         add_filter('rest_url', array($this, 'filter_rest_url_for_leading_slash'), 10, 2);
         /** @var WP_REST_Server $wp_rest_server */
         global $wp_rest_server;


### PR DESCRIPTION
See #310 for context.  Also note, that this bumps the **required** minimum version of WordPress to **4.5** because `wp_add_inline_script` was added in that verison of WP.