### PR TITLE
Remove unimplemented methods from AssetManager(&interface)

### DIFF
--- a/core/services/assets/AssetManager.php
+++ b/core/services/assets/AssetManager.php
@@ -113,15 +113,6 @@ abstract class AssetManager implements AssetManagerInterface
     }
 
 
-    /**
-     * @return JavascriptAsset[]
-     * @since 4.9.62.p
-     */
-    public function getJavascriptAssets()
-    {
-        return $this->assets->getJavascriptAssets();
-    }
-
 
     /**
      * @param string $handle
@@ -149,16 +140,6 @@ abstract class AssetManager implements AssetManagerInterface
         );
         $this->assets->add($asset, $handle);
         return $asset;
-    }
-
-
-    /**
-     * @return StylesheetAsset[]
-     * @since 4.9.62.p
-     */
-    public function getStylesheetAssets()
-    {
-        return $this->assets->getStylesheetAssets();
     }
 
 

--- a/core/services/assets/AssetManagerInterface.php
+++ b/core/services/assets/AssetManagerInterface.php
@@ -62,12 +62,6 @@ interface AssetManagerInterface
     );
 
 
-    /**
-     * @return JavascriptAsset[]
-     * @since 4.9.62.p
-     */
-    public function getJavascriptAssets();
-
 
     /**
      * @param string $handle
@@ -86,13 +80,6 @@ interface AssetManagerInterface
         array $dependencies = array(),
         $media = 'all'
     );
-
-
-    /**
-     * @return StylesheetAsset[]
-     * @since 4.9.62.p
-     */
-    public function getStylesheetAssets();
 
 
     /**


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

We currently have `getJavascriptAssets` and `getStylesheetAssets` in `AssetManager` which are not implemented anywhere and are also potentially gotchas since they return ALL registered assets in the `AssetCollection` (not just assets registered via the concrete manager).  After discussion with @tn3rb in slack, we both agreed that they can be nixed for now.

This pull takes care of removing them (along with the interface declaration)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Verified that there were no errors/warnings/fatals when loading a website with this branch active (this is a core system so if something was wrong it'd show up immediately)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
