### PR TITLE
Add one more check to make sure espresso-notices loads where expected

### DIFF
--- a/core/EE_Front_Controller.core.php
+++ b/core/EE_Front_Controller.core.php
@@ -418,6 +418,7 @@ final class EE_Front_Controller
             && is_main_query()
             && ! is_feed()
             && in_the_loop()
+            && did_action('wp_head')
             && $this->Request_Handler->is_espresso_page()
         ) {
             echo EE_Error::get_notices();


### PR DESCRIPTION
Sometimes espresso-notices end up at the very top of the document because some plugins and themes will fire loop_start very early in the request


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
<img width="924" alt="screen shot 2018-05-11 at 2 28 25 pm" src="https://user-images.githubusercontent.com/891156/39940578-b77a09c2-5527-11e8-849b-7c5ee85a40b3.png">

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
Checked to make sure notices display when and where expected.
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
