### PR TITLE
Remove default ALL_OPTIONS_SELECTED logic from selectors and fix bug when value is not set.

### DIFF
--- a/assets/src/components/form/select/build-options.js
+++ b/assets/src/components/form/select/build-options.js
@@ -29,8 +29,6 @@ const DEFAULT_MODEL_OPTIONS_MAP = {
 	},
 };
 
-export const OPTION_SELECT_ALL = 'ALL';
-
 /**
  * Receives an array of event entities and returns an array of simple objects
  * that can be passed along to the options array used for the WordPress
@@ -38,9 +36,6 @@ export const OPTION_SELECT_ALL = 'ALL';
  *
  * @param { Array } entities
  * @param { string } modelName
- * @param { string } addAllOptionLabel  If present then options array will be
- * 										prepended with an "ALL" option meaning
- * 										that all options are selected.
  * @param { Object } map
  * @return { Array }  Returns an array of simple objects formatted for any
  * select control that receives its options in the format of an array of objects
@@ -49,11 +44,10 @@ export const OPTION_SELECT_ALL = 'ALL';
 const buildOptions = (
 	entities,
 	modelName,
-	addAllOptionLabel = '',
 	map = DEFAULT_MODEL_OPTIONS_MAP,
 ) => {
 	const MAP_FOR_MODEL = map[ modelName ] ? map[ modelName ] : false;
-	const generatedOptions = entities && MAP_FOR_MODEL ?
+	return entities && MAP_FOR_MODEL ?
 		reduce( entities, function( options, entity ) {
 			const label = isFunction( MAP_FOR_MODEL.label ) ?
 				MAP_FOR_MODEL.label( entity ) :
@@ -67,13 +61,6 @@ const buildOptions = (
 			return options;
 		}, [] ) :
 		[];
-	if ( entities && addAllOptionLabel !== '' ) {
-		generatedOptions.unshift( {
-			label: addAllOptionLabel,
-			value: OPTION_SELECT_ALL,
-		} );
-	}
-	return generatedOptions;
 };
 
 export default buildOptions;

--- a/assets/src/components/form/select/model-select.js
+++ b/assets/src/components/form/select/model-select.js
@@ -60,7 +60,6 @@ export class ModelSelect extends Component {
 		} ),
 		getQueryString: PropTypes.func,
 		selectLabel: PropTypes.string,
-		addAllOptionLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -77,7 +76,6 @@ export class ModelSelect extends Component {
 			order: 'desc',
 		},
 		selectLabel: '',
-		addAllOptionLabel: '',
 		getQueryString: () => '',
 	};
 
@@ -108,20 +106,17 @@ export class ModelSelect extends Component {
 			modelName,
 			optionsEntityMap,
 			mapOptionsCallback,
-			addAllOptionLabel,
 		} = props;
 		if ( ! isEmpty( modelEntities ) ) {
 			return optionsEntityMap !== null ?
 				mapOptionsCallback(
 					modelEntities,
 					modelName,
-					addAllOptionLabel,
 					optionsEntityMap,
 				) :
 				mapOptionsCallback(
 					modelEntities,
 					modelName,
-					addAllOptionLabel,
 				);
 		}
 		return [];

--- a/assets/src/components/form/select/model-select.js
+++ b/assets/src/components/form/select/model-select.js
@@ -85,14 +85,11 @@ export class ModelSelect extends Component {
 		const selectedValue = ModelSelect.getOptionObjectForValue(
 			selectConfiguration.defaultValue, options
 		);
-		const updated = selectedValue !== null ?
-			{
-				options,
-				value: selectedValue,
-			} :
-			{
-				options,
-			};
+		const updated = {
+			options,
+			value: selectedValue,
+		};
+
 		return {
 			...REACT_SELECT_DEFAULTS,
 			...selectConfiguration,

--- a/assets/src/components/form/select/test/__snapshots__/model-select.js.snap
+++ b/assets/src/components/form/select/test/__snapshots__/model-select.js.snap
@@ -11,6 +11,7 @@ exports[`ModelSelect Snapshot with default options (with required modelName) sho
     name="model-select-1"
     options={Array []}
     placeholder="Select..."
+    value={null}
   />
 </React.Fragment>
 `;

--- a/assets/src/components/form/select/test/build-options.js
+++ b/assets/src/components/form/select/test/build-options.js
@@ -37,22 +37,8 @@ describe( 'buildOptions()', () => {
 		);
 	} );
 	it( 'returns expected values for options with a custom map.', () => {
-		expect( buildOptions( testResponse, 'event', '', customMap ) ).toEqual(
+		expect( buildOptions( testResponse, 'event', customMap ) ).toEqual(
 			[
-				{ label: 'Custom Property A', value: 'Test A' },
-				{ label: 'Custom Property B', value: 'Test B' },
-			]
-		);
-	} );
-	it( 'returns expected values for options when an "all options" label' +
-		' is included"', () => {
-		expect( buildOptions( testResponse,
-			'event',
-			'All Options',
-			customMap )
-		).toEqual(
-			[
-				{ label: 'All Options', value: OPTION_SELECT_ALL },
 				{ label: 'Custom Property A', value: 'Test A' },
 				{ label: 'Custom Property B', value: 'Test B' },
 			]

--- a/assets/src/components/form/select/test/build-options.js
+++ b/assets/src/components/form/select/test/build-options.js
@@ -1,4 +1,4 @@
-import buildOptions, { OPTION_SELECT_ALL } from '../build-options';
+import buildOptions from '../build-options';
 import moment from 'moment';
 import {
 	DATE_TIME_FORMAT_SITE,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

See #546 for context.  Essentially, with `react-select` there is no need for a dummy option for unselecting items because react-select has that built-in.  All that's necessary is for code implementing the selects to ensure they account correctly for when the `clear` action is pressed (or when `selectedValue === null` instead of an option representing the selected option) and use that to set `selectedEventId` (or its equivalent) on the resulting components.  Model-select will then use that as a trigger to correctly set the `value` prop for `react-select`.  It's recommended that any default values are `0` or an "falsey" equivalent.   However, technically they can be anything that doesn't match an option and `model-select` will automatically use that as an indicator to clear the set value.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] verified unit tests pass locally
* [x] Ran this against a branch I'm doing for the barcode scanner add-on to ensure selection clears as expected (see gif below)

![example-showing-clearing-selection](http://g.recordit.co/zKKfcPffj8.gif)

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
