### PR TITLE
Fix bug with lodash in vendor bundle trouncing the _ global used by underscore.

### DIFF
--- a/assets/dist/build-manifest.json
+++ b/assets/dist/build-manifest.json
@@ -1,7 +1,7 @@
 {
   "eejs.js": "ee-eejs.f110338acc2bc2da6dae.dist.js",
   "manifest.js": "ee-manifest.3b66c2f77d3b01c1b09a.dist.js",
-  "vendor.js": "ee-vendor.4d87d4d2bcb9de9d56bd.dist.js",
+  "vendor.js": "ee-vendor.a7c50608201c56d1424c.dist.js",
   "wp-plugins-page.css": "ee-wp-plugins-page.12612f6ab71570ab1af8.dist.css",
   "wp-plugins-page.js": "ee-wp-plugins-page.2d53dd52679d995d5e4b.dist.js"
 }

--- a/assets/src/eejs/vendor/index.js
+++ b/assets/src/eejs/vendor/index.js
@@ -4,6 +4,6 @@ module.exports = {
 	reactRedux: require( 'react-redux' ),
 	redux: require( 'redux' ),
 	classnames: require( 'classnames' ),
-	lodash: require( 'lodash' ),
+	lodash: require( 'lodash' ).noConflict(),
 	moment: require( 'moment' ),
 };


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Brent started getting a error message of `The editor has encountered an unexpected error.` while working on our gutenberg integration work.  I was able to reproduce a similar error and stack by adding a image block to gutenberg.  The root cause of the issue is our `vendor` js "library" build is exporting `lodash` directly and even though I assigned it's output to `eejs.vendor.lodash` lodash still assigns itself to the `_` global.  So `eejs.vendor.lodash` just ends up pointing to the reference.

The solution (as presented in this pull) is to simply export lodash via its `noConflict` method which unassigns itself from the root `_` global.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Both @tn3rb and I confirmed this fix fixes the error we were seeing in upstream branches and did not break our usage of lodash methods.
* [x] I verified this doesn't break any current js functionality for EE stuff using the `vendor` library.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
