### PR TITLE
add hookpoint for benchmarking

### DIFF
--- a/core/services/Benchmark.php
+++ b/core/services/Benchmark.php
@@ -156,7 +156,8 @@ class Benchmark
             'shutdown',
             function () use ($formatted) {
                 Benchmark::displayResults(true, $formatted);
-            }
+            },
+            999999
         );
     }
 
@@ -177,7 +178,8 @@ class Benchmark
             'shutdown',
             function () use ($filepath, $formatted, $append) {
                 Benchmark::writeResultsToFile($filepath, $formatted, $append);
-            }
+            },
+            999999
         );
     }
 

--- a/core/services/bootstrap/BootstrapCore.php
+++ b/core/services/bootstrap/BootstrapCore.php
@@ -83,6 +83,7 @@ class BootstrapCore
      */
     public function __construct()
     {
+        do_action('AHEE__EventEspresso_core_services_bootstrap_BootstrapCore___construct');
         // construct request stack and run middleware apps as soon as all WP plugins are loaded
         add_action('plugins_loaded', array($this, 'initialize'), 0);
     }


### PR DESCRIPTION
needed a new hookpoint for triggering benchmarking prior to EE bootstrapping and also needed to push benchmarking display back so it happens after everything else is done.