### PR TITLE
unsetting a global just removes the local reference. Set it ot null t…

### DIFF
--- a/tests/testcases/core/helpers/EEH_File_Test.php
+++ b/tests/testcases/core/helpers/EEH_File_Test.php
@@ -30,10 +30,13 @@ class EEH_File_Test extends EE_UnitTestCase
 
     function tearDown()
     {
+        // restore to using the normal WP filesystem
         global $wp_filesystem;
+        $wp_filesystem = null;
+        unset($wp_filesystem);
+
         remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         remove_filter('filesystem_method', array($this, 'filter_fs_method'));
-        unset($wp_filesystem);
 
         parent::tearDown();
     }

--- a/tests/testcases/core/helpers/EEH_File_Test.php
+++ b/tests/testcases/core/helpers/EEH_File_Test.php
@@ -31,9 +31,7 @@ class EEH_File_Test extends EE_UnitTestCase
     function tearDown()
     {
         // restore to using the normal WP filesystem
-        global $wp_filesystem;
-        $wp_filesystem = null;
-        unset($wp_filesystem);
+        unset($GLOBALS['wp_filesystem']);
 
         remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         remove_filter('filesystem_method', array($this, 'filter_fs_method'));

--- a/tests/testcases/core/helpers/EEH_File_Test.php
+++ b/tests/testcases/core/helpers/EEH_File_Test.php
@@ -32,7 +32,6 @@ class EEH_File_Test extends EE_UnitTestCase
     {
         // restore to using the normal WP filesystem
         unset($GLOBALS['wp_filesystem']);
-
         remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         remove_filter('filesystem_method', array($this, 'filter_fs_method'));
 


### PR DESCRIPTION
…o kill it


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
While running unit tests directly from Windows (not using a virtual machine), I was getting a fatal error at the end of running unit tests: 

```
Fatal error: Uncaught Error: Maximum function nesting level of '256' reached, aborting! in E:\Software\laragon\www\laragonwp\src\wp-includes\formatting.php on line 2656

Call Stack:
    0.0010     369400   1. {main}() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\phpunit:0
    0.0080     751104   2. PHPUnit\TextUI\Command::main() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\phpunit:53
    0.0080     754264   3. PHPUnit\TextUI\Command->run() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\src\TextUI\Command.php:140
    3.9632   54148408   4. PHPUnit\TextUI\TestRunner->doRun() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\src\TextUI\Command.php:209

Error: Maximum function nesting level of '256' reached, aborting! in E:\Software\laragon\www\laragonwp\src\wp-includes\formatting.php on line 2656

Call Stack:
    0.0010     369400   1. {main}() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\phpunit:0
    0.0080     751104   2. PHPUnit\TextUI\Command::main() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\phpunit:53
    0.0080     754264   3. PHPUnit\TextUI\Command->run() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\src\TextUI\Command.php:140
    3.9632   54148408   4. PHPUnit\TextUI\TestRunner->doRun() C:\Users\mnelson4\AppData\Roaming\Composer\vendor\phpunit\phpunit\src\TextUI\Command.php:209
    4.8243   54853264   5. shutdown_action_hook() E:\Software\laragon\www\laragonwp\src\wp-includes\load.php:0
    4.8243   54853264   6. do_action() E:\Software\laragon\www\laragonwp\src\wp-includes\load.php:750
    4.8243   54865984   7. WP_Hook->do_action() E:\Software\laragon\www\laragonwp\src\wp-includes\plugin.php:465
    4.8243   54865984   8. WP_Hook->apply_filters() E:\Software\laragon\www\laragonwp\src\wp-includes\class-wp-hook.php:310
    4.8333   54996760   9. EventEspresso\core\services\Benchmark::EventEspresso\core\services\{closure}() E:\Software\laragon\www\laragonwp\src\wp-includes\class-wp-hook.php:286
    4.8333   54996760  10. EventEspresso\core\services\Benchmark::writeResultsToFile() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\services\Benchmark.php:169
    4.8343   54996760  11. EEH_File::ensure_file_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\services\Benchmark.php:267
    4.8353   55065240  12. EEH_File::ensure_folder_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:295
    4.8353   55065432  13. EEH_File::ensure_folder_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:231

...

    4.8683   55080792 245. EEH_File::ensure_folder_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:231
    4.8683   55080856 246. EEH_File::ensure_folder_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:231
    4.8683   55080920 247. EEH_File::ensure_folder_exists_and_is_writable() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:231
    4.8683   55080984 248. EEH_File::convert_local_filepath_to_remote_filepath() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:229
    4.8683   55080984 249. WP_Filesystem_MockEEFS->wp_content_dir() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\core\helpers\EEH_File.helper.php:686
    4.8683   55080984 250. WP_Filesystem_MockEEFS->find_folder() E:\Software\laragon\www\laragonwp\src\wp-admin\includes\class-wp-filesystem-base.php:72
    4.8683   55081064 251. WP_Filesystem_MockEEFS->search_for_folder() E:\Software\laragon\www\laragonwp\src\wp-admin\includes\class-wp-filesystem-base.php:225
    4.8683   55081840 252. WP_Filesystem_MockEEFS->search_for_folder() E:\Software\laragon\www\laragonwp\src\wp-admin\includes\class-wp-filesystem-base.php:309
    4.8683   55082616 253. WP_Filesystem_MockEEFS->dirlist() E:\Software\laragon\www\laragonwp\src\wp-admin\includes\class-wp-filesystem-base.php:260
    4.8683   55082616 254. WP_Filesystem_MockEEFS->exists() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\tests\includes\mock-ee-fs.php:199
    4.8683   55082616 255. trailingslashit() E:\Software\laragon\www\laragonee\wp-content\plugins\event-espresso-core\tests\includes\mock-ee-fs.php:181
    4.8683   55082616 256. untrailingslashit() E:\Software\laragon\www\laragonwp\src\wp-includes\formatting.php:2641
```

So what why the infinite recursion? Because the filepath it was trying to verify existed was something like `E:\path\to\folder`. The folder actually exists on the *real* filesystem, but we're still using the mock filesystem from during `EEH_File_Text`. In the mock filesystem, that folder doesn't exist. So it would check the parent folder, `E:\path\to\`, and find it didn't exist either. It would go all the way up to `E:\`, and then it would keep checking to see if that "folder" exists (it's expecting the root to be a slash like on unix).
So maybe our filesystem code could handle Windows filesystem structure better, but certainly we shouldn't be using the mock filesystem after those tests are done.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
The problem only comes up during unit tests, so via the unit tests.

## Checklist

* [x] I have added a changelog entry for this pull request - packaged plugin is unaffected, so unnecessary
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
