### PR TITLE
Gutenberg/testing gb fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"eslint-plugin-react": "^7.8.2",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
 		"mini-css-extract-plugin": "^0.4.0",
-		"gutenberg": "Wordpress/gutenberg#master",
+		"gutenberg": "nerrad/gutenberg#BUG-try-removing-optional-dependencies",
 		"pegjs": "^0.10.0",
 		"pegjs-loader": "^0.5.4",
 		"postcss-loader": "^2.1.5",


### PR DESCRIPTION
This pull confirms that the issue with our tests failing is due to the upstream Wordpress/gutenberg change that made `fsevents` an `optionalDependencies` in their `package.json`.  I've [made a pull request regarding this](https://github.com/WordPress/gutenberg/pull/6792).  The current status is there are communications with the npm team seeing if this is something needing resolved in npm.

In the meantime, in order to keep running tests, I'd like to merge this pull pinning our package to use my fork until the issue is resolved upstream.