### PR TITLE
Fix state and country question types shortcode output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Headings should be (only add headings as needed):
 
 ## [$VID:$]
 
+### Fixed
+
+-  Fixed state and country question types shortcode output ([552](https://github.com/eventespresso/event-espresso-core/pull/552))
+
 ## [4.9.64.p]
 
 ### Added

--- a/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
@@ -184,7 +184,8 @@ class EE_Primary_Registration_Details_Shortcodes extends EE_Shortcodes
             }
 
             foreach ($primary_registration->questions as $ansid => $question) {
-                if (trim($question->get('QST_display_text')) == trim($shortcode)
+                if ($question instanceof EE_Question
+                    && trim($question->get('QST_display_text')) == trim($shortcode)
                     && isset($primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ])
                 ) {
                     return $primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ]->get_pretty(

--- a/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
@@ -185,19 +185,19 @@ class EE_Primary_Registration_Details_Shortcodes extends EE_Shortcodes
 
             foreach ($primary_registration->questions as $ansid => $question) {
                 if ($question instanceof EE_Question
-                    && trim($question->get('QST_display_text')) == trim($shortcode)
+                    && trim($question->get('QST_display_text')) === trim($shortcode)
                     && isset($primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ])
                 ) {
                     $primary_reg_ansid = $primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ];
                     
                     // what we show for the answer depends on the question type!
                     switch ($question->get('QST_type')) {
-                        case 'STATE':
+                        case EEM_Question::QST_type_state:
                             $state = EEM_State::instance()->get_one_by_ID($primary_reg_ansid->get('ANS_value'));
                             $answer = $state instanceof EE_State ? $state->name() : '';
                             break;
     
-                        case 'COUNTRY':
+                        case EEM_Question::QST_type_country:
                             $country = EEM_Country::instance()->get_one_by_ID($primary_reg_ansid->get('ANS_value'));
                             $answer = $country instanceof EE_Country ? $country->name() : '';
                             break;

--- a/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Primary_Registration_Details_Shortcodes.lib.php
@@ -188,10 +188,27 @@ class EE_Primary_Registration_Details_Shortcodes extends EE_Shortcodes
                     && trim($question->get('QST_display_text')) == trim($shortcode)
                     && isset($primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ])
                 ) {
-                    return $primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ]->get_pretty(
-                        'ANS_value',
-                        'no_wpautop'
-                    );
+                    $primary_reg_ansid = $primary_registration->registrations[ $primary_reg->ID() ]['ans_objs'][ $ansid ];
+                    
+                    // what we show for the answer depends on the question type!
+                    switch ($question->get('QST_type')) {
+                        case 'STATE':
+                            $state = EEM_State::instance()->get_one_by_ID($primary_reg_ansid->get('ANS_value'));
+                            $answer = $state instanceof EE_State ? $state->name() : '';
+                            break;
+    
+                        case 'COUNTRY':
+                            $country = EEM_Country::instance()->get_one_by_ID($primary_reg_ansid->get('ANS_value'));
+                            $answer = $country instanceof EE_Country ? $country->name() : '';
+                            break;
+    
+                        default:
+                            $answer = $primary_reg_ansid->get_pretty('ANS_value', 'no_wpautop');
+                            break;
+                    }
+                    
+                    return $answer;
+                    break;
                 }
             }
         }

--- a/core/libraries/shortcodes/EE_Recipient_Details_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Recipient_Details_Shortcodes.lib.php
@@ -211,19 +211,19 @@ class EE_Recipient_Details_Shortcodes extends EE_Shortcodes
 
             foreach ($this->_recipient->questions as $ansid => $question) {
                 if ($question instanceof EE_Question
-                    && trim($question->display_text()) == trim($shortcode)
+                    && trim($question->display_text()) === trim($shortcode)
                     && isset($this->_recipient->registrations[ $this->_recipient->reg_obj->ID() ]['ans_objs'][ $ansid ])
                 ) {
                     $recipient_ansid = $this->_recipient->registrations[ $this->_recipient->reg_obj->ID() ]['ans_objs'][ $ansid ];
                     
                     // what we show for the answer depends on the question type!
                     switch ($question->get('QST_type')) {
-                        case 'STATE':
+                        case EEM_Question::QST_type_state:
                             $state = EEM_State::instance()->get_one_by_ID($recipient_ansid->get('ANS_value'));
                             $answer = $state instanceof EE_State ? $state->name() : '';
                             break;
     
-                        case 'COUNTRY':
+                        case EEM_Question::QST_type_country:
                             $country = EEM_Country::instance()->get_one_by_ID($recipient_ansid->get('ANS_value'));
                             $answer = $country instanceof EE_Country ? $country->name() : '';
                             break;

--- a/core/libraries/shortcodes/EE_Recipient_Details_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Recipient_Details_Shortcodes.lib.php
@@ -214,8 +214,27 @@ class EE_Recipient_Details_Shortcodes extends EE_Shortcodes
                     && trim($question->display_text()) == trim($shortcode)
                     && isset($this->_recipient->registrations[ $this->_recipient->reg_obj->ID() ]['ans_objs'][ $ansid ])
                 ) {
-                    return $this->_recipient->registrations[ $this->_recipient->reg_obj->ID(
-                    ) ]['ans_objs'][ $ansid ]->get_pretty('ANS_value', 'no_wpautop');
+                    $recipient_ansid = $this->_recipient->registrations[ $this->_recipient->reg_obj->ID() ]['ans_objs'][ $ansid ];
+                    
+                    // what we show for the answer depends on the question type!
+                    switch ($question->get('QST_type')) {
+                        case 'STATE':
+                            $state = EEM_State::instance()->get_one_by_ID($recipient_ansid->get('ANS_value'));
+                            $answer = $state instanceof EE_State ? $state->name() : '';
+                            break;
+    
+                        case 'COUNTRY':
+                            $country = EEM_Country::instance()->get_one_by_ID($recipient_ansid->get('ANS_value'));
+                            $answer = $country instanceof EE_Country ? $country->name() : '';
+                            break;
+    
+                        default:
+                            $answer = $recipient_ansid->get_pretty('ANS_value', 'no_wpautop');
+                            break;
+                    }
+                    
+                    return $answer;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Reported [here](https://eventespresso.com/topic/shortcode-in-email-for-state-province-dropdown-question-type-displaying-numbers/) and confirmed on dev sites.

> On the registration form, I’ve created a question named, State Licensed, and selected ‘State/Province Dropdown’ as the Question Type. When exporting the registrant list to CSV, this field is displayed correctly as a list of state names.
> When trying to display this question in an email using the shortcode, [RECIPIENT_ANSWER_* State Licensed], the numeric option value is displayed instead of the state name. For example, 37 will show instead of New York.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Created custom questions that use State & Country question types and added shortcodes to messages to display the answers to those questions. The affected shortcodes include 
`[RECIPIENT_ANSWER_*]`
and
`[PRIMARY_REGISTRANT_ANSWER_*]`

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
