### PR TITLE
Bug/registry check addons exist before using them

### DIFF
--- a/core/EE_Registry.core.php
+++ b/core/EE_Registry.core.php
@@ -1454,7 +1454,11 @@ class EE_Registry implements ResettableInterface
     public function getAddon($class_name)
     {
         $class_name = str_replace('\\', '_', $class_name);
-        return $this->addons->{$class_name};
+        if (isset($this->addons->{$class_name})) {
+            return $this->addons->{$class_name};
+        } else {
+            return null;
+        }
     }
 
 
@@ -1467,7 +1471,9 @@ class EE_Registry implements ResettableInterface
     public function removeAddon($class_name)
     {
         $class_name = str_replace('\\', '_', $class_name);
-        unset($this->addons->{$class_name});
+        if (isset($this->addons->{$class_name})) {
+            unset($this->addons->{$class_name});
+        }
     }
 
 

--- a/core/EE_Registry.core.php
+++ b/core/EE_Registry.core.php
@@ -1471,9 +1471,7 @@ class EE_Registry implements ResettableInterface
     public function removeAddon($class_name)
     {
         $class_name = str_replace('\\', '_', $class_name);
-        if (isset($this->addons->{$class_name})) {
-            unset($this->addons->{$class_name});
-        }
+        unset($this->addons->{$class_name});
     }
 
 

--- a/tests/testcases/core/EE_Registry_Test.php
+++ b/tests/testcases/core/EE_Registry_Test.php
@@ -752,6 +752,26 @@ class EE_Registry_Test extends EE_UnitTestCase{
 	}
 
 
+    /**
+     * Corresponds to https://github.com/eventespresso/eventsmart.com-website/issues/36
+     * where fetching an add-on that isn't yet registered causes an error
+     */
+	public function testGetAddonThatDoesntExist()
+    {
+        EE_Registry_Mock::instance()->getAddon('foobar');
+        $this->assertTrue(true);
+    }
+
+
+    /**
+     * Corresponds to https://github.com/eventespresso/eventsmart.com-website/issues/36
+     * where fetching an add-on that isn't yet registered causes an error
+     */
+    public function testremoveAddonThatDoesntExist()
+    {
+        EE_Registry_Mock::instance()->removeAddon('foobar');
+        $this->assertTrue(true);
+    }
 
 }
 // End of file EE_Registry_Test.php


### PR DESCRIPTION
This resolves the saas issue https://github.com/eventespresso/eventsmart.com-website/issues/36.
Apparently if you try to access a non-existent property on an `stdClass` it can cause an error.
I don't think there is any way in EE core to reproduce the issue (besides the unit tests that I just added).