### PR TITLE
Enable Webpack CSS loading for Components

### DIFF
--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -72,6 +72,8 @@ class CoreAssetManager extends AssetManager
 
     const CSS_HANDLE_EE_CUSTOM = 'espresso_custom_css';
 
+    const CSS_HANDLE_EE_COMPONENTS = 'eventespresso-components';
+
     /**
      * @var EE_Currency_Config $currency_config
      */
@@ -294,6 +296,13 @@ class CoreAssetManager extends AssetManager
                 );
             }
         }
+        $this->addStylesheet(
+            CoreAssetManager::CSS_HANDLE_EE_COMPONENTS,
+            $this->registry->getCssUrl(
+                $this->domain->assetNamespace(),
+                'components'
+            )
+        );
     }
 
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -144,6 +144,7 @@ const config = [
 			components: assets + 'components/index.js',
 		},
 		externals: Object.assign( externals, {
+			'@eventespresso/higher-order-components': 'eejs.hocComponents',
 			'@eventespresso/helpers': 'eejs.helpers',
 			'@eventespresso/model': 'eejs.model',
 		} ),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -155,6 +155,36 @@ const config = [
 					exclude: /node_modules/,
 					loader: 'babel-loader',
 				},
+				{
+					test: /\.css$/,
+					use: [
+						miniExtract.loader,
+						{
+							loader: 'css-loader',
+							query: {
+								modules: true,
+								localIdentName: '[local]',
+							},
+							//can't use minimize because cssnano (the
+							// dependency) doesn't parser the browserlist
+							// extension in package.json correctly, there's
+							// a pending update for it but css-loader
+							// doesn't have the latest yet.
+							// options: {
+							//     minimize: true
+							// }
+						},
+						{
+							loader: 'postcss-loader',
+							options: {
+								plugins: function() {
+									return [ autoprefixer ];
+								},
+								sourceMap: true,
+							},
+						},
+					],
+				},
 			],
 		},
 		output: {


### PR DESCRIPTION
## Problem this Pull Request solves
ui components require stylesheet loading

## How has this been tested
in REM branch only

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
