### PR TITLE
Fix duplicate asset registration when do_action('admin_enqueue_scripts') is called multiple times on the same admin page Fixes #501

### DIFF
--- a/core/domain/DomainBase.php
+++ b/core/domain/DomainBase.php
@@ -160,6 +160,9 @@ abstract class DomainBase implements DomainInterface
      */
     private function setAssetNamespace()
     {
-        $this->asset_namespace = sanitize_key($this->plugin_basename);
+        $this->asset_namespace = sanitize_key(
+            // convert directory separators to dashes and remove file extension
+            str_replace(array('/', '.php'), array('-', ''), $this->plugin_basename)
+        );
     }
 }

--- a/core/services/assets/AssetManager.php
+++ b/core/services/assets/AssetManager.php
@@ -50,9 +50,25 @@ abstract class AssetManager implements AssetManagerInterface
         $this->assets = $assets;
         $this->registry = $registry;
         add_action('wp_enqueue_scripts', array($this, 'addManifestFile'), 0);
-        add_action('admin_enqueue_scripts', array($this, 'addManifestFile'), 0);
+        add_action('admin_enqueue_scripts', array($this, 'adminAddManifestFile'), 0);
         add_action('wp_enqueue_scripts', array($this, 'addAssets'), 2);
-        add_action('admin_enqueue_scripts', array($this, 'addAssets'), 2);
+        add_action('admin_enqueue_scripts', array($this, 'adminAddAssets'), 2);
+    }
+
+
+    /**
+     * @param string $hook_suffix
+     * @since $VID:$
+     * @throws DuplicateCollectionIdentifierException
+     * @throws InvalidDataTypeException
+     * @throws InvalidEntityException
+     */
+    public function adminAddManifestFile($hook_suffix)
+    {
+        if ($this->registry->dontRegisterForLocation($hook_suffix)) {
+            return;
+        }
+        $this->addManifestFile();
     }
 
 
@@ -81,6 +97,19 @@ abstract class AssetManager implements AssetManagerInterface
     public function getManifestFile()
     {
         return $this->assets->getManifestFiles();
+    }
+
+
+    /**
+     * @param string $hook_suffix
+     * @since $VID:$
+     */
+    public function adminAddAssets($hook_suffix)
+    {
+        if($this->registry->dontRegisterForLocation($hook_suffix)){
+            return;
+        }
+        $this->addAssets();
     }
 
 

--- a/core/services/assets/AssetManager.php
+++ b/core/services/assets/AssetManager.php
@@ -50,25 +50,9 @@ abstract class AssetManager implements AssetManagerInterface
         $this->assets = $assets;
         $this->registry = $registry;
         add_action('wp_enqueue_scripts', array($this, 'addManifestFile'), 0);
-        add_action('admin_enqueue_scripts', array($this, 'adminAddManifestFile'), 0);
+        add_action('admin_enqueue_scripts', array($this, 'addManifestFile'), 0);
         add_action('wp_enqueue_scripts', array($this, 'addAssets'), 2);
-        add_action('admin_enqueue_scripts', array($this, 'adminAddAssets'), 2);
-    }
-
-
-    /**
-     * @param string $hook_suffix
-     * @since $VID:$
-     * @throws DuplicateCollectionIdentifierException
-     * @throws InvalidDataTypeException
-     * @throws InvalidEntityException
-     */
-    public function adminAddManifestFile($hook_suffix)
-    {
-        if ($this->registry->dontRegisterForLocation($hook_suffix)) {
-            return;
-        }
-        $this->addManifestFile();
+        add_action('admin_enqueue_scripts', array($this, 'addAssets'), 2);
     }
 
 
@@ -97,19 +81,6 @@ abstract class AssetManager implements AssetManagerInterface
     public function getManifestFile()
     {
         return $this->assets->getManifestFiles();
-    }
-
-
-    /**
-     * @param string $hook_suffix
-     * @since $VID:$
-     */
-    public function adminAddAssets($hook_suffix)
-    {
-        if($this->registry->dontRegisterForLocation($hook_suffix)){
-            return;
-        }
-        $this->addAssets();
     }
 
 

--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -81,13 +81,13 @@ class Registry
         $this->assets = $assets;
         $this->i18n_registry = $i18n_registry;
         add_action('wp_enqueue_scripts', array($this, 'registerManifestFiles'), 1);
-        add_action('admin_enqueue_scripts', array($this, 'adminRegisterManifestFiles'), 1);
+        add_action('admin_enqueue_scripts', array($this, 'registerManifestFiles'), 1);
         add_action('wp_enqueue_scripts', array($this, 'registerScriptsAndStyles'), 3);
-        add_action('admin_enqueue_scripts', array($this, 'adminRegisterScriptsAndStyles'), 3);
+        add_action('admin_enqueue_scripts', array($this, 'registerScriptsAndStyles'), 3);
         add_action('wp_enqueue_scripts', array($this, 'enqueueData'), 4);
-        add_action('admin_enqueue_scripts', array($this, 'adminEnqueueData'), 4);
+        add_action('admin_enqueue_scripts', array($this, 'enqueueData'), 4);
         add_action('wp_print_footer_scripts', array($this, 'enqueueData'), 1);
-        add_action('admin_print_footer_scripts', array($this, 'adminEnqueueData'), 1);
+        add_action('admin_print_footer_scripts', array($this, 'enqueueData'), 1);
     }
 
 
@@ -102,19 +102,6 @@ class Registry
         return $this->i18n_registry;
     }
 
-
-    /**
-     * @param string $hook_suffix
-     * @since $VID:$
-     * @throws Exception
-     */
-    public function adminRegisterScriptsAndStyles($hook_suffix)
-    {
-        if ($this->dontRegisterForLocation($hook_suffix)) {
-            return;
-        }
-        $this->registerScriptsAndStyles();
-    }
 
     /**
      * Callback for the wp_enqueue_scripts actions used to register assets.
@@ -159,7 +146,7 @@ class Registry
                 $script->version(),
                 $script->loadInFooter()
             );
-            if (! $registered && $this->debug()) {
+            if (! $registered && defined('EE_DEBUG') && EE_DEBUG) {
                 throw new AssetRegistrationException($script->handle());
             }
             $script->setRegistered($registered);
@@ -205,19 +192,6 @@ class Registry
                 $style
             );
         }
-    }
-
-
-    /**
-     * @param string $hook_suffix
-     * @since $VID:$
-     */
-    public function adminEnqueueData($hook_suffix)
-    {
-        if ($this->dontRegisterForLocation($hook_suffix)) {
-            return;
-        }
-        $this->enqueueData();
     }
 
 
@@ -286,9 +260,6 @@ class Registry
         if (isset($this->jsdata[ $key ])
             && ! is_array($this->jsdata[ $key ])
         ) {
-            if(! $this->debug()) {
-                return;
-            }
             throw new InvalidArgumentException(
                 sprintf(
                     __(
@@ -320,9 +291,6 @@ class Registry
         }
         //no overrides allowed.
         if (isset($this->jsdata['templates'][ $template_reference ])) {
-            if (! $this->debug()) {
-                return;
-            }
             throw new InvalidArgumentException(
                 sprintf(
                     __(
@@ -376,9 +344,6 @@ class Registry
     protected function verifyDataNotExisting($key)
     {
         if (isset($this->jsdata[ $key ])) {
-            if (! $this->debug()) {
-                return false;
-            }
             if (is_array($this->jsdata[ $key ])) {
                 throw new InvalidArgumentException(
                     sprintf(
@@ -465,21 +430,6 @@ class Registry
 
 
     /**
-     * @param string $hook_suffix
-     * @since $VID:$
-     * @throws InvalidArgumentException
-     * @throws InvalidFilePathException
-     */
-    public function adminRegisterManifestFiles($hook_suffix)
-    {
-        if ($this->dontRegisterForLocation($hook_suffix)) {
-            return;
-        }
-        $this->registerManifestFiles();
-    }
-
-
-    /**
      * @since 4.9.62.p
      * @throws InvalidArgumentException
      * @throws InvalidFilePathException
@@ -510,9 +460,6 @@ class Registry
     public function registerManifestFile($namespace, $url_base, $manifest_file)
     {
         if (isset($this->manifest_data[ $namespace ])) {
-            if(! $this->debug()){
-                return;
-            }
             throw new InvalidArgumentException(
                 sprintf(
                     esc_html__(
@@ -630,42 +577,5 @@ class Registry
     public function registerTranslation($handle)
     {
         $this->i18n_registry->registerScriptI18n($handle);
-    }
-
-
-    /**
-     * Returns true if the supplied hook suffix is for an admin location
-     * that we do NOT want to register scripts for, such as nav menus or widgets.
-     * This does not mean that scripts won't be registered,
-     * but just that it won't happen at that exact moment.
-     *
-     * @param string $hook_suffix
-     * @since $VID:$
-     * @return bool
-     */
-    public function dontRegisterForLocation($hook_suffix)
-    {
-        return in_array(
-            $hook_suffix,
-            array(
-                'media-upload-popup',
-                'nav-menus.php',
-                'widgets.php',
-            ),
-            true
-        );
-    }
-
-
-    /**
-     * @since $VID:$
-     * @return bool
-     */
-    private function debug()
-    {
-        return apply_filters(
-            'FHEE__EventEspresso_core_services_assets_Registry__debug',
-            defined('EE_DEBUG') && EE_DEBUG
-        );
     }
 }

--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -146,7 +146,7 @@ class Registry
                 $script->version(),
                 $script->loadInFooter()
             );
-            if (! $registered && defined('EE_DEBUG') && EE_DEBUG) {
+            if (! $registered && $this->debug()) {
                 throw new AssetRegistrationException($script->handle());
             }
             $script->setRegistered($registered);
@@ -260,6 +260,9 @@ class Registry
         if (isset($this->jsdata[ $key ])
             && ! is_array($this->jsdata[ $key ])
         ) {
+            if (! $this->debug()) {
+                return;
+            }
             throw new InvalidArgumentException(
                 sprintf(
                     __(
@@ -291,6 +294,9 @@ class Registry
         }
         //no overrides allowed.
         if (isset($this->jsdata['templates'][ $template_reference ])) {
+            if (! $this->debug()) {
+                return;
+            }
             throw new InvalidArgumentException(
                 sprintf(
                     __(
@@ -344,6 +350,9 @@ class Registry
     protected function verifyDataNotExisting($key)
     {
         if (isset($this->jsdata[ $key ])) {
+            if (! $this->debug()) {
+                return false;
+            }
             if (is_array($this->jsdata[ $key ])) {
                 throw new InvalidArgumentException(
                     sprintf(
@@ -460,6 +469,9 @@ class Registry
     public function registerManifestFile($namespace, $url_base, $manifest_file)
     {
         if (isset($this->manifest_data[ $namespace ])) {
+            if (! $this->debug()) {
+                return;
+            }
             throw new InvalidArgumentException(
                 sprintf(
                     esc_html__(
@@ -577,5 +589,18 @@ class Registry
     public function registerTranslation($handle)
     {
         $this->i18n_registry->registerScriptI18n($handle);
+    }
+
+
+    /**
+     * @since $VID:$
+     * @return bool
+     */
+    private function debug()
+    {
+        return apply_filters(
+            'FHEE__EventEspresso_core_services_assets_Registry__debug',
+            defined('EE_DEBUG') && EE_DEBUG
+        );
     }
 }

--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -663,6 +663,9 @@ class Registry
      */
     private function debug()
     {
-        return defined('EE_DEBUG') && EE_DEBUG;
+        return apply_filters(
+            'FHEE__EventEspresso_core_services_assets_Registry__debug',
+            defined('EE_DEBUG') && EE_DEBUG
+        );
     }
 }

--- a/tests/testcases/core/services/assets/RegistryTest.php
+++ b/tests/testcases/core/services/assets/RegistryTest.php
@@ -37,6 +37,7 @@ class RegistryTest extends EE_UnitTestCase
      */
     public function setUp()
     {
+        add_filter('FHEE__EventEspresso_core_services_assets_Registry__debug', '__return_true');
         $domain = DomainFactory::getShared(
             new FullyQualifiedName(
                 'EventEspresso\core\domain\Domain'


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #501 
What's happening is that `do_action('admin_enqueue_scripts')` is triggered multiple times on some admin pages in various locations. 
This can result in our asset registry hooking into that action multiple times and attempting to run it's logic repeatedly.

I considered adding logic to the asset Registry for determining if `registerManifestFiles()` and/or other methods had already run, but was concerned that that may result in some assets not getting registered if their corresponding `AssetManager` failed to load in time.
So the reason for not proceeding with registration based on the `$hook_suffix` passed to the `admin_enqueue_scripts` action was because some of those actions are happening earlier than the typical `admin_enqueue_scripts` hookpoint you would expect for an admin page, and I was concerned that they would occur before all of the `AssetManager`s had a chance to load.
ie: if we only register assets once per request, and that happens during the `admin_enqueue_scripts` action where `$hook_suffix === 'nav-menus.php'`, but that occurs before an `AssetManager` is loaded, then those assets won't get registered.

## How has this been tested
confirmed fix using the Max Mega Menu plugin as described in 501 and via unit tests (no new ones added)
