### PR TITLE
Switch webpack-assets-manifest plugin config to use the assets configuration vs merge

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,6 +5,7 @@ const webpack = require( 'webpack' );
 const common = require( './webpack.common.js' );
 const CleanWebpackPlugin = require( 'clean-webpack-plugin' );
 const miniExtract = require( 'mini-css-extract-plugin' );
+const assetsData = Object.create( null );
 common.forEach( ( config, index ) => {
 	if ( common[ index ].configName === 'base' ) {
 		common[ index ].optimization = {
@@ -23,8 +24,7 @@ common.forEach( ( config, index ) => {
 				output: path.resolve( __dirname,
 					'assets/dist/build-manifest.json',
 				),
-				merge: true,
-				entrypoints: false,
+				assets: assetsData,
 			} ),
 			new webpack.ProvidePlugin( {
 				React: 'react',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -6,6 +6,7 @@ const webpack = require( 'webpack' );
 const CleanWebpackPlugin = require( 'clean-webpack-plugin' );
 const miniExtract = require( 'mini-css-extract-plugin' );
 const wpi18nExtractor = require( './bin/i18n-map-extractor.js' );
+const assetsData = Object.create( null );
 common.forEach( ( config, index ) => {
 	if ( common[ index ].configName === 'base' ) {
 		common[ index ].optimization = {
@@ -34,8 +35,7 @@ common.forEach( ( config, index ) => {
 				output: path.resolve( __dirname,
 					'assets/dist/build-manifest.json',
 				),
-				merge: true,
-				entrypoints: false,
+				assets: assetsData,
 			} ),
 			new webpack.ProvidePlugin( {
 				React: 'react',


### PR DESCRIPTION
We were experiencing some odd behaviour in upstream branches where the number of compilation configurations in webpack seems to be impacting the final `build-manifest.json` output.  It appears it was related to using `merge` in this plugins configuration instead of the `assets` option (which is explicitly FOR multiple compilation configurations).  Since this seemed to fix the issue we’re rolling with it.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Ensured the `build-manifest.json` file is correctly recording the map for chunk file to final build file.
* [x] Ensure the existing `exit-modal` still works as expected and there are no js errors in the browser console.
* [x] Ensure js tests pass.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
