### PR TITLE
Improve status model constants

### DIFF
--- a/assets/src/components/form/select/model-selects/status.js
+++ b/assets/src/components/form/select/model-selects/status.js
@@ -53,7 +53,7 @@ export default class StatusSelect extends Component {
 			model.STATUS_TYPE_TRANSACTION,
 		] ).isRequired,
 		selectedStatusId: PropTypes.oneOf(
-			model.ALL_STATUSES
+			model.ALL_STATUS_IDS
 		),
 		onStatusSelect: PropTypes.func,
 		selectLabel: PropTypes.string,

--- a/assets/src/components/form/select/model-selects/status.js
+++ b/assets/src/components/form/select/model-selects/status.js
@@ -52,7 +52,9 @@ export default class StatusSelect extends Component {
 			model.STATUS_TYPE_REGISTRATION,
 			model.STATUS_TYPE_TRANSACTION,
 		] ).isRequired,
-		selectedStatusId: PropTypes.string,
+		selectedStatusId: PropTypes.oneOf(
+			model.ALL_STATUSES
+		),
 		onStatusSelect: PropTypes.func,
 		selectLabel: PropTypes.string,
 		optionsEntityMap: PropTypes.object,

--- a/assets/src/data/model/registration/constants.js
+++ b/assets/src/data/model/registration/constants.js
@@ -1,13 +1,13 @@
+/**
+ * Internal Imports
+ */
 import * as statusModel from '../status/constants';
+
+/**
+ * External imports
+ */
+import { values } from 'lodash';
 
 export const MODEL_NAME = 'registration';
 
-export const REGISTRATION_STATUS_IDS = [
-	statusModel.STATUS_ID_REGISTRATION_APPROVED,
-	statusModel.STATUS_ID_REGISTRATION_CANCELLED,
-	statusModel.STATUS_ID_REGISTRATION_DECLINED,
-	statusModel.STATUS_ID_REGISTRATION_INCOMPLETE,
-	statusModel.STATUS_ID_REGISTRATION_NOT_APPROVED,
-	statusModel.STATUS_ID_REGISTRATION_PENDING_PAYMENT,
-	statusModel.STATUS_ID_REGISTRATION_WAIT_LIST,
-];
+export const REGISTRATION_STATUS_IDS = values( statusModel.registrationStatus );

--- a/assets/src/data/model/registration/constants.js
+++ b/assets/src/data/model/registration/constants.js
@@ -10,4 +10,6 @@ import { values } from 'lodash';
 
 export const MODEL_NAME = 'registration';
 
-export const REGISTRATION_STATUS_IDS = values( statusModel.registrationStatus );
+export const REGISTRATION_STATUS_IDS = values(
+	statusModel.REGISTRATION_STATUS_ID
+);

--- a/assets/src/data/model/registration/query.js
+++ b/assets/src/data/model/registration/query.js
@@ -1,7 +1,7 @@
 /**
  * External imports
  */
-import { isUndefined } from 'lodash';
+import { isUndefined, values } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -23,15 +23,7 @@ export const queryDataTypes = {
 	forAttendeeId: PropTypes.number,
 	forTransactionId: PropTypes.number,
 	forTicketId: PropTypes.number,
-	forStatusId: PropTypes.oneOf( [
-		statusModel.STATUS_ID_REGISTRATION_APPROVED,
-		statusModel.STATUS_ID_REGISTRATION_CANCELLED,
-		statusModel.STATUS_ID_REGISTRATION_DECLINED,
-		statusModel.STATUS_ID_REGISTRATION_INCOMPLETE,
-		statusModel.STATUS_ID_REGISTRATION_NOT_APPROVED,
-		statusModel.STATUS_ID_REGISTRATION_PENDING_PAYMENT,
-		statusModel.STATUS_ID_REGISTRATION_WAIT_LIST,
-	] ),
+	forStatusId: PropTypes.oneOf( values( statusModel.registrationStatus ) ),
 	queryData: PropTypes.shape( {
 		limit: PropTypes.number,
 		orderBy: PropTypes.oneOf( [

--- a/assets/src/data/model/registration/query.js
+++ b/assets/src/data/model/registration/query.js
@@ -23,7 +23,7 @@ export const queryDataTypes = {
 	forAttendeeId: PropTypes.number,
 	forTransactionId: PropTypes.number,
 	forTicketId: PropTypes.number,
-	forStatusId: PropTypes.oneOf( values( statusModel.registrationStatus ) ),
+	forStatusId: PropTypes.oneOf( values( statusModel.REGISTRATION_STATUS_ID ) ),
 	queryData: PropTypes.shape( {
 		limit: PropTypes.number,
 		orderBy: PropTypes.oneOf( [

--- a/assets/src/data/model/status/constants.js
+++ b/assets/src/data/model/status/constants.js
@@ -12,13 +12,13 @@ export const STATUS_TYPE_PAYMENT = 'payment';
 export const STATUS_TYPE_REGISTRATION = 'registration';
 export const STATUS_TYPE_TRANSACTION = 'transaction';
 // email
-export const emailStatus = {
+export const EMAIL_STATUS_ID = {
 	DRAFT: 'EDR',
 	SENT: 'ESN',
 	EXPIRED: 'EXP',
 };
 // event
-export const eventStatus = {
+export const EVENT_STATUS_ID = {
 	ACTIVE: 'ACT',
 	REGISTRATION_CLOSED: 'CLS',
 	DELETED: 'DEL',
@@ -32,7 +32,7 @@ export const eventStatus = {
 	SECONDARY: 'SEC',
 };
 // message
-export const messageStatus = {
+export const MESSAGE_STATUS_ID = {
 	DEBUG: 'MDO',
 	EXECUTING: 'MEX',
 	FAIL: 'MFL',
@@ -42,7 +42,7 @@ export const messageStatus = {
 	SENT: 'MSN',
 };
 // payment
-export const paymentStatus = {
+export const PAYMENT_STATUS_ID = {
 	APPROVED: 'PAP',
 	CANCELLED: 'PCN',
 	DECLINED: 'PDC',
@@ -50,7 +50,7 @@ export const paymentStatus = {
 	PENDING: 'PPN',
 };
 // registration
-export const registrationStatus = {
+export const REGISTRATION_STATUS_ID = {
 	APPROVED: 'RAP',
 	CANCELLED: 'RCN',
 	DECLINED: 'RDC',
@@ -60,7 +60,7 @@ export const registrationStatus = {
 	WAIT_LIST: 'RWL',
 };
 // transaction
-export const transactionStatus = {
+export const TRANSACTION_STATUS_ID = {
 	ABANDONED: 'TAB',
 	COMPLETE: 'TCM',
 	FAILED: 'TFL',
@@ -68,11 +68,11 @@ export const transactionStatus = {
 	OVERPAID: 'TOP',
 };
 
-export const ALL_STATUSES = [
-	...values( emailStatus ),
-	...values( eventStatus ),
-	...values( messageStatus ),
-	...values( paymentStatus ),
-	...values( registrationStatus ),
-	...values( transactionStatus ),
+export const ALL_STATUS_IDS = [
+	...values( EMAIL_STATUS_ID ),
+	...values( EVENT_STATUS_ID ),
+	...values( MESSAGE_STATUS_ID ),
+	...values( PAYMENT_STATUS_ID ),
+	...values( REGISTRATION_STATUS_ID ),
+	...values( TRANSACTION_STATUS_ID ),
 ];

--- a/assets/src/data/model/status/constants.js
+++ b/assets/src/data/model/status/constants.js
@@ -1,3 +1,8 @@
+/**
+ * External imports
+ */
+import { values } from 'lodash';
+
 export const MODEL_NAME = 'status';
 // types
 export const STATUS_TYPE_EMAIL = 'email';
@@ -7,46 +12,67 @@ export const STATUS_TYPE_PAYMENT = 'payment';
 export const STATUS_TYPE_REGISTRATION = 'registration';
 export const STATUS_TYPE_TRANSACTION = 'transaction';
 // email
-export const STATUS_ID_EMAIL_DRAFT = 'EDR';
-export const STATUS_ID_EMAIL_SENT = 'ESN';
-export const STATUS_ID_EMAIL_EXPIRED = 'EXP';
+export const emailStatus = {
+	DRAFT: 'EDR',
+	SENT: 'ESN',
+	EXPIRED: 'EXP',
+};
 // event
-export const STATUS_ID_EVENT_ACTIVE = 'ACT';
-export const STATUS_ID_EVENT_REGISTRATION_CLOSED = 'CLS';
-export const STATUS_ID_EVENT_DELETED = 'DEL';
-export const STATUS_ID_EVENT_DENIED = 'DEN';
-export const STATUS_ID_EVENT_DRAFT = 'DRF';
-export const STATUS_ID_EVENT_NOT_ACTIVE = 'NAC';
-export const STATUS_ID_EVENT_REGISTRATION_NOT_OPEN = 'NOP';
-export const STATUS_ID_EVENT_ONGOING = 'ONG';
-export const STATUS_ID_EVENT_REGISTRATION_OPEN = 'OPN';
-export const STATUS_ID_EVENT_PENDING = 'PND';
-export const STATUS_ID_EVENT_SECONDARY = 'SEC';
+export const eventStatus = {
+	ACTIVE: 'ACT',
+	REGISTRATION_CLOSED: 'CLS',
+	DELETED: 'DEL',
+	DENIED: 'DEN',
+	DRAFT: 'DRF',
+	NOT_ACTIVE: 'NAC',
+	NOT_OPEN: 'NOP',
+	ONGOING: 'ONG',
+	REGISTRATION_OPEN: 'OPN',
+	PENDING: 'PND',
+	SECONDARY: 'SEC',
+};
 // message
-export const STATUS_ID_MESSAGE_DEBUG = 'MDO';
-export const STATUS_ID_MESSAGE_EXECUTING = 'MEX';
-export const STATUS_ID_MESSAGE_FAIL = 'MFL';
-export const STATUS_ID_MESSAGE_INCOMPLETE = 'MIC';
-export const STATUS_ID_MESSAGE_IDLE = 'MID';
-export const STATUS_ID_MESSAGE_RESEND = 'MRS';
-export const STATUS_ID_MESSAGE_SENT = 'MSN';
+export const messageStatus = {
+	DEBUG: 'MDO',
+	EXECUTING: 'MEX',
+	FAIL: 'MFL',
+	INCOMPLETE: 'MIC',
+	IDLE: 'MID',
+	RESEND: 'MRS',
+	SENT: 'MSN',
+};
 // payment
-export const STATUS_ID_PAYMENT_APPROVED = 'PAP';
-export const STATUS_ID_PAYMENT_CANCELLED = 'PCN';
-export const STATUS_ID_PAYMENT_DECLINED = 'PDC';
-export const STATUS_ID_PAYMENT_FAILED = 'PFL';
-export const STATUS_ID_PAYMENT_PENDING = 'PPN';
+export const paymentStatus = {
+	APPROVED: 'PAP',
+	CANCELLED: 'PCN',
+	DECLINED: 'PDC',
+	FAILED: 'PFL',
+	PENDING: 'PPN',
+};
 // registration
-export const STATUS_ID_REGISTRATION_APPROVED = 'RAP';
-export const STATUS_ID_REGISTRATION_CANCELLED = 'RCN';
-export const STATUS_ID_REGISTRATION_DECLINED = 'RDC';
-export const STATUS_ID_REGISTRATION_INCOMPLETE = 'RIC';
-export const STATUS_ID_REGISTRATION_NOT_APPROVED = 'RNA';
-export const STATUS_ID_REGISTRATION_PENDING_PAYMENT = 'RPP';
-export const STATUS_ID_REGISTRATION_WAIT_LIST = 'RWL';
+export const registrationStatus = {
+	APPROVED: 'RAP',
+	CANCELLED: 'RCN',
+	DECLINED: 'RDC',
+	INCOMPLETE: 'RIC',
+	NOT_APPROVED: 'RNA',
+	PENDING_PAYMENT: 'RPP',
+	WAIT_LIST: 'RWL',
+};
 // transaction
-export const STATUS_ID_TRANSACTION_ABANDONED = 'TAB';
-export const STATUS_ID_TRANSACTION_COMPLETE = 'TCM';
-export const STATUS_ID_TRANSACTION_FAILED = 'TFL';
-export const STATUS_ID_TRANSACTION_INCOMPLETE = 'TIN';
-export const STATUS_ID_TRANSACTION_OVERPAID = 'TOP';
+export const transactionStatus = {
+	ABANDONED: 'TAB',
+	COMPLETE: 'TCM',
+	FAILED: 'TFL',
+	INCOMPLETE: 'TIN',
+	OVERPAID: 'TOP',
+};
+
+export const ALL_STATUSES = [
+	...values( emailStatus ),
+	...values( eventStatus ),
+	...values( messageStatus ),
+	...values( paymentStatus ),
+	...values( registrationStatus ),
+	...values( transactionStatus ),
+];


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Originally, the status model constants are singular matches from constant name to the value it represents.  One problem with this is it makes it harder to extract statuses by type.  In this pull I changed things so that the status constants are now grouped by model which provides the following improvements:

1. Less typing on imports.
2. Easier to do logic that gets all statuses for a model (i.e. using `lodash.values` you could do `const allRegStatuses = values( registrationStatus );`
3. the status model can also export all statuses in an array more easier.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] ensure all existing unit tests pass without any fails.  This should not affect any test snapshots or anything.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
