### PR TITLE
Improve tests to allow passes when times are within one minute (fixes #341)

### DIFF
--- a/tests/testcases/core/db_models/EEM_Base_Test.php
+++ b/tests/testcases/core/db_models/EEM_Base_Test.php
@@ -479,18 +479,17 @@ class EEM_Base_Test extends EE_UnitTestCase
         $datetime->setTimestamp(
             EEM_Datetime::instance()->current_time_for_query('DTT_EVT_start', true)
         );
-        $this->assertEquals(
-            Datetime::createFromFormat(
-                'Y-m-d H:i:s',
-                current_time('mysql')
-            ),
-            $datetime
+        $this->assertDateWithinOneMinute(
+            time(),
+            $datetime->format('U'),
+            'U'
         );
     }
 
 
 
     /**
+     * @group 341
      * @since 4.6.x
      */
     public function test_convert_datetime_for_query()
@@ -516,30 +515,49 @@ class EEM_Base_Test extends EE_UnitTestCase
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $now->format('F j, Y g:i a'),
                                          'F j, Y g:i a', 'UTC');
-            $this->assertEquals($now->format('F j, Y g:i a'), $converted->format('F j, Y g:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $now->format('F j, Y g:i a'),
+                $converted->format('F j, Y g:i a'),
+                'F j, Y g:i a',
+                sprintf('Dates not within one minute for timezone: %s', $timezone)
+            );
             //test getting correctly formatted string for different incoming format in same timezone.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $now->format('Y-m-d H:i:s'),
                                          'Y-m-d H:i:s', 'UTC');
-            $this->assertEquals($now->format('F j, Y g:i a'), $converted->format('F j, Y g:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $now->format('F j, Y g:i a'),
+                $converted->format('F j, Y g:i a'),
+                'F j, Y g:i a',
+                sprintf('Dates not within one minute for timezone tested: %s', $timezone)
+            );
             //test getting correctly formatted string for different incoming format in different incoming timezone.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $timezoneTest->format('Y-m-d H:i:s'),
                                          'Y-m-d H:i:s', 'America/Vancouver');
-            $this->assertEquals($now->format('F j, Y g:i a'), $converted->format('F j, Y g:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $now->format('F j, Y g:i a'),
+                $converted->format('F j, Y g:i a'),
+                'F j, Y g:i a',
+                sprintf('Dates not within one minute for timezone: %s', $timezone));
             //test getting correctly formatted string for unix_timestamp format.
             $converted = EEM_Datetime::instance()->convert_datetime_for_query('DTT_EVT_start', time(), 'U');
-            $this->assertEquals($now->format('F j, Y g:i a'), $converted->format('F j, Y g:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $now->format('F j, Y g:i a'),
+                $converted->format('F j, Y g:i a'),
+                'F j, Y g:i a',
+                sprintf('Timezone tested: %s', $timezone)
+            );
             //test getting correctly formatted string for current_time('mysql') format.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', current_time('mysql'),
                                          'Y-m-d H:i:s');
-            $this->assertEquals($now->format('F j, Y g:i a'), $converted->format('F j, Y g:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $now->format('F j, Y g:i a'),
+                $converted->format('F j, Y g:i a'),
+                'F j, Y g:i a',
+                sprintf('Dates not within one minute for timezone: %s', $timezone)
+            );
             //repeat above tests when internals on EE_Datetime_Field have been modified by new
             //datetime creation.
             $this->factory->datetime->create(array(
@@ -551,29 +569,49 @@ class EEM_Base_Test extends EE_UnitTestCase
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $timezoneTest->format('U'), 'U',
                                          'America/Vancouver');
-            $this->assertEquals($timezoneTest->format('d/m/Y h:i a'), $converted->format('d/m/Y h:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $timezoneTest->format('d/m/Y h:i a'),
+                $converted->format('d/m/Y h:i a'),
+                'd/m/Y h:i a',
+                sprintf('Dates not within one minute for timezone: %s', $timezone)
+            );
             //test getting correctly formatted string for different incoming format in same timezone.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $timezoneTest->format('Y-m-d H:i:s'),
                                          'Y-m-d H:i:s', 'America/Vancouver');
-            $this->assertEquals($timezoneTest->format('d/m/Y h:i a'), $converted->format('d/m/Y h:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $timezoneTest->format('d/m/Y h:i a'),
+                $converted->format('d/m/Y h:i a'),
+                'd/m/Y h:i a',
+                sprintf('Dates not within one minute for timezone tested: %s', $timezone)
+            );
             //test getting correctly formatted string for different incoming format in different incoming timezone.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', $now->format('U'), 'U', 'UTC');
-            $this->assertEquals($timezoneTest->format('d/m/Y h:i a'), $converted->format('d/m/Y h:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $timezoneTest->format('d/m/Y h:i a'),
+                $converted->format('d/m/Y h:i a'),
+                'd/m/Y h:i a',
+                sprintf('Dates not within one minute for timezone tested: %s', $timezone)
+            );
             //test getting correctly formatted string for time() format.
             $converted = EEM_Datetime::instance()->convert_datetime_for_query('DTT_EVT_start', time(), 'U');
-            $this->assertEquals($timezoneTest->format('d/m/Y h:i a'), $converted->format('d/m/Y h:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $timezoneTest->format('d/m/Y h:i a'),
+                $converted->format('d/m/Y h:i a'),
+                'd/m/Y h:i a',
+                sprintf('Dates not within one minute for timezone tested: %s', $timezone)
+            );
             //test getting correctly formatted string for current_time('mysql') format.
             $converted = EEM_Datetime::instance()
                                      ->convert_datetime_for_query('DTT_EVT_start', current_time('mysql'),
                                          'Y-m-d H:i:s');
-            $this->assertEquals($timezoneTest->format('d/m/Y h:i a'), $converted->format('d/m/Y h:i a'),
-                sprintf('Timezone tested: %s', $timezone));
+            $this->assertDateWithinOneMinute(
+                $timezoneTest->format('d/m/Y h:i a'),
+                $converted->format('d/m/Y h:i a'),
+                'd/m/Y h:i a',
+                sprintf('Dates not within one minute for timezone tested: %s', $timezone)
+            );
         }
         update_option('timezone_string', $original_timezone);
         update_option('gmt_offset', $original_offset);

--- a/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
+++ b/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
@@ -442,10 +442,18 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
      */
     public function testPrepareFieldValuesForJson($expected, $input, $field_obj)
     {
-        $this->assertEquals(
-            $expected,
-            ModelDataTranslator::prepareFieldValuesForJson($field_obj, $input, '4.8.36')
-        );
+        if ($field_obj instanceof EE_DateTime_Field && ! empty($expected)) {
+            $this->assertDateWithinOneMinute(
+                $expected,
+                ModelDataTranslator::prepareFieldValuesForJson($field_obj, $input, '4.8.36'),
+                'Y-m-d\TH:i:s'
+            );
+        } else {
+            $this->assertEquals(
+                $expected,
+                ModelDataTranslator::prepareFieldValuesForJson($field_obj, $input, '4.8.36')
+            );
+        }
     }
 
 


### PR DESCRIPTION
Precision is tricky in unit tests because things can affect the second precision when tests are run all in one go.  So changes for test artifacts to be off by one second are greater.  I think it’s sufficient to have a time tolerance of one minute difference within the unit tests for any comparisons between date and time strings.


