### PR TITLE
Bug/duplicate event categories

### DIFF
--- a/core/db_models/EEM_CPT_Base.model.php
+++ b/core/db_models/EEM_CPT_Base.model.php
@@ -325,6 +325,7 @@ abstract class EEM_CPT_Base extends EEM_Soft_Delete_Base
                         'name' => $category_name,
                         'slug' => $category_slug,
                     ),
+                    'Term_Taxonomy.taxonomy' => self::EVENT_CATEGORY_TAXONOMY
                 ),
             )
         );

--- a/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
+++ b/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
@@ -137,6 +137,48 @@ class EE_CPT_Base_Test extends EE_UnitTestCase{
         $this->assertNotEquals(0, $ee_term_taxonomy->get('term_count'));
         $this->assertEquals('espresso_event_categories', $ee_term_taxonomy->taxonomy());
     }
+
+
+    /**
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     */
+    public function testAddEventCategoryNoDuplicates()
+    {
+        $e = $this->new_model_obj_with_dependencies('Event');
+        $wp_term = $this->factory()->term->create_and_get(
+            array(
+                'name' => 'cars',
+                'taxonomy' => 'category',
+                'description' => 'regardless of whether this is a valid taxonomy, its certainl not the EE event category'
+            )
+        );
+        $this->assertNotInstanceOf('WP_Error', $wp_term);
+        $ee_term = $this->new_model_obj_with_dependencies(
+            'Term',
+            array(
+                'name' => 'cars',
+                'slug' => 'cars',
+
+            )
+        );
+        $ee_term_taxonomy = $this->new_model_obj_with_dependencies(
+            'Term_Taxonomy',
+            array(
+                'term_id' => $ee_term->ID(),
+                'taxonomy' => EEM_CPT_Base::EVENT_CATEGORY_TAXONOMY
+            )
+        );
+        //when adding the term to this event, it shouldn't createn a  new one
+        $term_taxonomy_used_for_relation = $e->add_event_category(
+            'cars',
+            'an actual ee category'
+        );
+        $this->assertEquals($ee_term_taxonomy, $term_taxonomy_used_for_relation);
+    }
 }
 
 // End of file EE_CPT_Base_Test.php

--- a/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
+++ b/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
@@ -172,7 +172,7 @@ class EE_CPT_Base_Test extends EE_UnitTestCase{
                 'taxonomy' => EEM_CPT_Base::EVENT_CATEGORY_TAXONOMY
             )
         );
-        //when adding the term to this event, it shouldn't createn a  new one
+        //when adding the term to this event, it shouldn't creating a new one
         $term_taxonomy_used_for_relation = $e->add_event_category(
             'cars',
             'an actual ee category'


### PR DESCRIPTION
Addresses https://github.com/eventespresso/event-espresso-core/issues/432 by adding a unit test, and verifies that EEM_CPT_Base::add_event_category creates a new term if none for the event category exists.