### PR TITLE
Fix statement not echoing its value.

### DIFF
--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -472,7 +472,7 @@ final class EE_Admin implements InterminableInterface
                     <input type="submit"<?php wp_nav_menu_disabled_check($nav_menu_selected_id); ?>
                            class="button-secondary submit-add-to-menu right"
                            value="<?php esc_attr_e('Add to Menu', 'event_espresso'); ?>" name="add-post-type-menu-item"
-                           id="<?php esc_attr('submit-posttype-extra-nav-menu-pages'); ?>"/>
+                           id="<?php echo esc_attr('submit-posttype-extra-nav-menu-pages'); ?>"/>
                     <span class="spinner"></span>
                 </span>
             </p>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Archive menu items cannot be added to a menu in the WordPress navigation menu admin.

It looks like at some point in master history I modified an incorrect usage of a localization method: `esc_attr_e` to `esc_attr`.    The localization method was being used on a css id value (we should not be localizing css attributes other than value for buttons/links/submits).  However, on modifying this I forgot to make sure we `echo` the value.  WP relies on this id for the js it uses to add the menu item.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] Verify that archive menu items can now be added.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
