### PR TITLE
Force curl to use TLS1.2 when connecting to PayPal.

### DIFF
--- a/core/EE_Payment_Processor.core.php
+++ b/core/EE_Payment_Processor.core.php
@@ -853,7 +853,7 @@ class EE_Payment_Processor extends EE_Processor_Base implements ResettableInterf
         if (strpos($url, 'https://') !== false && strpos($url, '.paypal.com') !== false) {
             // Use the value of the constant CURL_SSLVERSION_TLSv1 = 1
             // instead of the constant because it might not be defined
-            curl_setopt($handle, CURLOPT_SSLVERSION, 1);
+            curl_setopt($handle, CURLOPT_SSLVERSION, 6);
         }
     }
 }


### PR DESCRIPTION
## Problem this Pull Request solves
See:
https://eventespresso.com/topic/error-http_request_failed-curl-error-35-error14094410ssl-routinesssl3_read_/
https://eventespresso.com/topic/paypal-pci-issue/
https://eventespresso.com/topic/error-offsite-payment-method-was-not-configured-properly/

These users all seem to be using Bluehost and running into the same problem when connecting to PayPal. They have older version of cURL and OpenSSL which apparently can't be updated, running tests on the site using the TLS 1.2 plugin and also some custom code show the connection is using TLS1.2.

Discussed this with Josh a little in slack, we were both in favor of removing this completely but I did a little looking around and found Woo still have almost the exact same code, so I figure these still some setups were the default value wont work and this is still needed?

I saw Mikes comments in a couple of WP trac threads on this so this should probably be assigned to him. I also consider this High as users payments are being blocked.
