### PR TITLE
Fix section heading closing tag in `content-espresso_events-header.php`

### DIFF
--- a/public/Espresso_Arabica_2014/content-espresso_events-header.php
+++ b/public/Espresso_Arabica_2014/content-espresso_events-header.php
@@ -8,6 +8,6 @@ $tag = is_single() ? 'h1' : 'h2';
 		<a class="ee-event-header-lnk" href="<?php the_permalink(); ?>"<?php echo \EED_Events_Archive::link_target();?>>
             <?php the_title(); ?>
         </a>
-	<?php echo "</{$tag}"; ?>
+	<?php echo "</{$tag}>"; ?>
 	<?php if ( ! is_archive() && has_excerpt( $post->ID )): the_excerpt(); endif;?>
 </header>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Please see this screenshot of the source of event list html to see the problem:
![screen shot 2018-06-20 at 9 20 00 am](https://user-images.githubusercontent.com/891156/41661498-e78a9a0a-746c-11e8-92b5-84b93de84557.png)

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
viewed the source of the event list page. Please see screenshot:
![screen shot 2018-06-20 at 9 28 42 am](https://user-images.githubusercontent.com/891156/41661552-024f628a-746d-11e8-86b3-3e1ee60cba76.png)

## Checklist

Not Applicable
