### PR TITLE
Show attendees when specifying an archived ticket 

### DIFF
--- a/core/domain/entities/shortcodes/EspressoEventAttendees.php
+++ b/core/domain/entities/shortcodes/EspressoEventAttendees.php
@@ -274,6 +274,7 @@ class EspressoEventAttendees extends EspressoShortcode
                     array(
                         'Datetime.Ticket.TKT_ID' => $attributes['ticket_id'],
                     ),
+                    'default_where_conditions' => 'none'
                 ));
                 break;
             case is_espresso_event():


### PR DESCRIPTION
with `[ESPRESSO_EVENT_ATTENDEES]` shortcode


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://eventespresso.com/topic/espresso_event_attendees-not-working-for-archived-tickets/

and replicated locally

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Register for a ticket, note its ticket ID from the event editor
Change the ticket's price
place `[ESPRESSO_EVENT_ATTENDEES ticket_id={the archived ticket's ID}]` onto a page or within an event. On master you'll see an error message. With this branch you'll see the expected list of attendees.


## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
