### PR TITLE
Fix CPT query filters being applied twice Fixes #496

### DIFF
--- a/core/CPTs/EE_CPT_Event_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Event_Strategy.core.php
@@ -1,30 +1,27 @@
 <?php
 
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+
 /**
  *EE_CPT_Event_Strategy
  *
- * @package               Event Espresso
- * @subpackage            /core/CPTs/EE_CPT_Event_Strategy.core.php
- * @author                Brent Christensen
- *
- * ------------------------------------------------------------------------
+ * @package     Event Espresso
+ * @subpackage  /core/CPTs/EE_CPT_Event_Strategy.core.php
+ * @author      Brent Christensen
  */
 class EE_CPT_Event_Strategy
 {
 
     /**
-     * $CPT - the current page, if it utilizes CPTs
+     * the current page, if it utilizes CPTs
      *
-     * @var    object
-     * @access    protected
+     * @var object $CPT
      */
-    protected $CPT = null;
+    protected $CPT;
 
 
     /**
-     *    class constructor
-     *
-     * @access    public
      * @param WP_Query $wp_query
      * @param array    $CPT
      */
@@ -86,6 +83,7 @@ class EE_CPT_Event_Strategy
         $this->_remove_filters();
     }
 
+
     /**
      * Should eb called when the last filter or hook is fired for this CPT strategy.
      * This is to avoid applying this CPT strategy for other posts or CPTs (eg,
@@ -104,12 +102,13 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    posts_fields
-     *
-     * @access    public
-     * @param          $SQL
+     * @param string   $SQL
      * @param WP_Query $wp_query
      * @return    string
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public function posts_fields($SQL, WP_Query $wp_query)
     {
@@ -134,13 +133,13 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    posts_join
-     *
-     * @access    public
-     * @param          $SQL
+     * @param string   $SQL
      * @param WP_Query $wp_query
-     * @internal  param \WP_Query $WP_Query
-     * @return    string
+     * @return string
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public function posts_join($SQL, WP_Query $wp_query)
     {
@@ -162,12 +161,13 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    posts_where
-     *
-     * @access    public
-     * @param          $SQL
+     * @param string   $SQL
      * @param WP_Query $wp_query
-     * @return    string
+     * @return string
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public function posts_where($SQL, WP_Query $wp_query)
     {
@@ -191,12 +191,9 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    posts_orderby
-     *
-     * @access    public
-     * @param    string   $SQL
-     * @param    WP_Query $wp_query
-     * @return    string
+     * @param string   $SQL
+     * @param WP_Query $wp_query
+     * @return string
      */
     public function posts_orderby($SQL, WP_Query $wp_query)
     {
@@ -214,12 +211,9 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    posts_groupby
-     *
-     * @access    public
-     * @param          $SQL
+     * @param string   $SQL
      * @param WP_Query $wp_query
-     * @return    string
+     * @return string
      */
     public function posts_groupby($SQL, WP_Query $wp_query)
     {
@@ -241,12 +235,9 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    the_posts
-     *
-     * @access    public
-     * @param          $posts
+     * @param array    $posts
      * @param WP_Query $wp_query
-     * @return    array
+     * @return array
      */
     public function the_posts($posts, WP_Query $wp_query)
     {
@@ -255,9 +246,6 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     *    get_EE_post_type_metadata
-     *
-     * @access    public
      * @param null $meta_value
      * @param      $post_id
      * @param      $meta_key

--- a/core/CPTs/EE_CPT_Event_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Event_Strategy.core.php
@@ -72,8 +72,19 @@ class EE_CPT_Event_Strategy
         // add_filter( 'the_posts', array( $this, 'the_posts' ), 1, 2 );
         add_filter('posts_orderby', array($this, 'posts_orderby'), 1, 2);
         add_filter('posts_groupby', array($this, 'posts_groupby'), 1, 2);
+        add_action('posts_selection', array($this, 'remove_filters'));
     }
 
+
+    /**
+     * public access to _remove_filters()
+     *
+     * @since $VID:$
+     */
+    public function remove_filters()
+    {
+        $this->_remove_filters();
+    }
 
     /**
      * Should eb called when the last filter or hook is fired for this CPT strategy.
@@ -88,6 +99,7 @@ class EE_CPT_Event_Strategy
         // remove_filter( 'the_posts', array( $this, 'the_posts' ), 1 );
         remove_filter('posts_orderby', array($this, 'posts_orderby'), 1);
         remove_filter('posts_groupby', array($this, 'posts_groupby'), 1);
+        remove_action('posts_selection', array($this, 'remove_filters'));
     }
 
 

--- a/core/CPTs/EE_CPT_Event_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Event_Strategy.core.php
@@ -49,9 +49,9 @@ class EE_CPT_Event_Strategy
         if ($WP_Query instanceof WP_Query) {
             $WP_Query->is_espresso_event_single = is_singular()
                                                   && isset($WP_Query->query->post_type)
-                                                  && $WP_Query->query->post_type == 'espresso_events';
-            $WP_Query->is_espresso_event_archive = is_post_type_archive('espresso_events') ? true : false;
-            $WP_Query->is_espresso_event_taxonomy = is_tax('espresso_event_categories') ? true : false;
+                                                  && $WP_Query->query->post_type === 'espresso_events';
+            $WP_Query->is_espresso_event_archive = is_post_type_archive('espresso_events');
+            $WP_Query->is_espresso_event_taxonomy = is_tax('espresso_event_categories');
         }
     }
 
@@ -124,7 +124,9 @@ class EE_CPT_Event_Strategy
             $SQL .= ', ' . EEM_Datetime::instance()->table() . '.* ';
             if ($wp_query->is_espresso_event_archive || $wp_query->is_espresso_event_taxonomy) {
                 // because we only want to retrieve the next upcoming datetime for each event:
-                // add something like ", MIN( wp_esp_datetime.DTT_EVT_start ) as event_start_date " to WP Query SELECT statement
+                // add something like:
+                // ", MIN( wp_esp_datetime.DTT_EVT_start ) as event_start_date "
+                // to WP Query SELECT statement
                 $SQL .= ', MIN( ' . EEM_Datetime::instance()->table() . '.DTT_EVT_start ) as event_start_date ';
             }
         }
@@ -151,7 +153,9 @@ class EE_CPT_Event_Strategy
                 || $wp_query->is_espresso_event_taxonomy
             )
         ) {
-            // adds something like " LEFT JOIN wp_esp_datetime ON ( wp_esp_datetime.EVT_ID = wp_posts.ID ) " to WP Query JOIN statement
+            // adds something like:
+            // " LEFT JOIN wp_esp_datetime ON ( wp_esp_datetime.EVT_ID = wp_posts.ID ) "
+            // to WP Query JOIN statement
             $SQL .= ' INNER JOIN ' . EEM_Datetime::instance()->table() . ' ON ( ' . EEM_Event::instance()->table()
                     . '.ID = ' . EEM_Datetime::instance()->table() . '.'
                     . EEM_Event::instance()->primary_key_name() . ' ) ';
@@ -225,7 +229,8 @@ class EE_CPT_Event_Strategy
             )
         ) {
             // TODO: add event list option for displaying ALL datetimes in event list or only primary datetime (default)
-            // we're joining to the datetimes table, where there can be MANY datetimes for a single event, but we want to only show each event only once
+            // we're joining to the datetimes table, where there can be MANY datetimes for a single event,
+            // but we want to only show each event only once
             // (whereas if we didn't group them by the post's ID, then we would end up with many repeats)
             global $wpdb;
             $SQL = $wpdb->posts . '.ID ';

--- a/core/CPTs/EE_CPT_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Strategy.core.php
@@ -265,10 +265,10 @@ class EE_CPT_Strategy extends EE_Base
                     // but which CPT does that correspond to??? hmmm... guess we gotta go looping
                     foreach ($this->_CPTs as $post_type => $CPT) {
                         // verify our CPT has args, is public and has taxonomies set
-                        if (isset($CPT['args'], $CPT['args']['public'])
+                        if (isset($CPT['args']['public'])
                             && $CPT['args']['public']
                             && ! empty($CPT['args']['taxonomies'])
-                            && in_array($CPT_taxonomy, $CPT['args']['taxonomies'])
+                            && in_array($CPT_taxonomy, $CPT['args']['taxonomies'], true)
                         ) {
                             // if so, then add this CPT post_type to the current query's array of post_types'
                             $WP_Query->query_vars['post_type'] = isset($WP_Query->query_vars['post_type'])

--- a/core/CPTs/EE_CPT_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Strategy.core.php
@@ -2,6 +2,7 @@
 use EventEspresso\core\domain\entities\custom_post_types\CustomTaxonomyDefinitions;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
  * CPT_Strategy
@@ -344,14 +345,19 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @param \WP_Query $WP_Query
      * @param string    $post_type
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     protected function _generate_CptQueryModifier(WP_Query $WP_Query, $post_type)
     {
-        $this->query_modifier = new EventEspresso\core\CPTs\CptQueryModifier(
-            $post_type,
-            $this->_CPTs[ $post_type ],
-            $WP_Query,
-            EE_Registry::instance()->REQ
+        $this->query_modifier = LoaderFactory::getLoader()->getShared(
+            'EventEspresso\core\CPTs\CptQueryModifier',
+            array(
+                $post_type,
+                $this->_CPTs[ $post_type ],
+                $WP_Query,
+            )
         );
         $this->_CPT_taxonomies = $this->query_modifier->taxonomies();
     }

--- a/core/CPTs/EE_CPT_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Strategy.core.php
@@ -1,4 +1,6 @@
-<?php use EventEspresso\core\domain\entities\custom_post_types\CustomPostTypeDefinitions;
+<?php
+
+use EventEspresso\core\domain\entities\custom_post_types\CustomPostTypeDefinitions;
 use EventEspresso\core\domain\entities\custom_post_types\CustomTaxonomyDefinitions;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -15,19 +17,14 @@ class EE_CPT_Strategy extends EE_Base
 {
 
     /**
-     *    EE_CPT_Strategy Object
-     *
-     * @private    _instance
-     * @private    protected
+     * @var EE_CPT_Strategy $_instance
      */
     private static $_instance;
 
-
     /**
-     * $CPT - the current page, if it utilizes CPTs
+     * the current page, if it utilizes CPTs
      *
-     * @var    array
-     * @access    protected
+     * @var array $CPT
      */
     protected $CPT;
 
@@ -39,32 +36,27 @@ class EE_CPT_Strategy extends EE_Base
     protected $_CPTs = array();
 
     /**
-     * @var    array $_CPT_taxonomies
-     * @access    protected
+     * @var array $_CPT_taxonomies
      */
     protected $_CPT_taxonomies = array();
 
     /**
-     * @var    array $_CPT_terms
-     * @access    protected
+     * @var array $_CPT_terms
      */
     protected $_CPT_terms = array();
 
     /**
-     * @var    array $_CPT_endpoints
-     * @access    protected
+     * @var array $_CPT_endpoints
      */
     protected $_CPT_endpoints = array();
 
     /**
-     * $CPT_model
-     * @var EEM_Base
-     * @access    protected
+     * @var EEM_Base $CPT_model
      */
     protected $CPT_model;
 
     /**
-     * @var EventEspresso\Core\CPTs\CptQueryModifier
+     * @var EventEspresso\Core\CPTs\CptQueryModifier $query_modifier
      */
     protected $query_modifier;
 
@@ -91,7 +83,6 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     * @access protected
      * @param CustomPostTypeDefinitions $custom_post_types
      * @param CustomTaxonomyDefinitions $taxonomies
      */
@@ -108,9 +99,6 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _get_espresso_CPT_endpoints
-     *
-     * @access public
      * @return array
      */
     public function get_CPT_endpoints()
@@ -129,9 +117,8 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _set_CPT_endpoints - add CPT "slugs" to array of default espresso "pages"
+     * add CPT "slugs" to array of default espresso "pages"
      *
-     * @access private
      * @return array
      */
     private function _set_CPT_endpoints()
@@ -147,14 +134,16 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    pre_get_posts
      * If this query (not just "main" queries (ie, for WP's infamous "loop")) is for an EE CPT, then we want to
      * supercharge the get_posts query to add our EE stuff (like joining to our tables, selecting extra columns, and
      * adding EE objects to the post to facilitate further querying of related data etc)
      *
-     * @access public
      * @param WP_Query $WP_Query
      * @return void
+     * @throws \EE_Error
+     * @throws \InvalidArgumentException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      */
     public function pre_get_posts($WP_Query)
     {
@@ -176,9 +165,6 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _set_EE_tags_on_WP_Query
-     *
-     * @access private
      * @param WP_Query $WP_Query
      * @return void
      */
@@ -194,10 +180,11 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _set_CPT_terms
-     *
-     * @access private
      * @return void
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     private function _set_CPT_terms()
     {
@@ -213,11 +200,12 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _set_post_type_for_terms
-     *
-     * @access private
-     * @param $WP_Query
+     * @param WP_Query $WP_Query
      * @return void
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     private function _set_post_type_for_terms(WP_Query $WP_Query)
     {
@@ -250,9 +238,6 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     *    _set_paging
-     *
-     * @access public
      * @param WP_Query $WP_Query
      * @return void
      */
@@ -267,7 +252,6 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     * @access protected
      * @param \WP_Query $WP_Query
      */
     protected function _set_CPT_taxonomies_on_WP_Query(WP_Query $WP_Query)
@@ -314,8 +298,10 @@ class EE_CPT_Strategy extends EE_Base
 
 
     /**
-     * @access public
      * @param \WP_Query $WP_Query
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     protected function _process_WP_Query_post_types(WP_Query $WP_Query)
     {
@@ -369,7 +355,6 @@ class EE_CPT_Strategy extends EE_Base
      * we need to first inject what looks like one of our shortcodes,
      * so that it can be replaced with the actual M-Mode notice
      *
-     * @access public
      * @return string
      */
     public function inject_EE_shortcode_placeholder()
@@ -381,7 +366,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @return void
      */
     public function _possibly_set_ee_request_var()
@@ -393,7 +377,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param  $SQL
      * @return string
      */
@@ -409,7 +392,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param  $SQL
      * @return string
      */
@@ -425,7 +407,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param  \WP_Post[] $posts
      * @return \WP_Post[]
      */
@@ -441,7 +422,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param $url
      * @param $ID
      * @return string
@@ -458,7 +438,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param null $WP_Query
      */
     protected function _do_template_filters($WP_Query = null)
@@ -472,7 +451,6 @@ class EE_CPT_Strategy extends EE_Base
     /**
      * @deprecated
      * @since  4.8.41
-     * @access public
      * @param string $current_template Existing default template path derived for this page call.
      * @return string the path to the full template file.
      */

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -753,6 +753,14 @@ class EE_Dependency_Map
                 'EEM_Answer' => EE_Dependency_Map::load_from_cache,
                 'EEM_Question' => EE_Dependency_Map::load_from_cache,
             ),
+            'EventEspresso\core\CPTs\CptQueryModifier' => array(
+                null,
+                null,
+                null,
+                'EE_Request_Handler'                          => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\loaders\Loader'  => EE_Dependency_Map::load_from_cache,
+            ),
         );
     }
 
@@ -806,6 +814,10 @@ class EE_Dependency_Map
             'EE_Register_CPTs'                             => 'load_core',
             'EE_Admin'                                     => 'load_core',
             'EE_CPT_Strategy'                              => 'load_core',
+            'EE_CPT_Default_Strategy'                      => 'load_core',
+            'EE_CPT_Attendee_Strategy'                     => 'load_core',
+            'EE_CPT_Event_Strategy'                        => 'load_core',
+            'EE_CPT_Venue_Strategy'                        => 'load_core',
             // load_lib
             'EE_Message_Resource_Manager'                  => 'load_lib',
             'EE_Message_Type_Collection'                   => 'load_lib',
@@ -867,7 +879,7 @@ class EE_Dependency_Map
             },
             'EE_Admin_Config'                              => function () {
                 return EE_Config::instance()->admin;
-            }
+            },
         );
     }
 

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -353,6 +353,13 @@ class EE_Dependency_Map
         if (strpos($class_name, 'EEM_') === 0) {
             return 'load_model';
         }
+        // EE_CPT_*_Strategy classes like EE_CPT_Event_Strategy, EE_CPT_Venue_Strategy, etc
+        // perform strpos() first to avoid loading regex every time we load a class
+        if (strpos($class_name, 'EE_CPT_') === 0
+            && preg_match('^EE_CPT_([a-zA-Z]+)_Strategy$', $class_name)
+        ) {
+            return 'load_core';
+        }
         $class_name = $this->getFqnForAlias($class_name);
         return isset($this->_class_loaders[ $class_name ]) ? $this->_class_loaders[ $class_name ] : '';
     }
@@ -814,10 +821,6 @@ class EE_Dependency_Map
             'EE_Register_CPTs'                             => 'load_core',
             'EE_Admin'                                     => 'load_core',
             'EE_CPT_Strategy'                              => 'load_core',
-            'EE_CPT_Default_Strategy'                      => 'load_core',
-            'EE_CPT_Attendee_Strategy'                     => 'load_core',
-            'EE_CPT_Event_Strategy'                        => 'load_core',
-            'EE_CPT_Venue_Strategy'                        => 'load_core',
             // load_lib
             'EE_Message_Resource_Manager'                  => 'load_lib',
             'EE_Message_Type_Collection'                   => 'load_lib',

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -356,7 +356,7 @@ class EE_Dependency_Map
         // EE_CPT_*_Strategy classes like EE_CPT_Event_Strategy, EE_CPT_Venue_Strategy, etc
         // perform strpos() first to avoid loading regex every time we load a class
         if (strpos($class_name, 'EE_CPT_') === 0
-            && preg_match('^EE_CPT_([a-zA-Z]+)_Strategy$', $class_name)
+            && preg_match('/^EE_CPT_([a-zA-Z]+)_Strategy$/', $class_name)
         ) {
             return 'load_core';
         }

--- a/tests/testcases/core/EE_Dependency_Map_Test.php
+++ b/tests/testcases/core/EE_Dependency_Map_Test.php
@@ -80,9 +80,13 @@ class EE_Dependency_Map_Test extends EE_UnitTestCase {
      */
     public function test_core_class_loaders() {
 		$skip = array(
-			'EE_Admin' => 'messes with other unit tests',
-			'EE_Session' => 'session doesn\'t load during unit tests',
-			'EE_Messages_Template_Defaults' => 'Closure has required arguments'
+            'EE_Admin'                      => 'messes with other unit tests',
+            'EE_Session'                    => 'session doesn\'t load during unit tests',
+            'EE_Messages_Template_Defaults' => 'Closure has required arguments',
+            'EE_CPT_Default_Strategy'       => 'has required arguments',
+            'EE_CPT_Attendee_Strategy'      => 'has required arguments',
+            'EE_CPT_Event_Strategy'         => 'has required arguments',
+            'EE_CPT_Venue_Strategy'         => 'has required arguments',
 		);
 		//loop through and verify the class loader can successfully load the class it is set for
 		foreach ( $this->_dependency_map->class_loaders() as $class => $loader ) {


### PR DESCRIPTION
## Problem this Pull Request solves
In #496 it was discovered that running an additional `WP_Query` for an EE CPT within a template configured to load on that same EE CPT Archives page resulted in an SQL error because the same table alias was being applied to the query multiple times. There are apparently other conditions that can cause this to occur, but that was the only scenario presented in that issue.

This was occuring because of changes introduced by #339 which provides better control over caching of objects. Specifically it prevents caching when attempting to create a new shared instance of an object using a new set of properties, for example, a `User` object with the name property set via constructor args to "Bob" could be shared and a request for a shared instance of `User` with the name "Doug" would result in a new instance being returned. Previous to 339, a request for a new shared instance of "Doug" would result in "Bob" being returned because objects were being cached solely on their classnames with no regard to the initial constructor arguments.

Prior to #339, this is what would happen if a theme employed a custom template for the `/events/` archive page and that template ran its own `WP_Query` to retrieve a list of `espresso_events` posts.

-  `EE_CPT_Strategy` loads in order to monitor any `WP_Query` being performed to determine if they are for an EE CPT 
- because the current request was for the `/events/` archive endpoint, the WP main query would be for the `EE_Event` CPT
- `EE_CPT_Strategy` would generate a new instance of `EventEspresso\core\CPTs\CptQueryModifier` for the current `WP_Query` 
- `CptQueryModifier` would determine the requested EE CPT and use `EE_Registry` to load an instance of `EE_CPT_Event_Strategy` (as well as other stuff)
- **IMPORTANT** - `EE_Registry` would determine whether to load a new or cached version of `EE_CPT_Event_Strategy` based solely on the class name, which would result in a **new** instance of  `EE_CPT_Event_Strategy` being generated since no instances exist
- upon construction,  `EE_CPT_Event_Strategy` would set some class properties based on the supplied constructor parameters (<= also important)
- `EE_CPT_Event_Strategy` would then apply a set of filters to the `WP_Query` that was about to be performed
- **IMPORTANT** - `EE_CPT_Event_Strategy` did **not** remove the filters being applied, meaning that **any** additional `WP_Query`s would have those filters applied
- the `WP_Query` would run and return its results which at this point were for the WP main query that is run **prior to template loading**
- eventually the custom event archives template would load which would then generate its own `WP_Query` for the `EE_Event` CPT
- `EE_CPT_Strategy` which is still monitoring any `WP_Query`s sees another query for the `EE_Event` CPT
- `EE_CPT_Strategy` would generate another new instance of `EventEspresso\core\CPTs\CptQueryModifier` for this new `WP_Query` 
- `CptQueryModifier` would determine the requested EE CPT and use `EE_Registry` to load an instance of `EE_CPT_Event_Strategy`
- **IMPORTANT** - `EE_Registry` would determine whether to load a new or cached version of `EE_CPT_Event_Strategy` based solely on the class name, which would result in the **previously cached** instance of  `EE_CPT_Event_Strategy` being returned. Because a previously cached instance of  `EE_CPT_Event_Strategy` was returned, the constructor would not run again, and therefore the same properties for the previous query would be used for any subsequent queries. This was really not good because Query B was being modified based on some of the properties of Query A.
- **SUPER IMPORTANT** - because `EE_CPT_Event_Strategy` never removed the filters it had applied to the previous query, those same filters would run again on the new query. For any dissimilar queries this would not have mattered because the filter callbacks have some conditionals in place to determine whether they should still be applied or not, and most of the conditionals pertained to the `WP_Query` supplied to the callback, however, some pertained to the class properties that had been set upon construction.  In other words, despite the filters never being removed, a subsequent `WP_Query` for anything other than an `EE_Event` CPT would almost certainly not get applied because the incoming query was different enough, but any subsequent `WP_Query`s for an `EE_Event` CPT would have filters applied based partially on the **first**  `WP_Query`s for an `EE_Event` CPT.

- **TL;DR: requests for shared `EE_CPT_Event_Strategy(A)` and `EE_CPT_Event_Strategy(B)` objects resulted in a shared instance of `EE_CPT_Event_Strategy(A)` being used to apply filters to both `WP_Query(A)` and `WP_Query(B)`**

So what changed after implementing #339?

- changes to object caching allowed for an object's constructor arguments to be factored into how it would get shared. So two objects of the same class with different properties could both be shared: ie `User("Bob")` and `User("Doug")`. With regards to queries this meant that two queries for the same EE CPT, but with different arguments, could both be shared, ie: `WP_Query(A)` and  `WP_Query(B)` would ultimately result in the creation of `EE_CPT_Event_Strategy(A)` **and** `EE_CPT_Event_Strategy(B)`
- however because `EE_CPT_Event_Strategy` never removed the filters it had applied to a query, the filters added by `EE_CPT_Event_Strategy(A)` to `WP_Query(A)` would also get applied to `WP_Query(B)` **as well as** the filters added by `EE_CPT_Event_Strategy(B)`
- this meant that some of the query clauses had aliases like `event_start_date` added more than once to the same query, resulting in the `Not unique table/alias` error

#### the fix

So `EE_CPT_Event_Strategy` already contained logic for removing all of the filters it added to a query but that logic was not being applied anywhere. It's possible that this was the case at some point in time, but it had been discovered that the filters were missing on subsequent queries and so the filter removal was itself removed because that would have been the simplest most straightforward fix, albeit a seriously imperfect one. The primary fix in this branch is simply removing the query filters after they have been applied. Additional changes include always using the new `Loader` class (and/or injecting dependencies) for obtaining class instances because that minimizes the chance of caching errors.


## How has this been tested
browser testing only using the template supplied by @joshfeck in #496 

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
