### PR TITLE
Remove translation configuration related to eejs-core script

### DIFF
--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -160,7 +160,6 @@ class CoreAssetManager extends AssetManager
             $this->registry->getJsUrl($this->domain->assetNamespace(), 'eejs'),
             array(CoreAssetManager::JS_HANDLE_EE_MANIFEST)
         )
-        ->setRequiresTranslation()
         ->setHasLocalizedData();
 
         $this->addJavascript(

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -43,6 +43,7 @@ common.forEach( ( config, index ) => {
 				aliases: {
 					'wp-plugins-page': 'ee-wp-plugins-page',
 				},
+				excludes: [ 'eejs' ],
 			} ),
 			new WebpackAssetsManifest( {
 				output: path.resolve( __dirname,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -23,7 +23,7 @@ common.forEach( ( config, index ) => {
 			},
 		};
 		common[ index ].plugins = [
-			new CleanWebpackPlugin( [ 'assets/dist' ] ),
+			new CleanWebpackPlugin( [ 'assets/dist', 'translation-map.json' ] ),
 			new webpack.ProvidePlugin( {
 				'React': 'react', // eslint-disable-line quote-props
 			} ),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -32,15 +32,6 @@ common.forEach( ( config, index ) => {
 			} ),
 		];
 	}
-	if ( common[ index ].configName === 'eejs' ) {
-		common[ index ].plugins = [
-			new wpi18nExtractor( {
-				aliases: {
-					eejs: 'eejs-core',
-				},
-			} ),
-		];
-	}
 	common[ index ] = merge( config, {
 		plugins: [
 			new webpack.DefinePlugin( {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

`eejs-core` has a wrapper around `@wordpress/i18n` so gutenberg does not need loaded to get `wp.i18n`.  This means that eejs-core itself cannot have any translations in it because it would result in the inline script for `eejs-core` executing before it in the dom page load (resulting in `event_espresso` domain not found errors).

The work in this pull:

* removes registration of eejs-core php side as having translations.
* modifies the `i18n-map-extractor.js` Webpack plugin so that it accepts an array of entry names (chunk names) to exclude from parsing for strings.  This is then implemented to exclude the `eejs` chunk from being parsed.
*  delete `translation-map.json` before building it (in production builds).  Since its merged to vs being overwritten, this prevents the accumulation of invalid/obsolete strings over time in our build-machine.  It also ensures that the `translation-map.json` is always accurate for the state of strings in the code at the time of building.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] ensure automated tests don't fail
* [x] ensure exit modal loads as expected (and no js errors in the console).
* [x] ensure there are no errors in the console when loading any page in the EE admin (if there's no errors across a few pages then all should be well)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
