### PR TITLE
Check get_user_locale() exists before attempting to use it, compatibility fix for WP4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Headings should be (only add headings as needed):
 -  Added CSS bulletproofing to protect registration form from worse-case scenarios ([542](https://github.com/eventespresso/event-espresso-core/pull/542))
 -  Fixed REST API documentation links, and made REST API BETWEEN operator work as documented ([560](https://github.com/eventespresso/event-espresso-core/pull/560))
 -  Fixed privacy erasure so contact phones are also erased ([567](https://github.com/eventespresso/event-espresso-core/pull/567))
+-  Fixed fatal error thrown when using WP4.5 ([571](https://github.com/eventespresso/event-espresso-core/pull/571))
 
 ## [4.9.64.p]
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -231,17 +231,10 @@ class I18nRegistry
     {
         $translations = get_translations_for_domain($domain);
 
-        // check get_user_locale() exists before using it for compatibility with WP4.5
-        if(is_admin() && function_exists('get_user_locale')) {
-            $lang = get_user_locale();
-        } else {
-            $lang = get_locale();
-        }
-
         $locale = array(
             '' => array(
                 'domain' => $domain,
-                'lang'   => $lang,
+                'lang'   => is_admin() ? EEH_DTT_Helper::get_user_locale() : get_locale()
             ),
         );
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\services\assets;
 
 use EventEspresso\core\domain\DomainInterface;
+use EEH_DTT_Helper;
 
 /**
  * I18nRegistry
@@ -234,7 +235,7 @@ class I18nRegistry
         $locale = array(
             '' => array(
                 'domain' => $domain,
-                'lang'   => is_admin() ? \EEH_DTT_Helper::get_user_locale() : get_locale()
+                'lang'   => is_admin() ? EEH_DTT_Helper::get_user_locale() : get_locale()
             ),
         );
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -234,7 +234,7 @@ class I18nRegistry
         $locale = array(
             '' => array(
                 'domain' => $domain,
-                'lang'   => is_admin() ? EEH_DTT_Helper::get_user_locale() : get_locale()
+                'lang'   => is_admin() ? \EEH_DTT_Helper::get_user_locale() : get_locale()
             ),
         );
 

--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -231,10 +231,17 @@ class I18nRegistry
     {
         $translations = get_translations_for_domain($domain);
 
+        // check get_user_locale() exists before using it for compatibility with WP4.5
+        if(is_admin() && function_exists('get_user_locale')) {
+            $lang = get_user_locale();
+        } else {
+            $lang = get_locale();
+        }
+
         $locale = array(
             '' => array(
                 'domain' => $domain,
-                'lang'   => is_admin() ? get_user_locale() : get_locale(),
+                'lang'   => $lang,
             ),
         );
 


### PR DESCRIPTION
This fixes #508

## Problem this Pull Request solves
EE throws a fatal error on WP4.5 as its using a function that doesn't exist.

## How has this been tested
Activated EE on WP4.5 and confirmed no fatal in the admin.

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
