### PR TITLE
add changelogs to skeleton addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Headings should be (only add headings as needed):
 - Fixed (bug fixes)
 - Security (vulnerability fixes)
 
+See [our documentation](https://github.com/eventespresso/event-espresso-core/blob/master/docs/A--Best-Practices/change-log.md) for more details.
+
 ## [$VID:$]
 
 ### Changed

--- a/docs/A--Best-Practices/change-log.md
+++ b/docs/A--Best-Practices/change-log.md
@@ -23,6 +23,8 @@ The headings used for the changelog are:
 
 Before a pull request can be merged, it must have a changelog entry describing what has changed in the pull request.
 
+(Unless the code changed isn't part of a release. Eg code in /tests, /docs, /eslint, etc.)
+
 ## Tips on writing good changelog entries
 
 - Use declarative instead of imperative voice (i.e. 'Add project changelog' is imperative.  `Adds project changelog` is declarative.

--- a/tests/mocks/addons/eea-new-addon/CHANGELOG.md
+++ b/tests/mocks/addons/eea-new-addon/CHANGELOG.md
@@ -13,6 +13,8 @@ Headings should be (only add headings as needed):
 - Fixed (bug fixes)
 - Security (vulnerability fixes)
 
+See [our documentation](https://github.com/eventespresso/event-espresso-core/blob/master/docs/A--Best-Practices/change-log.md) for more details.
+
 ## [$VID:$]
 
 ### Added

--- a/tests/mocks/addons/eea-new-addon/CHANGELOG.md
+++ b/tests/mocks/addons/eea-new-addon/CHANGELOG.md
@@ -1,0 +1,19 @@
+# New Addon Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+Headings should be (only add headings as needed):
+
+- Added (new features)
+- Changed (changes in existing functionality)
+- Deprecated (soon to be removed features)
+- Removed (removed features)
+- Fixed (bug fixes)
+- Security (vulnerability fixes)
+
+## [$VID:$]
+
+### Added
+-  Initial version ([1](https://github.com/eventespresso/eea-new-addon/pull/1)) 

--- a/tests/mocks/addons/new-messages-template-pack-variation/CHANGELOG.md
+++ b/tests/mocks/addons/new-messages-template-pack-variation/CHANGELOG.md
@@ -13,6 +13,8 @@ Headings should be (only add headings as needed):
 - Fixed (bug fixes)
 - Security (vulnerability fixes)
 
+See [our documentation](https://github.com/eventespresso/event-espresso-core/blob/master/docs/A--Best-Practices/change-log.md) for more details.
+
 ## [$VID:$]
 
 ### Added

--- a/tests/mocks/addons/new-messages-template-pack-variation/CHANGELOG.md
+++ b/tests/mocks/addons/new-messages-template-pack-variation/CHANGELOG.md
@@ -1,0 +1,19 @@
+# New Messages Template Pack Variation Addon Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+Headings should be (only add headings as needed):
+
+- Added (new features)
+- Changed (changes in existing functionality)
+- Deprecated (soon to be removed features)
+- Removed (removed features)
+- Fixed (bug fixes)
+- Security (vulnerability fixes)
+
+## [$VID:$]
+
+### Added
+-  Initial version ([1](https://github.com/eventespresso/new-messages-template-pack-variation/pull/1)) 

--- a/tests/mocks/addons/new-messages-template-pack/CHANGELOG.md
+++ b/tests/mocks/addons/new-messages-template-pack/CHANGELOG.md
@@ -13,6 +13,8 @@ Headings should be (only add headings as needed):
 - Fixed (bug fixes)
 - Security (vulnerability fixes)
 
+See [our documentation](https://github.com/eventespresso/event-espresso-core/blob/master/docs/A--Best-Practices/change-log.md) for more details.
+
 ## [$VID:$]
 
 ### Added

--- a/tests/mocks/addons/new-messages-template-pack/CHANGELOG.md
+++ b/tests/mocks/addons/new-messages-template-pack/CHANGELOG.md
@@ -1,0 +1,19 @@
+# New Messages Template Pack Addon Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+Headings should be (only add headings as needed):
+
+- Added (new features)
+- Changed (changes in existing functionality)
+- Deprecated (soon to be removed features)
+- Removed (removed features)
+- Fixed (bug fixes)
+- Security (vulnerability fixes)
+
+## [$VID:$]
+
+### Added
+-  Initial version ([1](https://github.com/eventespresso/new-messages-template-pack/pull/1)) 

--- a/tests/mocks/addons/new-payment-method/CHANGELOG.md
+++ b/tests/mocks/addons/new-payment-method/CHANGELOG.md
@@ -13,6 +13,8 @@ Headings should be (only add headings as needed):
 - Fixed (bug fixes)
 - Security (vulnerability fixes)
 
+See [our documentation](https://github.com/eventespresso/event-espresso-core/blob/master/docs/A--Best-Practices/change-log.md) for more details.
+
 ## [$VID:$]
 
 ### Added

--- a/tests/mocks/addons/new-payment-method/CHANGELOG.md
+++ b/tests/mocks/addons/new-payment-method/CHANGELOG.md
@@ -1,0 +1,19 @@
+# New Payment Method Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+Headings should be (only add headings as needed):
+
+- Added (new features)
+- Changed (changes in existing functionality)
+- Deprecated (soon to be removed features)
+- Removed (removed features)
+- Fixed (bug fixes)
+- Security (vulnerability fixes)
+
+## [$VID:$]
+
+### Added
+-  Initial version ([1](https://github.com/eventespresso/new-payment-method/pull/1)) 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Adds changelogs to skeleton addons in tests/mocks/addons

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
It hasn't, but this file isn't included in EE core releases, and it's not used in add-ons anyways either.

## Checklist

* [ ] I have added a changelog entry for this pull request -> seeing how this isn't included in the released version, I don't think it should have a changelog entry
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
