### PR TITLE
Fix phpcs violations with specific rule exclusions on linting rules. (wip)

### DIFF
--- a/admin_pages/messages/espresso_events_Messages_Hooks.class.php
+++ b/admin_pages/messages/espresso_events_Messages_Hooks.class.php
@@ -1,42 +1,29 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * espresso_events_Messages_Hooks
  * Hooks various messages logic so that it runs on indicated Events Admin Pages.
  * Commenting/docs common to all children classes is found in the EE_Admin_Hooks parent.
- * 
  *
- * @package		espresso_events_Messages_Hooks
- * @subpackage	includes/core/admin/messages/espresso_events_Messages_Hooks.class.php
- * @author		Darren Ethier
+ *
+ * @package         espresso_events_Messages_Hooks
+ * @subpackage      includes/core/admin/messages/espresso_events_Messages_Hooks.class.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class espresso_events_Messages_Hooks extends EE_Admin_Hooks {
+class espresso_events_Messages_Hooks extends EE_Admin_Hooks
+{
 
 
-	public function __construct( EE_Admin_Page $admin_page ) {
-		parent::__construct($admin_page);
-	}
+    public function __construct(EE_Admin_Page $admin_page)
+    {
+        parent::__construct($admin_page);
+    }
 
 
-	protected function _set_hooks_properties() {
-		$this->_name = 'messages';
-	}
-	
+    protected function _set_hooks_properties()
+    {
+        $this->_name = 'messages';
+    }
 }

--- a/admin_pages/registration_form/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
+++ b/admin_pages/registration_form/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('NO direct script access allowed');
-}
 
 /**
  * Registration_Form_Questions_Overview_Help_Tour
@@ -17,13 +14,13 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
  */
 class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
 {
-    
+
     protected function _set_tour_properties()
     {
         $this->_label = __('Questions Overview Tour', 'event_espresso');
-        $this->_slug  = $this->_is_caf ? 'questions-overview-caf-joyride' : 'questions-overview-joyride';
+        $this->_slug = $this->_is_caf ? 'questions-overview-caf-joyride' : 'questions-overview-joyride';
     }
-    
+
     protected function _set_tour_stops()
     {
         $this->_stops = array(
@@ -36,8 +33,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'top',
                     'tipAdjustmentX' => -5,
-                    'tipAdjustmentY' => -25
-                )
+                    'tipAdjustmentY' => -25,
+                ),
             ),
             40  => array(
                 'id'      => 'admin_label',
@@ -45,8 +42,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'top',
                     'tipAdjustmentX' => 20,
-                    'tipAdjustmentY' => -25
-                )
+                    'tipAdjustmentY' => -25,
+                ),
             ),
             50  => array(
                 'id'      => 'type',
@@ -54,8 +51,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'top',
                     'tipAdjustmentX' => -5,
-                    'tipAdjustmentY' => -25
-                )
+                    'tipAdjustmentY' => -25,
+                ),
             ),
             60  => array(
                 'id'      => 'values',
@@ -63,8 +60,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'top',
                     'tipAdjustmentX' => -5,
-                    'tipAdjustmentY' => -25
-                )
+                    'tipAdjustmentY' => -25,
+                ),
             ),
             70  => array(
                 'id'      => 'required',
@@ -72,8 +69,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'top',
                     'tipAdjustmentY' => -20,
-                    'tipAdjustmentX' => -15
-                )
+                    'tipAdjustmentX' => -15,
+                ),
             ),
             /*80 => array(
                 'class' => 'bulkactions',
@@ -90,8 +87,8 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'left',
                     'tipAdjustmentY' => -50,
-                    'tipAdjustmentX' => -15
-                )
+                    'tipAdjustmentX' => -15,
+                ),
             ),
             100 => array(
                 'id'      => 'add-new-question',
@@ -99,62 +96,69 @@ class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
                 'options' => array(
                     'tipLocation'    => 'right',
                     'tipAdjustmentY' => -50,
-                    'tipAdjustmentX' => 15
-                )
+                    'tipAdjustmentX' => 15,
+                ),
             ),
         );
     }
-    
-    
+
+
     protected function _start()
     {
         $content = '<h3>' . __('Questions Overview', 'event_espresso') . '</h3>';
-        $content .= '<p>' . __('This tour of the Questions Overview page will go over different areas of the screen to help you understand what they are used for.',
-                'event_espresso') . '</p>';
-        
+        $content .= '<p>' . __(
+            'This tour of the Questions Overview page will go over different areas of the screen to help you understand what they are used for.',
+            'event_espresso'
+        ) . '</p>';
+
         return $content;
     }
-    
+
     protected function _display_text_stop()
     {
         return '<p>' . __('View available questions.', 'event_espresso') . '</p>';
     }
-    
+
     protected function _admin_label_stop()
     {
         return '<p>' . __('View the admin label for your questions.', 'event_espresso') . '</p>';
     }
-    
+
     protected function _type_stop()
     {
-        return '<p>' . __('View the type of question. Available options are Text, Textarea, Checkboxes, Radio Buttons, Dropdown, State/Province Dropdown, Country Dropdown, and Date Picker.',
-            'event_espresso') . '</p>';
+        return '<p>' . __(
+            'View the type of question. Available options are Text, Textarea, Checkboxes, Radio Buttons, Dropdown, State/Province Dropdown, Country Dropdown, and Date Picker.',
+            'event_espresso'
+        ) . '</p>';
     }
-    
+
     protected function _values_stop()
     {
-        return '<p>' . __('View stored values for checkboxes, radio buttons, and select boxes.',
-            'event_espresso') . '</p>';
+        return '<p>' . __(
+            'View stored values for checkboxes, radio buttons, and select boxes.',
+            'event_espresso'
+        ) . '</p>';
     }
-    
+
     protected function _required_stop()
     {
         return '<p>' . __('View if a question is required.', 'event_espresso') . '</p>';
     }
-    
+
     /* protected function _bulk_actions_stop() {
         return '<p>' . __('Perform bulk actions to multiple questions.', 'event_espresso') . '</p>';
     } */
-    
+
     protected function _search_stop()
     {
-        return '<p>' . __('Search through questions. The following sources will be searched: Name of Question (display text).',
-            'event_espresso') . '</p>';
+        return '<p>' . __(
+            'Search through questions. The following sources will be searched: Name of Question (display text).',
+            'event_espresso'
+        ) . '</p>';
     }
-    
+
     protected function _add_new_question_stop()
     {
         return '<p>' . __('Click here to add a new question.', 'event_espresso') . '</p>';
     }
-    
 }

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_List_Table.class.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_List_Table.class.php
@@ -1,32 +1,26 @@
 <?php
-/**
- * This file contains the Caffeinated version of the Event List Table.
- * @package      Event Espresso
- * @subpackage admin
- * @since           4.4.9
- */
-if ( ! defined('EVENT_ESPRESSO_VERSION')) exit('No direct script access allowed');
 
 /**
  * This is the caffeinated class for the event list table.  It is only loaded in caffeinated versions of Event
  * Espresso.
- * @package        Event Espresso
- * @subpackage  admin
+ *
+ * @package          Event Espresso
+ * @subpackage       admin
  * @since            4.4.9
- * @author          Darren Ethier
+ * @author           Darren Ethier
  */
-class Extend_Events_Admin_List_Table extends Events_Admin_List_Table {
+class Extend_Events_Admin_List_Table extends Events_Admin_List_Table
+{
 
-	protected function _column_name_action_setup( EE_Event $item ) {
-		$export_query_args = array(
-				'action' => 'export_events',
-				'EVT_ID' => $item->ID()
-			);
-		$export_event_link = EE_Admin_Page::add_query_args_and_nonce( $export_query_args, EVENTS_ADMIN_URL );
+    protected function _column_name_action_setup(EE_Event $item)
+    {
+        $export_query_args = array(
+            'action' => 'export_events',
+            'EVT_ID' => $item->ID(),
+        );
+        $export_event_link = EE_Admin_Page::add_query_args_and_nonce($export_query_args, EVENTS_ADMIN_URL);
 
-		$actions = parent::_column_name_action_setup( $item );
-//		$actions['export'] = '<a href="' . $export_event_link . '" title="' . __('Export Event', 'event_espresso') . '">' . __('Export', 'event_espresso') . '</a>';
-		return $actions;
-	}
-
-} //end Extend_Events_Admin_List_Table
+        $actions = parent::_column_name_action_setup($item);
+        return $actions;
+    }
+}

--- a/caffeinated/admin/extend/events/Tickets_List_Table.class.php
+++ b/caffeinated/admin/extend/events/Tickets_List_Table.class.php
@@ -1,166 +1,167 @@
-<?php if ( ! defined('EVENT_ESPRESSO_VERSION')) exit('No direct script access allowed');
+<?php
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Tickets_List_Table
  *
  * Class for preparing the table listing all the default tickets
  *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
- * @package			Tickets List Table
- * @subpackage		caffeinated/admin/new/tickets/Tickets_List_Table.core.php
- * @author			Darren Ethier
+ * @package            Tickets List Table
+ * @subpackage         caffeinated/admin/new/tickets/Tickets_List_Table.core.php
+ * @author             Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Tickets_List_Table extends EE_Admin_List_Table {
+class Tickets_List_Table extends EE_Admin_List_Table
+{
 
 
-	protected function _setup_data() {
-		$trashed = $this->_admin_page->get_view() == 'trashed' ? TRUE : FALSE;
-		$this->_data = $this->_admin_page->get_default_tickets( $this->_per_page, FALSE, $trashed );
-		$this->_all_data_count = $this->_admin_page->get_default_tickets( $this->_per_page, TRUE, FALSE );
-		$this->_trashed_count = $this->_admin_page->get_default_tickets( $this->_per_page, TRUE, TRUE );
-	}
+    protected function _setup_data()
+    {
+        $trashed = $this->_admin_page->get_view() == 'trashed' ? true : false;
+        $this->_data = $this->_admin_page->get_default_tickets($this->_per_page, false, $trashed);
+        $this->_all_data_count = $this->_admin_page->get_default_tickets($this->_per_page, true, false);
+        $this->_trashed_count = $this->_admin_page->get_default_tickets($this->_per_page, true, true);
+    }
 
 
+    protected function _set_properties()
+    {
+        $this->_wp_list_args = array(
+            'singular' => __('ticket', 'event_espresso'),
+            'plural'   => __('tickets', 'event_espresso'),
+            'ajax'     => true,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
 
-
-	protected function _set_properties() {
-		$this->_wp_list_args = array(
-				'singular' => __('ticket', 'event_espresso'),
-				'plural' => __('tickets', 'event_espresso'),
-				'ajax' => TRUE,
-				'screen' => $this->_admin_page->get_current_screen()->id
-			);
-
-		$this->_columns = array(
-				'cb' => '<input type="checkbox" />', //Render a checkbox instead of text
-				'TKT_name' => __('Name', 'event_espresso'),
-				'TKT_description' => __('Description', 'event_espresso'),
-				'TKT_qty' => __('Quantity', 'event_espresso'),
-				'TKT_uses' => __('Datetimes', 'event_espresso'),
-				'TKT_min' => __('Minimum', 'event_espresso'),
-				'TKT_max' => __('Maximum', 'event_espresso'),
-				'TKT_price' => __('Price', 'event_espresso'),
-				'TKT_taxable' => __('Taxable', 'event_espresso')
-			);
+        $this->_columns = array(
+            'cb'              => '<input type="checkbox" />', // Render a checkbox instead of text
+            'TKT_name'        => __('Name', 'event_espresso'),
+            'TKT_description' => __('Description', 'event_espresso'),
+            'TKT_qty'         => __('Quantity', 'event_espresso'),
+            'TKT_uses'        => __('Datetimes', 'event_espresso'),
+            'TKT_min'         => __('Minimum', 'event_espresso'),
+            'TKT_max'         => __('Maximum', 'event_espresso'),
+            'TKT_price'       => __('Price', 'event_espresso'),
+            'TKT_taxable'     => __('Taxable', 'event_espresso'),
+        );
 
         $this->_sortable_columns = array(
-				// TRUE means its already sorted
-				'TKT_name' => array( 'TKT_name' => TRUE ),
-				'TKT_description' => array( 'TKT_description' => FALSE ),
-				'TKT_qty' => array( 'TKT_qty' => FALSE ),
-				'TKT_uses' => array( 'TKT_uses' => FALSE ),
-				'TKT_min' => array( 'TKT_min' => FALSE ),
-				'TKT_max' => array( 'TKT_max' => FALSE ),
-				'TKT_price' => array( 'TKT_price' => FALSE )
-	        	);
+            // TRUE means its already sorted
+            'TKT_name'        => array('TKT_name' => true),
+            'TKT_description' => array('TKT_description' => false),
+            'TKT_qty'         => array('TKT_qty' => false),
+            'TKT_uses'        => array('TKT_uses' => false),
+            'TKT_min'         => array('TKT_min' => false),
+            'TKT_max'         => array('TKT_max' => false),
+            'TKT_price'       => array('TKT_price' => false),
+        );
 
-        $this->_hidden_columns = array(
-			);
-
-	}
+        $this->_hidden_columns = array();
+    }
 
 
+    protected function _get_table_filters()
+    {
+    }
 
 
-
-	protected function _get_table_filters() {
-	}
-
-
-
-
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_all_data_count;
-		$this->_views['trashed']['count'] = $this->_trashed_count;
-	}
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_all_data_count;
+        $this->_views['trashed']['count'] = $this->_trashed_count;
+    }
 
 
-
-	function column_cb($item) {
-		return $item->ID() === 1 ? '<span class="ee-lock-icon"></span>' : sprintf( '<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />', /* $1%s */ $item->ID() );
-
-	}
-
-
-
-	function column_TKT_name($item) {
-		//build row actions
-		$actions = array();
-
-		//trash links
-		if ( $item->ID() !== 1 ) {
-			if ( $this->_view == 'all' ) {
-				$trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action' => 'trash_ticket', 'TKT_ID' => $item->ID() ), EVENTS_ADMIN_URL );
-				$actions['trash'] = '<a href="' . $trash_lnk_url . '" title="' . esc_attr__('Move Ticket to trash', 'event_espresso') . '">' . __('Trash', 'event_espresso') . '</a>';
-			} else {
-				// restore price link
-				$restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'restore_ticket', 'TKT_ID'=>$item->ID() ), EVENTS_ADMIN_URL );
-				$actions['restore'] = '<a href="'.$restore_lnk_url.'" title="' . esc_attr__( 'Restore Ticket', 'event_espresso' ) . '">' . __( 'Restore', 'event_espresso' ) . '</a>';
-				// delete price link
-				$delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'delete_ticket', 'TKT_ID'=>$item->ID() ), EVENTS_ADMIN_URL );
-				$actions['delete'] = '<a href="'.$delete_lnk_url.'" title="' . esc_attr__( 'Delete Ticket Permanently', 'event_espresso' ) . '">' . __( 'Delete Permanently', 'event_espresso' ) . '</a>';
-			}
-		}
-
-		return $item->get('TKT_name') . $this->row_actions( $actions );
-	}
+    public function column_cb($item)
+    {
+        return $item->ID() === 1
+            ? '<span class="ee-lock-icon"></span>'
+            : sprintf(
+                '<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />',
+                $item->ID()
+            );
+    }
 
 
+    public function column_TKT_name($item)
+    {
+        // build row actions
+        $actions = array();
+
+        // trash links
+        if ($item->ID() !== 1) {
+            if ($this->_view == 'all') {
+                $trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'trash_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), EVENTS_ADMIN_URL);
+                $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                                    . esc_attr__('Move Ticket to trash', 'event_espresso') . '">'
+                                    . __('Trash', 'event_espresso') . '</a>';
+            } else {
+                // restore price link
+                $restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'restore_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), EVENTS_ADMIN_URL);
+                $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                                      . esc_attr__('Restore Ticket', 'event_espresso') . '">'
+                                      . __('Restore', 'event_espresso') . '</a>';
+                // delete price link
+                $delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'delete_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), EVENTS_ADMIN_URL);
+                $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                                     . esc_attr__('Delete Ticket Permanently', 'event_espresso') . '">'
+                                     . __('Delete Permanently', 'event_espresso') . '</a>';
+            }
+        }
+
+        return $item->get('TKT_name') . $this->row_actions($actions);
+    }
 
 
-	function column_TKT_description($item) {
-		return $item->get('TKT_description');
-	}
+    public function column_TKT_description($item)
+    {
+        return $item->get('TKT_description');
+    }
 
 
-
-	function column_TKT_qty($item) {
-		return $item->get_pretty('TKT_qty','text');
-	}
-
-
-
-	function column_TKT_uses($item) {
-		return $item->get_pretty('TKT_uses','text');
-	}
+    public function column_TKT_qty($item)
+    {
+        return $item->get_pretty('TKT_qty', 'text');
+    }
 
 
-	function column_TKT_min($item) {
-		return $item->get('TKT_min');
-	}
+    public function column_TKT_uses($item)
+    {
+        return $item->get_pretty('TKT_uses', 'text');
+    }
 
 
-
-	function column_TKT_max($item) {
-		return $item->get_pretty('TKT_max','text');
-	}
-
-
-
-	function column_TKT_price($item) {
-		return EEH_Template::format_currency($item->get('TKT_price'));
-	}
+    public function column_TKT_min($item)
+    {
+        return $item->get('TKT_min');
+    }
 
 
+    public function column_TKT_max($item)
+    {
+        return $item->get_pretty('TKT_max', 'text');
+    }
 
-	function column_TKT_taxable($item) {
-		return $item->get('TKT_taxable') ? __('Yes', 'event_espresso') : __('No', 'event_espresso');
-	}
 
-} //end Tickets_List_Table
+    public function column_TKT_price($item)
+    {
+        return EEH_Template::format_currency($item->get('TKT_price'));
+    }
+
+
+    public function column_TKT_taxable($item)
+    {
+        return $item->get('TKT_taxable') ? __('Yes', 'event_espresso') : __('No', 'event_espresso');
+    }
+}

--- a/caffeinated/admin/extend/messages/Custom_Messages_Template_List_Table.class.php
+++ b/caffeinated/admin/extend/messages/Custom_Messages_Template_List_Table.class.php
@@ -1,9 +1,9 @@
 <?php
-defined('EVENT_ESPRESSO_VERSION') || exit('No direct access allowed');
 
 /**
  * Messages_Template_List_Table
  * extends EE_Admin_List_Table class
+ *
  * @package         Event Espresso
  * @subpackage      /includes/core/admin/messages
  * @author          Darren Ethier
@@ -17,7 +17,7 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
      */
     protected function _setup_data()
     {
-        $this->_data           = $this->get_admin_page()->get_message_templates(
+        $this->_data = $this->get_admin_page()->get_message_templates(
             $this->_per_page,
             $this->_view,
             false,
@@ -43,19 +43,19 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
         $this->_wp_list_args = array(
             'singular' => esc_html__('Message Template Group', 'event_espresso'),
             'plural'   => esc_html__('Message Template', 'event_espresso'),
-            'ajax'     => true, //for now,
+            'ajax'     => true, // for now,
             'screen'   => $this->get_admin_page()->get_current_screen()->id,
         );
 
         $this->_columns = array_merge(
             array(
-                'cb' => '<input type="checkbox" />',
+                'cb'   => '<input type="checkbox" />',
                 'name' => esc_html__('Template Name', 'event_espresso'),
             ),
             $this->_columns,
             array(
-                'events' => esc_html__('Events', 'event_espresso'),
-                'actions' => ''
+                'events'  => esc_html__('Events', 'event_espresso'),
+                'actions' => '',
             )
         );
     }
@@ -135,7 +135,7 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
     protected function _add_view_counts()
     {
         foreach ($this->_views as $view => $args) {
-            $this->_views[$view]['count'] = $this->get_admin_page()->get_message_templates(
+            $this->_views[ $view ]['count'] = $this->get_admin_page()->get_message_templates(
                 $this->_per_page,
                 $view,
                 true,
@@ -161,6 +161,7 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
 
     /**
      * Add additional actions for custom message template list view.
+     *
      * @param EE_Message_Template_Group $item
      * @return array
      * @throws EE_Error
@@ -169,20 +170,23 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
     {
         $actions = parent::_get_actions_for_messenger_column($item);
 
-        //add additional actions for trash/restore etc.
-        $trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array('action'   => 'trash_message_template',
-                                                                       'id'       => $item->GRP_ID(),
-                                                                       'noheader' => true,
+        // add additional actions for trash/restore etc.
+        $trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+            'action'   => 'trash_message_template',
+            'id'       => $item->GRP_ID(),
+            'noheader' => true,
         ), EE_MSG_ADMIN_URL);
         // restore link
-        $restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array('action'   => 'restore_message_template',
-                                                                         'id'       => $item->GRP_ID(),
-                                                                         'noheader' => true,
+        $restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+            'action'   => 'restore_message_template',
+            'id'       => $item->GRP_ID(),
+            'noheader' => true,
         ), EE_MSG_ADMIN_URL);
         // delete price link
-        $delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array('action'   => 'delete_message_template',
-                                                                        'id'       => $item->GRP_ID(),
-                                                                        'noheader' => true,
+        $delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+            'action'   => 'delete_message_template',
+            'id'       => $item->GRP_ID(),
+            'noheader' => true,
         ), EE_MSG_ADMIN_URL);
 
         if (! $item->get('MTP_deleted')
@@ -234,6 +238,7 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
 
     /**
      * Generate dropdown filter select input for messengers
+     *
      * @param bool $global
      * @return string
      * @throws EE_Error
@@ -246,6 +251,7 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
 
     /**
      * Generate dropdown filter select input for message types
+     *
      * @param bool $global
      * @return string
      * @throws EE_Error

--- a/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
@@ -1,7 +1,5 @@
 <?php
 
-defined('EVENT_ESPRESSO_VERSION') || exit('No direct access allowed.');
-
 /**
  * espresso_events_Messages_Hooks_Extend
  * Hooks various messages logic so that it runs on indicated Events Admin Pages.
@@ -66,7 +64,7 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             ),
         );
 
-        //see explanation for layout in EE_Admin_Hooks
+        // see explanation for layout in EE_Admin_Hooks
         $this->_scripts_styles = array(
             'registers' => array(
                 'events_msg_admin'     => array(
@@ -103,15 +101,15 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
      */
     public function attach_evt_message_templates($event, $data)
     {
-        //first we remove all existing relations on the Event for message types.
+        // first we remove all existing relations on the Event for message types.
         $event->_remove_relations('Message_Template_Group');
-        //now let's just loop through the selected templates and add relations!
+        // now let's just loop through the selected templates and add relations!
         if (isset($data['event_message_templates_relation'])) {
             foreach ($data['event_message_templates_relation'] as $grp_ID) {
                 $event->_add_relation_to($grp_ID, 'Message_Template_Group');
             }
         }
-        //now save
+        // now save
         return $event->save();
     }
 
@@ -124,8 +122,8 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
      */
     public function messages_metabox($event, $callback_args)
     {
-        //let's get the active messengers (b/c messenger objects have the active message templates)
-        //convert 'evt_id' to 'EVT_ID'
+        // let's get the active messengers (b/c messenger objects have the active message templates)
+        // convert 'evt_id' to 'EVT_ID'
         $this->_req_data['EVT_ID'] = isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : null;
         $this->_req_data['EVT_ID'] = isset($this->_req_data['post']) && empty($this->_req_data['EVT_ID'])
             ? $this->_req_data['post']
@@ -136,18 +134,18 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             : $this->_req_data['EVT_ID'];
         /** @type EE_Message_Resource_Manager $message_resource_manager */
         $message_resource_manager = EE_Registry::instance()->load_lib('Message_Resource_Manager');
-        $active_messengers        = $message_resource_manager->active_messengers();
-        $tabs                     = array();
+        $active_messengers = $message_resource_manager->active_messengers();
+        $tabs = array();
 
-        //empty messengers?
-        //Note message types will always have at least one available because every messenger has a default message type
+        // empty messengers?
+        // Note message types will always have at least one available because every messenger has a default message type
         // associated with it (payment) if no other message types are selected.
         if (empty($active_messengers)) {
             $msg_activate_url = EE_Admin_Page::add_query_args_and_nonce(
                 array('action' => 'settings'),
                 EE_MSG_ADMIN_URL
             );
-            $error_msg        = sprintf(
+            $error_msg = sprintf(
                 esc_html__(
                     'There are no active messengers. So no notifications will go out for %1$sany%2$s events.  You will want to %3$sActivate a Messenger%4$s.',
                     'event_espresso'
@@ -157,7 +155,7 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
                 '<a href="' . $msg_activate_url . '">',
                 '</a>'
             );
-            $error_content    = '<div class="error"><p>' . $error_msg . '</p></div>';
+            $error_content = '<div class="error"><p>' . $error_msg . '</p></div>';
             $internal_content = '<div id="messages-error"><p>' . $error_msg . '</p></div>';
 
             echo $error_content;
@@ -166,9 +164,9 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
         }
 
         $event_id = isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : null;
-        //get content for active messengers
+        // get content for active messengers
         foreach ($active_messengers as $name => $messenger) {
-            //first check if there are any active message types for this messenger.
+            // first check if there are any active message types for this messenger.
             $active_mts = $message_resource_manager->get_active_message_types_for_messenger($name);
             if (empty($active_mts)) {
                 continue;
@@ -181,12 +179,12 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             );
 
             if (! empty($tab_content)) {
-                $tabs[$name] = $tab_content;
+                $tabs[ $name ] = $tab_content;
             }
         }
 
 
-        //we want this to be tabbed content so let's use the EEH_Tabbed_Content::display helper.
+        // we want this to be tabbed content so let's use the EEH_Tabbed_Content::display helper.
         $tabbed_content = EEH_Tabbed_Content::display($tabs);
         if ($tabbed_content instanceof WP_Error) {
             $tabbed_content = $tabbed_content->get_error_message();
@@ -195,8 +193,8 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
         $notices = '
 	<div id="espresso-ajax-loading" class="ajax-loader-grey">
 		<span class="ee-spinner ee-spin"></span><span class="hidden">'
-        . esc_html__('loading...', 'event_espresso')
-        . '</span>
+                   . esc_html__('loading...', 'event_espresso')
+                   . '</span>
 	</div>
 	<div class="ee-notices"></div>';
 
@@ -225,8 +223,8 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             wp_die(__('You don\'t have privileges to do this action', 'event_espresso'));
         }
 
-        //let's clean up the _POST global a bit for downstream usage of name and description.
-        $_POST['templateName']        = ! empty($this->_req_data['custom_template_args']['MTP_name'])
+        // let's clean up the _POST global a bit for downstream usage of name and description.
+        $_POST['templateName'] = ! empty($this->_req_data['custom_template_args']['MTP_name'])
             ? $this->_req_data['custom_template_args']['MTP_name']
             : '';
         $_POST['templateDescription'] = ! empty($this->_req_data['custom_template_args']['MTP_description'])
@@ -283,7 +281,7 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
         foreach ($message_template_groups as $message_template_group) {
             $new_event->_add_relation_to($message_template_group, 'Message_Template_Group');
         }
-        //save new event
+        // save new event
         $new_event->save();
     }
 }

--- a/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
+++ b/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
@@ -1,103 +1,128 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Extend_Registration_Form_Questions_Admin_List_Table
  *
  * Class for preparing the table listing all the custom event questions
  *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
- * @package		Extend_Registration_Form_Questions_Admin_List_Table
- * @subpackage	caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
- * @author		Darren Ethier
+ * @package         Extend_Registration_Form_Questions_Admin_List_Table
+ * @subpackage      caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
+class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_Form_Questions_Admin_List_Table
+{
 
-class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_Form_Questions_Admin_List_Table {
+    public function __construct($admin_page)
+    {
+        parent::__construct($admin_page);
+    }
 
-	public function __construct( $admin_page ) {
-		parent::__construct( $admin_page );
-	}
+    public function column_display_text(EE_Question $item)
+    {
+        $system_question = $item->is_system_question();
+        $actions = array();
 
-	public function column_display_text(EE_Question $item) {
-		$system_question = $item->is_system_question();
-		$actions = array();
+        if (! defined('REG_ADMIN_URL')) {
+            define('REG_ADMIN_URL', EVENTS_ADMIN_URL);
+        }
 
-		if ( !defined('REG_ADMIN_URL') )
-			define('REG_ADMIN_URL', EVENTS_ADMIN_URL);
+        $edit_query_args = array(
+            'action' => 'edit_question',
+            'QST_ID' => $item->ID(),
+        );
 
-		$edit_query_args = array(
-				'action' => 'edit_question',
-				'QST_ID' => $item->ID()
-			);
+        $trash_query_args = array(
+            'action' => 'trash_question',
+            'QST_ID' => $item->ID(),
+        );
 
-		$trash_query_args = array(
-				'action' => 'trash_question',
-				'QST_ID' => $item->ID()
-			);
+        $restore_query_args = array(
+            'action' => 'restore_question',
+            'QST_ID' => $item->ID(),
+        );
 
-		$restore_query_args = array(
-			'action' => 'restore_question',
-			'QST_ID' => $item->ID()
-			);
+        $delete_query_args = array(
+            'action' => 'delete_questions',
+            'QST_ID' => $item->ID(),
+        );
 
-		$delete_query_args = array(
-			'action' => 'delete_questions',
-			'QST_ID' => $item->ID()
-			);
+        $duplicate_query_args = array(
+            'action' => 'duplicate_question',
+            'QST_ID' => $item->ID(),
+        );
 
-		$duplicate_query_args = array(
-				'action' => 'duplicate_question',
-				'QST_ID' => $item->ID()
-			);
+        $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_FORMS_ADMIN_URL);
+        $trash_link = EE_Admin_Page::add_query_args_and_nonce($trash_query_args, EE_FORMS_ADMIN_URL);
+        $restore_link = EE_Admin_Page::add_query_args_and_nonce($restore_query_args, EE_FORMS_ADMIN_URL);
+        $delete_link = EE_Admin_Page::add_query_args_and_nonce($delete_query_args, EE_FORMS_ADMIN_URL);
+        $duplicate_link = EE_Admin_Page::add_query_args_and_nonce($duplicate_query_args, EE_FORMS_ADMIN_URL);
 
-		$edit_link = EE_Admin_Page::add_query_args_and_nonce( $edit_query_args, EE_FORMS_ADMIN_URL );
-		$trash_link = EE_Admin_Page::add_query_args_and_nonce( $trash_query_args, EE_FORMS_ADMIN_URL );
-		$restore_link = EE_Admin_Page::add_query_args_and_nonce( $restore_query_args, EE_FORMS_ADMIN_URL );
-		$delete_link = EE_Admin_Page::add_query_args_and_nonce( $delete_query_args, EE_FORMS_ADMIN_URL );
-		$duplicate_link = EE_Admin_Page::add_query_args_and_nonce( $duplicate_query_args, EE_FORMS_ADMIN_URL );
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_question',
+            'espresso_registration_form_edit_question',
+            $item->ID()
+        )) {
+            $actions = array(
+                'edit' => '<a href="' . $edit_link . '" title="'
+                          . __('Edit Question', 'event_espresso') . '">'
+                          . __('Edit', 'event_espresso') . '</a>',
+            );
+        }
 
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_edit_question', 'espresso_registration_form_edit_question', $item->ID() ) ) {
-			$actions = array(
-				'edit' => '<a href="' . $edit_link . '" title="' . __('Edit Question', 'event_espresso') . '">' . __('Edit', 'event_espresso') . '</a>'
-			);
-		}
+        if (! $system_question
+            && $this->_view != 'trash'
+            && EE_Registry::instance()->CAP->current_user_can(
+                'ee_delete_question',
+                'espresso_registration_form_trash_question',
+                $item->ID()
+            )) {
+                $actions['delete'] = '<a href="' . $trash_link . '" title="'
+                                     . __('Trash Question', 'event_espresso') . '">'
+                                     . __('Trash', 'event_espresso') . '</a>';
+        }
 
-		if ( ! $system_question && $this->_view != 'trash' && EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question', 'espresso_registration_form_trash_question', $item->ID() ) ) {
-			$actions['delete'] = '<a href="' . $trash_link . '" title="' . __('Trash Question', 'event_espresso') . '">' . __('Trash', 'event_espresso') . '</a>';
-		}
+        if ($this->_view == 'trash') {
+            if (EE_Registry::instance()->CAP->current_user_can(
+                'ee_delete_question',
+                'espresso_registration_form_restore_question',
+                $item->ID()
+            )) {
+                $actions['restore'] = '<a href="' . $restore_link . '" title="'
+                                      . __('Restore Question', 'event_espresso') . '">'
+                                      . __('Restore', 'event_espresso') . '</a>';
+            }
+            if ($item->count_related('Answer') === 0
+                && EE_Registry::instance()->CAP->current_user_can(
+                    'ee_delete_question',
+                    'espresso_registration_form_delete_questions',
+                    $item->ID()
+                )) {
+                    $actions['delete'] = '<a href="' . $delete_link . '" title="'
+                                         . __('Delete Question Permanently', 'event_espresso') . '">'
+                                         . __('Delete Permanently', 'event_espresso') . '</a>';
+            }
+        }
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_questions',
+            'espresso_registration_form_edit_question'
+        )) {
+            $actions['duplicate'] = '<a href="' . $duplicate_link . '" title="'
+                                    . __('Duplicate Question', 'event_espresso') . '">'
+                                    . __('Duplicate', 'event_espresso') . '</a>';
+        }
 
-		if ( $this->_view == 'trash' ) {
-			if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question', 'espresso_registration_form_restore_question', $item->ID() ) ) {
-				$actions['restore'] = '<a href="' . $restore_link . '" title="' . __('Restore Question', 'event_espresso') . '">' . __('Restore', 'event_espresso') . '</a>';
-			}
-			if ( $item->count_related('Answer') === 0 && EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question', 'espresso_registration_form_delete_questions', $item->ID() ) ) {
-				$actions['delete'] = '<a href="' . $delete_link . '" title="' . __('Delete Question Permanently', 'event_espresso') . '">' . __('Delete Permanently', 'event_espresso') . '</a>';
-			}
-		}
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_edit_questions', 'espresso_registration_form_edit_question' ) ) {
-			$actions[ 'duplicate' ] = '<a href="' . $duplicate_link . '" title="' . __('Duplicate Question', 'event_espresso') . '">' . __('Duplicate', 'event_espresso') . '</a>';
-		}
-
-		$content = EE_Registry::instance()->CAP->current_user_can( 'ee_edit_question', 'espresso_registration_form_edit_question', $item->ID() ) ? '<strong><a class="row-title" href="' . $edit_link . '">' . $item->display_text() . '</a></strong>' : $item->display_text();
-		$content .= $this->row_actions($actions);
-		return $content;
-	}
-
+        $content = EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_question',
+            'espresso_registration_form_edit_question',
+            $item->ID()
+        )
+            ? '<strong><a class="row-title" href="' . $edit_link . '">' . $item->display_text() . '</a></strong>'
+            : $item->display_text();
+        $content .= $this->row_actions($actions);
+        return $content;
+    }
 }

--- a/caffeinated/admin/extend/registration_form/Registration_Form_Question_Groups_Admin_List_Table.class.php
+++ b/caffeinated/admin/extend/registration_form/Registration_Form_Question_Groups_Admin_List_Table.class.php
@@ -1,18 +1,16 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
  * Event Espresso
  *
  * Event Registration and Management Plugin for Wordpress
  *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		3.2.P
+ * @package         Event Espresso
+ * @author          Seth Shoultes
+ * @copyright    (c)2009-2012 Event Espresso All Rights Reserved.
+ * @license         http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
+ * @link            http://www.eventespresso.com
+ * @version         3.2.P
  *
  * ------------------------------------------------------------------------
  *
@@ -22,191 +20,241 @@ if (!defined('EVENT_ESPRESSO_VERSION') )
  *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
- * @package		Registration_Form_Question_Groups_Admin_List_Table
- * @subpackage	includes/core/admin/events/Registration_Form_Question_Groups_Admin_List_Table.class.php
- * @author		Darren Ethier
+ * @package         Registration_Form_Question_Groups_Admin_List_Table
+ * @subpackage      includes/core/admin/events/Registration_Form_Question_Groups_Admin_List_Table.class.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_Table {
-
-
-	public function __construct( $admin_page ) {
-		parent::__construct($admin_page);
-	}
-
-
-
-
-	protected function _setup_data() {
-		$this->_data = $this->_view != 'trash' ? $this->_admin_page->get_question_groups( $this->_per_page,$this->_current_page, FALSE ) : $this->_admin_page->get_trashed_question_groups( $this->_per_page,$this->_current_page, FALSE );
-		$this->_all_data_count = $this->_view != 'trash' ? $this->_admin_page->get_question_groups( $this->_per_page,$this->_current_page, TRUE ) : $this->_admin_page->get_trashed_question_groups( $this->_per_page,$this->_current_page, TRUE );
-	}
-
-
-
-
-
-	protected function _set_properties() {
-		$this->_wp_list_args = array(
-			'singular' => __('question group', 'event_espresso' ),
-			'plural' => __('question groups', 'event_espresso' ),
-			'ajax' => TRUE, //for now,
-			'screen' => $this->_admin_page->get_current_screen()->id
-			);
-
-		$this->_columns = array(
-			'cb' => '<input type="checkbox" />',
-			'id' => __('ID', 'event_espresso'),
-			'name' => __('Group Name', 'event_espresso'),
-			'description' => __('Description', 'event_espresso'),
-			'show_group_name' => __('Show Name', 'event_espresso'),
-			'show_group_desc' => __('Show Desc', 'event_espresso')
-			);
-
-		$this->_sortable_columns = array(
-			'id' => array( 'QSG_ID' => FALSE ),
-			'name' => array( 'QSG_name' => FALSE )
-			);
-
-		$this->_hidden_columns = array(
-			'id'
-			);
-
-		$this->_ajax_sorting_callback = 'update_question_group_order';
-
-	}
-
-
-
-
-
-
-	//not needed
-	protected function _get_table_filters() {
-		return array();
-	}
-
-
-
-
-
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_admin_page->get_question_groups( $this->_per_page,$this->_current_page, TRUE );
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question_groups', 'espresso_registration_form_trash_question_group' ) ) {
-			$this->_views['trash']['count'] = $this->_admin_page->get_trashed_question_groups( $this->_per_page,$this->_current_page, TRUE );
-		}
-	}
-
-
-
-
-
-
-	public function column_cb($item) {
-		$system_group = $item->get('QSG_system');
-		$has_questions_with_answers = $item->has_questions_with_answers();
-		$lock_icon = $system_group === 0 && $this->_view == 'trash' && $has_questions_with_answers ? 'ee-lock-icon ee-alternate-color' : 'ee-lock-icon ee-system-lock';
-		return $system_group > 0 || ( $system_group === 0 && $this->_view == 'trash' && $has_questions_with_answers ) || ! EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question_groups', 'espresso_registration_form_trash_question_groups', $item->ID() ) ? '<span class="' . $lock_icon . '"></span>'  . sprintf( '<input type="hidden" name="hdnchk[%1$d]" value="%1$d" />', $item->ID() )  : sprintf( '<input type="checkbox" id="QSG_ID[%1$d]" name="checkbox[%1$d]" value="%1$d" />', $item->ID() );
-	}
-
-
-
-
-
-
-	public function column_id(EE_Question_Group $item) {
-		$content = $item->ID();
-		$content .= '  <span class="show-on-mobile-view-only">' .$item->name() . '</span>';
-		return $content;
-	}
-
-
-
-	public function column_name(EE_Question_Group $item) {
-		$actions = array();
-
-		//return $item->name();
-		if ( !defined('REG_ADMIN_URL') )
-			define('REG_ADMIN_URL', EVENTS_ADMIN_URL);
-
-		$edit_query_args = array(
-				'action' => 'edit_question_group',
-				'QSG_ID' => $item->ID()
-			);
-
-		$trash_query_args = array(
-				'action' => 'trash_question_group',
-				'QSG_ID' => $item->ID()
-			);
-
-		$restore_query_args = array(
-			'action' => 'restore_question_group',
-			'QSG_ID' => $item->ID()
-			);
-
-		$delete_query_args = array(
-			'action' => 'delete_question_group',
-			'QSG_ID' => $item->ID()
-			);
-
-
-
-		$edit_link = EE_Admin_Page::add_query_args_and_nonce( $edit_query_args, EE_FORMS_ADMIN_URL );
-		$trash_link = EE_Admin_Page::add_query_args_and_nonce( $trash_query_args, EE_FORMS_ADMIN_URL );
-		$restore_link = EE_Admin_Page::add_query_args_and_nonce( $restore_query_args, EE_FORMS_ADMIN_URL );
-		$delete_link = EE_Admin_Page::add_query_args_and_nonce( $delete_query_args, EE_FORMS_ADMIN_URL );
-
-		if (  EE_Registry::instance()->CAP->current_user_can( 'ee_edit_question_group', 'espresso_registration_form_edit_question_group', $item->ID() ) ) {
-			$actions = array(
-				'edit' => '<a href="' . $edit_link . '" title="' . esc_attr__('Edit Question Group', 'event_espresso') . '">' . __('Edit', 'event_espresso') . '</a>'
-			);
-		}
-		if ( $item->get('QSG_system') < 1 && $this->_view != 'trash' &&  EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question_group', 'espresso_registration_form_trash_question_group', $item->ID() ) ) {
-			$actions['delete'] = '<a href="' . $trash_link . '" title="' . esc_attr__('Delete Question Group', 'event_espresso') . '">' . __('Trash', 'event_espresso') . '</a>';
-		}
-
-		if ( $this->_view == 'trash' ) {
-
-			if (  EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question_group', 'espresso_registration_form_restore_question_group', $item->ID() ) ) {
-				$actions['restore'] = '<a href="' . $restore_link . '" title="' . esc_attr__('Restore Question Group', 'event_espresso') . '">' . __('Restore', 'event_espresso') . '</a>';
-			}
-
-			if ( !$item->has_questions_with_answers() &&  EE_Registry::instance()->CAP->current_user_can( 'ee_delete_question_group', 'espresso_registration_form_delete_question_group', $item->ID() ) ) {
-				$actions['delete'] = '<a href="' . $delete_link . '" title="' . esc_attr__('Delete Question Group Permanently', 'event_espresso') . '">' . __('Delete Permanently', 'event_espresso') . '</a>';
-			}
-		}
-
-		$content =  EE_Registry::instance()->CAP->current_user_can( 'ee_edit_question_group', 'espresso_registration_form_edit_question_group', $item->ID() ) ? '<strong><a class="row-title" href="' . $edit_link . '">' . $item->name() . '</a></strong>' : $item->name();
-		$content .= $this->row_actions($actions);
-		return $content;
-	}
-
-
-
-
-	public function column_identifier(EE_Question_Group $item) {
-		return $item->identifier();
-	}
-
-
-
-	public function column_description(EE_Question_Group $item) {
-		return $item->desc();
-	}
-
-
-
-	public function column_show_group_name(EE_Question_Group $item) {
-		return $this->_yes_no[ $item->show_group_name() ];
-	}
-
-
-
-	public function column_show_group_desc(EE_Question_Group $item) {
-		return $this->_yes_no[ $item->show_group_desc() ];
-	}
-
-
-
-} //end class Registration_Form_Questions_Admin_List_Table
+class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_Table
+{
+
+
+    public function __construct($admin_page)
+    {
+        parent::__construct($admin_page);
+    }
+
+
+    protected function _setup_data()
+    {
+        $this->_data = $this->_view != 'trash'
+            ? $this->_admin_page->get_question_groups($this->_per_page, $this->_current_page, false)
+            : $this->_admin_page->get_trashed_question_groups($this->_per_page, $this->_current_page, false);
+        $this->_all_data_count = $this->_view != 'trash'
+            ? $this->_admin_page->get_question_groups($this->_per_page, $this->_current_page, true)
+            : $this->_admin_page->get_trashed_question_groups($this->_per_page, $this->_current_page, true);
+    }
+
+
+    protected function _set_properties()
+    {
+        $this->_wp_list_args = array(
+            'singular' => __('question group', 'event_espresso'),
+            'plural'   => __('question groups', 'event_espresso'),
+            'ajax'     => true, // for now,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
+
+        $this->_columns = array(
+            'cb'              => '<input type="checkbox" />',
+            'id'              => __('ID', 'event_espresso'),
+            'name'            => __('Group Name', 'event_espresso'),
+            'description'     => __('Description', 'event_espresso'),
+            'show_group_name' => __('Show Name', 'event_espresso'),
+            'show_group_desc' => __('Show Desc', 'event_espresso'),
+        );
+
+        $this->_sortable_columns = array(
+            'id'   => array('QSG_ID' => false),
+            'name' => array('QSG_name' => false),
+        );
+
+        $this->_hidden_columns = array(
+            'id',
+        );
+
+        $this->_ajax_sorting_callback = 'update_question_group_order';
+    }
+
+
+    // not needed
+    protected function _get_table_filters()
+    {
+        return array();
+    }
+
+
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_admin_page->get_question_groups(
+            $this->_per_page,
+            $this->_current_page,
+            true
+        );
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_delete_question_groups',
+            'espresso_registration_form_trash_question_group'
+        )) {
+            $this->_views['trash']['count'] = $this->_admin_page->get_trashed_question_groups(
+                $this->_per_page,
+                $this->_current_page,
+                true
+            );
+        }
+    }
+
+
+    public function column_cb($item)
+    {
+        $system_group = $item->get('QSG_system');
+        $has_questions_with_answers = $item->has_questions_with_answers();
+        $lock_icon = $system_group === 0 && $this->_view == 'trash' && $has_questions_with_answers
+            ? 'ee-lock-icon ee-alternate-color'
+            : 'ee-lock-icon ee-system-lock';
+        return $system_group > 0
+               || ($system_group === 0
+                    && $this->_view == 'trash'
+                    && $has_questions_with_answers
+                )
+               || ! EE_Registry::instance()->CAP->current_user_can(
+                   'ee_delete_question_groups',
+                   'espresso_registration_form_trash_question_groups',
+                   $item->ID()
+               )
+            ? '<span class="' . $lock_icon . '"></span>'
+              . sprintf(
+                  '<input type="hidden" name="hdnchk[%1$d]" value="%1$d" />',
+                  $item->ID()
+              )
+            : sprintf(
+                '<input type="checkbox" id="QSG_ID[%1$d]" name="checkbox[%1$d]" value="%1$d" />',
+                $item->ID()
+            );
+    }
+
+
+    public function column_id(EE_Question_Group $item)
+    {
+        $content = $item->ID();
+        $content .= '  <span class="show-on-mobile-view-only">' . $item->name() . '</span>';
+        return $content;
+    }
+
+
+    public function column_name(EE_Question_Group $item)
+    {
+        $actions = array();
+
+        // return $item->name();
+        if (! defined('REG_ADMIN_URL')) {
+            define('REG_ADMIN_URL', EVENTS_ADMIN_URL);
+        }
+
+        $edit_query_args = array(
+            'action' => 'edit_question_group',
+            'QSG_ID' => $item->ID(),
+        );
+
+        $trash_query_args = array(
+            'action' => 'trash_question_group',
+            'QSG_ID' => $item->ID(),
+        );
+
+        $restore_query_args = array(
+            'action' => 'restore_question_group',
+            'QSG_ID' => $item->ID(),
+        );
+
+        $delete_query_args = array(
+            'action' => 'delete_question_group',
+            'QSG_ID' => $item->ID(),
+        );
+
+
+        $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_FORMS_ADMIN_URL);
+        $trash_link = EE_Admin_Page::add_query_args_and_nonce($trash_query_args, EE_FORMS_ADMIN_URL);
+        $restore_link = EE_Admin_Page::add_query_args_and_nonce($restore_query_args, EE_FORMS_ADMIN_URL);
+        $delete_link = EE_Admin_Page::add_query_args_and_nonce($delete_query_args, EE_FORMS_ADMIN_URL);
+
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_question_group',
+            'espresso_registration_form_edit_question_group',
+            $item->ID()
+        )) {
+            $actions = array(
+                'edit' => '<a href="' . $edit_link . '" title="'
+                          . esc_attr__('Edit Question Group', 'event_espresso') . '">'
+                          . __('Edit', 'event_espresso') . '</a>',
+            );
+        }
+        if ($item->get('QSG_system') < 1
+            && $this->_view != 'trash'
+            && EE_Registry::instance()->CAP->current_user_can(
+                'ee_delete_question_group',
+                'espresso_registration_form_trash_question_group',
+                $item->ID()
+            )) {
+            $actions['delete'] = '<a href="' . $trash_link . '" title="'
+                                 . esc_attr__('Delete Question Group', 'event_espresso') . '">'
+                                 . __('Trash', 'event_espresso') . '</a>';
+        }
+
+        if ($this->_view == 'trash') {
+            if (EE_Registry::instance()->CAP->current_user_can(
+                'ee_delete_question_group',
+                'espresso_registration_form_restore_question_group',
+                $item->ID()
+            )) {
+                $actions['restore'] = '<a href="' . $restore_link . '" title="'
+                                      . esc_attr__('Restore Question Group', 'event_espresso') . '">'
+                                      . __('Restore', 'event_espresso') . '</a>';
+            }
+
+            if (! $item->has_questions_with_answers()
+                && EE_Registry::instance()->CAP->current_user_can(
+                    'ee_delete_question_group',
+                    'espresso_registration_form_delete_question_group',
+                    $item->ID()
+                )) {
+                    $actions['delete'] = '<a href="' . $delete_link . '" title="'
+                                         . esc_attr__('Delete Question Group Permanently', 'event_espresso') . '">'
+                                         . __('Delete Permanently', 'event_espresso') . '</a>';
+            }
+        }
+
+        $content = EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_question_group',
+            'espresso_registration_form_edit_question_group',
+            $item->ID()
+        )
+            ? '<strong><a class="row-title" href="' . $edit_link . '">' . $item->name() . '</a></strong>'
+            : $item->name();
+        $content .= $this->row_actions($actions);
+        return $content;
+    }
+
+
+    public function column_identifier(EE_Question_Group $item)
+    {
+        return $item->identifier();
+    }
+
+
+    public function column_description(EE_Question_Group $item)
+    {
+        return $item->desc();
+    }
+
+
+    public function column_show_group_name(EE_Question_Group $item)
+    {
+        return $this->_yes_no[ $item->show_group_name() ];
+    }
+
+
+    public function column_show_group_desc(EE_Question_Group $item)
+    {
+        return $this->_yes_no[ $item->show_group_desc() ];
+    }
+}

--- a/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
@@ -3,12 +3,11 @@
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
-defined('EVENT_ESPRESSO_VERSION') || exit('No direct access allowed.');
-
 /**
  * espresso_events_Registration_Form_Hooks_Extend
  * Hooks various messages logic so that it runs on indicated Events Admin Pages.
  * Commenting/docs common to all children classes is found in the EE_Admin_Hooks parent.
+ *
  * @package         espresso_events_Registration_Form_Hooks_Extend
  * @subpackage      includes/core/admin/messages/espresso_events_Registration_Form_Hooks_Extend.class.php
  * @author          Darren Ethier
@@ -16,7 +15,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit('No direct access allowed.');
  */
 class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Registration_Form_Hooks
 {
-    
+
     /**
      * extending the properties set in espresso_events_Registration_From_Hooks
      *
@@ -25,7 +24,7 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
      */
     protected function _extend_properties()
     {
-        $this->_metaboxes      = array_merge(
+        $this->_metaboxes = array_merge(
             $this->_metaboxes,
             array(
                 1 => array(
@@ -58,7 +57,7 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
      */
     public function modify_callbacks($callbacks)
     {
-        $callbacks   = parent::modify_callbacks($callbacks);
+        $callbacks = parent::modify_callbacks($callbacks);
         $callbacks[] = array($this, 'additional_question_group_update');
         return $callbacks;
     }
@@ -80,11 +79,12 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
     {
         $post_evt = parent::restore_revision($post_id, $revision_id);
 
-        //restore revision for additional questions
+        // restore revision for additional questions
         $post_evt->restore_revision(
             $revision_id,
             array('Question_Group'),
-            array('Question_Group' => array('Event_Question_Group.EQG_primary' => 0)
+            array(
+                'Question_Group' => array('Event_Question_Group.EQG_primary' => 0),
             )
         );
     }
@@ -101,43 +101,43 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
     public function additional_questions($post_id, $post)
     {
         $this->_event = $this->_adminpage_obj->get_event_object();
-        $event_id     = $this->_event->ID();
+        $event_id = $this->_event->ID();
         ?>
         <div class="inside">
             <p><strong>
                     <?php _e('Question Groups', 'event_espresso'); ?>
                 </strong><br/>
                 <?php
-                    printf(
-                        esc_html__(
-                            'Add a pre-populated %1$sgroup of questions%2$s to your event.',
-                            'event_espresso'
-                        ),
-                        '<a href="admin.php?page=espresso_registration_form" target="_blank">',
-                        '</a>'
-                    );
+                printf(
+                    esc_html__(
+                        'Add a pre-populated %1$sgroup of questions%2$s to your event.',
+                        'event_espresso'
+                    ),
+                    '<a href="admin.php?page=espresso_registration_form" target="_blank">',
+                    '</a>'
+                );
                 ?>
             </p>
             <?php
 
             $qsg_where['QSG_deleted'] = false;
-            $query_params             = apply_filters(
+            $query_params = apply_filters(
                 'FHEE__espresso_events_Registration_Form_Hooks_Extend__additional_questions__question_group_query_parameters',
                 array($qsg_where, 'order_by' => array('QSG_order' => 'ASC'))
             );
-            $QSGs                     = EEM_Question_Group::instance()->get_all($query_params);
-            $EQGs                     = ! empty($event_id)
+            $QSGs = EEM_Question_Group::instance()->get_all($query_params);
+            $EQGs = ! empty($event_id)
                 ? $this->_event->get_many_related(
                     'Question_Group',
                     array(array('Event_Question_Group.EQG_primary' => 0))
                 )
                 : array();
-            $EQGids                   = array_keys($EQGs);
+            $EQGids = array_keys($EQGs);
 
             if (! empty($QSGs)) {
                 $html = count($QSGs) > 10 ? '<div style="height:250px;overflow:auto;">' : '';
                 foreach ($QSGs as $QSG) {
-                    $checked   = in_array($QSG->ID(), $EQGids, true) ? ' checked="checked" ' : '';
+                    $checked = in_array($QSG->ID(), $EQGids, true) ? ' checked="checked" ' : '';
                     $edit_link = EE_Admin_Page::add_query_args_and_nonce(
                         array(
                             'action' => 'edit_question_group',
@@ -149,7 +149,7 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
                     $html .= '
 					<p id="event-question-group-' . $QSG->ID() . '">
 						<input value="' . $QSG->ID() . '"'
-                        . ' type="checkbox" name="add_attendee_question_groups[' . $QSG->ID() . ']"' . $checked . ' />
+                             . ' type="checkbox" name="add_attendee_question_groups[' . $QSG->ID() . ']"' . $checked . ' />
 						<a href="' . $edit_link . '" title="'
                              . sprintf(
                                  esc_attr__('Edit %s Group', 'event_espresso'),
@@ -160,17 +160,16 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
                     if ($QSG->ID() === 2) {
                         $html .= '
 					<p id="question-group-requirements-notice-pg" class="important-notice small-text" style="display: none;">'
-                        . esc_html__(
-                            'The Personal Information question group is required whenever the Address Information question group is activated.',
-                            'event_espresso'
-                        )
-                        . '</p>';
+                                 . esc_html__(
+                                     'The Personal Information question group is required whenever the Address Information question group is activated.',
+                                     'event_espresso'
+                                 )
+                                 . '</p>';
                     }
                 }
                 $html .= count($QSGs) > 10 ? '</div>' : '';
 
                 echo $html;
-
             } else {
                 esc_html_e(
                     'There seems to be a problem with your questions. Please contact support@eventespresso.com',
@@ -189,20 +188,20 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
         $question_groups = ! empty($data['add_attendee_question_groups'])
             ? (array) $data['add_attendee_question_groups']
             : array();
-        $added_qgs       = array_keys($question_groups);
-        $success         = array();
+        $added_qgs = array_keys($question_groups);
+        $success = array();
 
-        //let's get all current question groups associated with this event.
+        // let's get all current question groups associated with this event.
         $current_qgs = $evtobj->get_many_related(
             'Question_Group',
             array(array('Event_Question_Group.EQG_primary' => 0))
         );
-        $current_qgs = array_keys($current_qgs); //we just want the ids
+        $current_qgs = array_keys($current_qgs); // we just want the ids
 
-        //now let's get the groups selected in the editor and update (IF we have data)
+        // now let's get the groups selected in the editor and update (IF we have data)
         if (! empty($question_groups)) {
             foreach ($question_groups as $id => $val) {
-                //add to event
+                // add to event
                 if ($val) {
                     $qg = $evtobj->_add_relation_to($id, 'Question_Group', array('EQG_primary' => 0));
                 }
@@ -210,11 +209,11 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
             }
         }
 
-        //wait a minute... are there question groups missing in the saved groups that ARE with the current event?
+        // wait a minute... are there question groups missing in the saved groups that ARE with the current event?
         $removed_qgs = array_diff($current_qgs, $added_qgs);
 
         foreach ($removed_qgs as $qgid) {
-            $qg        = $evtobj->_remove_relation_to($qgid, 'Question_Group', array('EQG_primary' => 0));
+            $qg = $evtobj->_remove_relation_to($qgid, 'Question_Group', array('EQG_primary' => 0));
             $success[] = ! empty($qg) ? 1 : 0;
         }
 

--- a/caffeinated/admin/extend/registration_form/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
+++ b/caffeinated/admin/extend/registration_form/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
@@ -1,18 +1,16 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
  * Event Espresso
  *
  * Event Registration and Management Plugin for Wordpress
  *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
+ * @package         Event Espresso
+ * @author          Seth Shoultes
+ * @copyright    (c)2009-2012 Event Espresso All Rights Reserved.
+ * @license         http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
+ * @link            http://www.eventespresso.com
+ * @version         4.0
  *
  * ------------------------------------------------------------------------
  *
@@ -21,137 +19,164 @@ if (!defined('EVENT_ESPRESSO_VERSION') )
  * This is the help tour object for the Questions Overview page
  *
  *
- * @package		Registration_Form_Questions_Overview_Help_Tour
- * @subpackage	includes/core/admin/registration/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
- * @author		Darren Ethier
+ * @package         Registration_Form_Questions_Overview_Help_Tour
+ * @subpackage      includes/core/admin/registration/help_tours/Registration_Form_Questions_Overview_Help_Tour.class.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour {
+class Registration_Form_Questions_Overview_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Questions Overview Tour', 'event_espresso');
-		$this->_slug = $this->_is_caf ? 'questions-overview-caf-joyride' : 'questions-overview-joyride';
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Questions Overview Tour', 'event_espresso');
+        $this->_slug = $this->_is_caf ? 'questions-overview-caf-joyride' : 'questions-overview-joyride';
+    }
 
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			30 => array(
-				'id' => 'display_text',
-				'content' => $this->_display_text_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => -5,
-					'tipAdjustmentY' => -25
-					)
-				),
-			40 => array(
-				'id' => 'admin_label',
-				'content' => $this->_admin_label_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => 20,
-					'tipAdjustmentY' => -25
-					)
-				),
-			50 => array(
-				'id' => 'type',
-				'content' => $this->_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => -5,
-					'tipAdjustmentY' => -25
-					)
-				),
-			60 => array(
-				'id' => 'values',
-				'content' => $this->_values_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => -5,
-					'tipAdjustmentY' => -25
-					)
-				),
-			70 => array(
-				'id' => 'required',
-				'content' => $this->_required_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -20,
-					'tipAdjustmentX' => -15
-					)
-				),
-			80 => array(
-				'class' => 'bulkactions',
-				'content' => $this->_bulk_actions_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -30,
-					'tipAdjustmentX' => -15
-					)
-				),
-			90 => array(
-				'id' => 'event-espresso_page_espresso_registration_form-search-input',
-				'content' => $this->_search_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),
-			100 => array(
-				'id' => 'add-new-question',
-				'content' => $this->_add_new_question_stop(),
-				'options' => array(
-					'tipLocation' => 'right',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => 15
-					)
-				),
-			);
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10  => array(
+                'content' => $this->_start(),
+            ),
+            30  => array(
+                'id'      => 'display_text',
+                'content' => $this->_display_text_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => -5,
+                    'tipAdjustmentY' => -25,
+                ),
+            ),
+            40  => array(
+                'id'      => 'admin_label',
+                'content' => $this->_admin_label_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => 20,
+                    'tipAdjustmentY' => -25,
+                ),
+            ),
+            50  => array(
+                'id'      => 'type',
+                'content' => $this->_type_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => -5,
+                    'tipAdjustmentY' => -25,
+                ),
+            ),
+            60  => array(
+                'id'      => 'values',
+                'content' => $this->_values_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => -5,
+                    'tipAdjustmentY' => -25,
+                ),
+            ),
+            70  => array(
+                'id'      => 'required',
+                'content' => $this->_required_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -20,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            80  => array(
+                'class'   => 'bulkactions',
+                'content' => $this->_bulk_actions_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -30,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            90  => array(
+                'id'      => 'event-espresso_page_espresso_registration_form-search-input',
+                'content' => $this->_search_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            100 => array(
+                'id'      => 'add-new-question',
+                'content' => $this->_add_new_question_stop(),
+                'options' => array(
+                    'tipLocation'    => 'right',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => 15,
+                ),
+            ),
+        );
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Questions Overview', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Questions Overview page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
+    protected function _start()
+    {
+        $content = '<h3>' . __('Questions Overview', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Questions Overview page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
 
-		return $content;
-	}
+        return $content;
+    }
 
-	protected function _display_text_stop() {
-		return '<p>' . __('View available questions.', 'event_espresso') . '</p>';
-	}
+    protected function _display_text_stop()
+    {
+        return '<p>' . __('View available questions.', 'event_espresso') . '</p>';
+    }
 
-	protected function _admin_label_stop() {
-		return '<p>' . __('View the admin label for your questions.', 'event_espresso') . '</p>';
-	}
+    protected function _admin_label_stop()
+    {
+        return '<p>' . __('View the admin label for your questions.', 'event_espresso') . '</p>';
+    }
 
-	protected function _type_stop() {
-		return '<p>' . __('View the type of question. Available options are Text, Textarea, Checkboxes, Radio Buttons, Dropdown, State/Province Dropdown, Country Dropdown, and Date Picker.', 'event_espresso') . '</p>';
-	}
+    protected function _type_stop()
+    {
+        return '<p>'
+               . __(
+                   'View the type of question. Available options are Text, Textarea, Checkboxes, Radio Buttons, Dropdown, State/Province Dropdown, Country Dropdown, and Date Picker.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _values_stop() {
-		return '<p>' . __('View stored values for checkboxes, radio buttons, and select boxes.', 'event_espresso') . '</p>';
-	}
+    protected function _values_stop()
+    {
+        return '<p>'
+               . __(
+                   'View stored values for checkboxes, radio buttons, and select boxes.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _required_stop() {
-		return '<p>' . __('View if a question is required.', 'event_espresso') . '</p>';
-	}
+    protected function _required_stop()
+    {
+        return '<p>' . __('View if a question is required.', 'event_espresso') . '</p>';
+    }
 
-	protected function _bulk_actions_stop() {
-		return '<p>' . __('Perform bulk actions to multiple questions.', 'event_espresso') . '</p>';
-	}
+    protected function _bulk_actions_stop()
+    {
+        return '<p>' . __('Perform bulk actions to multiple questions.', 'event_espresso') . '</p>';
+    }
 
-	protected function _search_stop() {
-		return '<p>' . __('Search through questions. The following sources will be searched: Name of Question (display text).', 'event_espresso') . '</p>';
-	}
+    protected function _search_stop()
+    {
+        return '<p>'
+               . __(
+                   'Search through questions. The following sources will be searched: Name of Question (display text).',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _add_new_question_stop() {
-		return '<p>' . __('Click here to add a new question.', 'event_espresso') . '</p>';
-	}
-
+    protected function _add_new_question_stop()
+    {
+        return '<p>' . __('Click here to add a new question.', 'event_espresso') . '</p>';
+    }
 }

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -4,109 +4,106 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\ui\browser\checkins\entities\CheckinStatusDashicon;
 
-defined('EVENT_ESPRESSO_VERSION') || exit('No direct script access allowed');
-
-
 /**
  * Class EE_Event_Registrations_List_Table
  *
  * @package       Event Espresso
  */
-class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
+class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
+{
 
-	/**
-	 * This property will hold the related Datetimes on an event IF the event id is included in the request.
-	 *
-	 * @var EE_Datetime[]
-	 */
-	protected $_dtts_for_event = array();
-
-
-
-	/**
-	 * The event if one is specified in the request
-	 *
-	 * @var EE_Event
-	 */
-	protected $_evt = null;
+    /**
+     * This property will hold the related Datetimes on an event IF the event id is included in the request.
+     *
+     * @var EE_Datetime[]
+     */
+    protected $_dtts_for_event = array();
 
 
-	/**
-	 * The DTT_ID if the current view has a specified datetime.
-	 *
-	 * @var int $_cur_dtt_id
-	 */
-	protected $_cur_dtt_id = 0;
+    /**
+     * The event if one is specified in the request
+     *
+     * @var EE_Event
+     */
+    protected $_evt = null;
 
 
-
-	/**
-	 * EE_Event_Registrations_List_Table constructor.
-	 *
-	 * @param \Registrations_Admin_Page $admin_page
-	 */
-	public function __construct( $admin_page ) {
-		parent::__construct( $admin_page );
-		$this->_status = $this->_admin_page->get_registration_status_array();
-	}
+    /**
+     * The DTT_ID if the current view has a specified datetime.
+     *
+     * @var int $_cur_dtt_id
+     */
+    protected $_cur_dtt_id = 0;
 
 
+    /**
+     * EE_Event_Registrations_List_Table constructor.
+     *
+     * @param \Registrations_Admin_Page $admin_page
+     */
+    public function __construct($admin_page)
+    {
+        parent::__construct($admin_page);
+        $this->_status = $this->_admin_page->get_registration_status_array();
+    }
 
-	protected function _setup_data() {
-		$this->_data = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees( $this->_per_page )
-			: $this->_admin_page->get_event_attendees( $this->_per_page, false, true );
-		$this->_all_data_count = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees(
-			$this->_per_page,
-			true
-		) : $this->_admin_page->get_event_attendees( $this->_per_page, true, true );
-	}
+
+    protected function _setup_data()
+    {
+        $this->_data = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees($this->_per_page)
+            : $this->_admin_page->get_event_attendees($this->_per_page, false, true);
+        $this->_all_data_count = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees(
+            $this->_per_page,
+            true
+        ) : $this->_admin_page->get_event_attendees($this->_per_page, true, true);
+    }
 
 
-
-	protected function _set_properties() {
-		$evt_id = isset( $this->_req_data['event_id'] ) ? $this->_req_data['event_id'] : null;
-		$this->_wp_list_args = array(
-			'singular' => __( 'registrant', 'event_espresso' ),
-			'plural'   => __( 'registrants', 'event_espresso' ),
-			'ajax'     => true,
-			'screen'   => $this->_admin_page->get_current_screen()->id,
-		);
-		$columns = array();
-		//$columns['_Reg_Status'] = '';
-		if ( ! empty( $evt_id ) ) {
-			$columns['cb'] = '<input type="checkbox" />'; //Render a checkbox instead of text
-			$this->_has_checkbox_column = true;
-		}
-		$this->_columns = array(
-			'_REG_att_checked_in' => '<span class="dashicons dashicons-yes ee-icon-size-18"></span>',
-			'ATT_name'            => __( 'Registrant', 'event_espresso' ),
-			'ATT_email'           => __( 'Email Address', 'event_espresso' ),
-			'Event'               => __( 'Event', 'event_espresso' ),
-			'PRC_name'            => __( 'TKT Option', 'event_espresso' ),
-			'_REG_final_price'    => __( 'Price', 'event_espresso' ),
-			'TXN_paid'            => __( 'Paid', 'event_espresso' ),
-			'TXN_total'           => __( 'Total', 'event_espresso' ),
-		);
-		$this->_columns = array_merge( $columns, $this->_columns );
-		$this->_primary_column = '_REG_att_checked_in';
-		if ( ! empty( $evt_id )
-		     && EE_Registry::instance()->CAP->current_user_can(
-				'ee_read_registrations',
-				'espresso_registrations_registrations_reports',
-				$evt_id
-			)
-		) {
-			$this->_bottom_buttons = array(
-				'report' => array(
-					'route'         => 'registrations_report',
-					'extra_request' =>
-						array(
-							'EVT_ID'     => $evt_id,
-							'return_url' => urlencode( "//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}" ),
-						),
-				),
-			);
-		}
+    protected function _set_properties()
+    {
+        $evt_id = isset($this->_req_data['event_id']) ? $this->_req_data['event_id'] : null;
+        $this->_wp_list_args = array(
+            'singular' => __('registrant', 'event_espresso'),
+            'plural'   => __('registrants', 'event_espresso'),
+            'ajax'     => true,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
+        $columns = array();
+        // $columns['_Reg_Status'] = '';
+        if (! empty($evt_id)) {
+            $columns['cb'] = '<input type="checkbox" />'; // Render a checkbox instead of text
+            $this->_has_checkbox_column = true;
+        }
+        $this->_columns = array(
+            '_REG_att_checked_in' => '<span class="dashicons dashicons-yes ee-icon-size-18"></span>',
+            'ATT_name'            => __('Registrant', 'event_espresso'),
+            'ATT_email'           => __('Email Address', 'event_espresso'),
+            'Event'               => __('Event', 'event_espresso'),
+            'PRC_name'            => __('TKT Option', 'event_espresso'),
+            '_REG_final_price'    => __('Price', 'event_espresso'),
+            'TXN_paid'            => __('Paid', 'event_espresso'),
+            'TXN_total'           => __('Total', 'event_espresso'),
+        );
+        $this->_columns = array_merge($columns, $this->_columns);
+        $this->_primary_column = '_REG_att_checked_in';
+        if (! empty($evt_id)
+            && EE_Registry::instance()->CAP->current_user_can(
+                'ee_read_registrations',
+                'espresso_registrations_registrations_reports',
+                $evt_id
+            )
+        ) {
+            $this->_bottom_buttons = array(
+                'report' => array(
+                    'route'         => 'registrations_report',
+                    'extra_request' =>
+                        array(
+                            'EVT_ID'     => $evt_id,
+                            'return_url' => urlencode("//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"),
+                        ),
+                ),
+            );
+        }
         $this->_bottom_buttons['report_filtered'] = array(
             'route'         => 'registrations_checkin_report',
             'extra_request' => array(
@@ -129,7 +126,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
                 'return_url'  => urlencode("//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"),
             ),
         );
-		$this->_sortable_columns = array(
+        $this->_sortable_columns = array(
             /**
              * Allows users to change the default sort if they wish.
              * Returning a falsey on this filter will result in the default sort to be by firstname rather than last name.
@@ -138,167 +135,170 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
              * change the sorts on any list table involving registration contacts.  If you want to only change the filter
              * for a specific list table you can use the provided reference to this object instance.
              */
-			'ATT_name' => array(
-                    'FHEE__EE_Registrations_List_Table___set_properties__default_sort_by_registration_last_name',
-                    true,
-                    $this
+            'ATT_name' => array(
+                'FHEE__EE_Registrations_List_Table___set_properties__default_sort_by_registration_last_name',
+                true,
+                $this,
+            )
+                ? array('ATT_lname' => true)
+                : array('ATT_fname' => true),
+            'Event'    => array('Event.EVT.Name' => false),
+        );
+        $this->_hidden_columns = array();
+        $this->_evt = EEM_Event::instance()->get_one_by_ID($evt_id);
+        $this->_dtts_for_event = $this->_evt instanceof EE_Event ? $this->_evt->datetimes_ordered() : array();
+    }
+
+
+    /**
+     * @param \EE_Registration $item
+     * @return string
+     */
+    protected function _get_row_class($item)
+    {
+        $class = parent::_get_row_class($item);
+        // add status class
+        $class .= ' ee-status-strip reg-status-' . $item->status_ID();
+        if ($this->_has_checkbox_column) {
+            $class .= ' has-checkbox-column';
+        }
+        return $class;
+    }
+
+
+    /**
+     * @return array
+     * @throws \EE_Error
+     */
+    protected function _get_table_filters()
+    {
+        $filters = $where = array();
+        $current_EVT_ID = isset($this->_req_data['event_id']) ? (int) $this->_req_data['event_id'] : 0;
+        if (empty($this->_dtts_for_event) || count($this->_dtts_for_event) === 1) {
+            // this means we don't have an event so let's setup a filter dropdown for all the events to select
+            // note possible capability restrictions
+            if (! EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_events')) {
+                $where['status**'] = array('!=', 'private');
+            }
+            if (! EE_Registry::instance()->CAP->current_user_can('ee_read_others_events', 'get_events')) {
+                $where['EVT_wp_user'] = get_current_user_id();
+            }
+            $events = EEM_Event::instance()->get_all(
+                array(
+                    $where,
+                    'order_by' => array('Datetime.DTT_EVT_start' => 'DESC'),
                 )
-                ? array( 'ATT_lname' => true )
-                : array( 'ATT_fname' => true ),
-			'Event'    => array( 'Event.EVT.Name' => false ),
-		);
-		$this->_hidden_columns = array();
-		$this->_evt = EEM_Event::instance()->get_one_by_ID( $evt_id );
-		$this->_dtts_for_event = $this->_evt instanceof EE_Event ? $this->_evt->datetimes_ordered() : array();
-	}
-
-
-
-	/**
-	 * @param \EE_Registration $item
-	 * @return string
-	 */
-	protected function _get_row_class( $item ) {
-		$class = parent::_get_row_class( $item );
-		//add status class
-		$class .= ' ee-status-strip reg-status-' . $item->status_ID();
-		if ( $this->_has_checkbox_column ) {
-			$class .= ' has-checkbox-column';
-		}
-		return $class;
-	}
-
-
-
-	/**
-	 * @return array
-	 * @throws \EE_Error
-	 */
-	protected function _get_table_filters() {
-		$filters = $where = array();
-		$current_EVT_ID = isset( $this->_req_data['event_id'] ) ? (int) $this->_req_data['event_id'] : 0;
-		if ( empty( $this->_dtts_for_event ) || count( $this->_dtts_for_event ) === 1 ) {
-			//this means we don't have an event so let's setup a filter dropdown for all the events to select
-			//note possible capability restrictions
-			if ( ! EE_Registry::instance()->CAP->current_user_can( 'ee_read_private_events', 'get_events' ) ) {
-				$where['status**'] = array( '!=', 'private' );
-			}
-			if ( ! EE_Registry::instance()->CAP->current_user_can( 'ee_read_others_events', 'get_events' ) ) {
-				$where['EVT_wp_user'] = get_current_user_id();
-			}
-			$events = EEM_Event::instance()->get_all(
-				array(
-					$where,
-					'order_by' => array( 'Datetime.DTT_EVT_start' => 'DESC' ),
-				)
-			);
-			$evts[] = array(
-				'id'   => 0,
-				'text' => __( 'To toggle Check-in status, select an event', 'event_espresso' ),
-			);
-			$checked = 'checked';
-			/** @var EE_Event $evt */
-			foreach ( $events as $evt ) {
-				//any registrations for this event?
-				if ( ! $evt->get_count_of_all_registrations() ) {
-					continue;
-				}
-                                $evts[] = array(
-					'id'    => $evt->ID(),
-					'text'  => apply_filters('FHEE__EE_Event_Registrations___get_table_filters__event_name', $evt->get( 'EVT_name' ), $evt),
-					'class' => $evt->is_expired() ? 'ee-expired-event' : '',
-				);
-				if ( $evt->ID() === $current_EVT_ID && $evt->is_expired() ) {
-					$checked = '';
-				}
-			}
-			$event_filter = '<div class="ee-event-filter">';
-			$event_filter .= EEH_Form_Fields::select_input( 'event_id', $evts, $current_EVT_ID );
-			$event_filter .= '<span class="ee-event-filter-toggle">';
-			$event_filter .= '<input type="checkbox" id="js-ee-hide-expired-events" ' . $checked . '> ';
-			$event_filter .= __( 'Hide Expired Events', 'event_espresso' );
-			$event_filter .= '</span>';
-			$event_filter .= '</div>';
-			$filters[] = $event_filter;
-		}
-		if ( ! empty( $this->_dtts_for_event ) ) {
-			//DTT datetimes filter
-			$this->_cur_dtt_id = isset( $this->_req_data['DTT_ID'] ) ? $this->_req_data['DTT_ID'] : 0;
-			if ( count( $this->_dtts_for_event ) > 1 ) {
-				$dtts[0] = __( 'To toggle check-in status, select a datetime.', 'event_espresso' );
-				foreach ( $this->_dtts_for_event as $dtt ) {
+            );
+            $evts[] = array(
+                'id'   => 0,
+                'text' => __('To toggle Check-in status, select an event', 'event_espresso'),
+            );
+            $checked = 'checked';
+            /** @var EE_Event $evt */
+            foreach ($events as $evt) {
+                // any registrations for this event?
+                if (! $evt->get_count_of_all_registrations()) {
+                    continue;
+                }
+                $evts[] = array(
+                    'id'    => $evt->ID(),
+                    'text'  => apply_filters(
+                        'FHEE__EE_Event_Registrations___get_table_filters__event_name',
+                        $evt->get('EVT_name'),
+                        $evt
+                    ),
+                    'class' => $evt->is_expired() ? 'ee-expired-event' : '',
+                );
+                if ($evt->ID() === $current_EVT_ID && $evt->is_expired()) {
+                    $checked = '';
+                }
+            }
+            $event_filter = '<div class="ee-event-filter">';
+            $event_filter .= EEH_Form_Fields::select_input('event_id', $evts, $current_EVT_ID);
+            $event_filter .= '<span class="ee-event-filter-toggle">';
+            $event_filter .= '<input type="checkbox" id="js-ee-hide-expired-events" ' . $checked . '> ';
+            $event_filter .= __('Hide Expired Events', 'event_espresso');
+            $event_filter .= '</span>';
+            $event_filter .= '</div>';
+            $filters[] = $event_filter;
+        }
+        if (! empty($this->_dtts_for_event)) {
+            // DTT datetimes filter
+            $this->_cur_dtt_id = isset($this->_req_data['DTT_ID']) ? $this->_req_data['DTT_ID'] : 0;
+            if (count($this->_dtts_for_event) > 1) {
+                $dtts[0] = __('To toggle check-in status, select a datetime.', 'event_espresso');
+                foreach ($this->_dtts_for_event as $dtt) {
                     $datetime_string = $dtt->name();
-                    $datetime_string = ! empty($datetime_string ) ? ' (' . $datetime_string . ')' : '';
-					$datetime_string = $dtt->start_date_and_time() . ' - ' . $dtt->end_date_and_time() . $datetime_string;
-					$dtts[ $dtt->ID() ] = $datetime_string;
-				}
-				$input = new EE_Select_Input(
-					$dtts,
-					array(
-						'html_name' => 'DTT_ID',
-						'html_id'   => 'DTT_ID',
-						'default'   => $this->_cur_dtt_id,
-					)
-				);
-				$filters[] = $input->get_html_for_input();
-				$filters[] = '<input type="hidden" name="event_id" value="' . $current_EVT_ID . '">';
-			}
-		}
-		return $filters;
-	}
+                    $datetime_string = ! empty($datetime_string) ? ' (' . $datetime_string . ')' : '';
+                    $datetime_string = $dtt->start_date_and_time() . ' - ' . $dtt->end_date_and_time() . $datetime_string;
+                    $dtts[ $dtt->ID() ] = $datetime_string;
+                }
+                $input = new EE_Select_Input(
+                    $dtts,
+                    array(
+                        'html_name' => 'DTT_ID',
+                        'html_id'   => 'DTT_ID',
+                        'default'   => $this->_cur_dtt_id,
+                    )
+                );
+                $filters[] = $input->get_html_for_input();
+                $filters[] = '<input type="hidden" name="event_id" value="' . $current_EVT_ID . '">';
+            }
+        }
+        return $filters;
+    }
 
 
-
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_get_total_event_attendees();
-	}
-
-
-
-	/**
-	 * @return int
-	 * @throws \EE_Error
-	 */
-	protected function _get_total_event_attendees() {
-		$EVT_ID = isset( $this->_req_data['event_id'] ) ? absint( $this->_req_data['event_id'] ) : false;
-		$DTT_ID = $this->_cur_dtt_id;
-		$query_params = array();
-		if ( $EVT_ID ) {
-			$query_params[0]['EVT_ID'] = $EVT_ID;
-		}
-		//if DTT is included we only show for that datetime.  Otherwise we're showing for all datetimes (the event).
-		if ( $DTT_ID ) {
-			$query_params[0]['Ticket.Datetime.DTT_ID'] = $DTT_ID;
-		}
-		$status_ids_array = apply_filters(
-			'FHEE__Extend_Registrations_Admin_Page__get_event_attendees__status_ids_array',
-			array( EEM_Registration::status_id_pending_payment, EEM_Registration::status_id_approved )
-		);
-		$query_params[0]['STS_ID'] = array( 'IN', $status_ids_array );
-		return EEM_Registration::instance()->count( $query_params );
-	}
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_get_total_event_attendees();
+    }
 
 
+    /**
+     * @return int
+     * @throws \EE_Error
+     */
+    protected function _get_total_event_attendees()
+    {
+        $EVT_ID = isset($this->_req_data['event_id']) ? absint($this->_req_data['event_id']) : false;
+        $DTT_ID = $this->_cur_dtt_id;
+        $query_params = array();
+        if ($EVT_ID) {
+            $query_params[0]['EVT_ID'] = $EVT_ID;
+        }
+        // if DTT is included we only show for that datetime.  Otherwise we're showing for all datetimes (the event).
+        if ($DTT_ID) {
+            $query_params[0]['Ticket.Datetime.DTT_ID'] = $DTT_ID;
+        }
+        $status_ids_array = apply_filters(
+            'FHEE__Extend_Registrations_Admin_Page__get_event_attendees__status_ids_array',
+            array(EEM_Registration::status_id_pending_payment, EEM_Registration::status_id_approved)
+        );
+        $query_params[0]['STS_ID'] = array('IN', $status_ids_array);
+        return EEM_Registration::instance()->count($query_params);
+    }
 
-	/**
-	 * @param \EE_Registration $item
-	 * @return string
-	 */
-	public function column__Reg_Status( EE_Registration $item ) {
-		return '<span class="ee-status-strip ee-status-strip-td reg-status-' . $item->status_ID() . '"></span>';
-	}
+
+    /**
+     * @param \EE_Registration $item
+     * @return string
+     */
+    public function column__Reg_Status(EE_Registration $item)
+    {
+        return '<span class="ee-status-strip ee-status-strip-td reg-status-' . $item->status_ID() . '"></span>';
+    }
 
 
-
-	/**
-	 * @param \EE_Registration $item
-	 * @return string
-	 * @throws \EE_Error
-	 */
-	public function column_cb( $item ) {
-		return sprintf( '<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />', $item->ID() );
-	}
-
+    /**
+     * @param \EE_Registration $item
+     * @return string
+     * @throws \EE_Error
+     */
+    public function column_cb($item)
+    {
+        return sprintf('<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />', $item->ID());
+    }
 
 
     /**
@@ -311,261 +311,263 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table {
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-	public function column__REG_att_checked_in( EE_Registration $item ) {
-		$attendee = $item->attendee();
-		$attendee_name = $attendee instanceof EE_Attendee ? $attendee->full_name() : '';
+    public function column__REG_att_checked_in(EE_Registration $item)
+    {
+        $attendee = $item->attendee();
+        $attendee_name = $attendee instanceof EE_Attendee ? $attendee->full_name() : '';
 
-		if ( $this->_cur_dtt_id === 0 && count( $this->_dtts_for_event ) === 1 ) {
-			$latest_related_datetime = $item->get_latest_related_datetime();
-			if ( $latest_related_datetime instanceof EE_Datetime ) {
-				$this->_cur_dtt_id = $latest_related_datetime->ID();
-			}
-		}
+        if ($this->_cur_dtt_id === 0 && count($this->_dtts_for_event) === 1) {
+            $latest_related_datetime = $item->get_latest_related_datetime();
+            if ($latest_related_datetime instanceof EE_Datetime) {
+                $this->_cur_dtt_id = $latest_related_datetime->ID();
+            }
+        }
         $checkin_status_dashicon = CheckinStatusDashicon::fromRegistrationAndDatetimeId(
-		    $item,
+            $item,
             $this->_cur_dtt_id
         );
-		$nonce = wp_create_nonce( 'checkin_nonce' );
-		$toggle_active = ! empty ( $this->_cur_dtt_id )
-		                 && EE_Registry::instance()->CAP->current_user_can(
-			'ee_edit_checkin',
-			'espresso_registrations_toggle_checkin_status',
-			$item->ID()
-		)
-			? ' clickable trigger-checkin'
-			: '';
-		$mobile_view_content = ' <span class="show-on-mobile-view-only">' . $attendee_name . '</span>';
-		return '<span class="' . $checkin_status_dashicon->cssClasses() . $toggle_active . '"'
-		       . ' data-_regid="' . $item->ID() . '"'
-		       . ' data-dttid="' . $this->_cur_dtt_id . '"'
-		       . ' data-nonce="' . $nonce . '">'
-		       . '</span>'
-		       . $mobile_view_content;
-	}
+        $nonce = wp_create_nonce('checkin_nonce');
+        $toggle_active = ! empty($this->_cur_dtt_id)
+                         && EE_Registry::instance()->CAP->current_user_can(
+                             'ee_edit_checkin',
+                             'espresso_registrations_toggle_checkin_status',
+                             $item->ID()
+                         )
+            ? ' clickable trigger-checkin'
+            : '';
+        $mobile_view_content = ' <span class="show-on-mobile-view-only">' . $attendee_name . '</span>';
+        return '<span class="' . $checkin_status_dashicon->cssClasses() . $toggle_active . '"'
+               . ' data-_regid="' . $item->ID() . '"'
+               . ' data-dttid="' . $this->_cur_dtt_id . '"'
+               . ' data-nonce="' . $nonce . '">'
+               . '</span>'
+               . $mobile_view_content;
+    }
 
 
-
-	/**
-	 * @param \EE_Registration $item
-	 * @return mixed|string|void
-	 * @throws \EE_Error
-	 */
-	public function column_ATT_name( EE_Registration $item ) {
-		$attendee = $item->attendee();
-		if ( ! $attendee instanceof EE_Attendee ) {
-			return __( 'No contact record for this registration.', 'event_espresso' );
-		}
-		// edit attendee link
-		$edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-			array( 'action' => 'view_registration', '_REG_ID' => $item->ID() ),
-			REG_ADMIN_URL
-		);
-		$name_link = EE_Registry::instance()->CAP->current_user_can(
-			'ee_edit_contacts',
-			'espresso_registrations_edit_attendee'
-		)
-			? '<a href="' . $edit_lnk_url . '" title="' . esc_attr__( 'View Registration Details', 'event_espresso' ) . '">'
-			    . $item->attendee()->full_name()
-			    . '</a>'
-			: $item->attendee()->full_name();
-		$name_link .= $item->count() === 1
-			? '&nbsp;<sup><div class="dashicons dashicons-star-filled lt-blue-icon ee-icon-size-8"></div></sup>	'
-			: '';
-		//add group details
-		$name_link .= '&nbsp;' . sprintf( __( '(%s of %s)', 'event_espresso' ), $item->count(), $item->group_size() );
-		//add regcode
-		$link = EE_Admin_Page::add_query_args_and_nonce(
-			array( 'action' => 'view_registration', '_REG_ID' => $item->ID() ),
-			REG_ADMIN_URL
-		);
-		$name_link .= '<br>';
-		$name_link .= EE_Registry::instance()->instance()->CAP->current_user_can(
-			'ee_read_registration',
-			'view_registration',
-			$item->ID()
-		)
-			? '<a href="' . $link . '" title="' . esc_attr__( 'View Registration Details', 'event_espresso' ) . '">'
-			  . $item->reg_code()
-			  . '</a>'
-			: $item->reg_code();
-		//status
-		$name_link .= '<br><span class="ee-status-text-small">';
-		$name_link .= EEH_Template::pretty_status( $item->status_ID(), false, 'sentence' );
-		$name_link .= '</span>';
-		$actions = array();
-		$DTT_ID = $this->_cur_dtt_id;
-		$latest_related_datetime = empty( $DTT_ID ) && ! empty( $this->_req_data['event_id'] ) && $item instanceof EE_Registration
-			? $item->get_latest_related_datetime()
-			: null;
-		$DTT_ID = $latest_related_datetime instanceof EE_Datetime
-			? $latest_related_datetime->ID()
-			: $DTT_ID;
-		if ( ! empty( $DTT_ID )
-		     && EE_Registry::instance()->CAP->current_user_can(
-				'ee_read_checkins',
-				'espresso_registrations_registration_checkins'
-			)
-		) {
-			$checkin_list_url = EE_Admin_Page::add_query_args_and_nonce(
-				array( 'action' => 'registration_checkins', '_REG_ID' => $item->ID(), 'DTT_ID' => $DTT_ID ),
+    /**
+     * @param \EE_Registration $item
+     * @return mixed|string|void
+     * @throws \EE_Error
+     */
+    public function column_ATT_name(EE_Registration $item)
+    {
+        $attendee = $item->attendee();
+        if (! $attendee instanceof EE_Attendee) {
+            return __('No contact record for this registration.', 'event_espresso');
+        }
+        // edit attendee link
+        $edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+            array('action' => 'view_registration', '_REG_ID' => $item->ID()),
+            REG_ADMIN_URL
+        );
+        $name_link = EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_contacts',
+            'espresso_registrations_edit_attendee'
+        )
+            ? '<a href="' . $edit_lnk_url . '" title="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
+              . $item->attendee()->full_name()
+              . '</a>'
+            : $item->attendee()->full_name();
+        $name_link .= $item->count() === 1
+            ? '&nbsp;<sup><div class="dashicons dashicons-star-filled lt-blue-icon ee-icon-size-8"></div></sup>	'
+            : '';
+        // add group details
+        $name_link .= '&nbsp;' . sprintf(__('(%s of %s)', 'event_espresso'), $item->count(), $item->group_size());
+        // add regcode
+        $link = EE_Admin_Page::add_query_args_and_nonce(
+            array('action' => 'view_registration', '_REG_ID' => $item->ID()),
+            REG_ADMIN_URL
+        );
+        $name_link .= '<br>';
+        $name_link .= EE_Registry::instance()->instance()->CAP->current_user_can(
+            'ee_read_registration',
+            'view_registration',
+            $item->ID()
+        )
+            ? '<a href="' . $link . '" title="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
+              . $item->reg_code()
+              . '</a>'
+            : $item->reg_code();
+        // status
+        $name_link .= '<br><span class="ee-status-text-small">';
+        $name_link .= EEH_Template::pretty_status($item->status_ID(), false, 'sentence');
+        $name_link .= '</span>';
+        $actions = array();
+        $DTT_ID = $this->_cur_dtt_id;
+        $latest_related_datetime = empty($DTT_ID) && ! empty($this->_req_data['event_id']) && $item instanceof EE_Registration
+            ? $item->get_latest_related_datetime()
+            : null;
+        $DTT_ID = $latest_related_datetime instanceof EE_Datetime
+            ? $latest_related_datetime->ID()
+            : $DTT_ID;
+        if (! empty($DTT_ID)
+            && EE_Registry::instance()->CAP->current_user_can(
+                'ee_read_checkins',
+                'espresso_registrations_registration_checkins'
+            )
+        ) {
+            $checkin_list_url = EE_Admin_Page::add_query_args_and_nonce(
+                array('action' => 'registration_checkins', '_REG_ID' => $item->ID(), 'DTT_ID' => $DTT_ID),
                 REG_ADMIN_URL
-			);
-			// get the timestamps for this registration's checkins, related to the selected datetime
-			$timestamps = $item->get_many_related( 'Checkin', array( array( 'DTT_ID' => $DTT_ID ) ) );
-			if( ! empty( $timestamps ) ) {
-				// get the last timestamp
-				$last_timestamp = end( $timestamps );
-				// checked in or checked out?
-				$checkin_status = $last_timestamp->get( 'CHK_in' )
-					? esc_html__( 'Checked In', 'event_espresso' )
-					: esc_html__( 'Checked Out', 'event_espresso' );
-				// get timestamp string
-				$timestamp_string = $last_timestamp->get_datetime( 'CHK_timestamp' );
-				$actions['checkin'] = '<a href="' . $checkin_list_url . '" title="' . esc_attr__(
-						'View this registrant\'s check-ins/checkouts for the datetime',
-						'event_espresso'
-					) . '">' . $checkin_status . ': ' . $timestamp_string . '</a>';
-			}
-		}
-		return ( ! empty( $DTT_ID ) && ! empty( $timestamps ) )
-			? sprintf( '%1$s %2$s', $name_link, $this->row_actions( $actions, true ) )
-			: $name_link;
-	}
+            );
+            // get the timestamps for this registration's checkins, related to the selected datetime
+            $timestamps = $item->get_many_related('Checkin', array(array('DTT_ID' => $DTT_ID)));
+            if (! empty($timestamps)) {
+                // get the last timestamp
+                $last_timestamp = end($timestamps);
+                // checked in or checked out?
+                $checkin_status = $last_timestamp->get('CHK_in')
+                    ? esc_html__('Checked In', 'event_espresso')
+                    : esc_html__('Checked Out', 'event_espresso');
+                // get timestamp string
+                $timestamp_string = $last_timestamp->get_datetime('CHK_timestamp');
+                $actions['checkin'] = '<a href="' . $checkin_list_url . '" title="'
+                                      . esc_attr__(
+                                          'View this registrant\'s check-ins/checkouts for the datetime',
+                                          'event_espresso'
+                                      ) . '">' . $checkin_status . ': ' . $timestamp_string . '</a>';
+            }
+        }
+        return (! empty($DTT_ID) && ! empty($timestamps))
+            ? sprintf('%1$s %2$s', $name_link, $this->row_actions($actions, true))
+            : $name_link;
+    }
 
 
-
-	/**
-	 * @param \EE_Registration $item
-	 * @return string
-	 */
-	public function column_ATT_email( EE_Registration $item ) {
-		$attendee = $item->attendee();
-		return $attendee instanceof EE_Attendee ? $attendee->email() : '';
-	}
-
-
-
-	/**
-	 * @param \EE_Registration $item
-	 * @return bool|string
-	 * @throws \EE_Error
-	 */
-	public function column_Event( EE_Registration $item ) {
-		try {
-			$event = $this->_evt instanceof EE_Event ? $this->_evt : $item->event();
-			$chkin_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-				array( 'action' => 'event_registrations', 'event_id' => $event->ID() ),
-				REG_ADMIN_URL
-			);
-			$event_label = EE_Registry::instance()->CAP->current_user_can(
-				'ee_read_checkins',
-				'espresso_registrations_registration_checkins'
-			) ? '<a href="' . $chkin_lnk_url . '" title="' . esc_attr__(
-					'View Checkins for this Event',
-					'event_espresso'
-				) . '">' . $event->name() . '</a>' : $event->name();
-		} catch ( \EventEspresso\core\exceptions\EntityNotFoundException $e ) {
-			$event_label = esc_html__( 'Unknown', 'event_espresso' );
-		}
-		return $event_label;
-	}
+    /**
+     * @param \EE_Registration $item
+     * @return string
+     */
+    public function column_ATT_email(EE_Registration $item)
+    {
+        $attendee = $item->attendee();
+        return $attendee instanceof EE_Attendee ? $attendee->email() : '';
+    }
 
 
+    /**
+     * @param \EE_Registration $item
+     * @return bool|string
+     * @throws \EE_Error
+     */
+    public function column_Event(EE_Registration $item)
+    {
+        try {
+            $event = $this->_evt instanceof EE_Event ? $this->_evt : $item->event();
+            $chkin_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+                array('action' => 'event_registrations', 'event_id' => $event->ID()),
+                REG_ADMIN_URL
+            );
+            $event_label = EE_Registry::instance()->CAP->current_user_can(
+                'ee_read_checkins',
+                'espresso_registrations_registration_checkins'
+            ) ? '<a href="' . $chkin_lnk_url . '" title="'
+                . esc_attr__(
+                    'View Checkins for this Event',
+                    'event_espresso'
+                ) . '">' . $event->name() . '</a>' : $event->name();
+        } catch (\EventEspresso\core\exceptions\EntityNotFoundException $e) {
+            $event_label = esc_html__('Unknown', 'event_espresso');
+        }
+        return $event_label;
+    }
 
-	/**
-	 * @param \EE_Registration $item
-	 * @return mixed|string|void
-	 */
-	public function column_PRC_name( EE_Registration $item ) {
-		return $item->ticket() instanceof EE_Ticket ? $item->ticket()->name() : __( "Unknown", "event_espresso" );
-	}
+
+    /**
+     * @param \EE_Registration $item
+     * @return mixed|string|void
+     */
+    public function column_PRC_name(EE_Registration $item)
+    {
+        return $item->ticket() instanceof EE_Ticket ? $item->ticket()->name() : __("Unknown", "event_espresso");
+    }
 
 
+    /**
+     * column_REG_final_price
+     *
+     * @param \EE_Registration $item
+     * @return string
+     */
+    public function column__REG_final_price(EE_Registration $item)
+    {
+        return '<span class="reg-pad-rght">' . ' ' . $item->pretty_final_price() . '</span>';
+    }
 
-	/**
-	 * column_REG_final_price
-	 *
-	 * @param \EE_Registration $item
-	 * @return string
-	 */
-	public function column__REG_final_price( EE_Registration $item ) {
-		return '<span class="reg-pad-rght">' . ' ' . $item->pretty_final_price() . '</span>';
-	}
 
-
-
-	/**
-	 * column_TXN_paid
-	 *
-	 * @param \EE_Registration $item
-	 * @return string
-	 * @throws \EE_Error
-	 */
-	public function column_TXN_paid( EE_Registration $item ) {
-		if ( $item->count() === 1 ) {
-			if ( $item->transaction()->paid() >= $item->transaction()->total() ) {
-				return '<span class="reg-pad-rght"><div class="dashicons dashicons-yes green-icon"></div></span>';
-			} else {
-				$view_txn_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-					array( 'action' => 'view_transaction', 'TXN_ID' => $item->transaction_ID() ),
-					TXN_ADMIN_URL
-				);
-				return EE_Registry::instance()->CAP->current_user_can(
-					'ee_read_transaction',
-					'espresso_transactions_view_transaction'
-				) ? '
+    /**
+     * column_TXN_paid
+     *
+     * @param \EE_Registration $item
+     * @return string
+     * @throws \EE_Error
+     */
+    public function column_TXN_paid(EE_Registration $item)
+    {
+        if ($item->count() === 1) {
+            if ($item->transaction()->paid() >= $item->transaction()->total()) {
+                return '<span class="reg-pad-rght"><div class="dashicons dashicons-yes green-icon"></div></span>';
+            } else {
+                $view_txn_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+                    array('action' => 'view_transaction', 'TXN_ID' => $item->transaction_ID()),
+                    TXN_ADMIN_URL
+                );
+                return EE_Registry::instance()->CAP->current_user_can(
+                    'ee_read_transaction',
+                    'espresso_transactions_view_transaction'
+                ) ? '
 				<span class="reg-pad-rght">
 					<a class="status-'
-				    . $item->transaction()->status_ID()
-				    . '" href="'
-				    . $view_txn_lnk_url
-				    . '"  title="'
-				    . esc_attr__( 'View Transaction', 'event_espresso' )
-				    . '">
+                    . $item->transaction()->status_ID()
+                    . '" href="'
+                    . $view_txn_lnk_url
+                    . '"  title="'
+                    . esc_attr__('View Transaction', 'event_espresso')
+                    . '">
 						'
-				    . $item->transaction()->pretty_paid()
-				    . '
+                    . $item->transaction()->pretty_paid()
+                    . '
 					</a>
 				<span>' : '<span class="reg-pad-rght">' . $item->transaction()->pretty_paid() . '</span>';
-			}
-		} else {
-			return '<span class="reg-pad-rght"></span>';
-		}
-	}
+            }
+        } else {
+            return '<span class="reg-pad-rght"></span>';
+        }
+    }
 
 
-
-	/**
-	 *        column_TXN_total
-	 *
-	 * @param \EE_Registration $item
-	 * @return string
-	 * @throws \EE_Error
-	 */
-	public function column_TXN_total( EE_Registration $item ) {
-		$txn = $item->transaction();
-		$view_txn_url = add_query_arg( array( 'action' => 'view_transaction', 'TXN_ID' => $txn->ID() ), TXN_ADMIN_URL );
-		if ( $item->get( 'REG_count' ) === 1 ) {
-			$line_total_obj = $txn->total_line_item();
-			$txn_total = $line_total_obj instanceof EE_Line_Item
-				? $line_total_obj->get_pretty( 'LIN_total' )
-				: __(
-					'View Transaction',
-					'event_espresso'
-				);
-			return EE_Registry::instance()->CAP->current_user_can(
-				'ee_read_transaction',
-				'espresso_transactions_view_transaction'
-			) ? '<a href="'
-			    . $view_txn_url
-			    . '" title="'
-			    . esc_attr__( 'View Transaction', 'event_espresso' )
-			    . '"><span class="reg-pad-rght">'
-			    . $txn_total
-			    . '</span></a>' : '<span class="reg-pad-rght">' . $txn_total . '</span>';
-		} else {
-			return '<span class="reg-pad-rght"></span>';
-		}
-	}
-
+    /**
+     *        column_TXN_total
+     *
+     * @param \EE_Registration $item
+     * @return string
+     * @throws \EE_Error
+     */
+    public function column_TXN_total(EE_Registration $item)
+    {
+        $txn = $item->transaction();
+        $view_txn_url = add_query_arg(array('action' => 'view_transaction', 'TXN_ID' => $txn->ID()), TXN_ADMIN_URL);
+        if ($item->get('REG_count') === 1) {
+            $line_total_obj = $txn->total_line_item();
+            $txn_total = $line_total_obj instanceof EE_Line_Item
+                ? $line_total_obj->get_pretty('LIN_total')
+                : __(
+                    'View Transaction',
+                    'event_espresso'
+                );
+            return EE_Registry::instance()->CAP->current_user_can(
+                'ee_read_transaction',
+                'espresso_transactions_view_transaction'
+            ) ? '<a href="'
+                . $view_txn_url
+                . '" title="'
+                . esc_attr__('View Transaction', 'event_espresso')
+                . '"><span class="reg-pad-rght">'
+                . $txn_total
+                . '</span></a>' : '<span class="reg-pad-rght">' . $txn_total . '</span>';
+        } else {
+            return '<span class="reg-pad-rght"></span>';
+        }
+    }
 }

--- a/caffeinated/admin/extend/registrations/EE_Registration_CheckIn_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Registration_CheckIn_List_Table.class.php
@@ -1,159 +1,172 @@
-<?php use EventEspresso\ui\browser\checkins\entities\CheckinStatusDashicon;
+<?php
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) exit('No direct script access allowed');
+use EventEspresso\ui\browser\checkins\entities\CheckinStatusDashicon;
+
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for WordPress
- *
- * @ package		Event Espresso
- * @ author			Seth Shoultes
- * @ copyright		(c) 2008-2011 Event Espresso  All Rights Reserved.
- * @ license			{@link http://eventespresso.com/support/terms-conditions/}   * see Plugin Licensing *
- * @ link			{@link http://www.eventespresso.com}
- * @ since		 	4.0
- *
- * ------------------------------------------------------------------------
- *
  * EE_Registration_CheckIn_List_Table
- * This class handles all the logic for the display of the Check-in List table.  When viewed, all Check-ins for a given registration are displayed.
+ * This class handles all the logic for the display of the Check-in List table.  When viewed, all Check-ins for a given
+ * registration are displayed.
  *
- * @package			Event Espresso
- * @subpackage		includes/core/admin/registrations/EE_Registration_CheckIn_List_Table
- * @author			Darren Ethier
+ * @package            Event Espresso
+ * @subpackage         includes/core/admin/registrations/EE_Registration_CheckIn_List_Table
+ * @author             Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
+class EE_Registration_CheckIn_List_Table extends EE_Admin_List_Table
+{
 
 
-class EE_Registration_CheckIn_List_Table extends EE_Admin_List_Table {
+    public function __construct($admin_page)
+    {
+        parent::__construct($admin_page);
+    }
 
 
-
-	public function __construct( $admin_page ) {
-		parent::__construct($admin_page);
-	}
-
-
-
-
-	protected function _setup_data() {
-		$this->_data = $this->_get_checkins( $this->_per_page );
-		$this->_all_data_count = $this->_get_checkins(  $this->_per_page, TRUE );
-	}
+    protected function _setup_data()
+    {
+        $this->_data = $this->_get_checkins($this->_per_page);
+        $this->_all_data_count = $this->_get_checkins($this->_per_page, true);
+    }
 
 
+    protected function _set_properties()
+    {
+        $this->_wp_list_args = array(
+            'singular' => __('check-in', 'event_espresso'),
+            'plural'   => __('check-ins', 'event_espresso'),
+            'ajax'     => true,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
+
+        $this->_columns = array(
+            'cb'            => '<input type="checkbox" />', // Render a checkbox instead of text
+            'CHK_in'        => __('Check-In', 'event_espresso'),
+            'CHK_timestamp' => __('Timestamp', 'event_espresso'),
+        );
+
+        $this->_sortable_columns = array(
+            'CHK_timestamp' => array('CHK_timestamp' => true),
+        );
+
+        $this->_primary_column = 'CHK_in';
+
+        $this->_hidden_columns = array();
+    }
 
 
-	protected function _set_properties() {
-		$this->_wp_list_args = array(
-			'singular' => __('check-in', 'event_espresso'),
-			'plural' => __('check-ins', 'event_espresso'),
-			'ajax' => TRUE,
-			'screen' => $this->_admin_page->get_current_screen()->id
-			);
+    protected function _get_table_filters()
+    {
+        return array();
+    }
 
-		$this->_columns = array(
-			'cb' => '<input type="checkbox" />', //Render a checkbox instead of text
-			'CHK_in' => __('Check-In', 'event_espresso'),
-			'CHK_timestamp' => __('Timestamp', 'event_espresso')
-			);
-
-		$this->_sortable_columns = array(
-			'CHK_timestamp' => array( 'CHK_timestamp' => TRUE )
-			);
-
-		$this->_primary_column = 'CHK_in';
-
-		$this->_hidden_columns = array();
-	}
+    // remove the search box
+    public function search_box($text, $input_id)
+    {
+        return '';
+    }
 
 
-	protected function _get_table_filters() {
-		return array();
-	}
-
-	//remove the search box
-	function search_box($text, $input_id) {
-		return '';
-	}
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_get_checkins(null, true);
+    }
 
 
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_get_checkins(NULL, true);
-	}
+    public function column_cb($item)
+    {
+        return sprintf('<input type="checkbox" name="checkbox[%1$s]" />', $item->ID());
+    }
 
 
-	function column_cb($item ) {
-		return sprintf( '<input type="checkbox" name="checkbox[%1$s]" />', $item->ID() );
-	}
-
-
-	public function column_CHK_in( EE_Checkin $item ) {
+    public function column_CHK_in(EE_Checkin $item)
+    {
         $checkin_status_dashicon = CheckinStatusDashicon::fromCheckin($item);
         return '<span class="' . $checkin_status_dashicon->cssClasses() . '"></span><span class="show-on-mobile-view-only">' . $item->get_datetime('CHK_timestamp') . '</span>';
-	}
+    }
 
 
+    public function column_CHK_timestamp(EE_Checkin $item)
+    {
+        $actions = array();
+        $delete_url = EE_Admin_Page::add_query_args_and_nonce(array('action'  => 'delete_checkin_row',
+                                                                    'DTT_ID'  => $this->_req_data['DTT_ID'],
+                                                                    '_REG_ID' => $this->_req_data['_REG_ID'],
+                                                                    'CHK_ID'  => $item->ID(),
+        ));
+        $actions['delete_checkin'] = EE_Registry::instance()->CAP->current_user_can(
+            'ee_delete_checkins',
+            'espresso_registrations_delete_checkin_row'
+        )
+            ? '<a href="' . $delete_url . '" title="'
+              . esc_attr__('Click here to delete this check-in record', 'event_espresso') . '">'
+              . __('Delete', 'event_espresso') . '</a>'
+            : '';
 
-	function column_CHK_timestamp( EE_Checkin $item ) {
-		$actions = array();
-		$delete_url = EE_Admin_Page::add_query_args_and_nonce( array('action' => 'delete_checkin_row', 'DTT_ID' => $this->_req_data['DTT_ID'], '_REG_ID' => $this->_req_data['_REG_ID'], 'CHK_ID' => $item->ID() ) );
-		$actions['delete_checkin'] = EE_Registry::instance()->CAP->current_user_can( 'ee_delete_checkins', 'espresso_registrations_delete_checkin_row' ) ? '<a href="' . $delete_url . '" title="' . esc_attr__('Click here to delete this check-in record', 'event_espresso') . '">' . __('Delete', 'event_espresso') . '</a>' : '';
-
-		return sprintf( '%1$s %2$s', $item->get_datetime('CHK_timestamp'), $this->row_actions($actions) );
-	}
+        return sprintf('%1$s %2$s', $item->get_datetime('CHK_timestamp'), $this->row_actions($actions));
+    }
 
 
+    /**
+     * This retrieves all the Check-ins for the given parameters.
+     * experimenting with having the query for the table values within the list table.
+     *
+     * @access protected
+     * @param int  $per_page How many to retrieve per page
+     * @param bool $count    Whether to return a count or not
+     * @return EE_Checkin[]|int
+     */
+    protected function _get_checkins($per_page = 10, $count = false)
+    {
+        $REG_ID = isset($this->_req_data['_REG_ID']) ? $this->_req_data['_REG_ID'] : false;
+        $DTT_ID = isset($this->_req_data['DTT_ID']) ? $this->_req_data['DTT_ID'] : false;
 
+        // if user does not have the capability for the checkins for this registration then get out!
+        if (! EE_Registry::instance()->CAP->current_user_can(
+            'ee_read_checkin',
+            'espresso_registrations_registration_checkins',
+            $REG_ID
+        )) {
+            return $count ? 0 : array();
+        }
 
-	/**
-	 * This retrieves all the Check-ins for the given parameters.
-	 * experimenting with having the query for the table values within the list table.
-	 *
-	 * @access protected
-	 * @param int     $per_page     How many to retrieve per page
-	 * @param bool    $count        Whether to return a count or not
-	 * @return EE_Checkin[]|int
-	 */
-	protected function _get_checkins( $per_page = 10, $count = FALSE ) {
-		$REG_ID = isset( $this->_req_data['_REG_ID'] ) ? $this->_req_data['_REG_ID'] : FALSE;
-		$DTT_ID = isset( $this->_req_data['DTT_ID'] ) ? $this->_req_data['DTT_ID'] : FALSE;
+        // if no reg id then get out cause need a reg id
+        if (empty($REG_ID) || empty($DTT_ID)) {
+            throw new EE_Error(
+                __(
+                    'This route cannot be viewed unless registration and datetime IDs are included in the request (via REG_ID and DTT_ID parameters)',
+                    'event_espresso'
+                )
+            );
+        }
 
-		//if user does not have the capability for the checkins for this registration then get out!
-		if ( ! EE_Registry::instance()->CAP->current_user_can( 'ee_read_checkin', 'espresso_registrations_registration_checkins', $REG_ID ) ) {
-			return $count ? 0 : array();
-		}
+        // set orderby
+        $orderby = 'CHK_timestamp'; // note that with this table we're only providing the option to orderby the timestamp value.
 
-		//if no reg id then get out cause need a reg id
-		if ( empty( $REG_ID ) || empty( $DTT_ID ) )
-			throw new EE_Error(__('This route cannot be viewed unless registration and datetime IDs are included in the request (via REG_ID and DTT_ID parameters)', 'event_espresso') );
+        $order = ! empty($this->_req_data['order']) ? $this->_req_data['order'] : 'ASC';
 
-		//set orderby
-		$orderby = 'CHK_timestamp'; //note that with this table we're only providing the option to orderby the timestamp value.
+        $current_page = isset($this->_req_data['paged']) && ! empty($this->_req_data['paged']) ? $this->_req_data['paged'] : 1;
+        $per_page = isset($this->_req_data['perpage']) && ! empty($this->_req_data['perpage']) ? $this->_req_data['perpage'] : $per_page;
+        $limit = null;
+        if (! $count) {
+            $offset = ($current_page - 1) * $per_page;
+            $limit = array($offset, $per_page);
+        }
 
-		$order = !empty( $this->_req_data['order'] ) ? $this->_req_data['order'] : 'ASC';
+        $_where = array(
+            'REG_ID' => $REG_ID,
+            'DTT_ID' => $DTT_ID,
+        );
 
-		$current_page = isset( $this->_req_data['paged'] ) && !empty( $this->_req_data['paged'] ) ? $this->_req_data['paged'] : 1;
-		$per_page = isset( $this->_req_data['perpage'] ) && !empty( $this->_req_data['perpage'] ) ? $this->_req_data['perpage'] : $per_page;
-		$limit = NULL;
-		if ( !$count ) {
-			$offset = ($current_page-1)*$per_page;
-			$limit = array( $offset, $per_page );
-		}
+        $query_params = array($_where, 'order_by' => array($orderby => $order), 'limit' => $limit);
 
-		$_where = array(
-			'REG_ID' => $REG_ID,
-			'DTT_ID' => $DTT_ID
-			);
+        // if no per_page value then we just want to return a count of all Check-ins
+        if ($count) {
+            return EEM_Checkin::instance()->count(array($_where));
+        }
 
-		$query_params = array( $_where, 'order_by' => array( $orderby => $order ), 'limit' => $limit );
-
-		//if no per_page value then we just want to return a count of all Check-ins
-		if ( $count )
-			return EEM_Checkin::instance()->count( array( $_where ) );
-
-		return $count ? EEM_Checkin::instance()->count( array( $_where ) ) : EEM_Checkin::instance()->get_all($query_params);
-	}
-
-} //end class EE_Registration_CheckIn_List_Table
+        return $count
+            ? EEM_Checkin::instance()->count(array($_where))
+            : EEM_Checkin::instance()->get_all($query_params);
+    }
+}

--- a/caffeinated/admin/extend/registrations/Extend_EE_Attendee_Contact_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/Extend_EE_Attendee_Contact_List_Table.class.php
@@ -1,46 +1,31 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Extend_Registrations_Admin_Page
  *
  * This is the Registrations Caffeinated admin page.
  *
  *
- * @package		Extend_Registrations_Admin_Page
- * @subpackage	caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
- * @author		Darren Ethier
+ * @package         Extend_Registrations_Admin_Page
+ * @subpackage      caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Extend_EE_Attendee_Contact_List_Table extends EE_Attendee_Contact_List_Table {
+class Extend_EE_Attendee_Contact_List_Table extends EE_Attendee_Contact_List_Table
+{
 
-	protected function _set_properties() {
-		parent::_set_properties();
-		$this->_bottom_buttons = array(
-			'contact_list_report' => array(
-				'route' => 'contact_list_report',
-				'extra_request' =>  
-						array( 
-							'return_url' => urlencode( "//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}" ) ) 
-			),
-//			'contact_list_export'=> array(
-//				'route' => 'contact_list_export'
-//			)
-		);
-	}
+    protected function _set_properties()
+    {
+        parent::_set_properties();
+        $this->_bottom_buttons = array(
+            'contact_list_report' => array(
+                'route'         => 'contact_list_report',
+                'extra_request' =>
+                    array(
+                        'return_url' => urlencode("//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}"),
+                    ),
+            ),
+        );
+    }
 }

--- a/caffeinated/admin/extend/registrations/Extend_EE_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/Extend_EE_Registrations_List_Table.class.php
@@ -3,8 +3,6 @@
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
-defined('EVENT_ESPRESSO_VERSION') || exit('No direct access allowed.');
-
 /**
  * Extend_EE_Registrations_List_Table
  *
@@ -24,11 +22,11 @@ class Extend_EE_Registrations_List_Table extends EE_Registrations_List_Table
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    function column__REG_date(EE_Registration $item)
+    public function column__REG_date(EE_Registration $item)
     {
         $date_linked = parent::column__REG_date($item);
         $actions = array();
-        //Build row actions
+        // Build row actions
         $check_in_url = EE_Admin_Page::add_query_args_and_nonce(array(
             'action'   => 'event_registrations',
             'event_id' => $item->event_ID(),
@@ -111,15 +109,15 @@ class Extend_EE_Registrations_List_Table extends EE_Registrations_List_Table
                         array('event_id' => $EVT_ID, 'datetime_id' => $datetime->ID()),
                         REG_ADMIN_URL
                     )
-                           . '" title="' . sprintf(
-                               esc_attr__(
-                                   'Filter this list to only show registrations for this datetime %s',
-                                   'event_espresso'
-                               ),
-                               $datetime->name()
-                           ) . '">'
-                           . esc_html__('View Registrations', 'event_espresso')
-                           . '</a>',
+                                               . '" title="' . sprintf(
+                                                   esc_attr__(
+                                                       'Filter this list to only show registrations for this datetime %s',
+                                                       'event_espresso'
+                                                   ),
+                                                   $datetime->name()
+                                               ) . '">'
+                                               . esc_html__('View Registrations', 'event_espresso')
+                                               . '</a>',
                 )
             );
             $datetimes_for_display[] = $datetime_string;

--- a/caffeinated/admin/hooks/Global_EE_Caf_Hooks.class.php
+++ b/caffeinated/admin/hooks/Global_EE_Caf_Hooks.class.php
@@ -1,62 +1,56 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Global_EE_Caf_Hooks
  *
  * This class is just a wrapper for some global hooks that are run on EE_Admin pages.
  *
  *
- * @package		Global_EE_Caf_Hooks
- * @subpackage	caffeinated/admin/hooks/Global_EE_Caf_Hooks.core.php
- * @author		Darren Ethier
+ * @package         Global_EE_Caf_Hooks
+ * @subpackage      caffeinated/admin/hooks/Global_EE_Caf_Hooks.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Global_EE_Caf_Hooks {
+class Global_EE_Caf_Hooks
+{
 
-	public function __construct() {
-		$this->_do_hooks();
-	}
-
-
-
-	private function _do_hooks() {
-		add_filter('FHEE_show_sponsors_meta_box', '__return_false', 10 );
-		add_filter('FHEE_show_ratings_request_meta_box', '__return_false', 10 );
-		add_filter('FHEE__EE_Admin_Page_Core__load_global_scripts_styles__loader_containers', array( $this, 'forums_lazy_loading'), 10 );
-		add_action('AHEE__EE_Admin_Page__espresso_news_post_box__after_content', array( $this, 'extra_news_box_content' ), 10 );
-	}
+    public function __construct()
+    {
+        $this->_do_hooks();
+    }
 
 
+    private function _do_hooks()
+    {
+        add_filter('FHEE_show_sponsors_meta_box', '__return_false', 10);
+        add_filter('FHEE_show_ratings_request_meta_box', '__return_false', 10);
+        add_filter(
+            'FHEE__EE_Admin_Page_Core__load_global_scripts_styles__loader_containers',
+            array($this, 'forums_lazy_loading'),
+            10
+        );
+        add_action(
+            'AHEE__EE_Admin_Page__espresso_news_post_box__after_content',
+            array($this, 'extra_news_box_content'),
+            10
+        );
+    }
 
 
-	public function extra_news_box_content( $content ) {
-		echo '<h3 style="margin:0">' . __('From the Forums', 'event_espresso') . '</h3>';
-		echo '<div id="ee_forum_posts_content">';
-		$url = 'http://eventespresso.com/forum/event-espresso-support/feed/';
-		EE_Admin_Page::cached_rss_display( 'ee_forum_posts_content', $url);
-		echo '</div>';
-	}
+    public function extra_news_box_content($content)
+    {
+        echo '<h3 style="margin:0">' . __('From the Forums', 'event_espresso') . '</h3>';
+        echo '<div id="ee_forum_posts_content">';
+        $url = 'http://eventespresso.com/forum/event-espresso-support/feed/';
+        EE_Admin_Page::cached_rss_display('ee_forum_posts_content', $url);
+        echo '</div>';
+    }
 
 
-	public function forums_lazy_loading( $ids ) {
-		$ids[] = 'ee_forum_posts_content';
-		return $ids;
-	}
-
-} //end class Global_EE_Caf_Hooks
+    public function forums_lazy_loading($ids)
+    {
+        $ids[] = 'ee_forum_posts_content';
+        return $ids;
+    }
+}

--- a/caffeinated/admin/new/pricing/Price_Types_List_Table.class.php
+++ b/caffeinated/admin/new/pricing/Price_Types_List_Table.class.php
@@ -1,169 +1,203 @@
-<?php if ( ! defined('EVENT_ESPRESSO_VERSION')) exit('No direct script access allowed');
+<?php
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Price_Types_List_Table
  *
  * Class for preparing the table listing all the event categories
  *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
- * @package			Event_Categories_Admin_List_Table
- * @subpackage		includes/core/admin/pricing_manager/Prices_List_Table.core.php
- * @author				Brent Christensen
+ * @package               Event_Categories_Admin_List_Table
+ * @subpackage            includes/core/admin/pricing_manager/Prices_List_Table.core.php
+ * @author                Brent Christensen
  *
  * ------------------------------------------------------------------------
  */
-class Price_Types_List_Table extends EE_Admin_List_Table {
+class Price_Types_List_Table extends EE_Admin_List_Table
+{
 
-	public function __construct( $admin_page ) {
-		parent::__construct($admin_page);
-		require_once(EE_MODELS . 'EEM_Price_Type.model.php');
-		$this->_PRT = EEM_Price_Type::instance();
-	}
-
-
-
-
-	protected function _setup_data() {
-		$trashed = $this->_admin_page->get_view() == 'trashed' ? TRUE : FALSE;
-		$this->_data = $this->_admin_page->get_price_types_overview_data( $this->_per_page, FALSE, $trashed );
-		$this->_all_data_count = $this->_admin_page->get_price_types_overview_data( $this->_per_page, TRUE, FALSE );
-		$this->_trashed_count = $this->_admin_page->get_price_types_overview_data( $this->_per_page, TRUE, TRUE );
-	}
+    public function __construct($admin_page)
+    {
+        parent::__construct($admin_page);
+        require_once(EE_MODELS . 'EEM_Price_Type.model.php');
+        $this->_PRT = EEM_Price_Type::instance();
+    }
 
 
-
-	protected function _set_properties() {
-		$this->_wp_list_args = array(
-				'singular' => __('price type', 'event_espresso'),
-				'plural' => __('price types', 'event_espresso'),
-				'ajax' => TRUE,
-				'screen' => $this->_admin_page->get_current_screen()->id
-			);
-
-		$this->_columns = array(
-				'cb' => '<input type="checkbox" />', //Render a checkbox instead of text
-				'name' => __('Name', 'event_espresso'),
-				'base_type' => '<div class="jst-cntr">' . __('Base Type', 'event_espresso') . '</div>',
-				'percent' => '<div class="jst-cntr">' . __('Applied', 'event_espresso') . '<br/>' . __('as ', 'event_espresso') . '<span class="big-text">' . __('%', 'event_espresso') . '</span>' . __(' or ', 'event_espresso') . '<span class="big-text">' . __('$', 'event_espresso') . '</span></div>',
-				'order' => '<div class="jst-cntr">' . __('Order of', 'event_espresso') . '<br/>' . __('Application', 'event_espresso') . '</div>'
-			);
-
-		$this->_sortable_columns = array(
-			// TRUE means its already sorted
-			'name' => array( 'name' => FALSE )
-		);
-
-		$this->_hidden_columns = array();
-
-	}
+    protected function _setup_data()
+    {
+        $trashed = $this->_admin_page->get_view() == 'trashed' ? true : false;
+        $this->_data = $this->_admin_page->get_price_types_overview_data($this->_per_page, false, $trashed);
+        $this->_all_data_count = $this->_admin_page->get_price_types_overview_data($this->_per_page, true, false);
+        $this->_trashed_count = $this->_admin_page->get_price_types_overview_data($this->_per_page, true, true);
+    }
 
 
+    protected function _set_properties()
+    {
+        $this->_wp_list_args = array(
+            'singular' => __('price type', 'event_espresso'),
+            'plural'   => __('price types', 'event_espresso'),
+            'ajax'     => true,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
+
+        $this->_columns = array(
+            'cb'        => '<input type="checkbox" />', // Render a checkbox instead of text
+            'name'      => __('Name', 'event_espresso'),
+            'base_type' => '<div class="jst-cntr">' . __('Base Type', 'event_espresso') . '</div>',
+            'percent'   => '<div class="jst-cntr">' . __('Applied', 'event_espresso') . '<br/>'
+                           . __('as ', 'event_espresso') . '<span class="big-text">'
+                           . __('%', 'event_espresso') . '</span>'
+                           . __(' or ', 'event_espresso') . '<span class="big-text">'
+                           . __('$', 'event_espresso') . '</span></div>',
+            'order'     => '<div class="jst-cntr">' . __('Order of', 'event_espresso') . '<br/>'
+                           . __('Application', 'event_espresso') . '</div>',
+        );
+
+        $this->_sortable_columns = array(
+            // TRUE means its already sorted
+            'name' => array('name' => false),
+        );
+
+        $this->_hidden_columns = array();
+    }
 
 
-
-	protected function _get_table_filters() {}
-
-
-
-
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_all_data_count;
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_default_price_types', 'pricing_trash_price_type' ) ) {
-			$this->_views['trashed']['count'] = $this->_trashed_count;
-		}
-	}
+    protected function _get_table_filters()
+    {
+    }
 
 
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_all_data_count;
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_delete_default_price_types',
+            'pricing_trash_price_type'
+        )) {
+            $this->_views['trashed']['count'] = $this->_trashed_count;
+        }
+    }
 
 
-
-	function column_cb($item) {
-		if ( $item->base_type() !== 1 )
-			return sprintf( '<input type="checkbox" name="checkbox[%1$s]" />', /* $1%s */ $item->ID() );
-		return '';
-	}
-
-
-
-
-
-	function column_name($item) {
-
-		//Build row actions
-		$actions = array();
-		// edit price link
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_edit_default_price_type', 'pricing_edit_price_type', $item->ID() ) ) {
-			$edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'edit_price_type', 'id'=>$item->ID() ), PRICING_ADMIN_URL );
-			$actions['edit'] = '<a href="'.$edit_lnk_url.'" title="' . esc_attr__( 'Edit Price Type', 'event_espresso' ) . '">' . __( 'Edit', 'event_espresso' ) . '</a>';
-		}
-
-		$name_link = EE_Registry::instance()->CAP->current_user_can( 'ee_edit_default_price_type', 'pricing_edit_price_type', $item->ID() ) ? '<a href="'.$edit_lnk_url.'" title="' . esc_attr__( 'Edit Price Type', 'event_espresso' ) . '">' . stripslashes( $item->name() ) . '</a>' : $item->name();
-
-		if ( $item->base_type() !== 1 ) {
-			if ( $this->_view == 'all' ) {
-				// trash price link
-				if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_default_price_type', 'pricing_trash_price_type', $item->ID() ) ) {
-					$trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'trash_price_type', 'id'=>$item->ID(), 'noheader' => TRUE ), PRICING_ADMIN_URL );
-					$actions['trash'] = '<a href="'.$trash_lnk_url.'" title="' . esc_attr__( 'Move Price Type to Trash', 'event_espresso' ) . '">' . __( 'Move to Trash', 'event_espresso' ) . '</a>';
-				}
-			} else {
-				// restore price link
-				if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_default_price_type', 'pricing_restore_price_type', $item->ID() ) ) {
-					$restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'restore_price_type', 'id'=>$item->ID(), 'noheader' => TRUE ), PRICING_ADMIN_URL );
-					$actions['restore'] = '<a href="'.$restore_lnk_url.'" title="' . esc_attr__( 'Restore Price Type', 'event_espresso' ) . '">' . __( 'Restore', 'event_espresso' ) . '</a>';
-				}
-				// delete price link
-				if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_default_price_type', 'pricing_delete_price_type', $item->ID() ) ) {
-					$delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'delete_price_type', 'id'=>$item->ID(), 'noheader' => TRUE ), PRICING_ADMIN_URL );
-					$actions['delete'] = '<a href="'.$delete_lnk_url.'" title="' . esc_attr__( 'Delete Price Type Permanently', 'event_espresso' ) . '">' . __( 'Delete Permanently', 'event_espresso' ) . '</a>';
-				}
-			}
-		}
-
-		//Return the name contents
-		return sprintf('%1$s <span style="color:silver">(id:%2$s)</span>%3$s',
-										/* $1%s */ $name_link,
-										/* $2%s */ $item->ID(),
-										/* $3%s */ $this->row_actions($actions)
-		);
-	}
+    public function column_cb($item)
+    {
+        if ($item->base_type() !== 1) {
+            return sprintf(
+                '<input type="checkbox" name="checkbox[%1$s]" />',
+                $item->ID()
+            );
+        }
+        return '';
+    }
 
 
+    public function column_name($item)
+    {
+
+        // Build row actions
+        $actions = array();
+        // edit price link
+        if (EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_default_price_type',
+            'pricing_edit_price_type',
+            $item->ID()
+        )) {
+            $edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                'action' => 'edit_price_type',
+                'id'     => $item->ID(),
+            ), PRICING_ADMIN_URL);
+            $actions['edit'] = '<a href="' . $edit_lnk_url . '" title="'
+                               . esc_attr__('Edit Price Type', 'event_espresso') . '">'
+                               . __('Edit', 'event_espresso') . '</a>';
+        }
+
+        $name_link = EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_default_price_type',
+            'pricing_edit_price_type',
+            $item->ID()
+        )
+            ? '<a href="' . $edit_lnk_url . '" title="'
+              . esc_attr__('Edit Price Type', 'event_espresso') . '">'
+              . stripslashes($item->name()) . '</a>'
+            : $item->name();
+
+        if ($item->base_type() !== 1) {
+            if ($this->_view == 'all') {
+                // trash price link
+                if (EE_Registry::instance()->CAP->current_user_can(
+                    'ee_delete_default_price_type',
+                    'pricing_trash_price_type',
+                    $item->ID()
+                )) {
+                    $trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                        'action'   => 'trash_price_type',
+                        'id'       => $item->ID(),
+                        'noheader' => true,
+                    ), PRICING_ADMIN_URL);
+                    $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                                        . esc_attr__('Move Price Type to Trash', 'event_espresso') . '">'
+                                        . __('Move to Trash', 'event_espresso') . '</a>';
+                }
+            } else {
+                // restore price link
+                if (EE_Registry::instance()->CAP->current_user_can(
+                    'ee_delete_default_price_type',
+                    'pricing_restore_price_type',
+                    $item->ID()
+                )) {
+                    $restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                        'action'   => 'restore_price_type',
+                        'id'       => $item->ID(),
+                        'noheader' => true,
+                    ), PRICING_ADMIN_URL);
+                    $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                                          . esc_attr__('Restore Price Type', 'event_espresso') . '">'
+                                          . __('Restore', 'event_espresso') . '</a>';
+                }
+                // delete price link
+                if (EE_Registry::instance()->CAP->current_user_can(
+                    'ee_delete_default_price_type',
+                    'pricing_delete_price_type',
+                    $item->ID()
+                )) {
+                    $delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                        'action'   => 'delete_price_type',
+                        'id'       => $item->ID(),
+                        'noheader' => true,
+                    ), PRICING_ADMIN_URL);
+                    $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                                         . esc_attr__('Delete Price Type Permanently', 'event_espresso') . '">'
+                                         . __('Delete Permanently', 'event_espresso') . '</a>';
+                }
+            }
+        }
+
+        // Return the name contents
+        return sprintf(
+            '%1$s <span style="color:silver">(id:%2$s)</span>%3$s',
+            $name_link,
+            $item->ID(),
+            $this->row_actions($actions)
+        );
+    }
 
 
-
-	function column_base_type($item) {
-		return '<div class="jst-cntr">' . $item->base_type_name()  . '</div>';
-	}
-
-
+    public function column_base_type($item)
+    {
+        return '<div class="jst-cntr">' . $item->base_type_name() . '</div>';
+    }
 
 
-	function column_percent($item) {
-		return '<div class="jst-cntr">' . ( $item->is_percent() ? '%' : EE_Registry::instance()->CFG->currency->sign ) . '</div>';
-	}
+    public function column_percent($item)
+    {
+        return '<div class="jst-cntr">' . ($item->is_percent() ? '%' : EE_Registry::instance()->CFG->currency->sign) . '</div>';
+    }
 
 
-
-
-
-	function column_order($item) {
-		return '<div class="jst-cntr">' . $item->order() . '</div>';
-	}
-
-
+    public function column_order($item)
+    {
+        return '<div class="jst-cntr">' . $item->order() . '</div>';
+    }
 }

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -3,10 +3,6 @@
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
-defined('EVENT_ESPRESSO_VERSION') || exit('NO direct script access allowed');
-
-
-
 /**
  * espresso_events_Pricing_Hooks
  * Hooks various messages logic so that it runs on indicated Events Admin Pages.
@@ -51,7 +47,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     protected function _set_hooks_properties()
     {
         $this->_name = 'pricing';
-        //capability check
+        // capability check
         if (! EE_Registry::instance()->CAP->current_user_can(
             'ee_read_default_prices',
             'advanced_ticket_datetime_metabox'
@@ -79,8 +75,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _setup_metaboxes()
     {
-        //if we were going to add our own metaboxes we'd use the below.
-        $this->_metaboxes        = array(
+        // if we were going to add our own metaboxes we'd use the below.
+        $this->_metaboxes = array(
             0 => array(
                 'page_route' => array('edit', 'create_new'),
                 'func'       => 'pricing_metabox',
@@ -119,16 +115,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'time' => 'h:i a',
             )
         );
-        //validate
+        // validate
         $this->_date_format_strings['date'] = isset($this->_date_format_strings['date'])
             ? $this->_date_format_strings['date']
             : null;
         $this->_date_format_strings['time'] = isset($this->_date_format_strings['time'])
             ? $this->_date_format_strings['time']
             : null;
-        $this->_date_time_format            = $this->_date_format_strings['date']
-                                              . ' '
-                                              . $this->_date_format_strings['time'];
+        $this->_date_time_format = $this->_date_format_strings['date']
+                                   . ' '
+                                   . $this->_date_format_strings['time'];
     }
 
 
@@ -137,7 +133,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _validate_format_strings()
     {
-        //validate format strings
+        // validate format strings
         $format_validation = EEH_DTT_Helper::validate_format_string(
             $this->_date_time_format
         );
@@ -281,9 +277,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     public function datetime_and_tickets_caf_update($event, $data)
     {
-        //first we need to start with datetimes cause they are the "root" items attached to events.
+        // first we need to start with datetimes cause they are the "root" items attached to events.
         $saved_datetimes = $this->_update_datetimes($event, $data);
-        //next tackle the tickets (and prices?)
+        // next tackle the tickets (and prices?)
         $this->_update_tickets($event, $saved_datetimes, $data);
     }
 
@@ -303,8 +299,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _update_datetimes($event, $data)
     {
-        $timezone       = isset($data['timezone_string']) ? $data['timezone_string'] : null;
-        $saved_dtt_ids  = array();
+        $timezone = isset($data['timezone_string']) ? $data['timezone_string'] : null;
+        $saved_dtt_ids = array();
         $saved_dtt_objs = array();
         if (empty($data['edit_event_datetimes']) || ! is_array($data['edit_event_datetimes'])) {
             throw new InvalidArgumentException(
@@ -315,10 +311,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             );
         }
         foreach ($data['edit_event_datetimes'] as $row => $datetime_data) {
-            //trim all values to ensure any excess whitespace is removed.
-            $datetime_data                = array_map(
-                function ($datetime_data)
-                {
+            // trim all values to ensure any excess whitespace is removed.
+            $datetime_data = array_map(
+                function ($datetime_data) {
                     return is_array($datetime_data) ? $datetime_data : trim($datetime_data);
                 },
                 $datetime_data
@@ -327,7 +322,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                                             && ! empty($datetime_data['DTT_EVT_end'])
                 ? $datetime_data['DTT_EVT_end']
                 : $datetime_data['DTT_EVT_start'];
-            $datetime_values              = array(
+            $datetime_values = array(
                 'DTT_ID'          => ! empty($datetime_data['DTT_ID'])
                     ? $datetime_data['DTT_ID']
                     : null,
@@ -352,7 +347,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $datetime = EE_Registry::instance()
                                        ->load_model('Datetime', array($timezone))
                                        ->get_one_by_ID($datetime_data['DTT_ID']);
-                //set date and time format according to what is set in this class.
+                // set date and time format according to what is set in this class.
                 $datetime->set_date_format($this->_date_format_strings['date']);
                 $datetime->set_time_format($this->_date_format_strings['time']);
                 foreach ($datetime_values as $field => $value) {
@@ -387,13 +382,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $datetime = EEH_DTT_Helper::date_time_add($datetime, 'DTT_EVT_end', 'days');
                 $datetime->save();
             }
-            //	now we have to make sure we add the new DTT_ID to the $saved_dtt_ids array
+            // now we have to make sure we add the new DTT_ID to the $saved_dtt_ids array
             // because it is possible there was a new one created for the autosave.
             // (save the ID for both key and value to avoid duplications)
-            $DTT_ID                   = $datetime->ID();
+            $DTT_ID = $datetime->ID();
             $saved_dtt_ids[ $DTT_ID ] = $DTT_ID;
-            $saved_dtt_objs[ $row ]   = $datetime;
-            //todo if ANY of these updates fail then we want the appropriate global error message.
+            $saved_dtt_objs[ $row ] = $datetime;
+            // @todo if ANY of these updates fail then we want the appropriate global error message.
         }
         $event->save();
         // now we need to REMOVE any datetimes that got deleted.
@@ -409,7 +404,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     continue;
                 }
                 $dtt_to_remove = EE_Registry::instance()->load_model('Datetime')->get_one_by_ID($id);
-                //remove tkt relationships.
+                // remove tkt relationships.
                 $related_tickets = $dtt_to_remove->get_many_related('Ticket');
                 foreach ($related_tickets as $tkt) {
                     $dtt_to_remove->_remove_relation_to($tkt, 'Ticket');
@@ -438,13 +433,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _update_tickets($event, $saved_datetimes, $data)
     {
-        $new_tkt     = null;
+        $new_tkt = null;
         $new_default = null;
-        //stripslashes because WP filtered the $_POST ($data) array to add slashes
-        $data          = stripslashes_deep($data);
-        $timezone      = isset($data['timezone_string']) ? $data['timezone_string'] : null;
+        // stripslashes because WP filtered the $_POST ($data) array to add slashes
+        $data = stripslashes_deep($data);
+        $timezone = isset($data['timezone_string']) ? $data['timezone_string'] : null;
         $saved_tickets = $datetimes_on_existing = array();
-        $old_tickets   = isset($data['ticket_IDs']) ? explode(',', $data['ticket_IDs']) : array();
+        $old_tickets = isset($data['ticket_IDs']) ? explode(',', $data['ticket_IDs']) : array();
         if (empty($data['edit_tickets']) || ! is_array($data['edit_tickets'])) {
             throw new InvalidArgumentException(
                 esc_html__(
@@ -458,13 +453,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // figure out what datetimes were added to the ticket
             // and what datetimes were removed from the ticket in the session.
             $starting_tkt_dtt_rows = explode(',', $data['starting_ticket_datetime_rows'][ $row ]);
-            $tkt_dtt_rows          = explode(',', $data['ticket_datetime_rows'][ $row ]);
-            $datetimes_added       = array_diff($tkt_dtt_rows, $starting_tkt_dtt_rows);
-            $datetimes_removed     = array_diff($starting_tkt_dtt_rows, $tkt_dtt_rows);
+            $tkt_dtt_rows = explode(',', $data['ticket_datetime_rows'][ $row ]);
+            $datetimes_added = array_diff($tkt_dtt_rows, $starting_tkt_dtt_rows);
+            $datetimes_removed = array_diff($starting_tkt_dtt_rows, $tkt_dtt_rows);
             // trim inputs to ensure any excess whitespace is removed.
             $tkt = array_map(
-                function ($ticket_data)
-                {
+                function ($ticket_data) {
                     return is_array($ticket_data) ? $ticket_data : trim($ticket_data);
                 },
                 $tkt
@@ -475,31 +469,31 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $ticket_price = isset($tkt['TKT_price'])
                 ? round((float) $tkt['TKT_price'], 3)
                 : 0;
-            //note incoming base price needs converted from localized value.
+            // note incoming base price needs converted from localized value.
             $base_price = isset($tkt['TKT_base_price'])
                 ? EEH_Money::convert_to_float_from_localized_money($tkt['TKT_base_price'])
                 : 0;
-            //if ticket price == 0 and $base_price != 0 then ticket price == base_price
-            $ticket_price  = $ticket_price === 0 && $base_price !== 0
+            // if ticket price == 0 and $base_price != 0 then ticket price == base_price
+            $ticket_price = $ticket_price === 0 && $base_price !== 0
                 ? $base_price
                 : $ticket_price;
             $base_price_id = isset($tkt['TKT_base_price_ID'])
                 ? $tkt['TKT_base_price_ID']
                 : 0;
-            $price_rows    = is_array($data['edit_prices']) && isset($data['edit_prices'][ $row ])
+            $price_rows = is_array($data['edit_prices']) && isset($data['edit_prices'][ $row ])
                 ? $data['edit_prices'][ $row ]
                 : array();
-            $now           = null;
+            $now = null;
             if (empty($tkt['TKT_start_date'])) {
-                //lets' use now in the set timezone.
-                $now                   = new DateTime('now', new DateTimeZone($event->get_timezone()));
+                // lets' use now in the set timezone.
+                $now = new DateTime('now', new DateTimeZone($event->get_timezone()));
                 $tkt['TKT_start_date'] = $now->format($this->_date_time_format);
             }
             if (empty($tkt['TKT_end_date'])) {
                 /**
                  * set the TKT_end_date to the first datetime attached to the ticket.
                  */
-                $first_dtt           = $saved_datetimes[ reset($tkt_dtt_rows) ];
+                $first_dtt = $saved_datetimes[ reset($tkt_dtt_rows) ];
                 $tkt['TKT_end_date'] = $first_dtt->start_date_and_time($this->_date_time_format);
             }
             $TKT_values = array(
@@ -508,9 +502,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'TKT_name'        => ! empty($tkt['TKT_name']) ? $tkt['TKT_name'] : '',
                 'TKT_description' => ! empty($tkt['TKT_description'])
                                      && $tkt['TKT_description'] !== esc_html__(
-                    'You can modify this description',
-                    'event_espresso'
-                )
+                                         'You can modify this description',
+                                         'event_espresso'
+                                     )
                     ? $tkt['TKT_description']
                     : '',
                 'TKT_start_date'  => $tkt['TKT_start_date'],
@@ -532,9 +526,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // if this is a default TKT, then we need to set the TKT_ID to 0 and update accordingly,
             // which means in turn that the prices will become new prices as well.
             if (isset($tkt['TKT_is_default']) && $tkt['TKT_is_default']) {
-                $TKT_values['TKT_ID']         = 0;
+                $TKT_values['TKT_ID'] = 0;
                 $TKT_values['TKT_is_default'] = 0;
-                $update_prices                = true;
+                $update_prices = true;
             }
             // if we have a TKT_ID then we need to get that existing TKT_obj and update it
             // we actually do our saves ahead of doing any add_relations to
@@ -562,7 +556,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                             ),
                         )
                     );
-                    //set ticket formats
+                    // set ticket formats
                     $ticket->set_date_format($this->_date_format_strings['date']);
                     $ticket->set_time_format($this->_date_format_strings['time']);
                     // let's just check the total price for the existing ticket
@@ -570,7 +564,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     // if they are different then we create a new ticket (if tickets sold)
                     // if they aren't different then we go ahead and modify existing ticket.
                     $create_new_TKT = $tickets_sold > 0 && $ticket_price !== $ticket->price() && ! $ticket->deleted();
-                    //set new values
+                    // set new values
                     foreach ($TKT_values as $field => $value) {
                         if ($field === 'TKT_qty') {
                             $ticket->set_qty($value);
@@ -600,7 +594,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 if ($ticket instanceof EE_Ticket) {
                     // make sure ticket has an ID of setting relations won't work
                     $ticket->save();
-                    $ticket        = $this->_update_ticket_datetimes(
+                    $ticket = $this->_update_ticket_datetimes(
                         $ticket,
                         $saved_datetimes,
                         $datetimes_added,
@@ -609,15 +603,15 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     $update_prices = true;
                 }
             }
-            //make sure any current values have been saved.
-            //$ticket->save();
+            // make sure any current values have been saved.
+            // $ticket->save();
             // before going any further make sure our dates are setup correctly
             // so that the end date is always equal or greater than the start date.
             if ($ticket->get_raw('TKT_start_date') > $ticket->get_raw('TKT_end_date')) {
                 $ticket->set('TKT_end_date', $ticket->get('TKT_start_date'));
                 $ticket = EEH_DTT_Helper::date_time_add($ticket, 'TKT_end_date', 'days');
             }
-            //let's make sure the base price is handled
+            // let's make sure the base price is handled
             $ticket = ! $create_new_TKT
                 ? $this->_add_prices_to_ticket(
                     array(),
@@ -627,16 +621,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     $base_price_id
                 )
                 : $ticket;
-            //add/update price_modifiers
+            // add/update price_modifiers
             $ticket = ! $create_new_TKT
                 ? $this->_add_prices_to_ticket($price_rows, $ticket, $update_prices)
                 : $ticket;
-            //need to make sue that the TKT_price is accurate after saving the prices.
+            // need to make sue that the TKT_price is accurate after saving the prices.
             $ticket->ensure_TKT_Price_correct();
-            //handle CREATING a default tkt from the incoming tkt but ONLY if this isn't an autosave.
+            // handle CREATING a default tkt from the incoming tkt but ONLY if this isn't an autosave.
             if (! defined('DOING_AUTOSAVE') && ! empty($tkt['TKT_is_default_selector'])) {
                 $update_prices = true;
-                $new_default   = clone $ticket;
+                $new_default = clone $ticket;
                 $new_default->set('TKT_ID', 0);
                 $new_default->set('TKT_is_default', 1);
                 $new_default->set('TKT_row', 1);
@@ -644,13 +638,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 // remove any dtt relations cause we DON'T want dtt relations attached
                 // (note this is just removing the cached relations in the object)
                 $new_default->_remove_relations('Datetime');
-                //todo we need to add the current attached prices as new prices to the new default ticket.
+                // @todo we need to add the current attached prices as new prices to the new default ticket.
                 $new_default = $this->_add_prices_to_ticket(
                     $price_rows,
                     $new_default,
                     $update_prices
                 );
-                //don't forget the base price!
+                // don't forget the base price!
                 $new_default = $this->_add_prices_to_ticket(
                     array(),
                     $new_default,
@@ -672,13 +666,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // TODO... not sure exactly how we're going to do this considering we don't know
             // what current ticket the archived tickets are related to
             // (and TKT_parent is used for autosaves so that's not a field we can reliably use).
-            //let's assign any tickets that have been setup to the saved_tickets tracker
-            //save existing TKT
+            // let's assign any tickets that have been setup to the saved_tickets tracker
+            // save existing TKT
             $ticket->save();
             if ($create_new_TKT && $new_tkt instanceof EE_Ticket) {
-                //save new TKT
+                // save new TKT
                 $new_tkt->save();
-                //add new ticket to array
+                // add new ticket to array
                 $saved_tickets[ $new_tkt->ID() ] = $new_tkt;
                 do_action(
                     'AHEE__espresso_events_Pricing_Hooks___update_tkts_new_ticket',
@@ -688,7 +682,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     $data
                 );
             } else {
-                //add tkt to saved tkts
+                // add tkt to saved tkts
                 $saved_tickets[ $ticket->ID() ] = $ticket;
                 do_action(
                     'AHEE__espresso_events_Pricing_Hooks___update_tkts_update_ticket',
@@ -704,13 +698,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // (i.e. autosaves are happening and then in between autosaves the user trashes a ticket).
         // Or a draft event was saved and in the process of editing a ticket is trashed.
         // No sense in keeping all the related data in the db!
-        $old_tickets     = isset($old_tickets[0]) && $old_tickets[0] === '' ? array() : $old_tickets;
+        $old_tickets = isset($old_tickets[0]) && $old_tickets[0] === '' ? array() : $old_tickets;
         $tickets_removed = array_diff($old_tickets, array_keys($saved_tickets));
         foreach ($tickets_removed as $id) {
             $id = absint($id);
-            //get the ticket for this id
+            // get the ticket for this id
             $tkt_to_remove = EE_Registry::instance()->load_model('Ticket')->get_one_by_ID($id);
-            //if this tkt is a default tkt we leave it alone cause it won't be attached to the datetime
+            // if this tkt is a default tkt we leave it alone cause it won't be attached to the datetime
             if ($tkt_to_remove->get('TKT_is_default')) {
                 continue;
             }
@@ -826,7 +820,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $new_ticket->save();
         // we also need to make sure this new ticket gets the same datetime attachments as the archived ticket
         $datetimes_on_existing = $ticket->datetimes();
-        $new_ticket            = $this->_update_ticket_datetimes(
+        $new_ticket = $this->_update_ticket_datetimes(
             $new_ticket,
             $datetimes_on_existing,
             array_keys($datetimes_on_existing)
@@ -838,9 +832,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $new_qty = $ticket->qty() - $ticket->sold();
             $new_ticket->set_qty($new_qty);
         }
-        //now we update the prices just for this ticket
+        // now we update the prices just for this ticket
         $new_ticket = $this->_add_prices_to_ticket($price_rows, $new_ticket, true);
-        //and we update the base price
+        // and we update the base price
         $new_ticket = $this->_add_prices_to_ticket(
             array(),
             $new_ticket,
@@ -883,7 +877,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $current_prices_on_ticket = $base_price !== false
             ? $ticket->base_price(true)
             : $ticket->price_modifiers();
-        $updated_prices           = array();
+        $updated_prices = array();
         // if $base_price ! FALSE then updating a base price.
         if ($base_price !== false) {
             $prices[1] = array(
@@ -894,7 +888,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'PRC_desc'   => $ticket->get('TKT_description'),
             );
         }
-        //possibly need to save tkt
+        // possibly need to save tkt
         if (! $ticket->ID()) {
             $ticket->save();
         }
@@ -910,12 +904,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'PRC_name'       => ! empty($prc['PRC_name']) ? $prc['PRC_name'] : '',
                 'PRC_desc'       => ! empty($prc['PRC_desc']) ? $prc['PRC_desc'] : '',
                 'PRC_is_default' => false,
-                //make sure we set PRC_is_default to false for all ticket saves from event_editor
+                // make sure we set PRC_is_default to false for all ticket saves from event_editor
                 'PRC_order'      => $row,
             );
             if ($new_prices || empty($PRC_values['PRC_ID'])) {
                 $PRC_values['PRC_ID'] = 0;
-                $price                = EE_Registry::instance()->load_class(
+                $price = EE_Registry::instance()->load_class(
                     'Price',
                     array($PRC_values),
                     false,
@@ -923,7 +917,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 );
             } else {
                 $price = EE_Registry::instance()->load_model('Price')->get_one_by_ID($prc['PRC_ID']);
-                //update this price with new values
+                // update this price with new values
                 foreach ($PRC_values as $field => $value) {
                     $price->set($field, $value);
                 }
@@ -932,16 +926,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $updated_prices[ $price->ID() ] = $price;
             $ticket->_add_relation_to($price, 'Price');
         }
-        //now let's remove any prices that got removed from the ticket
-        if (! empty ($current_prices_on_ticket)) {
-            $current          = array_keys($current_prices_on_ticket);
-            $updated          = array_keys($updated_prices);
+        // now let's remove any prices that got removed from the ticket
+        if (! empty($current_prices_on_ticket)) {
+            $current = array_keys($current_prices_on_ticket);
+            $updated = array_keys($updated_prices);
             $prices_to_remove = array_diff($current, $updated);
             if (! empty($prices_to_remove)) {
                 foreach ($prices_to_remove as $prc_id) {
                     $p = $current_prices_on_ticket[ $prc_id ];
                     $ticket->_remove_relation_to($p, 'Price');
-                    //delete permanently the price
+                    // delete permanently the price
                     $p->delete_permanently();
                 }
             }
@@ -957,7 +951,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     public function autosave_handling(Events_Admin_Page $event_admin_obj)
     {
         return $event_admin_obj;
-        //doing nothing for the moment.
+        // doing nothing for the moment.
         // todo when I get to this remember that I need to set the template args on the $event_admin_obj
         // (use the set_template_args() method)
         /**
@@ -993,11 +987,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     public function pricing_metabox()
     {
         $existing_datetime_ids = $existing_ticket_ids = $datetime_tickets = $ticket_datetimes = array();
-        $event                 = $this->_adminpage_obj->get_cpt_model_obj();
-        //set is_creating_event property.
-        $EVT_ID                   = $event->ID();
+        $event = $this->_adminpage_obj->get_cpt_model_obj();
+        // set is_creating_event property.
+        $EVT_ID = $event->ID();
         $this->_is_creating_event = empty($this->_req_data['post']);
-        //default main template args
+        // default main template args
         $main_template_args = array(
             'event_datetime_help_link' => EEH_Template::get_help_tab_link(
                 'event_editor_event_datetimes_help_tab',
@@ -1017,18 +1011,18 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 false,
                 false
             ),
-            //todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
+            // todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
             'datetime_rows'            => '',
             'show_tickets_container'   => '',
-            //$this->_adminpage_obj->get_cpt_model_obj()->ID() > 1 ? ' style="display:none;"' : '',
+            // $this->_adminpage_obj->get_cpt_model_obj()->ID() > 1 ? ' style="display:none;"' : '',
             'ticket_rows'              => '',
             'existing_ticket_ids'      => '',
             'total_ticket_rows'        => 1,
             'ticket_js_structure'      => '',
             'ee_collapsible_status'    => ' ee-collapsible-open'
-            //$this->_adminpage_obj->get_cpt_model_obj()->ID() > 0 ? ' ee-collapsible-closed' : ' ee-collapsible-open'
+            // $this->_adminpage_obj->get_cpt_model_obj()->ID() > 0 ? ' ee-collapsible-closed' : ' ee-collapsible-open'
         );
-        $timezone           = $event instanceof EE_Event ? $event->timezone_string() : null;
+        $timezone = $event instanceof EE_Event ? $event->timezone_string() : null;
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         /**
          * 1. Start with retrieving Datetimes
@@ -1036,8 +1030,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
          * 3. For each ticket get related prices
          */
         /** @var EEM_Datetime $datetime_model */
-        $datetime_model                       = EE_Registry::instance()->load_model('Datetime', array($timezone));
-        $datetimes                            = $datetime_model->get_all_event_dates($EVT_ID);
+        $datetime_model = EE_Registry::instance()->load_model('Datetime', array($timezone));
+        $datetimes = $datetime_model->get_all_event_dates($EVT_ID);
         $main_template_args['total_dtt_rows'] = count($datetimes);
         /**
          * @see https://events.codebasehq.com/projects/event-espresso/tickets/9486
@@ -1048,7 +1042,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $DTT_ID = $datetime->get('DTT_ID');
             $datetime->set('DTT_order', $datetime_row);
             $existing_datetime_ids[] = $DTT_ID;
-            //tickets attached
+            // tickets attached
             $related_tickets = $datetime->ID() > 0
                 ? $datetime->get_many_related(
                     'Ticket',
@@ -1061,17 +1055,17 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     )
                 )
                 : array();
-            //if there are no related tickets this is likely a new event OR autodraft
+            // if there are no related tickets this is likely a new event OR autodraft
             // event so we need to generate the default tickets because datetimes
             // ALWAYS have at least one related ticket!!.  EXCEPT, we dont' do this if there is already more than one
             // datetime on the event.
-            if (empty ($related_tickets) && count($datetimes) < 2) {
+            if (empty($related_tickets) && count($datetimes) < 2) {
                 /** @var EEM_Ticket $ticket_model */
-                $ticket_model    = EE_Registry::instance()->load_model('Ticket');
+                $ticket_model = EE_Registry::instance()->load_model('Ticket');
                 $related_tickets = $ticket_model->get_all_default_tickets();
                 // this should be ordered by TKT_ID, so let's grab the first default ticket
                 // (which will be the main default) and ensure it has any default prices added to it (but do NOT save).
-                $default_prices      = EEM_Price::instance()->get_all_default_prices();
+                $default_prices = EEM_Price::instance()->get_all_default_prices();
                 $main_default_ticket = reset($related_tickets);
                 if ($main_default_ticket instanceof EE_Ticket) {
                     foreach ($default_prices as $default_price) {
@@ -1085,20 +1079,19 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // we can't actually setup rows in this loop yet cause we don't know all
             // the unique tickets for this event yet (tickets are linked through all datetimes).
             // So we're going to temporarily cache some of that information.
-            //loop through and setup the ticket rows and make sure the order is set.
+            // loop through and setup the ticket rows and make sure the order is set.
             foreach ($related_tickets as $ticket) {
-                $TKT_ID     = $ticket->get('TKT_ID');
+                $TKT_ID = $ticket->get('TKT_ID');
                 $ticket_row = $ticket->get('TKT_row');
-                //we only want unique tickets in our final display!!
+                // we only want unique tickets in our final display!!
                 if (! in_array($TKT_ID, $existing_ticket_ids, true)) {
                     $existing_ticket_ids[] = $TKT_ID;
-                    $all_tickets[]         = $ticket;
+                    $all_tickets[] = $ticket;
                 }
-                //temporary cache of this ticket info for this datetime for later processing of datetime rows.
+                // temporary cache of this ticket info for this datetime for later processing of datetime rows.
                 $datetime_tickets[ $DTT_ID ][] = $ticket_row;
-                //temporary cache of this datetime info for this ticket for later processing of ticket rows.
-                if (
-                    ! isset($ticket_datetimes[ $TKT_ID ])
+                // temporary cache of this datetime info for this ticket for later processing of ticket rows.
+                if (! isset($ticket_datetimes[ $TKT_ID ])
                     || ! in_array($datetime_row, $ticket_datetimes[ $TKT_ID ], true)
                 ) {
                     $ticket_datetimes[ $TKT_ID ][] = $datetime_row;
@@ -1106,14 +1099,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             }
             $datetime_row++;
         }
-        $main_template_args['total_ticket_rows']     = count($existing_ticket_ids);
-        $main_template_args['existing_ticket_ids']   = implode(',', $existing_ticket_ids);
+        $main_template_args['total_ticket_rows'] = count($existing_ticket_ids);
+        $main_template_args['existing_ticket_ids'] = implode(',', $existing_ticket_ids);
         $main_template_args['existing_datetime_ids'] = implode(',', $existing_datetime_ids);
-        //sort $all_tickets by order
+        // sort $all_tickets by order
         usort(
             $all_tickets,
-            function (EE_Ticket $a, EE_Ticket $b)
-            {
+            function (EE_Ticket $a, EE_Ticket $b) {
                 $a_order = (int) $a->get('TKT_order');
                 $b_order = (int) $b->get('TKT_order');
                 if ($a_order === $b_order) {
@@ -1136,7 +1128,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             );
             $datetime_row++;
         }
-        //then loop through all tickets for the ticket rows.
+        // then loop through all tickets for the ticket rows.
         $ticket_row = 1;
         foreach ($all_tickets as $ticket) {
             $main_template_args['ticket_rows'] .= $this->_get_ticket_row(
@@ -1216,8 +1208,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     protected function _get_dtt_edit_row($datetime_row, $datetime, $default, $all_datetimes)
     {
         // if the incoming $datetime object is NOT an instance of EE_Datetime then force default to true.
-        $default                     = ! $datetime instanceof EE_Datetime ? true : $default;
-        $template_args               = array(
+        $default = ! $datetime instanceof EE_Datetime ? true : $default;
+        $template_args = array(
             'dtt_row'              => $default ? 'DTTNUM' : $datetime_row,
             'event_datetimes_name' => $default ? 'DTTNAMEATTR' : 'edit_event_datetimes',
             'edit_dtt_expanded'    => '',
@@ -1251,7 +1243,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $template_args['show_trash'] = count($all_datetimes) === 1 && $template_args['trash_icon'] !== 'ee-lock-icon'
             ? ' style="display:none"'
             : '';
-        //allow filtering of template args at this point.
+        // allow filtering of template args at this point.
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_dtt_edit_row__template_args',
             $template_args,
@@ -1299,10 +1291,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 false,
                 false
             ),
-            //todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
+            // todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
             'DTT_ID'                            => $default ? '' : $datetime->ID(),
         );
-        //need to setup the list items (but only if this isn't a default skeleton setup)
+        // need to setup the list items (but only if this isn't a default skeleton setup)
         if (! $default) {
             $ticket_row = 1;
             foreach ($all_tickets as $ticket) {
@@ -1317,7 +1309,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $ticket_row++;
             }
         }
-        //filter template args at this point
+        // filter template args at this point
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_dtt_attached_ticket_row__template_args',
             $template_args,
@@ -1355,11 +1347,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $datetime_tickets = array(),
         $default
     ) {
-        $dtt_tkts      = $datetime instanceof EE_Datetime && isset($datetime_tickets[ $datetime->ID() ])
+        $dtt_tkts = $datetime instanceof EE_Datetime && isset($datetime_tickets[ $datetime->ID() ])
             ? $datetime_tickets[ $datetime->ID() ]
             : array();
-        $display_row   = $ticket instanceof EE_Ticket ? $ticket->get('TKT_row') : 0;
-        $no_ticket     = $default && empty($ticket);
+        $display_row = $ticket instanceof EE_Ticket ? $ticket->get('TKT_row') : 0;
+        $no_ticket = $default && empty($ticket);
         $template_args = array(
             'dtt_row'                 => $default
                 ? 'DTTNUM'
@@ -1380,7 +1372,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? ' tkt-status-' . EE_Ticket::onsale
                 : ' tkt-status-' . $ticket->ticket_status(),
         );
-        //filter template args
+        // filter template args
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_datetime_tickets_list_item__template_args',
             $template_args,
@@ -1431,8 +1423,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     ) {
         // if $ticket is not an instance of EE_Ticket then force default to true.
         $default = ! $ticket instanceof EE_Ticket ? true : $default;
-        $prices  = ! empty($ticket) && ! $default ? $ticket->get_many_related('Price',
-            array('default_where_conditions' => 'none', 'order_by' => array('PRC_order' => 'ASC'))) : array();
+        $prices = ! empty($ticket) && ! $default
+            ? $ticket->get_many_related(
+                'Price',
+                array('default_where_conditions' => 'none', 'order_by' => array('PRC_order' => 'ASC'))
+            )
+            : array();
         // if there is only one price (which would be the base price)
         // or NO prices and this ticket is a default ticket,
         // let's just make sure there are no cached default prices on the object.
@@ -1444,14 +1440,14 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // we don't want any starting_ticket_datetime_row values set
         // (otherwise there won't be any new relationships created for tickets based off of the default ticket).
         // This will future proof in case there is ever any behaviour change between what the primary_key defaults to.
-        $default_dtt      = $default || ($ticket instanceof EE_Ticket && $ticket->is_default());
-        $tkt_datetimes    = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
+        $default_dtt = $default || ($ticket instanceof EE_Ticket && $ticket->is_default());
+        $tkt_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
             ? $ticket_datetimes[ $ticket->ID() ]
             : array();
-        $ticket_subtotal  = $default ? 0 : $ticket->get_ticket_subtotal();
-        $base_price       = $default ? null : $ticket->base_price();
+        $ticket_subtotal = $default ? 0 : $ticket->get_ticket_subtotal();
+        $base_price = $default ? null : $ticket->base_price();
         $count_price_mods = EEM_Price::instance()->get_all_default_prices(true);
-        //breaking out complicated condition for ticket_status
+        // breaking out complicated condition for ticket_status
         if ($default) {
             $ticket_status_class = ' tkt-status-' . EE_Ticket::onsale;
         } else {
@@ -1459,7 +1455,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? ' tkt-status-' . EE_Ticket::onsale
                 : ' tkt-status-' . $ticket->ticket_status();
         }
-        //breaking out complicated condition for TKT_taxable
+        // breaking out complicated condition for TKT_taxable
         if ($default) {
             $TKT_taxable = '';
         } else {
@@ -1482,10 +1478,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $TKT_min = '';
             }
         }
-        $template_args                 = array(
+        $template_args = array(
             'tkt_row'                       => $default ? 'TICKETNUM' : $ticket_row,
             'TKT_order'                     => $default ? 'TICKETNUM' : $ticket_row,
-            //on initial page load this will always be the correct order.
+            // on initial page load this will always be the correct order.
             'tkt_status_class'              => $ticket_status_class,
             'display_edit_tkt_row'          => ' style="display:none;"',
             'edit_tkt_expanded'             => '',
@@ -1586,15 +1582,17 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $template_args['trash_hidden'] = count($all_tickets) === 1 && $template_args['trash_icon'] !== 'ee-lock-icon'
             ? ' style="display:none"'
             : '';
-        //handle rows that should NOT be empty
+        // handle rows that should NOT be empty
         if (empty($template_args['TKT_start_date'])) {
-            //if empty then the start date will be now.
-            $template_args['TKT_start_date']   = date($this->_date_time_format,
-                current_time('timestamp'));
+            // if empty then the start date will be now.
+            $template_args['TKT_start_date'] = date(
+                $this->_date_time_format,
+                current_time('timestamp')
+            );
             $template_args['tkt_status_class'] = ' tkt-status-' . EE_Ticket::onsale;
         }
         if (empty($template_args['TKT_end_date'])) {
-            //get the earliest datetime (if present);
+            // get the earliest datetime (if present);
             $earliest_dtt = $this->_adminpage_obj->get_cpt_model_obj()->ID() > 0
                 ? $this->_adminpage_obj->get_cpt_model_obj()->get_first_related(
                     'Datetime',
@@ -1607,17 +1605,22 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     $this->_date_time_format
                 );
             } else {
-                //default so let's just use what's been set for the default date-time which is 30 days from now.
+                // default so let's just use what's been set for the default date-time which is 30 days from now.
                 $template_args['TKT_end_date'] = date(
                     $this->_date_time_format,
                     mktime(
-                        24, 0, 0, date('m'), date('d') + 29, date('Y')
+                        24,
+                        0,
+                        0,
+                        date('m'),
+                        date('d') + 29,
+                        date('Y')
                     )
                 );
             }
             $template_args['tkt_status_class'] = ' tkt-status-' . EE_Ticket::onsale;
         }
-        //generate ticket_datetime items
+        // generate ticket_datetime items
         if (! $default) {
             $datetime_row = 1;
             foreach ($all_datetimes as $datetime) {
@@ -1641,8 +1644,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $price_row++;
                 continue;
             }
-            $show_trash                         = ! ((count($prices) > 1 && $price_row === 1) || count($prices) === 1);
-            $show_create                        = ! (count($prices) > 1 && count($prices) !== $price_row);
+            $show_trash = ! ((count($prices) > 1 && $price_row === 1) || count($prices) === 1);
+            $show_create = ! (count($prices) > 1 && count($prices) !== $price_row);
             $template_args['ticket_price_rows'] .= $this->_get_ticket_price_row(
                 $ticket_row,
                 $price_row,
@@ -1654,7 +1657,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             );
             $price_row++;
         }
-        //filter $template_args
+        // filter $template_args
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_ticket_row__template_args',
             $template_args,
@@ -1687,7 +1690,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         /** @var EE_Price[] $taxes */
         $taxes = empty($ticket) ? EE_Taxes::get_taxes_for_admin() : $ticket->get_ticket_taxes_for_admin();
         foreach ($taxes as $tax) {
-            $tax_added     = $this->_get_tax_added($tax, $ticket);
+            $tax_added = $this->_get_tax_added($tax, $ticket);
             $template_args = array(
                 'display_tax'       => ! empty($ticket) && $ticket->get('TKT_taxable')
                     ? ''
@@ -1706,7 +1709,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $ticket,
                 $this->_is_creating_event
             );
-            $tax_rows      .= EEH_Template::display_template(
+            $tax_rows .= EEH_Template::display_template(
                 PRICING_TEMPLATE_PATH . 'event_tickets_datetime_ticket_tax_row.template.php',
                 $template_args,
                 true
@@ -1798,8 +1801,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 : '',
             'PRC_amount'            => $default && empty($price)
                 ? 0
-                : $price->get_pretty('PRC_amount',
-                    'localized_float'),
+                : $price->get_pretty('PRC_amount', 'localized_float'),
             'show_percentage'       => ($default && empty($price)) || ! $price->is_percent()
                 ? ' style="display:none;"'
                 : '',
@@ -1929,8 +1931,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             ? 'edit_prices[TICKETNUM][PRICENUM][PRT_ID]'
             : 'edit_prices[' . $ticket_row . '][' . $price_row . '][PRT_ID]';
         /** @var EEM_Price_Type $price_type_model */
-        $price_type_model       = EE_Registry::instance()->load_model('Price_Type');
-        $price_types            = $price_type_model->get_all(array(
+        $price_type_model = EE_Registry::instance()->load_model('Price_Type');
+        $price_types = $price_type_model->get_all(array(
             array(
                 'OR' => array(
                     'PBT_ID'  => '2',
@@ -1938,19 +1940,19 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ),
             ),
         ));
-        $all_price_types        = $default && ! $price instanceof EE_Price
+        $all_price_types = $default && ! $price instanceof EE_Price
             ? array(esc_html__('Select Modifier', 'event_espresso'))
             : array();
         $selected_price_type_id = $default && ! $price instanceof EE_Price ? 0 : $price->type();
-        $price_option_spans     = '';
-        //setup price types for selector
+        $price_option_spans = '';
+        // setup price types for selector
         foreach ($price_types as $price_type) {
             if (! $price_type instanceof EE_Price_Type) {
                 continue;
             }
             $all_price_types[ $price_type->ID() ] = $price_type->get('PRT_name');
-            //while we're in the loop let's setup the option spans used by js
-            $span_args          = array(
+            // while we're in the loop let's setup the option spans used by js
+            $span_args = array(
                 'PRT_ID'         => $price_type->ID(),
                 'PRT_operator'   => $price_type->is_discount() ? '-' : '+',
                 'PRT_is_percent' => $price_type->get('PRT_is_percent') ? 1 : 0,
@@ -1961,9 +1963,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 true
             );
         }
-        $select_name               = $disabled ? 'archive_price[' . $ticket_row . '][' . $price_row . '][PRT_ID]'
+        $select_name = $disabled ? 'archive_price[' . $ticket_row . '][' . $price_row . '][PRT_ID]'
             : $select_name;
-        $select_input              = new EE_Select_Input(
+        $select_input = new EE_Select_Input(
             $all_price_types,
             array(
                 'default'               => $selected_price_type_id,
@@ -1972,11 +1974,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'html_other_attributes' => $disabled ? 'style="width:auto;" disabled' : 'style="width:auto;"',
             )
         );
-        $price_selected_operator   = $price instanceof EE_Price && $price->is_discount() ? '-' : '+';
-        $price_selected_operator   = $default && ! $price instanceof EE_Price ? '' : $price_selected_operator;
+        $price_selected_operator = $price instanceof EE_Price && $price->is_discount() ? '-' : '+';
+        $price_selected_operator = $default && ! $price instanceof EE_Price ? '' : $price_selected_operator;
         $price_selected_is_percent = $price instanceof EE_Price && $price->is_percent() ? 1 : 0;
         $price_selected_is_percent = $default && ! $price instanceof EE_Price ? '' : $price_selected_is_percent;
-        $template_args             = array(
+        $template_args = array(
             'tkt_row'                   => $default ? 'TICKETNUM' : $ticket_row,
             'PRC_order'                 => $default && ! $price instanceof EE_Price ? 'PRICENUM' : $price_row,
             'price_modifier_selector'   => $select_input->get_html_for_input(),
@@ -1987,7 +1989,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'price_selected_is_percent' => $price_selected_is_percent,
             'disabled'                  => $disabled,
         );
-        $template_args             = apply_filters(
+        $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_price_modifier_template__template_args',
             $template_args,
             $ticket_row,
@@ -2134,7 +2136,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 true
             ),
         );
-        $ticket_row    = 1;
+        $ticket_row = 1;
         foreach ($all_tickets as $ticket) {
             $template_args['existing_available_datetime_tickets_list'] .= $this->_get_datetime_tickets_list_item(
                 'DTTNUM',
@@ -2159,28 +2161,28 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $datetime_row++;
         }
         /** @var EEM_Price $price_model */
-        $price_model    = EE_Registry::instance()->load_model('Price');
+        $price_model = EE_Registry::instance()->load_model('Price');
         $default_prices = $price_model->get_all_default_prices();
-        $price_row      = 1;
+        $price_row = 1;
         foreach ($default_prices as $price) {
             if (! $price instanceof EE_Price) {
                 continue;
             }
             if ($price->is_base_price()) {
-                $template_args['default_base_price_amount']      = $price->get_pretty(
+                $template_args['default_base_price_amount'] = $price->get_pretty(
                     'PRC_amount',
                     'localized_float'
                 );
-                $template_args['default_base_price_name']        = $price->get('PRC_name');
+                $template_args['default_base_price_name'] = $price->get('PRC_name');
                 $template_args['default_base_price_description'] = $price->get('PRC_desc');
                 $price_row++;
                 continue;
             }
-            $show_trash                          = ! ((count($default_prices) > 1 && $price_row === 1)
-                                                      || count($default_prices) === 1);
-            $show_create                         = ! (count($default_prices) > 1
-                                                      && count($default_prices)
-                                                         !== $price_row);
+            $show_trash = ! ((count($default_prices) > 1 && $price_row === 1)
+                             || count($default_prices) === 1);
+            $show_create = ! (count($default_prices) > 1
+                              && count($default_prices)
+                                 !== $price_row);
             $template_args['default_price_rows'] .= $this->_get_ticket_price_row(
                 'TICKETNUM',
                 $price_row,
@@ -2205,4 +2207,4 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             true
         );
     }
-} //end class espresso_events_Pricing_Hooks
+}

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Default_Price_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Default_Price_Help_Tour.class.php
@@ -1,102 +1,110 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Add_New_Default_Price_Help_Tour
  *
  * This is the help tour object for the Default Prices page
  *
  *
- * @package		Pricing_Add_New_Default_Price_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Default_Price_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Add_New_Default_Price_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Default_Price_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Add_New_Default_Price_Help_Tour extends EE_Help_Tour {
+class Pricing_Add_New_Default_Price_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Add New Default Price Tour', 'event_espresso');
-		$this->_slug = 'add-new-default-price-joyride';
-	}
-    
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			20 => array(
-				'id' => 'PRT_ID',
-				'content' => $this->_price_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),
-			30 => array(
-				'id' => 'PRC_name',
-				'content' => $this->_price_name_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			40 => array(
-				'id' => 'PRC_desc',
-				'content' => $this->_price_description_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			50 => array(
-				'id' => 'PRC_amount',
-				'content' => $this->_price_amount_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				)
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Add New Default Price Tour', 'event_espresso');
+        $this->_slug = 'add-new-default-price-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Add New Default Price', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the add new default price page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            20 => array(
+                'id'      => 'PRT_ID',
+                'content' => $this->_price_type_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            30 => array(
+                'id'      => 'PRC_name',
+                'content' => $this->_price_name_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            40 => array(
+                'id'      => 'PRC_desc',
+                'content' => $this->_price_description_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            50 => array(
+                'id'      => 'PRC_amount',
+                'content' => $this->_price_amount_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+        );
+    }
 
-	protected function _price_type_stop() {
-		return '<p>' . __('Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs.', 'event_espresso') . '</p>';
-	}
 
-	protected function _price_name_stop() {
-		return '<p>' . __('The name of the price, discount, tax, or surcharge that will be seen by your customers.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Add New Default Price', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the add new default price page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _price_description_stop() {
-		return '<p>' . __('View the price type (price, discount, tax or surcharge) description.', 'event_espresso') . '</p>';
-	}
+    protected function _price_type_stop()
+    {
+        return '<p>'
+               . __(
+                   'Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _price_amount_stop() {
-		return '<p>' . __('The ticket amount before any deductions.', 'event_espresso') . '</p>';
-	}
+    protected function _price_name_stop()
+    {
+        return '<p>'
+               . __(
+                   'The name of the price, discount, tax, or surcharge that will be seen by your customers.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
+    protected function _price_description_stop()
+    {
+        return '<p>'
+               . __(
+                   'View the price type (price, discount, tax or surcharge) description.',
+                   'event_espresso'
+               ) . '</p>';
+    }
+
+    protected function _price_amount_stop()
+    {
+        return '<p>' . __('The ticket amount before any deductions.', 'event_espresso') . '</p>';
+    }
 }

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Price_Type_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Price_Type_Help_Tour.class.php
@@ -1,102 +1,98 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Add_New_Price_Type_Help_Tour
  *
  * This is the help tour object for the Default Prices page
  *
  *
- * @package		Pricing_Add_New_Price_Type_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Price_Type_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Add_New_Price_Type_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Pricing_Add_New_Price_Type_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Add_New_Price_Type_Help_Tour extends EE_Help_Tour {
+class Pricing_Add_New_Price_Type_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Add New Price Type Tour', 'event_espresso');
-		$this->_slug = 'add-new-price-type-joyride';
-	}
-    
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			20 => array(
-				'id' => 'base_type',
-				'content' => $this->_basic_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),
-			30 => array(
-				'id' => 'PRT_name',
-				'content' => $this->_price_type_name_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			40 => array(
-				'id' => 'PRT_name',
-				'content' => $this->_percentage_dollar_amount_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => 45
-					)
-				),
-			50 => array(
-				'id' => 'PRT_order',
-				'content' => $this->_order_of_application_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				)
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Add New Price Type Tour', 'event_espresso');
+        $this->_slug = 'add-new-price-type-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Add New Price Type', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Add New Price Type page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
-	
-	protected function _basic_type_stop() {
-		return '<p>' . __('Set a price type to be a discount, surcharge, or tax.', 'event_espresso') . '</p>';
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            20 => array(
+                'id'      => 'base_type',
+                'content' => $this->_basic_type_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            30 => array(
+                'id'      => 'PRT_name',
+                'content' => $this->_price_type_name_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            40 => array(
+                'id'      => 'PRT_name',
+                'content' => $this->_percentage_dollar_amount_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => 45,
+                ),
+            ),
+            50 => array(
+                'id'      => 'PRT_order',
+                'content' => $this->_order_of_application_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+        );
+    }
 
-	protected function _price_type_name_stop() {
-		return '<p>' . __('The name of the price type.', 'event_espresso') . '</p>';
-	}
 
-	protected function _percentage_dollar_amount_stop() {
-		return '<p>' . __('Set a price type to be percentage-based or a fixed amount.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Add New Price Type', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Add New Price Type page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _order_of_application_stop() {
-		return '<p>' . __('Set the order of application for a price type.', 'event_espresso') . '</p>';
-	}
+    protected function _basic_type_stop()
+    {
+        return '<p>' . __('Set a price type to be a discount, surcharge, or tax.', 'event_espresso') . '</p>';
+    }
 
+    protected function _price_type_name_stop()
+    {
+        return '<p>' . __('The name of the price type.', 'event_espresso') . '</p>';
+    }
+
+    protected function _percentage_dollar_amount_stop()
+    {
+        return '<p>' . __('Set a price type to be percentage-based or a fixed amount.', 'event_espresso') . '</p>';
+    }
+
+    protected function _order_of_application_stop()
+    {
+        return '<p>' . __('Set the order of application for a price type.', 'event_espresso') . '</p>';
+    }
 }

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Default_Prices_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Default_Prices_Help_Tour.class.php
@@ -1,131 +1,149 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Default_Prices_Help_Tour
  *
  * This is the help tour object for the Default Prices page
  *
  *
- * @package		Pricing_Default_Prices_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Pricing_Default_Prices_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Default_Prices_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Pricing_Default_Prices_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Default_Prices_Help_Tour extends EE_Help_Tour {
+class Pricing_Default_Prices_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Default Pricing Tour', 'event_espresso');
-		$this->_slug = 'default-prices-joyride';
-	}
-
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			20 => array(
-				'id' => 'name',
-				'content' => $this->_name_column_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => -5,
-					'tipAdjustmentY' => -30
-					)
-				),
-			30 => array(
-				'id' => 'type',
-				'content' => $this->_type_column_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => 5,
-					'tipAdjustmentY' => -30
-					)
-				),
-			40 => array(
-				'id' => 'description',
-				'content' => $this->_description_column_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => 5,
-					'tipAdjustmentY' => -30
-					)
-				),
-			50 => array(
-				'id' => 'amount',
-				'content' => $this->_amount_column_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => 20,
-					)
-				),
-			60 => array(
-				'class' => 'bulkactions',
-				'content' => $this->_bulk_actions_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -75,
-					)
-				),
-			70 => array(
-				'id' => 'event-espresso_page_pricing-search-input',
-				'content' => $this->_search_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Default Pricing Tour', 'event_espresso');
+        $this->_slug = 'default-prices-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Default Pricing', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Default Pricing page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            20 => array(
+                'id'      => 'name',
+                'content' => $this->_name_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => -5,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            30 => array(
+                'id'      => 'type',
+                'content' => $this->_type_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => 5,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            40 => array(
+                'id'      => 'description',
+                'content' => $this->_description_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => 5,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            50 => array(
+                'id'      => 'amount',
+                'content' => $this->_amount_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => 20,
+                ),
+            ),
+            60 => array(
+                'class'   => 'bulkactions',
+                'content' => $this->_bulk_actions_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -75,
+                ),
+            ),
+            70 => array(
+                'id'      => 'event-espresso_page_pricing-search-input',
+                'content' => $this->_search_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+        );
+    }
 
-	protected function _name_column_stop() {
-		return '<p>' . __('The name of the price, discount, tax, or surcharge that will be seen by your customers. Can be sorted in ascending or descending order.', 'event_espresso') . '</p>';
-	}
 
-	protected function _type_column_stop() {
-		return '<p>' . __('Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs. Can be sorted in ascending or descending order.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Default Pricing', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Default Pricing page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _description_column_stop() {
-		return '<p>' . __('View the price type (price, discount, tax or surcharge) description.', 'event_espresso') . '</p>';
-	}
+    protected function _name_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'The name of the price, discount, tax, or surcharge that will be seen by your customers. Can be sorted in ascending or descending order.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _amount_column_stop() {
-		return '<p>' . __('The ticket amount before any deductions. Can be sorted in ascending or descending order.', 'event_espresso') . '</p>';
-	}
+    protected function _type_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs. Can be sorted in ascending or descending order.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _bulk_actions_stop() {
-		return '<p>' . __('Perform bulk actions to multiple price types.', 'event_espresso') . '</p>';
-	}
+    protected function _description_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'View the price type (price, discount, tax or surcharge) description.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _search_stop() {
-		return '<p>' . __('Search through default pricing. The following sources will be searched: Price Name, Price Type, Price Description, and Price Amount.', 'event_espresso') . '</p>';
-	}
+    protected function _amount_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'The ticket amount before any deductions. Can be sorted in ascending or descending order.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
+    protected function _bulk_actions_stop()
+    {
+        return '<p>' . __('Perform bulk actions to multiple price types.', 'event_espresso') . '</p>';
+    }
+
+    protected function _search_stop()
+    {
+        return '<p>'
+               . __(
+                   'Search through default pricing. The following sources will be searched: Price Name, Price Type, Price Description, and Price Amount.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 }

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Default_Price_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Default_Price_Help_Tour.class.php
@@ -1,102 +1,110 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Edit_Default_Price_Help_Tour
  *
  * This is the help tour object for the Default Prices page
  *
  *
- * @package		Pricing_Edit_Default_Price_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Default_Price_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Edit_Default_Price_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Default_Price_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Edit_Default_Price_Help_Tour extends EE_Help_Tour {
+class Pricing_Edit_Default_Price_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Edit Default Price Tour', 'event_espresso');
-		$this->_slug = 'edit-default-price-joyride';
-	}
-    
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			/*20 => array(
-				'id' => 'PRT_ID',
-				'content' => $this->_price_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),*/
-			30 => array(
-				'id' => 'PRC_name',
-				'content' => $this->_price_name_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			40 => array(
-				'id' => 'PRC_desc',
-				'content' => $this->_price_description_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			50 => array(
-				'id' => 'PRC_amount',
-				'content' => $this->_price_amount_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				)
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Edit Default Price Tour', 'event_espresso');
+        $this->_slug = 'edit-default-price-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Edit Default Price', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Edit Default Price page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            /*20 => array(
+                'id' => 'PRT_ID',
+                'content' => $this->_price_type_stop(),
+                'options' => array(
+                    'tipLocation' => 'top',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15
+                    )
+                ),*/
+            30 => array(
+                'id'      => 'PRC_name',
+                'content' => $this->_price_name_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            40 => array(
+                'id'      => 'PRC_desc',
+                'content' => $this->_price_description_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            50 => array(
+                'id'      => 'PRC_amount',
+                'content' => $this->_price_amount_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+        );
+    }
 
-	protected function _price_type_stop() {
-		return '<p>' . __('Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs.', 'event_espresso') . '</p>';
-	}
 
-	protected function _price_name_stop() {
-		return '<p>' . __('The name of the price, discount, tax, or surcharge that will be seen by your customers.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Edit Default Price', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Edit Default Price page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _price_description_stop() {
-		return '<p>' . __('View the price type (price, discount, tax or surcharge) description.', 'event_espresso') . '</p>';
-	}
+    protected function _price_type_stop()
+    {
+        return '<p>'
+               . __(
+                   'Price Types are a way of categorizing a price, discount, tax, or surcharge and indicating how it gets applied to a running total when a transaction occurs.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _price_amount_stop() {
-		return '<p>' . __('The ticket amount before any deductions.', 'event_espresso') . '</p>';
-	}
+    protected function _price_name_stop()
+    {
+        return '<p>'
+               . __(
+                   'The name of the price, discount, tax, or surcharge that will be seen by your customers.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
+    protected function _price_description_stop()
+    {
+        return '<p>'
+               . __(
+                   'View the price type (price, discount, tax or surcharge) description.',
+                   'event_espresso'
+               ) . '</p>';
+    }
+
+    protected function _price_amount_stop()
+    {
+        return '<p>' . __('The ticket amount before any deductions.', 'event_espresso') . '</p>';
+    }
 }

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Price_Type_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Price_Type_Help_Tour.class.php
@@ -1,102 +1,98 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Edit_Price_Type_Help_Tour
  *
  * This is the help tour object for the Default Prices page
  *
  *
- * @package		Pricing_Edit_Price_Type_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Price_Type_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Edit_Price_Type_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Pricing_Edit_Price_Type_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Edit_Price_Type_Help_Tour extends EE_Help_Tour {
+class Pricing_Edit_Price_Type_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Edit Price Type Tour', 'event_espresso');
-		$this->_slug = 'edit-price-type-joyride';
-	}
-    
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			20 => array(
-				'id' => 'base_type',
-				'content' => $this->_basic_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				),
-			30 => array(
-				'id' => 'PRT_name',
-				'content' => $this->_price_type_name_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				),
-			40 => array(
-				'id' => 'PRT_name',
-				'content' => $this->_percentage_dollar_amount_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => 45
-					)
-				),
-			50 => array(
-				'id' => 'PRT_order',
-				'content' => $this->_order_of_application_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentY' => -40
-					)
-				)
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Edit Price Type Tour', 'event_espresso');
+        $this->_slug = 'edit-price-type-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Edit Price Type', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Edit Price Type page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            20 => array(
+                'id'      => 'base_type',
+                'content' => $this->_basic_type_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+            30 => array(
+                'id'      => 'PRT_name',
+                'content' => $this->_price_type_name_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+            40 => array(
+                'id'      => 'PRT_name',
+                'content' => $this->_percentage_dollar_amount_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => 45,
+                ),
+            ),
+            50 => array(
+                'id'      => 'PRT_order',
+                'content' => $this->_order_of_application_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentY' => -40,
+                ),
+            ),
+        );
+    }
 
-	protected function _basic_type_stop() {
-		return '<p>' . __('Set a price type to be a discount, surcharge, or tax.', 'event_espresso') . '</p>';
-	}
 
-	protected function _price_type_name_stop() {
-		return '<p>' . __('The name of the price type.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Edit Price Type', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Edit Price Type page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _percentage_dollar_amount_stop() {
-		return '<p>' . __('Set a price type to be percentage-based or a fixed amount.', 'event_espresso') . '</p>';
-	}
+    protected function _basic_type_stop()
+    {
+        return '<p>' . __('Set a price type to be a discount, surcharge, or tax.', 'event_espresso') . '</p>';
+    }
 
-	protected function _order_of_application_stop() {
-		return '<p>' . __('Set the order of application for a price type.', 'event_espresso') . '</p>';
-	}
+    protected function _price_type_name_stop()
+    {
+        return '<p>' . __('The name of the price type.', 'event_espresso') . '</p>';
+    }
 
+    protected function _percentage_dollar_amount_stop()
+    {
+        return '<p>' . __('Set a price type to be percentage-based or a fixed amount.', 'event_espresso') . '</p>';
+    }
+
+    protected function _order_of_application_stop()
+    {
+        return '<p>' . __('Set the order of application for a price type.', 'event_espresso') . '</p>';
+    }
 }

--- a/caffeinated/admin/new/pricing/help_tours/Pricing_Price_Types_Default_Help_Tour.class.php
+++ b/caffeinated/admin/new/pricing/help_tours/Pricing_Price_Types_Default_Help_Tour.class.php
@@ -1,135 +1,154 @@
 <?php
-if (!defined('EVENT_ESPRESSO_VERSION') )
-	exit('NO direct script access allowed');
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
- *
  * Pricing_Price_Types_Default_Help_Tour
  *
  * This is the help tour object for the Default Price Types page
  *
  *
- * @package		Pricing_Price_Types_Default_Help_Tour
- * @subpackage	caffeinated/admin/new/pricing/help_tours/Price_Types_Default_Help_Tour.core.php
- * @author		Darren Ethier
+ * @package         Pricing_Price_Types_Default_Help_Tour
+ * @subpackage      caffeinated/admin/new/pricing/help_tours/Price_Types_Default_Help_Tour.core.php
+ * @author          Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Pricing_Price_Types_Default_Help_Tour extends EE_Help_Tour {
+class Pricing_Price_Types_Default_Help_Tour extends EE_Help_Tour
+{
 
-	protected function _set_tour_properties() {
-		$this->_label = __('Price Types Tour', 'event_espresso');
-		$this->_slug = 'default-price-types-joyride';
-	}
-
-
-	protected function _set_tour_stops() {
-		$this->_stops = array(
-			10 => array(
-				'content' => $this->_start(),
-				),
-			20 => array(
-				'id' => 'name',
-				'content' => $this->_name_column_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => -5,
-					'tipAdjustmentY' => -30
-					)
-				),
-			30 => array(
-				'id' => 'base_type',
-				'content' => $this->_base_type_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => 120,
-					'tipAdjustmentY' => -30
-					)
-				),
-			40 => array(
-				'id' => 'percent',
-				'content' => $this->_percent_column_stop(),
-				'options' => array(
-					'tipLocation' => 'top',
-					'tipAdjustmentX' => 120,
-					'tipAdjustmentY' => -30
-					)
-				),
-			50 => array(
-				'id' => 'order',
-				'content' => $this->_order_column_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -30,
-					'tipAdjustmentX' => 100,
-					)
-				),
-			60 => array(
-				'class' => 'bulkactions',
-				'content' => $this->_bulk_actions_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -75
-					)
-				),
-			70 => array(
-				'id' => 'event-espresso_page_pricing-search-input',
-				'content' => $this->_search_stop(),
-				'options' => array(
-					'tipLocation' => 'left',
-					'tipAdjustmentY' => -50,
-					'tipAdjustmentX' => -15
-					)
-				)
-			);
-	}
+    protected function _set_tour_properties()
+    {
+        $this->_label = __('Price Types Tour', 'event_espresso');
+        $this->_slug = 'default-price-types-joyride';
+    }
 
 
-	protected function _start() {
-		$content = '<h3>' . __('Price Types', 'event_espresso') . '</h3>';
-		$content .= '<p>' . __('This tour of the Price Types page will go over different areas of the screen to help you understand what they are used for.', 'event_espresso') . '</p>';
-		return $content;
-	}
+    protected function _set_tour_stops()
+    {
+        $this->_stops = array(
+            10 => array(
+                'content' => $this->_start(),
+            ),
+            20 => array(
+                'id'      => 'name',
+                'content' => $this->_name_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => -5,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            30 => array(
+                'id'      => 'base_type',
+                'content' => $this->_base_type_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => 120,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            40 => array(
+                'id'      => 'percent',
+                'content' => $this->_percent_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'top',
+                    'tipAdjustmentX' => 120,
+                    'tipAdjustmentY' => -30,
+                ),
+            ),
+            50 => array(
+                'id'      => 'order',
+                'content' => $this->_order_column_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -30,
+                    'tipAdjustmentX' => 100,
+                ),
+            ),
+            60 => array(
+                'class'   => 'bulkactions',
+                'content' => $this->_bulk_actions_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -75,
+                ),
+            ),
+            70 => array(
+                'id'      => 'event-espresso_page_pricing-search-input',
+                'content' => $this->_search_stop(),
+                'options' => array(
+                    'tipLocation'    => 'left',
+                    'tipAdjustmentY' => -50,
+                    'tipAdjustmentX' => -15,
+                ),
+            ),
+        );
+    }
 
-	protected function _name_column_stop() {
-		return '<p>' . __('The name of the price type. Can be sorted in ascending or descending order.', 'event_espresso') . '</p>';
-	}
 
-	protected function _base_type_stop() {
-		return '<p>' . __('View if a price type is a discount, surcharge, or tax.', 'event_espresso') . '</p>';
-	}
+    protected function _start()
+    {
+        $content = '<h3>' . __('Price Types', 'event_espresso') . '</h3>';
+        $content .= '<p>'
+                    . __(
+                        'This tour of the Price Types page will go over different areas of the screen to help you understand what they are used for.',
+                        'event_espresso'
+                    ) . '</p>';
+        return $content;
+    }
 
-	protected function _member_column_stop() {
-		return '<p>' . __('Here you can see if the discount/surcharge is percentage based or a flat monetary amount.', 'event_espresso') . '</p>';
-	}
+    protected function _name_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'The name of the price type. Can be sorted in ascending or descending order.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _percent_column_stop() {
-		return '<p>' . __('View if the discount, surcharge, or tax is percentage-based or a fixed amount.', 'event_espresso') . '</p>';
-	}
+    protected function _base_type_stop()
+    {
+        return '<p>' . __('View if a price type is a discount, surcharge, or tax.', 'event_espresso') . '</p>';
+    }
 
-	protected function _order_column_stop() {
-		return '<p>' . __('View the order in which each discount, surcharge, or tax will be applied to the base ticket cost. Zero (0) means it will be applied first.', 'event_espresso') . '</p>';
-	}
+    protected function _member_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'Here you can see if the discount/surcharge is percentage based or a flat monetary amount.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _bulk_actions_stop() {
-		return '<p>' . __('Perform bulk actions to multiple price types.', 'event_espresso') . '</p>';
-	}
+    protected function _percent_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'View if the discount, surcharge, or tax is percentage-based or a fixed amount.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
-	protected function _search_stop() {
-		return '<p>' . __('Search through price types. The following source will be searched: Price Type Name.', 'event_espresso') . '</p>';
-	}
+    protected function _order_column_stop()
+    {
+        return '<p>'
+               . __(
+                   'View the order in which each discount, surcharge, or tax will be applied to the base ticket cost. Zero (0) means it will be applied first.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 
+    protected function _bulk_actions_stop()
+    {
+        return '<p>' . __('Perform bulk actions to multiple price types.', 'event_espresso') . '</p>';
+    }
+
+    protected function _search_stop()
+    {
+        return '<p>'
+               . __(
+                   'Search through price types. The following source will be searched: Price Type Name.',
+                   'event_espresso'
+               ) . '</p>';
+    }
 }

--- a/caffeinated/admin/new/tickets/Tickets_List_Table.class.php
+++ b/caffeinated/admin/new/tickets/Tickets_List_Table.class.php
@@ -1,18 +1,6 @@
-<?php if ( ! defined('EVENT_ESPRESSO_VERSION')) exit('No direct script access allowed');
+<?php
 
 /**
- * Event Espresso
- *
- * Event Registration and Management Plugin for Wordpress
- *
- * @package		Event Espresso
- * @author		Seth Shoultes
- * @copyright	(c)2009-2012 Event Espresso All Rights Reserved.
- * @license		http://eventespresso.com/support/terms-conditions/  ** see Plugin Licensing **
- * @link		http://www.eventespresso.com
- * @version		4.0
- *
- * ------------------------------------------------------------------------
  *
  * Tickets_List_Table
  *
@@ -20,148 +8,163 @@
  *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
- * @package			Tickets List Table
- * @subpackage		caffeinated/admin/new/tickets/Tickets_List_Table.core.php
- * @author			Darren Ethier
+ * @package            Tickets List Table
+ * @subpackage         caffeinated/admin/new/tickets/Tickets_List_Table.core.php
+ * @author             Darren Ethier
  *
  * ------------------------------------------------------------------------
  */
-class Tickets_List_Table extends EE_Admin_List_Table {
+class Tickets_List_Table extends EE_Admin_List_Table
+{
 
 
-	protected function _setup_data() {
-		$trashed = $this->_admin_page->get_view() == 'trashed' ? TRUE : FALSE;
-		$this->_data = $this->_admin_page->get_default_tickets( $this->_per_page, FALSE, $trashed );
-		$this->_all_data_count = $this->_admin_page->get_default_tickets( $this->_per_page, TRUE, FALSE );
-		$this->_trashed_count = $this->_admin_page->get_default_tickets( $this->_per_page, TRUE, TRUE );
-	}
+    protected function _setup_data()
+    {
+        $trashed = $this->_admin_page->get_view() == 'trashed' ? true : false;
+        $this->_data = $this->_admin_page->get_default_tickets($this->_per_page, false, $trashed);
+        $this->_all_data_count = $this->_admin_page->get_default_tickets($this->_per_page, true, false);
+        $this->_trashed_count = $this->_admin_page->get_default_tickets($this->_per_page, true, true);
+    }
 
 
+    protected function _set_properties()
+    {
+        $this->_wp_list_args = array(
+            'singular' => __('ticket', 'event_espresso'),
+            'plural'   => __('tickets', 'event_espresso'),
+            'ajax'     => true,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        );
 
-
-	protected function _set_properties() {
-		$this->_wp_list_args = array(
-				'singular' => __('ticket', 'event_espresso'),
-				'plural' => __('tickets', 'event_espresso'),
-				'ajax' => TRUE,
-				'screen' => $this->_admin_page->get_current_screen()->id
-			);
-
-		$this->_columns = array(
-				'cb' => '<input type="checkbox" />', //Render a checkbox instead of text
-				'TKT_name' => __('Name', 'event_espresso'),
-				'TKT_description' => __('Description', 'event_espresso'),
-				'TKT_qty' => __('Quantity', 'event_espresso'),
-				'TKT_uses' => __('Uses', 'event_espresso'),
-				'TKT_min' => __('Minimum', 'event_espresso'),
-				'TKT_max' => __('Maximum', 'event_espresso'),
-				'TKT_price' => __('Price', 'event_espresso'),
-				'TKT_taxable' => __('Taxable', 'event_espresso')
-			);
+        $this->_columns = array(
+            'cb'              => '<input type="checkbox" />', // Render a checkbox instead of text
+            'TKT_name'        => __('Name', 'event_espresso'),
+            'TKT_description' => __('Description', 'event_espresso'),
+            'TKT_qty'         => __('Quantity', 'event_espresso'),
+            'TKT_uses'        => __('Uses', 'event_espresso'),
+            'TKT_min'         => __('Minimum', 'event_espresso'),
+            'TKT_max'         => __('Maximum', 'event_espresso'),
+            'TKT_price'       => __('Price', 'event_espresso'),
+            'TKT_taxable'     => __('Taxable', 'event_espresso'),
+        );
 
         $this->_sortable_columns = array(
-				// TRUE means its already sorted
-				'TKT_name' => array( 'TKT_name', TRUE ),
-				'TKT_description' => array( 'TKT_description', FALSE ),
-				'TKT_qty' => array( 'TKT_qty', FALSE ),
-				'TKT_uses' => array( 'TKT_uses', FALSE ),
-				'TKT_min' => array( 'TKT_min', FALSE ),
-				'TKT_max' => array( 'TKT_max', FALSE ),
-				'TKT_price' => array( 'TKT_price', FALSE )
-	        	);
+            // TRUE means its already sorted
+            'TKT_name'        => array('TKT_name', true),
+            'TKT_description' => array('TKT_description', false),
+            'TKT_qty'         => array('TKT_qty', false),
+            'TKT_uses'        => array('TKT_uses', false),
+            'TKT_min'         => array('TKT_min', false),
+            'TKT_max'         => array('TKT_max', false),
+            'TKT_price'       => array('TKT_price', false),
+        );
 
-        $this->_hidden_columns = array(
-			);
-
-	}
+        $this->_hidden_columns = array();
+    }
 
 
+    protected function _get_table_filters()
+    {
+    }
 
 
-
-	protected function _get_table_filters() {
-	}
-
-
-
-
-	protected function _add_view_counts() {
-		$this->_views['all']['count'] = $this->_all_data_count;
-		if ( EE_Registry::instance()->CAP->current_user_can( 'ee_delete_default_tickets', 'trash_ticket'))
-		$this->_views['trashed']['count'] = $this->_trashed_count;
-	}
+    protected function _add_view_counts()
+    {
+        $this->_views['all']['count'] = $this->_all_data_count;
+        if (EE_Registry::instance()->CAP->current_user_can('ee_delete_default_tickets', 'trash_ticket')) {
+            $this->_views['trashed']['count'] = $this->_trashed_count;
+        }
+    }
 
 
-
-	function column_cb($item) {
-		return $item->ID() === 1 ? '<span class="ee-lock-icon"></span>' : sprintf( '<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />', /* $1%s */ $item->ID() );
-
-	}
-
-
-
-	function column_TKT_name($item) {
-		//build row actions
-		$actions = array();
-
-		//trash links
-		if ( $item->ID() !== 1 ) {
-			if ( $this->_view == 'all' ) {
-				$trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action' => 'trash_ticket', 'TKT_ID' => $item->ID() ), TICKETS_ADMIN_URL );
-				$actions['trash'] = '<a href="' . $trash_lnk_url . '" title="' . esc_attr__('Move Ticket to trash', 'event_espresso') . '">' . __('Trash', 'event_espresso') . '</a>';
-			} else {
-				// restore price link
-				$restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'restore_ticket', 'TKT_ID'=>$item->ID() ), TICKETS_ADMIN_URL );
-				$actions['restore'] = '<a href="'.$restore_lnk_url.'" title="' . esc_attr__( 'Restore Ticket', 'event_espresso' ) . '">' . __( 'Restore', 'event_espresso' ) . '</a>';
-				// delete price link
-				$delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce( array( 'action'=>'delete_ticket', 'TKT_ID'=>$item->ID() ), TICKETS_ADMIN_URL );
-				$actions['delete'] = '<a href="'.$delete_lnk_url.'" title="' . esc_attr__( 'Delete Ticket Permanently', 'event_espresso' ) . '">' . __( 'Delete Permanently', 'event_espresso' ) . '</a>';
-			}
-		}
-
-		return $item->get('TKT_name') . $this->row_actions( $actions );
-	}
+    public function column_cb($item)
+    {
+        return $item->ID() === 1
+            ? '<span class="ee-lock-icon"></span>'
+            : sprintf(
+                '<input type="checkbox" name="checkbox[%1$s]" value="%1$s" />',
+                $item->ID()
+            );
+    }
 
 
+    public function column_TKT_name($item)
+    {
+        // build row actions
+        $actions = array();
+
+        // trash links
+        if ($item->ID() !== 1) {
+            if ($this->_view == 'all') {
+                $trash_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'trash_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), TICKETS_ADMIN_URL);
+                $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                                    . esc_attr__('Move Ticket to trash', 'event_espresso') . '">'
+                                    . __('Trash', 'event_espresso') . '</a>';
+            } else {
+                // restore price link
+                $restore_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'restore_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), TICKETS_ADMIN_URL);
+                $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                                      . esc_attr__('Restore Ticket', 'event_espresso') . '">'
+                                      . __('Restore', 'event_espresso') . '</a>';
+                // delete price link
+                $delete_lnk_url = EE_Admin_Page::add_query_args_and_nonce(array(
+                    'action' => 'delete_ticket',
+                    'TKT_ID' => $item->ID(),
+                ), TICKETS_ADMIN_URL);
+                $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                                     . esc_attr__('Delete Ticket Permanently', 'event_espresso') . '">'
+                                     . __('Delete Permanently', 'event_espresso') . '</a>';
+            }
+        }
+
+        return $item->get('TKT_name') . $this->row_actions($actions);
+    }
 
 
-	function column_TKT_description($item) {
-		return $item->get('TKT_description');
-	}
+    public function column_TKT_description($item)
+    {
+        return $item->get('TKT_description');
+    }
 
 
-
-	function column_TKT_qty($item) {
-		return $item->get_pretty('TKT_qty','text');
-	}
-
-
-
-	function column_TKT_uses($item) {
-		return $item->get_pretty('TKT_uses','text');
-	}
+    public function column_TKT_qty($item)
+    {
+        return $item->get_pretty('TKT_qty', 'text');
+    }
 
 
-	function column_TKT_min($item) {
-		return $item->get('TKT_min');
-	}
+    public function column_TKT_uses($item)
+    {
+        return $item->get_pretty('TKT_uses', 'text');
+    }
 
 
-
-	function column_TKT_max($item) {
-		return $item->get_pretty('TKT_max','text');
-	}
-
-
-
-	function column_TKT_price($item) {
-		return EEH_Template::format_currency($item->get('TKT_price'));
-	}
+    public function column_TKT_min($item)
+    {
+        return $item->get('TKT_min');
+    }
 
 
+    public function column_TKT_max($item)
+    {
+        return $item->get_pretty('TKT_max', 'text');
+    }
 
-	function column_TKT_taxable($item) {
-		return $item->get('TKT_taxable') ? __('Yes', 'event_espresso') : __('No', 'event_espresso');
-	}
 
-} //end Tickets_List_Table
+    public function column_TKT_price($item)
+    {
+        return EEH_Template::format_currency($item->get('TKT_price'));
+    }
+
+
+    public function column_TKT_taxable($item)
+    {
+        return $item->get('TKT_taxable') ? __('Yes', 'event_espresso') : __('No', 'event_espresso');
+    }
+}

--- a/caffeinated/brewing_regular.php
+++ b/caffeinated/brewing_regular.php
@@ -5,9 +5,6 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\interfaces\InterminableInterface;
 use EventEspresso\core\services\database\TableAnalysis;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
 /**
  * the purpose of this file is to simply contain any action/filter hook callbacks etc for specific aspects of EE
  * related to caffeinated (regular) use.  Before putting any code in here, First be certain that it isn't better to
@@ -18,7 +15,6 @@ define('EE_CAF_URL', EE_PLUGIN_DIR_URL . 'caffeinated/');
 define('EE_CAF_CORE', EE_CAFF_PATH . 'core' . DS);
 define('EE_CAF_LIBRARIES', EE_CAF_CORE . 'libraries' . DS);
 define('EE_CAF_PAYMENT_METHODS', EE_CAFF_PATH . 'payment_methods' . DS);
-
 
 
 /**
@@ -39,6 +35,7 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
 
     /**
      * EE_Brewing_Regular constructor.
+     *
      * @throws \DomainException
      * @throws \EE_Error
      * @throws InvalidDataTypeException
@@ -63,20 +60,19 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
             // load caff scripts
             add_action('wp_enqueue_scripts', array($this, 'enqueue_caffeinated_scripts'), 10);
             add_filter('FHEE__EE_Registry__load_helper__helper_paths', array($this, 'caf_helper_paths'), 10);
-            //add_filter('FHEE__EE_Registry__load_helper__helper_paths', array($this, 'caf_helper_paths'), 10);
+            // add_filter('FHEE__EE_Registry__load_helper__helper_paths', array($this, 'caf_helper_paths'), 10);
             EE_Register_Payment_Method::register(
                 'caffeinated_payment_methods',
                 array(
-                    'payment_method_paths' => glob(EE_CAF_PAYMENT_METHODS . '*', GLOB_ONLYDIR)
+                    'payment_method_paths' => glob(EE_CAF_PAYMENT_METHODS . '*', GLOB_ONLYDIR),
                 )
             );
             // caffeinated constructed
             do_action('AHEE__EE_Brewing_Regular__construct__complete');
-            //seeing how this is caf, which isn't put on WordPress.org, we can have affiliate links without a disclaimer
+            // seeing how this is caf, which isn't put on WordPress.org, we can have affiliate links without a disclaimer
             add_filter('FHEE__ee_show_affiliate_links', '__return_false');
         }
     }
-
 
 
     /**
@@ -90,7 +86,6 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
         $paths[] = EE_CAF_CORE . 'helpers' . DS;
         return $paths;
     }
-
 
 
     /**
@@ -107,12 +102,12 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
     public function initialize_caf_db_content()
     {
         global $wpdb;
-        //use same method of getting creator id as the version introducing the change
+        // use same method of getting creator id as the version introducing the change
         $default_creator_id = apply_filters('FHEE__EE_DMS_Core_4_5_0__get_default_creator_id', get_current_user_id());
         $price_type_table = $wpdb->prefix . "esp_price_type";
         $price_table = $wpdb->prefix . "esp_price";
         if ($this->_get_table_analysis()->tableExists($price_type_table)) {
-            $SQL = 'SELECT COUNT(PRT_ID) FROM ' . $price_type_table . ' WHERE PBT_ID=4';//include trashed price types
+            $SQL = 'SELECT COUNT(PRT_ID) FROM ' . $price_type_table . ' WHERE PBT_ID=4';// include trashed price types
             $tax_price_type_count = $wpdb->get_var($SQL);
             if ($tax_price_type_count <= 1) {
                 $wpdb->insert(
@@ -126,15 +121,15 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
                         'PRT_wp_user'    => $default_creator_id,
                     ),
                     array(
-                        '%s',//PRT_name
-                        '%d',//PBT_id
-                        '%d',//PRT_is_percent
-                        '%d',//PRT_order
-                        '%d',//PRT_deleted
-                        '%d', //PRT_wp_user
+                        '%s',// PRT_name
+                        '%d',// PBT_id
+                        '%d',// PRT_is_percent
+                        '%d',// PRT_order
+                        '%d',// PRT_deleted
+                        '%d', // PRT_wp_user
                     )
                 );
-                //federal tax
+                // federal tax
                 $result = $wpdb->insert(
                     $price_type_table,
                     array(
@@ -146,12 +141,12 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
                         'PRT_wp_user'    => $default_creator_id,
                     ),
                     array(
-                        '%s',//PRT_name
-                        '%d',//PBT_id
-                        '%d',//PRT_is_percent
-                        '%d',//PRT_order
-                        '%d',//PRT_deleted
-                        '%d' //PRT_wp_user
+                        '%s',// PRT_name
+                        '%d',// PBT_id
+                        '%d',// PRT_is_percent
+                        '%d',// PRT_order
+                        '%d',// PRT_deleted
+                        '%d' // PRT_wp_user
                     )
                 );
                 if ($result) {
@@ -170,23 +165,22 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
                             'PRC_wp_user'    => $default_creator_id,
                         ),
                         array(
-                            '%d',//PRT_id
-                            '%f',//PRC_amount
-                            '%s',//PRC_name
-                            '%s',//PRC_desc
-                            '%d',//PRC_is_default
-                            '%d',//PRC_overrides
-                            '%d',//PRC_deleted
-                            '%d',//PRC_order
-                            '%d',//PRC_parent
-                            '%d' //PRC_wp_user
+                            '%d',// PRT_id
+                            '%f',// PRC_amount
+                            '%s',// PRC_name
+                            '%s',// PRC_desc
+                            '%d',// PRC_is_default
+                            '%d',// PRC_overrides
+                            '%d',// PRC_deleted
+                            '%d',// PRC_order
+                            '%d',// PRC_parent
+                            '%d' // PRC_wp_user
                         )
                     );
                 }
             }
         }
     }
-
 
 
     /**
@@ -242,12 +236,10 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
     }
 
 
-
     public function enqueue_caffeinated_scripts()
     {
         // sound of crickets...
     }
-
 
 
     /**
@@ -263,7 +255,6 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
     }
 
 
-
     /**
      * @param array $cpt_array
      * @return mixed
@@ -273,7 +264,6 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
         $cpt_array['espresso_venues']['args']['show_in_nav_menus'] = true;
         return $cpt_array;
     }
-
 
 
     /**
@@ -311,7 +301,6 @@ class EE_Brewing_Regular extends EE_BASE implements InterminableInterface
         }
     }
 }
-
 
 
 $brewing = new EE_Brewing_Regular(

--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/eventespresso/ee-coding-standards.git",
-                "reference": "9f360c91801430bbb1ad9c103d9c171cbd43960f"
+                "reference": "e3a24f3019f0b553bb61e4b4cceb82996d0d9a40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/9f360c91801430bbb1ad9c103d9c171cbd43960f",
-                "reference": "9f360c91801430bbb1ad9c103d9c171cbd43960f",
+                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/e3a24f3019f0b553bb61e4b4cceb82996d0d9a40",
+                "reference": "e3a24f3019f0b553bb61e4b4cceb82996d0d9a40",
                 "shasum": ""
             },
             "require": {
@@ -188,7 +188,7 @@
                 "issues": "https://github.com/eventespresso/ee-coding-standards/issues",
                 "source": "https://github.com/eventespresso/ee-coding-standards/tree/master"
             },
-            "time": "2018-05-02T17:54:58+00:00"
+            "time": "2018-05-04T17:36:46+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/core/bootstrap_espresso.php
+++ b/core/bootstrap_espresso.php
@@ -1,8 +1,5 @@
 <?php
 
-defined('EVENT_ESPRESSO_MAIN_FILE') || exit;
-
-
 /**
  *    espresso_load_error_handling
  *    this function loads EE's class for handling exceptions and errors
@@ -41,7 +38,7 @@ function espresso_load_required($classname, $full_path_to_file)
     if (is_readable($full_path_to_file)) {
         require_once $full_path_to_file;
     } else {
-        throw new \EE_Error (
+        throw new \EE_Error(
             sprintf(
                 esc_html__(
                     'The %s class file could not be located or is not readable due to file permissions.',
@@ -105,7 +102,3 @@ function bootstrap_espresso()
         new EventEspresso\core\exceptions\ExceptionStackTraceDisplay($e);
     }
 }
-
-
-
-

--- a/core/espresso_definitions.php
+++ b/core/espresso_definitions.php
@@ -5,17 +5,17 @@ define('EE_MIN_WP_VER_REQUIRED', '4.5');
 define('EE_MIN_WP_VER_RECOMMENDED', '4.9');
 define('EE_MIN_PHP_VER_RECOMMENDED', '5.6.32');
 define('EE_SUPPORT_EMAIL', 'support@eventespresso.com');
-//used to be DIRECTORY_SEPARATOR, but that caused issues on windows
-if ( ! defined('DS')) {
+// used to be DIRECTORY_SEPARATOR, but that caused issues on windows
+if (! defined('DS')) {
     define('DS', '/');
 }
-if ( ! defined('PS')) {
+if (! defined('PS')) {
     define('PS', PATH_SEPARATOR);
 }
-if ( ! defined('SP')) {
+if (! defined('SP')) {
     define('SP', ' ');
 }
-if ( ! defined('EENL')) {
+if (! defined('EENL')) {
     define('EENL', "\n");
 }
 // define the plugin directory and URL
@@ -68,11 +68,11 @@ define('EVENT_ESPRESSO_GATEWAY_URL', $uploads['baseurl'] . DS . 'espresso' . DS 
 // languages folder/path
 define('EE_LANGUAGES_SAFE_LOC', '..' . DS . 'uploads' . DS . 'espresso' . DS . 'languages' . DS);
 define('EE_LANGUAGES_SAFE_DIR', EVENT_ESPRESSO_UPLOAD_DIR . 'languages' . DS);
-//check for DOMPDF fonts in uploads
+// check for DOMPDF fonts in uploads
 if (file_exists(EVENT_ESPRESSO_UPLOAD_DIR . 'fonts' . DS)) {
     define('DOMPDF_FONT_DIR', EVENT_ESPRESSO_UPLOAD_DIR . 'fonts' . DS);
 }
-//ajax constants
+// ajax constants
 define(
     'EE_FRONT_AJAX',
     isset($_REQUEST['ee_front_ajax']) || isset($_REQUEST['data']['ee_front_ajax'])
@@ -81,16 +81,13 @@ define(
     'EE_ADMIN_AJAX',
     isset($_REQUEST['ee_admin_ajax']) || isset($_REQUEST['data']['ee_admin_ajax'])
 );
-//just a handy constant occasionally needed for finding values representing infinity in the DB
-//you're better to use this than its straight value (currently -1) in case you ever
-//want to change its default value! or find when -1 means infinity
+// just a handy constant occasionally needed for finding values representing infinity in the DB
+// you're better to use this than its straight value (currently -1) in case you ever
+// want to change its default value! or find when -1 means infinity
 define('EE_INF_IN_DB', -1);
-define('EE_INF', INF > (float)PHP_INT_MAX ? INF : PHP_INT_MAX);
+define('EE_INF', INF > (float) PHP_INT_MAX ? INF : PHP_INT_MAX);
 define('EE_DEBUG', false);
 // for older WP versions
-if ( ! defined('MONTH_IN_SECONDS')) {
+if (! defined('MONTH_IN_SECONDS')) {
     define('MONTH_IN_SECONDS', DAY_IN_SECONDS * 30);
 }
-
-// End of file espresso_definitions.php
-// Location: ${NAMESPACE}/espresso_definitions.php

--- a/espresso.php
+++ b/espresso.php
@@ -1,15 +1,15 @@
 <?php defined('ABSPATH') || exit('No direct script access allowed');
 /*
-  Plugin Name:		Event Espresso
-  Plugin URI:  		http://eventespresso.com/pricing/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
-  Description: 		Manage events, sell tickets, and receive payments from your WordPress website. Reduce event administration time, cut-out ticketing fees, and own your customer data. | <a href="https://eventespresso.com/add-ons/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Extensions</a> | <a href="https://eventespresso.com/pricing/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Sales</a> | <a href="admin.php?page=espresso_support">Support</a>
-  Version:			4.9.62.rc.034
-  Author:			Event Espresso
-  Author URI: 		http://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
-  License: 		     GPLv2
-  Text Domain: 		 event_espresso
+  Plugin Name:Event Espresso
+  Plugin URI: http://eventespresso.com/pricing/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
+  Description: Manage events, sell tickets, and receive payments from your WordPress website. Reduce event administration time, cut-out ticketing fees, and own your customer data. | <a href="https://eventespresso.com/add-ons/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Extensions</a> | <a href="https://eventespresso.com/pricing/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Sales</a> | <a href="admin.php?page=espresso_support">Support</a>
+  Version: 4.9.62.rc.034
+  Author: Event Espresso
+  Author URI: http://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
+  License: GPLv2
+  Text Domain: event_espresso
   GitHub Plugin URI: https://github.com/eventespresso/event-espresso-core
-  Copyright 		(c) 2008-2017 Event Espresso  All Rights Reserved.
+  Copyright (c) 2008-2017 Event Espresso  All Rights Reserved.
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -29,13 +29,13 @@
  * Event Espresso
  * Event Registration and Management Plugin for WordPress
  *
- * @package     Event Espresso
- * @author      Seth Shoultes
+ * @package         Event Espresso
+ * @author          Seth Shoultes
  * @copyright   (c) 2008-2018 Event Espresso  All Rights Reserved.
- * @license     {@link http://eventespresso.com/support/terms-conditions/}
- * @see         Plugin Licensing
- * @link        {@link http://www.eventespresso.com}
- * @since       4.0
+ * @license         {@link http://eventespresso.com/support/terms-conditions/}
+ * @see             Plugin Licensing
+ * @link            {@link http://www.eventespresso.com}
+ * @since           4.0
  */
 if (function_exists('espresso_version')) {
     if (! function_exists('espresso_duplicate_plugin_error')) {
@@ -60,12 +60,12 @@ if (function_exists('espresso_version')) {
         }
     }
     add_action('admin_notices', 'espresso_duplicate_plugin_error', 1);
-
 } else {
     define('EE_MIN_PHP_VER_REQUIRED', '5.4.0');
     if (! version_compare(PHP_VERSION, EE_MIN_PHP_VER_REQUIRED, '>=')) {
         /**
          * espresso_minimum_php_version_error
+         *
          * @return void
          */
         function espresso_minimum_php_version_error()

--- a/modules/single_page_checkout/inc/EE_SPCO_JSON_Response.php
+++ b/modules/single_page_checkout/inc/EE_SPCO_JSON_Response.php
@@ -1,411 +1,412 @@
-<?php if ( ! defined('EVENT_ESPRESSO_VERSION')) { exit('No direct script access allowed'); }
- /**
+<?php
+
+/**
  *
  * Class EE_SPCO_JSON_Response
  *
  * Description
  *
- * @package         Event Espresso
- * @subpackage    core
- * @author				Brent Christensen
+ * @package               Event Espresso
+ * @subpackage            core
+ * @author                Brent Christensen
  *
  *
  */
-class EE_SPCO_JSON_Response {
+class EE_SPCO_JSON_Response
+{
 
-	/**
-	 * @var string
-	 */
-	protected $_errors = '';
+    /**
+     * @var string
+     */
+    protected $_errors = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_unexpected_errors = '';
+    /**
+     * @var string
+     */
+    protected $_unexpected_errors = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_attention = '';
+    /**
+     * @var string
+     */
+    protected $_attention = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_success = '';
+    /**
+     * @var string
+     */
+    protected $_success = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_plz_select_method_of_payment = '';
+    /**
+     * @var string
+     */
+    protected $_plz_select_method_of_payment = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_redirect_url = '';
+    /**
+     * @var string
+     */
+    protected $_redirect_url = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_registration_time_limit = '';
+    /**
+     * @var string
+     */
+    protected $_registration_time_limit = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_redirect_form = '';
+    /**
+     * @var string
+     */
+    protected $_redirect_form = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_reg_step_html = '';
+    /**
+     * @var string
+     */
+    protected $_reg_step_html = '';
 
-	/**
-	 * @var string
-	 */
-	protected $_method_of_payment = '';
+    /**
+     * @var string
+     */
+    protected $_method_of_payment = '';
 
-	/**
-	 * @var float
-	 */
-	protected $_payment_amount;
+    /**
+     * @var float
+     */
+    protected $_payment_amount;
 
-	/**
-	 * @var array
-	 */
-	protected $_return_data = array();
-
-
-	/**
-	 *  @var array
-	 */
-	protected $_validation_rules = array();
+    /**
+     * @var array
+     */
+    protected $_return_data = array();
 
 
+    /**
+     * @var array
+     */
+    protected $_validation_rules = array();
 
 
-	/**
-	 *    class constructor
-   */
-	public function __construct(  ) {
-	}
+    /**
+     *    class constructor
+     */
+    public function __construct()
+    {
+    }
 
 
+    /**
+     *    __toString
+     *
+     *        allows you to simply echo or print an EE_SPCO_JSON_Response object to produce a  JSON encoded string
+     *        ie: $json_response = new EE_SPCO_JSON_Response();
+     *        echo $json_response;
+     *
+     * @access    public
+     * @return    string
+     */
+    public function __toString()
+    {
+        $JSON_response = array();
+        // grab notices
+        $notices = EE_Error::get_notices(false);
+        $this->set_attention(isset($notices['attention']) ? $notices['attention'] : '');
+        $this->set_errors(isset($notices['errors']) ? $notices['errors'] : '');
+        $this->set_success(isset($notices['success']) ? $notices['success'] : '');
+        // add notices to JSON response, but only if they exist
+        if ($this->attention()) {
+            $JSON_response['attention'] = $this->attention();
+        }
+        if ($this->errors()) {
+            $JSON_response['errors'] = $this->errors();
+        }
+        if ($this->unexpected_errors()) {
+            $JSON_response['unexpected_errors'] = $this->unexpected_errors();
+        }
+        if ($this->success()) {
+            $JSON_response['success'] = $this->success();
+        }
+        // but if NO notices are set... at least set the "success" as a key so that the JS knows everything worked
+        if (! isset($JSON_response['attention']) && ! isset($JSON_response['errors']) && ! isset($JSON_response['success'])) {
+            $JSON_response['success'] = null;
+        }
+        // set redirect_url, IF it exists
+        if ($this->redirect_url()) {
+            $JSON_response['redirect_url'] = $this->redirect_url();
+        }
+        // set registration_time_limit, IF it exists
+        if ($this->registration_time_limit()) {
+            $JSON_response['registration_time_limit'] = $this->registration_time_limit();
+        }
+        // set payment_amount, IF it exists
+        if ($this->payment_amount() !== null) {
+            $JSON_response['payment_amount'] = $this->payment_amount();
+        }
+        // grab generic return data
+        $return_data = $this->return_data();
+        // add billing form validation rules
+        if ($this->validation_rules()) {
+            $return_data['validation_rules'] = $this->validation_rules();
+        }
+        // set reg_step_html, IF it exists
+        if ($this->reg_step_html()) {
+            $return_data['reg_step_html'] = $this->reg_step_html();
+        }
+        // set method of payment, IF it exists
+        if ($this->method_of_payment()) {
+            $return_data['method_of_payment'] = $this->method_of_payment();
+        }
+        // set "plz_select_method_of_payment" message, IF it exists
+        if ($this->plz_select_method_of_payment()) {
+            $return_data['plz_select_method_of_payment'] = $this->plz_select_method_of_payment();
+        }
+        // set redirect_form, IF it exists
+        if ($this->redirect_form()) {
+            $return_data['redirect_form'] = $this->redirect_form();
+        }
+        // and finally, add return_data array to main JSON response array, IF it contains anything
+        // why did we add some of the above properties to the return data array?
+        // because it is easier and cleaner in the Javascript to deal with this way
+        if (! empty($return_data)) {
+            $JSON_response['return_data'] = $return_data;
+        }
+        // filter final array
+        $JSON_response = apply_filters('FHEE__EE_SPCO_JSON_Response___toString__JSON_response', $JSON_response);
+        // return encoded array
+        return (string) wp_json_encode($JSON_response);
+    }
 
 
-	/**
-	 *    __toString
-	 *
-	 * 		allows you to simply echo or print an EE_SPCO_JSON_Response object to produce a  JSON encoded string
-	 * 		ie: $json_response = new EE_SPCO_JSON_Response();
-	 * 		echo $json_response;
-	 *
-	 * @access    public
-	 * @return    string
-	 */
-	public function __toString() {
-		$JSON_response = array();
-		// grab notices
-		$notices = EE_Error::get_notices( FALSE );
-		$this->set_attention( isset( $notices['attention'] ) ? $notices['attention'] : '' );
-		$this->set_errors( isset( $notices['errors'] ) ? $notices['errors'] : '' );
-		$this->set_success( isset( $notices['success'] ) ? $notices['success'] : '' );
-		// add notices to JSON response, but only if they exist
-		if ( $this->attention() ) {
-			$JSON_response['attention'] = $this->attention();
-		}
-		if ( $this->errors() ) {
-			$JSON_response['errors'] = $this->errors();
-		}
-		if ( $this->unexpected_errors() ) {
-			$JSON_response['unexpected_errors'] = $this->unexpected_errors();
-		}
-		if ( $this->success() ) {
-			$JSON_response['success'] = $this->success();
-		}
-		// but if NO notices are set... at least set the "success" as a key so that the JS knows everything worked
-		if ( ! isset( $JSON_response[ 'attention' ] ) && ! isset( $JSON_response[ 'errors' ] ) && ! isset( $JSON_response[ 'success' ] ) ) {
-			$JSON_response['success'] = null;
-		}
-		// set redirect_url, IF it exists
-		if ( $this->redirect_url() ) {
-			$JSON_response['redirect_url'] = $this->redirect_url();
-		}
-		// set registration_time_limit, IF it exists
-		if ( $this->registration_time_limit() ) {
-			$JSON_response['registration_time_limit'] = $this->registration_time_limit();
-		}
-		// set payment_amount, IF it exists
-		if ( $this->payment_amount() !== null ) {
-			$JSON_response[ 'payment_amount' ] = $this->payment_amount();
-		}
-		// grab generic return data
-		$return_data = $this->return_data();
-		// add billing form validation rules
-		if ( $this->validation_rules() ) {
-			$return_data['validation_rules'] = $this->validation_rules();
-		}
-		// set reg_step_html, IF it exists
-		if ( $this->reg_step_html() ) {
-			$return_data['reg_step_html'] = $this->reg_step_html();
-		}
-		// set method of payment, IF it exists
-		if ( $this->method_of_payment() ) {
-			$return_data['method_of_payment'] = $this->method_of_payment();
-		}
-		// set "plz_select_method_of_payment" message, IF it exists
-		if ( $this->plz_select_method_of_payment() ) {
-			$return_data['plz_select_method_of_payment'] = $this->plz_select_method_of_payment();
-		}
-		// set redirect_form, IF it exists
-		if ( $this->redirect_form() ) {
-			$return_data['redirect_form'] = $this->redirect_form();
-		}
-		// and finally, add return_data array to main JSON response array, IF it contains anything
-		// why did we add some of the above properties to the return data array?
-		// because it is easier and cleaner in the Javascript to deal with this way
-		if ( ! empty( $return_data )) {
-			$JSON_response['return_data'] = $return_data;
-		}
-		// filter final array
-		$JSON_response = apply_filters( 'FHEE__EE_SPCO_JSON_Response___toString__JSON_response', $JSON_response );
-		// return encoded array
-		return (string) wp_json_encode( $JSON_response );
-	}
+    /**
+     * @param string $attention
+     */
+    public function set_attention($attention)
+    {
+        $this->_attention = $attention;
+    }
 
 
-
-	/**
-	 * @param string $attention
-	 */
-	public function set_attention( $attention ) {
-		$this->_attention = $attention;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function attention() {
-		return $this->_attention;
-	}
+    /**
+     * @return string
+     */
+    public function attention()
+    {
+        return $this->_attention;
+    }
 
 
-
-	/**
-	 * @param string $errors
-	 */
-	public function set_errors( $errors ) {
-		$this->_errors = $errors;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function errors() {
-		return $this->_errors;
-	}
+    /**
+     * @param string $errors
+     */
+    public function set_errors($errors)
+    {
+        $this->_errors = $errors;
+    }
 
 
-
-	/**
-	 * @return string
-	 */
-	public function unexpected_errors() {
-		return $this->_unexpected_errors;
-	}
-
-
-
-	/**
-	 * @param string $unexpected_errors
-	 */
-	public function set_unexpected_errors( $unexpected_errors ) {
-		$this->_unexpected_errors = $unexpected_errors;
-	}
+    /**
+     * @return string
+     */
+    public function errors()
+    {
+        return $this->_errors;
+    }
 
 
-
-	/**
-	 * @param string $success
-	 */
-	public function set_success( $success ) {
-		$this->_success = $success;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function success() {
-		return $this->_success;
-	}
+    /**
+     * @return string
+     */
+    public function unexpected_errors()
+    {
+        return $this->_unexpected_errors;
+    }
 
 
-
-	/**
-	 * @param string $method_of_payment
-	 */
-	public function set_method_of_payment( $method_of_payment ) {
-		$this->_method_of_payment = $method_of_payment;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function method_of_payment() {
-		return $this->_method_of_payment;
-	}
+    /**
+     * @param string $unexpected_errors
+     */
+    public function set_unexpected_errors($unexpected_errors)
+    {
+        $this->_unexpected_errors = $unexpected_errors;
+    }
 
 
+    /**
+     * @param string $success
+     */
+    public function set_success($success)
+    {
+        $this->_success = $success;
+    }
 
-	/**
-	 * @return float
-	 */
-	public function payment_amount() {
-		return $this->_payment_amount;
-	}
+
+    /**
+     * @return string
+     */
+    public function success()
+    {
+        return $this->_success;
+    }
+
+
+    /**
+     * @param string $method_of_payment
+     */
+    public function set_method_of_payment($method_of_payment)
+    {
+        $this->_method_of_payment = $method_of_payment;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function method_of_payment()
+    {
+        return $this->_method_of_payment;
+    }
+
+
+    /**
+     * @return float
+     */
+    public function payment_amount()
+    {
+        return $this->_payment_amount;
+    }
 
 
     /**
      * @param float $payment_amount
      * @throws EE_Error
      */
-	public function set_payment_amount( $payment_amount ) {
-		$this->_payment_amount = (float)$payment_amount;
-	}
+    public function set_payment_amount($payment_amount)
+    {
+        $this->_payment_amount = (float) $payment_amount;
+    }
 
 
-
-	/**
-	 * @param string $next_step_html
-	 */
-	public function set_reg_step_html( $next_step_html ) {
-		$this->_reg_step_html = $next_step_html;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function reg_step_html() {
-		return $this->_reg_step_html;
-	}
+    /**
+     * @param string $next_step_html
+     */
+    public function set_reg_step_html($next_step_html)
+    {
+        $this->_reg_step_html = $next_step_html;
+    }
 
 
-
-	/**
-	 * @param string $redirect_form
-	 */
-	public function set_redirect_form( $redirect_form ) {
-		$this->_redirect_form = $redirect_form;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function redirect_form() {
-		return ! empty( $this->_redirect_form ) ? $this->_redirect_form : FALSE;
-	}
+    /**
+     * @return string
+     */
+    public function reg_step_html()
+    {
+        return $this->_reg_step_html;
+    }
 
 
-
-	/**
-	 * @param string $plz_select_method_of_payment
-	 */
-	public function set_plz_select_method_of_payment( $plz_select_method_of_payment ) {
-		$this->_plz_select_method_of_payment = $plz_select_method_of_payment;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function plz_select_method_of_payment() {
-		return $this->_plz_select_method_of_payment;
-	}
+    /**
+     * @param string $redirect_form
+     */
+    public function set_redirect_form($redirect_form)
+    {
+        $this->_redirect_form = $redirect_form;
+    }
 
 
-
-	/**
-	 * @param string $redirect_url
-	 */
-	public function set_redirect_url( $redirect_url ) {
-		$this->_redirect_url = $redirect_url;
-	}
-
-
-
-	/**
-	 * @return string
-	 */
-	public function redirect_url() {
-		return $this->_redirect_url;
-	}
+    /**
+     * @return string
+     */
+    public function redirect_form()
+    {
+        return ! empty($this->_redirect_form) ? $this->_redirect_form : false;
+    }
 
 
-
-	/**
-	 * @return string
-	 */
-	public function registration_time_limit() {
-		return $this->_registration_time_limit;
-	}
-
-
-
-	/**
-	 * @param string $registration_time_limit
-	 */
-	public function set_registration_time_limit( $registration_time_limit ) {
-		$this->_registration_time_limit = $registration_time_limit;
-	}
+    /**
+     * @param string $plz_select_method_of_payment
+     */
+    public function set_plz_select_method_of_payment($plz_select_method_of_payment)
+    {
+        $this->_plz_select_method_of_payment = $plz_select_method_of_payment;
+    }
 
 
-
-	/**
-	 * @param array $return_data
-	 */
-	public function set_return_data( $return_data ) {
-		$this->_return_data = array_merge( $this->_return_data, $return_data );
-	}
-
-
-
-	/**
-	 * @return array
-	 */
-	public function return_data() {
-		return $this->_return_data;
-	}
+    /**
+     * @return string
+     */
+    public function plz_select_method_of_payment()
+    {
+        return $this->_plz_select_method_of_payment;
+    }
 
 
-
-	/**
-	 * @param array $validation_rules
-	 */
-	public function add_validation_rules(array $validation_rules = array()) {
-		if ( is_array( $validation_rules ) && ! empty( $validation_rules )) {
-			$this->_validation_rules = array_merge( $this->_validation_rules, $validation_rules );
-		}
-	}
+    /**
+     * @param string $redirect_url
+     */
+    public function set_redirect_url($redirect_url)
+    {
+        $this->_redirect_url = $redirect_url;
+    }
 
 
+    /**
+     * @return string
+     */
+    public function redirect_url()
+    {
+        return $this->_redirect_url;
+    }
 
-	/**
-	 * @return array | bool
-	 */
-	public function validation_rules() {
-		return ! empty( $this->_validation_rules ) ? $this->_validation_rules : FALSE;
-	}
+
+    /**
+     * @return string
+     */
+    public function registration_time_limit()
+    {
+        return $this->_registration_time_limit;
+    }
+
+
+    /**
+     * @param string $registration_time_limit
+     */
+    public function set_registration_time_limit($registration_time_limit)
+    {
+        $this->_registration_time_limit = $registration_time_limit;
+    }
+
+
+    /**
+     * @param array $return_data
+     */
+    public function set_return_data($return_data)
+    {
+        $this->_return_data = array_merge($this->_return_data, $return_data);
+    }
+
+
+    /**
+     * @return array
+     */
+    public function return_data()
+    {
+        return $this->_return_data;
+    }
+
+
+    /**
+     * @param array $validation_rules
+     */
+    public function add_validation_rules(array $validation_rules = array())
+    {
+        if (is_array($validation_rules) && ! empty($validation_rules)) {
+            $this->_validation_rules = array_merge($this->_validation_rules, $validation_rules);
+        }
+    }
+
+
+    /**
+     * @return array | bool
+     */
+    public function validation_rules()
+    {
+        return ! empty($this->_validation_rules) ? $this->_validation_rules : false;
+    }
 
 
     public function echoAndExit()
@@ -413,7 +414,4 @@ class EE_SPCO_JSON_Response {
         echo $this;
         exit();
     }
-
 }
-// End of file EE_SPCO_JSON_Response.php
-// Location: /EE_SPCO_JSON_Response.php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Recently I added phpcs linting to EE core (and [addons](https://github.com/eventespresso/event-espresso-core/issues/380).  As a part of that work, I just added a full exclusion for all our legacy files.  However I realized as I was working on the add-ons that:

- some legacy files had bad translation function usage (missing text domain or incorrect function usage).
- we're still stuck with some of these legacy files for a while so we lose the benefit of code linting if they aren't covered.

I realized that instead of full exclusions I can just exclude the _specific_ rules that apply to legacy files which _cannot_ be changed (CamelCase methods etc) and then fix all the violations that still can and should apply.

This will take a bit of time to do but I can take the weekend to do it and then we'll have a clean slate for _all_ our files going forward.  I think its a worthwhile endeavour.
