### PR TITLE
sync labels to ee private

### DIFF
--- a/.github/label-sync.yml
+++ b/.github/label-sync.yml
@@ -54,6 +54,7 @@
     - eventespresso/eea-event-app-customization
     - eventespresso/grunt-wp-plugin-buildmachine
     - eventespresso/eea-paypal-smart-buttons
+    - eventespresso/event-espresso-private
   milestones: []
   labels:
   # status labels


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Syncs labels to our new private github EE repo.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Ran it locally. I sync'd labels (but not pipelines) to event-espresso-private

## Checklist

* [x] I have added a changelog entry for this pull request - unnecessary seeing how this doesn't affect the packaged plugin
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
