### PR TITLE
make sure `transform-class-properties` is included in jest tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,10 @@
 		"test": {
 			"presets" : [
 				"@wordpress/default"
-			]
+			],
+			"plugins": [
+				"transform-class-properties"
+			],
 		},
 		"production": {
 			"plugins": [


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

We were getting `js: Missing class properties transform.` on any jest tests covering a component that uses class fields.  This pull fixes that.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] verify jest tests pass (including in branches where class fields are in use).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
