### PR TITLE
even if the ee_error_js is already enqueued, we should still localize… Fixes #589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Headings should be (only add headings as needed):
 -  Fixed privacy erasure so contact phones are also erased ([567](https://github.com/eventespresso/event-espresso-core/pull/567))
 -  Fixed fatal error thrown when using WP4.5 ([571](https://github.com/eventespresso/event-espresso-core/pull/571))
 -  Fixed issue with [ESPRESSO_EVENT_ATTENDEES] shortcode to allow displaying attendees when specifying an archived ticket ([583](https://github.com/eventespresso/event-espresso-core/pull/583))
-
+-  Fixed a javascript error on admin pages showing both an EE error and persistent notice. ([592](https://github.com/eventespresso/event-espresso-core/pull/592))
 ## [4.9.64.p]
 
 ### Added

--- a/core/EE_Error.core.php
+++ b/core/EE_Error.core.php
@@ -1002,14 +1002,14 @@ class EE_Error extends Exception
     private static function _print_scripts($force_print = false)
     {
         if (! $force_print && (did_action('admin_enqueue_scripts') || did_action('wp_enqueue_scripts'))) {
-            if (wp_script_is('ee_error_js', 'enqueued')) {
-                return '';
-            }
             if (wp_script_is('ee_error_js', 'registered')) {
                 wp_enqueue_style('espresso_default');
                 wp_enqueue_style('espresso_custom_css');
                 wp_enqueue_script('ee_error_js');
+            }
+            if (wp_script_is('ee_error_js', 'enqueued')) {
                 wp_localize_script('ee_error_js', 'ee_settings', array('wp_debug' => WP_DEBUG));
+                return '';
             }
         } else {
             return '


### PR DESCRIPTION
… its script


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Fixes #589 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
See the ticket's "steps to reproduce" section

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
