### PR TITLE
TermSelectControl - A React component for adding a select input for choosing a term from a list of options

### DIFF
--- a/assets/src/components/index.js
+++ b/assets/src/components/index.js
@@ -1,1 +1,2 @@
 export { default as EventSelect } from './selection/event-select';
+export { TermSelectControl } from './selection/term-select';

--- a/assets/src/components/index.js
+++ b/assets/src/components/index.js
@@ -1,2 +1,2 @@
 export { default as EventSelect } from './selection/event-select';
-export { TermSelectControl } from './selection/term-select';
+export { default as TermSelectControl } from './selection/term-select';

--- a/assets/src/components/selection/term-select/index.js
+++ b/assets/src/components/selection/term-select/index.js
@@ -7,7 +7,7 @@ import { __ } from '@eventespresso/i18n';
 /**
  * WordPress dependencies
  */
-const { SelectControl } = '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 
 function getSelectOptions( terms, level = 0 ) {
 	return flatMap( terms, ( term ) => [

--- a/assets/src/components/selection/term-select/index.js
+++ b/assets/src/components/selection/term-select/index.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { unescape as unescapeString, repeat, flatMap, compact } from 'lodash';
+import { __ } from '@eventespresso/i18n';
+
+/**
+ * WordPress dependencies
+ */
+const { SelectControl } = '@wordpress/components';
+
+function getSelectOptions( terms, level = 0 ) {
+	return flatMap( terms, ( term ) => [
+		{
+			value: term.slug,
+			label: repeat( '\u00A0', level * 3 ) + unescapeString( term.name ),
+		},
+		...getSelectOptions( term.children, level + 1 ),
+	] );
+}
+
+export const TermSelectControl = ( {
+	selectedTerm,
+	terms,
+	label,
+	noOptionLabel,
+	onChange,
+} ) => {
+	const options = compact( [
+		noOptionLabel && { value: '', label: noOptionLabel },
+		...getSelectOptions( terms ),
+	] );
+	return (
+		<SelectControl
+			{ ...{ label, options, onChange } }
+			value={ selectedTerm }
+		/>
+	);
+};

--- a/assets/src/components/selection/term-select/index.js
+++ b/assets/src/components/selection/term-select/index.js
@@ -33,7 +33,7 @@ const TermSelectControl = ( {
 	noSelectionLabel = __( 'Please make a selection', 'event_espresso' ),
 	onChange,
 } ) => {
-	if ( !onChange || isEmpty( terms ) ) {
+	if ( ! onChange || isEmpty( terms ) ) {
 		return null;
 	}
 	const options = compact( [

--- a/assets/src/components/selection/term-select/index.js
+++ b/assets/src/components/selection/term-select/index.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { unescape as unescapeString, repeat, flatMap, compact } from 'lodash';
+import {
+	unescape,
+	repeat,
+	flatMap,
+	compact,
+	isEmpty,
+} from 'lodash';
+import PropTypes from 'prop-types';
 import { __ } from '@eventespresso/i18n';
 
 /**
@@ -13,21 +20,24 @@ function getSelectOptions( terms, level = 0 ) {
 	return flatMap( terms, ( term ) => [
 		{
 			value: term.slug,
-			label: repeat( '\u00A0', level * 3 ) + unescapeString( term.name ),
+			label: repeat( '\u00A0', level * 3 ) + unescape( term.name ),
 		},
 		...getSelectOptions( term.children, level + 1 ),
 	] );
 }
 
-export const TermSelectControl = ( {
+const TermSelectControl = ( {
 	selectedTerm,
 	terms,
 	label,
-	noOptionLabel,
+	noSelectionLabel = __( 'Please make a selection', 'event_espresso' ),
 	onChange,
 } ) => {
+	if ( !onChange || isEmpty( terms ) ) {
+		return null;
+	}
 	const options = compact( [
-		noOptionLabel && { value: '', label: noOptionLabel },
+		noSelectionLabel && { value: '', label: noSelectionLabel },
 		...getSelectOptions( terms ),
 	] );
 	return (
@@ -37,3 +47,19 @@ export const TermSelectControl = ( {
 		/>
 	);
 };
+
+TermSelectControl.propTypes = {
+	selectedTerm: PropTypes.string,
+	terms: PropTypes.arrayOf(
+		PropTypes.shape( {
+			slug: PropTypes.string.required,
+			name: PropTypes.string.required,
+			children: PropTypes.array,
+		} ),
+	),
+	label: PropTypes.string,
+	noSelectionLabel: PropTypes.string,
+	onChange: PropTypes.func,
+};
+
+export default TermSelectControl;

--- a/assets/src/components/selection/term-select/test/index.js
+++ b/assets/src/components/selection/term-select/test/index.js
@@ -57,7 +57,7 @@ describe( 'TermSelectControl with no selected Term', () => {
 		expect( termSelect.props().value ).toBe( '' );
 		// and options
 		const termSelectOptions = wrapper.find( 'option' );
-		expect( termSelectOptions.length ).toEqual( terms.length + 1 );
+		expect( termSelectOptions ).toHaveLength( terms.length + 1 );
 		expect( termSelectOptions.at( 0 ).props().value ).toBe( '' );
 		expect( termSelectOptions.at( 0 ).text() ).toEqual(
 			'Please make a selection'

--- a/assets/src/components/selection/term-select/test/index.js
+++ b/assets/src/components/selection/term-select/test/index.js
@@ -6,11 +6,105 @@ import { mount } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { TermSelectControl } from '../';
+import { default as TermSelectControl } from '../';
 
 describe( 'TermSelectControl with no options provided', () => {
 	it( 'should return nothing', () => {
-		const wrapper = mount( <TermSelectControl/> );
-		expect( wrapper.instance() ).toBe( null );
+		const wrapper = mount( <TermSelectControl /> );
+		expect( wrapper.instance() ).toBeNull();
+	} );
+} );
+
+describe( 'TermSelectControl with empty options provided', () => {
+	it( 'should return nothing', () => {
+		const terms = [];
+		const wrapper = mount( <TermSelectControl terms={ terms } /> );
+		expect( wrapper.instance() ).toBeNull();
+	} );
+} );
+
+describe( 'TermSelectControl with no selected Term', () => {
+	it( 'should have default option added and selected', () => {
+		// set up props
+		const selectedTerm = '';
+		const terms = [
+			{
+				slug: 'one',
+				name: 'One',
+			},
+			{
+				slug: 'two',
+				name: 'Two',
+			},
+			{
+				slug: 'three',
+				name: 'Three',
+			},
+		];
+		const label = 'Select one to three';
+		const onChange = jest.fn();
+
+		const wrapper = mount(
+			<TermSelectControl
+				selectedTerm={ selectedTerm }
+				terms={ terms }
+				label={ label }
+				onChange={ onChange }
+			/>
+		);
+		// test select input
+		const termSelect = wrapper.find( 'select' );
+		expect( termSelect.props().value ).toBe( '' );
+		// and options
+		const termSelectOptions = wrapper.find( 'option' );
+		expect( termSelectOptions.length ).toEqual( terms.length + 1 );
+		expect( termSelectOptions.at( 0 ).props().value ).toBe( '' );
+		expect( termSelectOptions.at( 0 ).text() ).toEqual(
+			'Please make a selection'
+		);
+		expect( termSelectOptions.at( 1 ).props().value ).toBe( 'one' );
+		expect( termSelectOptions.at( 2 ).props().value ).toBe( 'two' );
+		expect( termSelectOptions.at( 3 ).props().value ).toBe( 'three' );
+		// and label
+		const selectLabel = wrapper.find( 'label' );
+		expect( selectLabel.text() ).toEqual( 'Select one to three' );
+		// test onChange
+		termSelect.simulate( 'change', { target: { value: 'two' } } );
+		expect( onChange ).toHaveBeenCalledWith( 'two' );
+	} );
+} );
+
+describe( 'TermSelectControl with previously selected Term', () => {
+	it( 'should have that term selected', () => {
+		// set up props
+		const selectedTerm = 'two';
+		const terms = [
+			{
+				slug: 'one',
+				name: 'One',
+			},
+			{
+				slug: 'two',
+				name: 'Two',
+			},
+			{
+				slug: 'three',
+				name: 'Three',
+			},
+		];
+		const label = 'Select one to three';
+		const onChange = jest.fn();
+
+		const wrapper = mount(
+			<TermSelectControl
+				selectedTerm={ selectedTerm }
+				terms={ terms }
+				label={ label }
+				onChange={ onChange }
+			/>
+		);
+		// test select input
+		const termSelect = wrapper.find( 'select' );
+		expect( termSelect.props().value ).toBe( 'two' );
 	} );
 } );

--- a/assets/src/components/selection/term-select/test/index.js
+++ b/assets/src/components/selection/term-select/test/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { TermSelectControl } from '../';
+
+describe( 'TermSelectControl with no options provided', () => {
+	it( 'should return nothing', () => {
+		const wrapper = mount( <TermSelectControl/> );
+		expect( wrapper.instance() ).toBe( null );
+	} );
+} );

--- a/docs/AA--Javascript-in-EE/Blocks-and-Components/components/selection/term-select.md
+++ b/docs/AA--Javascript-in-EE/Blocks-and-Components/components/selection/term-select.md
@@ -1,0 +1,131 @@
+TermSelectControl
+=======
+
+A React component for adding a select input for choosing a term from a list of options
+
+
+## Usage Overview
+
+```jsx
+<TermSelectControl 
+    selectedTerm={ 'two' } 
+    terms={
+        [ 
+            { slug: 'one', name: 'One'  }, 
+            { slug: 'two', name: 'Two' }, 
+            { slug: 'three', name: 'Three' }, 
+        ]
+    } 
+    label={ 'Select one to three' } 
+    noSelectionLabel={ 'please make a selection' } 
+    onChange={ 
+        ( value ) => setAttributes( { selectedTerm: value } ) 
+    } 
+/> 
+```
+
+## Props
+
+### selectedTerm
+
+The previously selected value for the input
+
+- Type: `string`
+- Required: No
+
+### terms
+
+The options that will populate the select input.
+ 
+- Type: `Array`
+- Required: No
+
+Each element of the array should be an object with the following properties:
+
+ * **slug** a unique identifier for the option
+    * Type: `String`
+    * Required: Yes
+ * **name** the text that will be displayed for the option
+    * Type: `String`
+    * Required: Yes
+ * **children** an array of additional options
+    * Type: `Array`
+    * Required: No
+    
+### label
+
+The text to be used for the input's corresponding label
+
+- Type: `String`
+- Required: Yes
+    
+### noSelectionLabel
+
+The text to be displayed for the first option if no option has been set as the selected value
+
+- Type: `String`
+- Required: No
+- Default: "Please make a selection"
+
+### onChange
+
+The  function called when a change of value is detected. Used for saving the value for the "selectedTerm" attribute.
+
+- Type: `Function`
+- Required: Yes
+
+
+## Usage within a Block's edit callback
+
+This is assuming the `TermSelectControl ` component will be utilized within an `InspectorControls` component
+
+### Step 1
+Import the following external dependencies:
+
+```jsx
+import { __ } from '@eventespresso/i18n';
+import { TermSelectControl  } from '@eventespresso/components';
+import { PanelBody } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/editor';
+```
+
+### Step 2
+Add a "limit" attribute:
+
+```jsx
+attributes: {
+    selectedTerm: {
+        type: 'string',
+    },
+},
+```
+
+### Step 3
+Wrap the TermSelectControl component within the InspectorControls and PanelBody components
+ (currently shown within a block's edit() function)
+
+```jsx
+edit: ( ( { attributes, setAttributes } ) => {
+    const { selectedTerm } = attributes; 
+    const terms = [ 
+        { slug: 'one', name: 'One'  }, 
+        { slug: 'two', name: 'Two' }, 
+        { slug: 'three', name: 'Three' }, 
+    ]; 
+    const label = __( 'Select one to three', 'event_espresso' ); 
+    return (
+        <InspectorControls>
+            <PanelBody>
+                <TermSelectControl 
+                    selectedTerm={ selectedTerm } 
+                    terms={ terms } 
+                    label={ label }
+                    onChange={ 
+                        ( value ) => setAttributes( { selectedTerm: value } ) 
+                    } 
+                />
+            </PanelBody>
+        </InspectorControls>
+    );
+})
+```


### PR DESCRIPTION
## Problem this Pull Request solves
Boilerplate component for creating other more specific term selector components such as an Event Category select component

## How has this been tested
with an actual block and via included jest tests

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
