### PR TITLE
Bug/fix domain not found js error (fixes #478)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # auto-generated/build-artifact files that should not be committed
 core/third_party_libs/dompdf/lib/fonts/log.htm
 coverage
-translation-map.json
 *-translations.php
 *.pot
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -91,7 +91,7 @@ class I18nRegistry
      */
     public function queueI18n(array $handles)
     {
-        if (empty($this->queued_scripts) || empty($this->i18n_map)) {
+        if (empty($this->queued_scripts)) {
             return $handles;
         }
         foreach ($handles as $handle) {

--- a/translation-map.json
+++ b/translation-map.json
@@ -1,0 +1,7 @@
+{
+  "ee-wp-plugins-page": [
+    "Do you have a moment to share why you are deactivating Event Espresso?",
+    "Sure I'll help",
+    "Skip"
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Fixes the error described in #478 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x]  The error can be reproduced on master by either not having `translation-map.json` in the root `event-espresso-core-reg` plugin path, or renaming it to something different.  Then switch to this branch and the error should be gone (see #478 for reference on what "the error" is).
* [x] I've verified that the exit-modal still works as expected on the plugins page.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
