### PR TITLE
remove unnecessary dependencies

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -719,15 +719,6 @@ class EE_Dependency_Map
             'EventEspresso\core\services\loaders\ObjectIdentifier'                                                        => array(
                 'EventEspresso\core\services\loaders\ClassInterfaceCache' => EE_Dependency_Map::load_from_cache,
             ),
-            'EventEspresso\core\domain\entities\editor\blocks\CoreBlocksAssetManager'                                     => array(
-                'EventEspresso\core\domain\Domain'            => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\assets\Registry' => EE_Dependency_Map::load_from_cache,
-            ),
-            'EventEspresso\core\services\assets\AssetManager'                                                             => array(
-                'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
-            ),
             'EventEspresso\core\domain\services\assets\CoreAssetManager'                                                  => array(
                 'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
                 'EE_Currency_Config'                                 => EE_Dependency_Map::load_from_cache,


### PR DESCRIPTION
## Problem this Pull Request solves
removes the following unnecessary dependencies from the map in `EE_Dependency_Map`

- `EventEspresso\core\domain\entities\editor\blocks\CoreBlocksAssetManager` which is added in `Gutenberg/block-manager`
- `EventEspresso\core\services\assets\AssetManager` which is an abstract class and therefore can not be instantiated directly

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
to avoid merge conflicts with the Gutenberg branches

## How has this been tested
 - unit tests pass (locally)
 - site no go boom
