### PR TITLE
Bug/privacy policy fatal error in maintenance mode fixes #489

### DIFF
--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1199,17 +1199,9 @@ final class EE_System implements ResettableInterface
         );
         $rewrite_rules->flushRewriteRules();
         add_action('admin_bar_init', array($this, 'addEspressoToolbar'));
-        if ($this->request->isAdmin()) {
-            $this->loader->getShared('EventEspresso\core\services\privacy\policy\PrivacyPolicyManager');
+        if($this->request->isAjax() && $this->maintenance_mode->models_can_query()) {
             $this->loader->getShared('EventEspresso\core\services\privacy\export\PersonalDataExporterManager');
             $this->loader->getShared('EventEspresso\core\services\privacy\erasure\PersonalDataEraserManager');
-        }
-        if ($this->request->isAjax()) {
-            $this->loader->getShared('EventEspresso\core\services\privacy\export\PersonalDataExporterManager');
-            $this->loader->getShared('EventEspresso\core\services\privacy\erasure\PersonalDataEraserManager');
-        }
-        if ($this->request->isAdmin() && function_exists('wp_add_privacy_policy_content')) {
-            $this->loader->getShared('EventEspresso\core\services\privacy\policy\PrivacyPolicyManager');
         }
     }
 

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1199,7 +1199,8 @@ final class EE_System implements ResettableInterface
         );
         $rewrite_rules->flushRewriteRules();
         add_action('admin_bar_init', array($this, 'addEspressoToolbar'));
-        if ($this->request->isAjax() && $this->maintenance_mode->models_can_query()) {
+        if (($this->request->isAjax() || $this->request->isAdmin())
+            && $this->maintenance_mode->models_can_query()) {
             $this->loader->getShared('EventEspresso\core\services\privacy\export\PersonalDataExporterManager');
             $this->loader->getShared('EventEspresso\core\services\privacy\erasure\PersonalDataEraserManager');
         }

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1199,7 +1199,7 @@ final class EE_System implements ResettableInterface
         );
         $rewrite_rules->flushRewriteRules();
         add_action('admin_bar_init', array($this, 'addEspressoToolbar'));
-        if($this->request->isAjax() && $this->maintenance_mode->models_can_query()) {
+        if ($this->request->isAjax() && $this->maintenance_mode->models_can_query()) {
             $this->loader->getShared('EventEspresso\core\services\privacy\export\PersonalDataExporterManager');
             $this->loader->getShared('EventEspresso\core\services\privacy\erasure\PersonalDataEraserManager');
         }

--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -194,7 +194,7 @@ final class EE_Admin implements InterminableInterface
     {
         // only enable most of the EE_Admin IF we're not in full maintenance mode
         if (EE_Maintenance_Mode::instance()->models_can_query()) {
-           $this->initModelsReady();
+            $this->initModelsReady();
         }
         // run the admin page factory but ONLY if we are doing an ee admin ajax request
         if (! defined('DOING_AJAX') || EE_ADMIN_AJAX) {

--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -8,7 +8,7 @@ use EventEspresso\core\interfaces\InterminableInterface;
 use EventEspresso\core\services\container\exceptions\ServiceNotFoundException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\notifications\PersistentAdminNoticeManager;
-use WPStaging\Utils\Loader;
+use EventEspresso\core\services\loaders\LoaderInterface;
 
 /**
  * EE_Admin
@@ -31,7 +31,7 @@ final class EE_Admin implements InterminableInterface
     private $persistent_admin_notice_manager;
 
     /**
-     * @var Loader
+     * @var LoaderInterface
      */
     protected $loader;
 
@@ -222,14 +222,14 @@ final class EE_Admin implements InterminableInterface
 
     /**
      * Gets the loader (and if it wasn't previously set, sets it)
-     * @return \EventEspresso\core\services\loaders\LoaderInterface|Loader
+     * @return LoaderInterface
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
     protected function getLoader()
     {
-        if (! $this->loader instanceof Loader){
+        if (! $this->loader instanceof LoaderInterface) {
             $this->loader = LoaderFactory::getLoader();
         }
         return $this->loader;

--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -194,24 +194,7 @@ final class EE_Admin implements InterminableInterface
     {
         // only enable most of the EE_Admin IF we're not in full maintenance mode
         if (EE_Maintenance_Mode::instance()->models_can_query()) {
-            // ok so we want to enable the entire admin
-            $this->persistent_admin_notice_manager = LoaderFactory::getLoader()->getShared(
-                'EventEspresso\core\services\notifications\PersistentAdminNoticeManager'
-            );
-            $this->persistent_admin_notice_manager->setReturnUrl(
-                EE_Admin_Page::add_query_args_and_nonce(
-                    array(
-                        'page'   => EE_Registry::instance()->REQ->get('page', ''),
-                        'action' => EE_Registry::instance()->REQ->get('action', ''),
-                    ),
-                    EE_ADMIN_URL
-                )
-            );
-            $this->maybeSetDatetimeWarningNotice();
-            // at a glance dashboard widget
-            add_filter('dashboard_glance_items', array($this, 'dashboard_glance_items'), 10);
-            // filter for get_edit_post_link used on comments for custom post types
-            add_filter('get_edit_post_link', array($this, 'modify_edit_post_link'), 10, 2);
+           $this->initModelsReady();
         }
         // run the admin page factory but ONLY if we are doing an ee admin ajax request
         if (! defined('DOING_AJAX') || EE_ADMIN_AJAX) {
@@ -228,6 +211,39 @@ final class EE_Admin implements InterminableInterface
         add_action('admin_head', array($this, 'register_custom_nav_menu_boxes'), 10);
         // exclude EE critical pages from all nav menus and wp_list_pages
         add_filter('nav_menu_meta_box_object', array($this, 'remove_pages_from_nav_menu'), 10);
+    }
+
+
+    /**
+     * Method that's fired on admin requests (including admin ajax) but only when the models are usable
+     * (ie, the site isn't in maintenance mode)
+     * @since $VID:$
+     * @return void
+     */
+    protected function initModelsReady()
+    {
+        $loader = LoaderFactory::getLoader();
+        // ok so we want to enable the entire admin
+        $this->persistent_admin_notice_manager = $loader->getShared(
+            'EventEspresso\core\services\notifications\PersistentAdminNoticeManager'
+        );
+        $this->persistent_admin_notice_manager->setReturnUrl(
+            EE_Admin_Page::add_query_args_and_nonce(
+                array(
+                    'page'   => EE_Registry::instance()->REQ->get('page', ''),
+                    'action' => EE_Registry::instance()->REQ->get('action', ''),
+                ),
+                EE_ADMIN_URL
+            )
+        );
+        $this->maybeSetDatetimeWarningNotice();
+        // at a glance dashboard widget
+        add_filter('dashboard_glance_items', array($this, 'dashboard_glance_items'), 10);
+        // filter for get_edit_post_link used on comments for custom post types
+        add_filter('get_edit_post_link', array($this, 'modify_edit_post_link'), 10, 2);
+        if (function_exists('wp_add_privacy_policy_content')) {
+            $loader->getShared('EventEspresso\core\services\privacy\policy\PrivacyPolicyManager');
+        }
     }
 
 

--- a/core/domain/services/contexts/RequestTypeContextCheckerInterface.php
+++ b/core/domain/services/contexts/RequestTypeContextCheckerInterface.php
@@ -38,6 +38,7 @@ interface RequestTypeContextCheckerInterface
 
     /**
      * true if the current request is for the admin AND is being made via AJAX
+     * and the ajax request contains the request parameter "ee_admin_ajax"
      *
      * @return bool
      */

--- a/core/services/privacy/policy/PrivacyPolicyManager.php
+++ b/core/services/privacy/policy/PrivacyPolicyManager.php
@@ -11,7 +11,7 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\collections\CollectionDetails;
 use EventEspresso\core\services\collections\CollectionInterface;
 use EventEspresso\core\services\collections\CollectionLoader;
-use WP_Post;
+use WP_Screen;
 
 /**
  * Class PrivacyPolicyManager
@@ -30,16 +30,20 @@ class PrivacyPolicyManager
     }
 
 
-
     /**
      * For all the registered `PrivacyPolicyInterface`s, add their privacy policy content
      *
-     * @param WP_Post $post
+     * @param WP_Screen $screen
+     * @throws InvalidClassException
+     * @throws InvalidDataTypeException
+     * @throws InvalidEntityException
+     * @throws InvalidFilePathException
+     * @throws InvalidIdentifierException
+     * @throws InvalidInterfaceException
      */
-    public function addPrivacyPolicy()
+    public function addPrivacyPolicy(WP_Screen $screen)
     {
-        $screen = get_current_screen();
-        if ($screen instanceof \WP_Screen
+        if ($screen instanceof WP_Screen
             && $screen->id === 'tools'
             && isset($_GET['wp-privacy-policy-guide'])) {
             // load all the privacy policy stuff

--- a/core/services/privacy/policy/PrivacyPolicyManager.php
+++ b/core/services/privacy/policy/PrivacyPolicyManager.php
@@ -26,8 +26,9 @@ class PrivacyPolicyManager
 
     public function __construct()
     {
-        add_action('admin_init', array($this, 'addPrivacyPolicy'), 9);
+        add_action('current_screen', array($this, 'addPrivacyPolicy'), 9);
     }
+
 
 
     /**
@@ -37,14 +38,15 @@ class PrivacyPolicyManager
      */
     public function addPrivacyPolicy()
     {
-        $policy_page_id = (int) get_option('wp_page_for_privacy_policy');
-        if (! $policy_page_id) {
-            return;
-        }
-        // load all the privacy policy stuff
-        // add post policy text
-        foreach ($this->loadPrivacyPolicyCollection() as $privacy_policy) {
-            wp_add_privacy_policy_content($privacy_policy->getName(), $privacy_policy->getContent());
+        $screen = get_current_screen();
+        if ($screen instanceof \WP_Screen
+            && $screen->id === 'tools'
+            && isset($_GET['wp-privacy-policy-guide'])) {
+            // load all the privacy policy stuff
+            // add post policy text
+            foreach ($this->loadPrivacyPolicyCollection() as $privacy_policy) {
+                wp_add_privacy_policy_content($privacy_policy->getName(), $privacy_policy->getContent());
+            }
         }
     }
 

--- a/espresso.php
+++ b/espresso.php
@@ -3,7 +3,7 @@
   Plugin Name:Event Espresso
   Plugin URI: http://eventespresso.com/pricing/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
   Description: Manage events, sell tickets, and receive payments from your WordPress website. Reduce event administration time, cut-out ticketing fees, and own your customer data. | <a href="https://eventespresso.com/add-ons/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Extensions</a> | <a href="https://eventespresso.com/pricing/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Sales</a> | <a href="admin.php?page=espresso_support">Support</a>
-  Version: 4.9.63.rc.007
+  Version: 4.9.63.rc.008
   Author: Event Espresso
   Author URI: http://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
   License: GPLv2
@@ -102,7 +102,7 @@ if (function_exists('espresso_version')) {
          */
         function espresso_version()
         {
-            return apply_filters('FHEE__espresso__espresso_version', '4.9.63.rc.007');
+            return apply_filters('FHEE__espresso__espresso_version', '4.9.63.rc.008');
         }
 
         /**


### PR DESCRIPTION
Addresses https://github.com/eventespresso/event-espresso-core/issues/489 by only loading the privacy policy code when the site isn't in full maintenance mode. 
Also introduces `EE_Admin::initModelsReady()` which should be used for admin code that only runs when the site is in NOT in full maintenance mode.