### PR TITLE
just always load template tags to avoid problems in page builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 ## [$VID:$]
 
+### Fixed
+- Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
+
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1161,15 +1161,9 @@ final class EE_System implements ResettableInterface
         // integrate WP_Query with the EE models
         $this->loader->getShared('EE_CPT_Strategy');
         do_action('AHEE__EE_System__core_loaded_and_ready');
-        // load_espresso_template_tags
-        if (($this->request->isFrontend()
-             || $this->request->isIframe()
-             || $this->request->isFeed()
-             ||  $this->request->isAjax()
-            ) && is_readable(EE_PUBLIC . 'template_tags.php')
-        ) {
-            require_once EE_PUBLIC . 'template_tags.php';
-        }
+        // always load template tags, because it's faster than checking if it's a front-end request, and many page
+        // builders require these even on the front-end
+        require_once EE_PUBLIC . 'template_tags.php';
         do_action('AHEE__EE_System__set_hooks_for_shortcodes_modules_and_addons');
     }
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/360
Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
Appropriate question for once. It was suggested this could be handled by an add-on or shim or code snippet, and we may go for that. But these are the reasons I thought it best to fix this issue in EE core and just always include the template tags, even on admin requests:
* loading the template tags file takes about 1 millisecond, and the conditional to determine if we should include it also takes about 1 second. Because it takes just as long to check as it does to just include it, no speed is saved by checking in the admin. In fact, it's a hair-width quicker to NOT check and just always include it
* it will be a bit of a pain to list out all the page builders out there, this avoids that
* when new page-builders are introduced, we don't have to include it in the whitelist

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Use elementor plugin, add an upcoming events widget to a page and try to save it. Upon reloading the page, I got the error from the issue. But on this branch it works fine
* [ ] Seth said he reproduced the issue in Beaver Builder (not sure what steps he took to reproduce)
* [ ] A general scan of the EE admin would be good too, just in case this somehow has unexpected consequences in there
* [ ] Test a theme that customizes EE's default templates. They should continue to work as normal.

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
