### PR TITLE
Fix i18n api loading strings twice per handle

### DIFF
--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -20,7 +20,7 @@ class I18nRegistry
     private $domain;
 
     /**
-     * Will hold all registered i18n scripts.
+     * Will hold all registered i18n scripts.  Prevents script handles from being registered more than once.
      *
      * @var array
      */
@@ -33,6 +33,13 @@ class I18nRegistry
      * @var array
      */
     private $queued_handle_translations = array();
+
+    /**
+     * Used to track script handles queued for adding translation strings as inline data in the dom.
+     *
+     * @var array
+     */
+    private $queued_scripts = array();
 
 
     /**
@@ -68,7 +75,10 @@ class I18nRegistry
      */
     public function registerScriptI18n($handle, $domain = 'event_espresso')
     {
-        $this->registered_i18n[$handle] = $domain;
+        if(! isset($this->registered_i18n[$handle])) {
+            $this->registered_i18n[ $handle ] = 1;
+            $this->queued_scripts[ $handle ] = $domain;
+        }
     }
 
 
@@ -81,7 +91,7 @@ class I18nRegistry
      */
     public function queueI18n(array $handles)
     {
-        if (empty($this->registered_i18n) || empty($this->i18n_map)) {
+        if (empty($this->queued_scripts) || empty($this->i18n_map)) {
             return $handles;
         }
         foreach ($handles as $handle) {
@@ -124,8 +134,8 @@ class I18nRegistry
      */
     private function queueI18nTranslationsForHandle($handle)
     {
-        if (isset($this->registered_i18n[$handle])) {
-            $domain = $this->registered_i18n[$handle];
+        if (isset($this->queued_scripts[$handle])) {
+            $domain = $this->queued_scripts[$handle];
             $translations = $this->getJedLocaleDataForDomainAndChunk($handle, $domain);
             if (count($translations) > 0) {
                 $this->queued_handle_translations[$handle] = array(
@@ -133,7 +143,7 @@ class I18nRegistry
                     'translations' => $translations,
                 );
             }
-            unset($this->registered_i18n[$handle]);
+            unset($this->queued_scripts[$handle]);
         }
     }
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -108,7 +108,7 @@ class I18nRegistry
      * @param string $domain       Domain for translations.  If left empty then strings are registered with the default
      *                             domain for the javascript.
      */
-    private function registerInlineScript($handle, array $translations, $domain)
+    protected function registerInlineScript($handle, array $translations, $domain)
     {
         $script = $domain ?
             'eejs.i18n.setLocaleData( ' . wp_json_encode($translations) . ', "' . $domain . '" );' :

--- a/tests/mocks/core/services/assets/I18nRegistryMock.php
+++ b/tests/mocks/core/services/assets/I18nRegistryMock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace EventEspresso\tests\mocks\core\services\assets;
+
+
+use EventEspresso\core\services\assets\I18nRegistry;
+
+class I18nRegistryMock extends I18nRegistry
+{
+
+    private $track_calls_to_method = array();
+
+
+    protected function registerInlineScript($handle, array $translations, $domain)
+    {
+        $this->incrementCallToMethod(__METHOD__);
+        parent::registerInlineScript($handle, $translations, $domain);
+    }
+
+
+    private function incrementCallToMethod($method_name)
+    {
+        if (! isset($this->track_calls_to_method[ $method_name ])) {
+            $this->track_calls_to_method[ $method_name ] = 0;
+        }
+        $this->track_calls_to_method[ $method_name ]++;
+    }
+
+
+    public function getCountOfMethodCalled($method_name)
+    {
+        return isset($this->track_calls_to_method[ $method_name ])
+            ? $this->track_calls_to_method[ $method_name ]
+            : 0;
+    }
+}

--- a/tests/testcases/core/services/assets/I18nRegistryTest.php
+++ b/tests/testcases/core/services/assets/I18nRegistryTest.php
@@ -67,6 +67,7 @@ class I18nRegistryTest extends EE_UnitTestCase
 
         //let's trigger `print_scripts_array` twice.
         apply_filters('print_scripts_array', array('test'));
+        apply_filters('print_scripts_array', array('test'));
 
         //now we expect `registerInlineScript to have been called only once
         $this->assertEquals( 1, $this->i18n->getCountOfMethodCalled(

--- a/tests/testcases/core/services/assets/I18nRegistryTest.php
+++ b/tests/testcases/core/services/assets/I18nRegistryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use EventEspresso\core\domain\DomainFactory;
+use EventEspresso\core\domain\values\FilePath;
+use EventEspresso\core\domain\values\FullyQualifiedName;
+use EventEspresso\core\domain\values\Version;
+use EventEspresso\tests\mocks\core\services\assets\I18nRegistryMock;
+
+class I18nRegistryTest extends EE_UnitTestCase
+{
+
+    /**
+     * @var I18nRegistryMock
+     */
+    private $i18n;
+
+
+    /**
+     * @throws DomainException
+     * @throws InvalidArgumentException
+     * @throws \EventEspresso\core\exceptions\InvalidClassException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws \EventEspresso\core\exceptions\InvalidFilePathException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws EE_Error
+     */
+    public function setUp()
+    {
+        $domain = DomainFactory::getShared(
+            new FullyQualifiedName(
+                'EventEspresso\core\domain\Domain'
+            ),
+            array(
+                new FilePath(EVENT_ESPRESSO_MAIN_FILE),
+                Version::fromString(espresso_version())
+            )
+        );
+        $test_map = array(
+            'test' =>  array(
+                'Do you have a moment to share why you are deactivating Event Espresso?',
+                "Sure I'll help",
+                'Skip'
+            ),
+        );
+        $this->i18n = new I18nRegistryMock(
+            $test_map,
+            $domain
+        );
+        parent::setUp();
+    }
+
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->i18n = null;
+    }
+
+
+    /**
+     * @group testing
+     */
+    public function testInlineScriptsOnlyQueuedOnce()
+    {
+        // simulate registering the script handle
+        $this->i18n->registerScriptI18n('test');
+
+        //let's trigger `print_scripts_array` twice.
+        apply_filters('print_scripts_array', array('test'));
+
+        //now we expect `registerInlineScript to have been called only once
+        $this->assertEquals( 1, $this->i18n->getCountOfMethodCalled(
+            'EventEspresso\tests\mocks\core\services\assets\I18nRegistryMock::registerInlineScript'
+        ) );
+    }
+}

--- a/tests/testcases/core/services/assets/I18nRegistryTest.php
+++ b/tests/testcases/core/services/assets/I18nRegistryTest.php
@@ -58,7 +58,8 @@ class I18nRegistryTest extends EE_UnitTestCase
 
 
     /**
-     * @group testing
+     * see https://github.com/eventespresso/event-espresso-core/pull/458
+     * @group 458
      */
     public function testInlineScriptsOnlyQueuedOnce()
     {
@@ -70,6 +71,17 @@ class I18nRegistryTest extends EE_UnitTestCase
         apply_filters('print_scripts_array', array('test'));
 
         //now we expect `registerInlineScript to have been called only once
+        $this->assertEquals( 1, $this->i18n->getCountOfMethodCalled(
+            'EventEspresso\tests\mocks\core\services\assets\I18nRegistryMock::registerInlineScript'
+        ) );
+
+        //register script again *gasp*
+        $this->i18n->registerScriptI18n('test');
+
+        //call apply_filters again
+        apply_filters('print_scripts_array', array('test'));
+
+        //still should only have been called once
         $this->assertEquals( 1, $this->i18n->getCountOfMethodCalled(
             'EventEspresso\tests\mocks\core\services\assets\I18nRegistryMock::registerInlineScript'
         ) );


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

While testing some gutenberg stuff, I noticed in the branch I was testing that there were duplicate calls to `eejs.i18n.setLocaleData` before a script.  In this pull request:

* I created a phpunit test that demonstrates the flaw.
* I refactored i18n to fix the flaw.

Essentially the core problem is that `i18nRegistry` hooks into `print_scripts_array` to work its magic.  However this hook can potentially get invoked multiple times in the request (at least twice, once for the header, and once for the footer).  If `I18nRegistry::registerScriptI18n` only gets called once in a request for a script handle, then there would be no issues.  But if there's a set of conditions where it gets called subsequently _after_ `print_scripts_array` has been invoked, then the existing logic attempting to prevent multiple calls to `wp_add_inline_script` for a script handle will fail.  So the fix in this pull addresses that.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ]  Currently automated phpunit tests.
* [x] Verify that the systems using this mechanism (currently only the exit modal stuff) continue to work as expected and there are no js related errors in the browser console.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
