### PR TITLE
Add classname to the markup that wraps the Event phone

### DIFF
--- a/public/Espresso_Arabica_2014/content-espresso_events-details.php
+++ b/public/Espresso_Arabica_2014/content-espresso_events-details.php
@@ -18,7 +18,7 @@ global $post;
 <?php endif;
 	$event_phone = espresso_event_phone( $post->ID, FALSE );
 	if ( $event_phone != '' ) : ?>
-	<p>
+	<p class="event-phone">
 		<span class="small-text"><strong><?php _e( 'Event Phone:', 'event_espresso' ); ?> </strong></span> <?php echo $event_phone; ?>
 	</p>
 <?php endif;  ?>

--- a/public/Espresso_Arabica_2014/content-espresso_events-details.php
+++ b/public/Espresso_Arabica_2014/content-espresso_events-details.php
@@ -19,7 +19,7 @@ global $post;
 	$event_phone = espresso_event_phone( $post->ID, FALSE );
 	if ( $event_phone != '' ) : ?>
 	<p class="event-phone">
-		<span class="small-text"><strong><?php _e( 'Event Phone:', 'event_espresso' ); ?> </strong></span> <?php echo $event_phone; ?>
+		<span class="small-text"><strong><?php esc_html_e( 'Event Phone:', 'event_espresso' ); ?> </strong></span> <?php echo $event_phone; ?>
 	</p>
 <?php endif;  ?>
 <?php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Allows easier & more resilient customization with CSS.
## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Viewed Source of event page for an event that has a phone number set. 
## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
