### PR TITLE
Add license checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,11 +88,16 @@ jobs:
         - npm install || exit 1
         - npm run ci || exit 1
     - php: 7.2
+      env:
+        - LICENSE_CHECK=1
+      script:
+        - npm install || exit 1
+        - npm run lc || exit 1
+    - php: 7.2
     - php: 7.1
     - php: 7.0
     - php: 5.6
     - php: 5.5
-    - php: 5.4
     # multisite
     - php: 7.2
       env: WP_MULTISITE=1

--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,0 +1,33 @@
+{
+	"greenLicenses": [
+		"GPL-2.0",
+		"GPL-2.0-or-later",
+		"GPL-2.0+",
+		"LGPL-2.1",
+		"(GPL-2.0 OR MIT)",
+		"MIT",
+		"ISC",
+		"BSD",
+		"BSD-2-Clause",
+		"BSD-3-Clause",
+		"CC0-1.0"
+	],
+	"packageWhitelist": [
+		"@eventespresso/react-exit-modal-typeform",
+		"@wordpress/jest-preset-default",
+		"js-green-licenses",
+		"@typeform/embed",
+		"scrollbar-width",
+		"webfontloader",
+		"validate-npm-package-license",
+		"spdx-correct",
+		"spdx-exceptions",
+		"domutils",
+		"domelementtype",
+		"domelementtype",
+		"nomnom",
+		"colors",
+		"underscore",
+		"spdx-ranges"
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -648,6 +648,12 @@
 			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
 			"dev": true
 		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
 		"acorn": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -795,7 +801,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -850,6 +855,11 @@
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-includes": {
 			"version": "3.0.3",
@@ -1044,6 +1054,15 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
 			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+			"requires": {
+				"follow-redirects": "^1.3.0",
+				"is-buffer": "^1.1.5"
+			}
 		},
 		"axobject-query": {
 			"version": "0.1.0",
@@ -1344,12 +1363,12 @@
 			}
 		},
 		"babel-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.4.3"
+				"babel-preset-jest": "^22.4.4"
 			}
 		},
 		"babel-loader": {
@@ -1392,9 +1411,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ=="
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
@@ -1935,11 +1954,11 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.4.3",
+				"babel-plugin-jest-hoist": "^22.4.4",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
@@ -2376,6 +2395,11 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
 		},
+		"builtins": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+		},
 		"cacache": {
 			"version": "10.0.4",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
@@ -2561,6 +2585,11 @@
 			"requires": {
 				"rsvp": "^3.3.3"
 			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3272,6 +3301,14 @@
 				"@emotion/is-prop-valid": "^0.6.1"
 			}
 		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "^1.0.0"
+			}
+		},
 		"create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -3703,6 +3740,12 @@
 				"ms": "2.0.0"
 			}
 		},
+		"debuglog": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+			"dev": true
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -3734,8 +3777,7 @@
 		"deep-extend": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-			"dev": true
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -3855,6 +3897,16 @@
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
+		"dezalgo": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+			"dev": true,
+			"requires": {
+				"asap": "^2.0.0",
+				"wrappy": "1"
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -3969,8 +4021,7 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.5.4",
@@ -4955,6 +5006,24 @@
 				"readable-stream": "^2.0.4"
 			}
 		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -5652,8 +5721,7 @@
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -6268,8 +6336,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
@@ -6622,6 +6689,11 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -6639,8 +6711,7 @@
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-scoped": {
 			"version": "1.0.0",
@@ -6899,13 +6970,13 @@
 			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
-			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
+			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
 			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.3"
+				"jest-cli": "^22.4.4"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -6953,9 +7024,9 @@
 					}
 				},
 				"jest-cli": {
-					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+					"version": "22.4.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -6969,20 +7040,20 @@
 						"istanbul-lib-coverage": "^1.1.1",
 						"istanbul-lib-instrument": "^1.8.0",
 						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.4.3",
-						"jest-config": "^22.4.3",
-						"jest-environment-jsdom": "^22.4.3",
-						"jest-get-type": "^22.4.3",
-						"jest-haste-map": "^22.4.3",
-						"jest-message-util": "^22.4.3",
-						"jest-regex-util": "^22.4.3",
-						"jest-resolve-dependencies": "^22.4.3",
-						"jest-runner": "^22.4.3",
-						"jest-runtime": "^22.4.3",
-						"jest-snapshot": "^22.4.3",
-						"jest-util": "^22.4.3",
-						"jest-validate": "^22.4.3",
-						"jest-worker": "^22.4.3",
+						"jest-changed-files": "^22.2.0",
+						"jest-config": "^22.4.4",
+						"jest-environment-jsdom": "^22.4.1",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^22.4.2",
+						"jest-message-util": "^22.4.0",
+						"jest-regex-util": "^22.1.0",
+						"jest-resolve-dependencies": "^22.1.0",
+						"jest-runner": "^22.4.4",
+						"jest-runtime": "^22.4.4",
+						"jest-snapshot": "^22.4.0",
+						"jest-util": "^22.4.1",
+						"jest-validate": "^22.4.4",
+						"jest-worker": "^22.2.2",
 						"micromatch": "^2.3.11",
 						"node-notifier": "^5.2.1",
 						"realpath-native": "^1.0.0",
@@ -7045,22 +7116,22 @@
 			}
 		},
 		"jest-config": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
-			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.3",
-				"jest-environment-node": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"jest-environment-jsdom": "^22.4.1",
+				"jest-environment-node": "^22.4.1",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^22.4.4",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"pretty-format": {
@@ -7235,21 +7306,21 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
-			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^22.4.3",
+				"expect": "^22.4.0",
 				"graceful-fs": "^4.1.11",
 				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-snapshot": "^22.4.3",
-				"jest-util": "^22.4.3",
+				"jest-diff": "^22.4.0",
+				"jest-matcher-utils": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-snapshot": "^22.4.0",
+				"jest-util": "^22.4.1",
 				"source-map-support": "^0.5.0"
 			}
 		},
@@ -7416,43 +7487,43 @@
 			}
 		},
 		"jest-runner": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
-				"jest-config": "^22.4.3",
-				"jest-docblock": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-leak-detector": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-runtime": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-worker": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-docblock": "^22.4.0",
+				"jest-haste-map": "^22.4.2",
+				"jest-jasmine2": "^22.4.4",
+				"jest-leak-detector": "^22.4.0",
+				"jest-message-util": "^22.4.0",
+				"jest-runtime": "^22.4.4",
+				"jest-util": "^22.4.1",
+				"jest-worker": "^22.2.2",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.3",
+				"babel-jest": "^22.4.4",
 				"babel-plugin-istanbul": "^4.1.5",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-haste-map": "^22.4.2",
+				"jest-regex-util": "^22.1.0",
+				"jest-resolve": "^22.4.2",
+				"jest-util": "^22.4.1",
+				"jest-validate": "^22.4.4",
 				"json-stable-stringify": "^1.0.1",
 				"micromatch": "^2.3.11",
 				"realpath-native": "^1.0.0",
@@ -7600,16 +7671,16 @@
 			}
 		},
 		"jest-validate": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
-			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-config": "^22.4.3",
-				"jest-get-type": "^22.4.3",
+				"jest-config": "^22.4.4",
+				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^22.4.3"
+				"pretty-format": "^22.4.0"
 			},
 			"dependencies": {
 				"pretty-format": {
@@ -7638,6 +7709,28 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
 			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
 			"dev": true
+		},
+		"js-green-licenses": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.5.0.tgz",
+			"integrity": "sha512-HM/SKwAl1R0y9kkBili6GqKc31ZnjzY7JHC2uO9bAHJNRmY5c/s+2cETyaqX0kBD8gX8QVhS4dJjRtY1nAwb4w==",
+			"requires": {
+				"argparse": "^1.0.9",
+				"axios": "^0.18.0",
+				"npm-package-arg": "^6.0.0",
+				"package-json": "^4.0.1",
+				"pify": "^3.0.0",
+				"spdx-correct": "^3.0.0",
+				"spdx-satisfies": "^4.0.0",
+				"strip-json-comments": "^2.0.1"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -8003,6 +8096,45 @@
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"license-checker": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/license-checker/-/license-checker-20.0.0.tgz",
+			"integrity": "sha512-+t0H3LfpLahbiUBDueiltAAQygYUWFBbfrWlxTNIgbCRIhPHECc41kM8vfKYwNAWRAT0OgomRYm1WUFZquh9qA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"debug": "^3.1.0",
+				"mkdirp": "^0.5.1",
+				"nopt": "^4.0.1",
+				"read-installed": "~4.0.3",
+				"semver": "^5.5.0",
+				"spdx": "^0.5.1",
+				"spdx-correct": "^3.0.0",
+				"spdx-satisfies": "^4.0.0",
+				"strip-ansi": "^4.0.0",
+				"treeify": "^1.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"listr": {
@@ -8442,8 +8574,7 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.2",
@@ -8965,6 +9096,16 @@
 				"underscore": "~1.4.4"
 			}
 		},
+		"nopt": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1",
+				"osenv": "^0.1.4"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -9001,6 +9142,17 @@
 				"prepend-http": "^1.0.0",
 				"query-string": "^4.1.0",
 				"sort-keys": "^1.0.0"
+			}
+		},
+		"npm-package-arg": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+			"requires": {
+				"hosted-git-info": "^2.6.0",
+				"osenv": "^0.1.5",
+				"semver": "^5.5.0",
+				"validate-npm-package-name": "^3.0.0"
 			}
 		},
 		"npm-run-path": {
@@ -9289,8 +9441,7 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
@@ -9306,8 +9457,16 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
 		},
 		"p-cancelable": {
 			"version": "0.4.1",
@@ -9383,6 +9542,45 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"requires": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"got": {
+					"version": "6.7.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+					"requires": {
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
+					}
+				},
+				"url-parse-lax": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+					"requires": {
+						"prepend-http": "^1.0.1"
+					}
+				}
+			}
 		},
 		"pako": {
 			"version": "1.0.6",
@@ -11451,8 +11649,7 @@
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"preserve": {
 			"version": "0.2.0",
@@ -11677,6 +11874,24 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
+		"rc": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+			"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+			"requires": {
+				"deep-extend": "^0.5.1",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
 		"react": {
 			"version": "16.3.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
@@ -11780,6 +11995,34 @@
 				}
 			}
 		},
+		"read-installed": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+			"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+			"dev": true,
+			"requires": {
+				"debuglog": "^1.0.1",
+				"graceful-fs": "^4.1.2",
+				"read-package-json": "^2.0.0",
+				"readdir-scoped-modules": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"slide": "~1.1.3",
+				"util-extend": "^1.0.1"
+			}
+		},
+		"read-package-json": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.2",
+				"json-parse-better-errors": "^1.0.1",
+				"normalize-package-data": "^2.0.0",
+				"slash": "^1.0.0"
+			}
+		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -11830,6 +12073,18 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"readdir-scoped-modules": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+			"integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+			"dev": true,
+			"requires": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"graceful-fs": "^4.1.2",
+				"once": "^1.3.0"
 			}
 		},
 		"readdirp": {
@@ -11984,6 +12239,23 @@
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
 				"regjsparser": "^0.1.4"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+			"requires": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -13175,6 +13447,40 @@
 			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
 			"dev": true
 		},
+		"spdx": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/spdx/-/spdx-0.5.1.tgz",
+			"integrity": "sha1-02wnUIi0jXWpBGzUSoOM5LUzmZg=",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^1.0.0",
+				"spdx-license-ids": "^1.0.0"
+			},
+			"dependencies": {
+				"spdx-exceptions": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz",
+					"integrity": "sha1-nSGsTaS9tx0GD7dOWmdTHQMsu6Y=",
+					"dev": true
+				},
+				"spdx-license-ids": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+					"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+					"dev": true
+				}
+			}
+		},
+		"spdx-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+			"integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+			"requires": {
+				"array-find-index": "^1.0.2",
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-ranges": "^2.0.0"
+			}
+		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -13203,6 +13509,21 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
+		"spdx-ranges": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
+			"integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA=="
+		},
+		"spdx-satisfies": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
+			"integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
+			"requires": {
+				"spdx-compare": "^1.0.0",
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-ranges": "^2.0.0"
+			}
+		},
 		"spin.js": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/spin.js/-/spin.js-2.3.2.tgz",
@@ -13219,8 +13540,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.14.1",
@@ -13441,8 +13761,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"stylis": {
 			"version": "3.5.0",
@@ -13599,8 +13918,7 @@
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
@@ -13710,6 +14028,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
 			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+			"dev": true
+		},
+		"treeify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+			"integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
 			"dev": true
 		},
 		"trim-right": {
@@ -13979,6 +14303,11 @@
 			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
 			"dev": true
 		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
@@ -14092,6 +14421,12 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
+		"util-extend": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+			"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+			"dev": true
+		},
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
@@ -14121,6 +14456,14 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"validate-npm-package-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"requires": {
+				"builtins": "^1.0.3"
 			}
 		},
 		"vendors": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"test-unit": "wp-scripts test-unit-js --config tests/javascript-config/unit/jest.config.json",
 		"test-unit:coverage": "npm run test-unit -- --coverage",
 		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",
-		"test-unit:watch": "npm run test-unit -- --watch"
+		"test-unit:watch": "npm run test-unit -- --watch",
+		"lc": "jsgl --local ./"
 	},
 	"author": "Event Espresso",
 	"license": "GPL-2.0",
@@ -56,6 +57,7 @@
 		"eslint-plugin-jsx-a11y": "^6.0.3",
 		"eslint-plugin-react": "^7.8.2",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#1774343f6226052a46b081e01db3fca8793cc9f1",
+		"license-checker": "^20.0.0",
 		"mini-css-extract-plugin": "^0.4.0",
 		"pegjs": "^0.10.0",
 		"postcss-loader": "^2.1.5",
@@ -72,6 +74,7 @@
 		"@wordpress/i18n": "^1.1.1",
 		"@wordpress/jest-preset-default": "^1.0.6",
 		"classnames": "^2.2.5",
+		"js-green-licenses": "^0.5.0",
 		"lodash": "^4.17.10",
 		"querystringify": "^1.0.0",
 		"react": "^16.3.0",


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

With the new build system, its really easy to add npm packages without giving thought to any licenses that package (or its dependencies) may have.  In order to prevent conflicts with our GPLv2 license, I've added a license checker package that will check licenses in install packages (dependencies only, we don't need to worry about devDependencies).  If there's a package that fails, then it will fail a travis build.  The tool can also be used outside of travis by just running `npm run lc`.

For this first iteration, I've added the configuration file that enables all our current packages to run green (whitelisted packages are either only used in development type environments or is something we already bundle in production (something thats embedded in our usage of typeform).  We may need to revisit in the future our `exit-modal-embed` package because it's license may not be compatible with the licenses in the typeform tree.  But for now I've added an exclusion.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] I ran the new script `npm run lc` and verified it passed all license checks.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
