### PR TITLE
Configure wp global so its aliased to external packages in webpack

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,21 @@ const autoprefixer = require( 'autoprefixer' );
 const externals = {
 	jquery: 'jQuery',
 	'@eventespresso/eejs': 'eejs',
+	'@wordpress/api-request': {
+		this: [ 'wp', 'apiRequest' ],
+	},
+	'@wordpress/data': {
+		this: [ 'wp', 'data' ],
+	},
+	'@wordpress/element': {
+		this: [ 'wp', 'element' ],
+	},
+	'@wordpress/components': {
+		this: [ 'wp', 'components' ],
+	},
+	'@wordpress/i18n': {
+		this: [ 'wp', 'i18n' ],
+	},
 };
 const reactVendorPackages = [
 	'react',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,9 +18,6 @@ const externals = {
 	'@wordpress/components': {
 		this: [ 'wp', 'components' ],
 	},
-	'@wordpress/i18n': {
-		this: [ 'wp', 'i18n' ],
-	},
 };
 const reactVendorPackages = [
 	'react',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This allows us to import the services as packages rather than access the global directly in our builds.  This helps future proof things - should WordPress publish any of these services as actual npm packages, we can just import them directly and then modify the webpack config, avoiding the necessity to go through all our files and modify them there.

With this change, instead of doing something like this in your js source:

```js
const { Component }  = wp.element;
const { Placeholder } = wp.components;
```

You'd do:

```js
import { Component } from '@wordpress/element';
import { Placeholder } from '@wordpress/components';
```

Currently the following `wp` objects are aliased to package notation:

| wp notation | package notation |
| ------------ | ---------------- |
| wp.apiRequest | `@wordpress/api-request`
wp.data | `@wordpress/data`
wp.element | `@wordpress/element`
wp.components | `@wordpress/components`

If you come across need for any more to get mapped you just need to add it to `webpack.common.js` like I did in this pull.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

I've run `npm install` and `npm run watch` and there are no errors.  `npm run build` should get run as a part of the test build on this pull.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
