### PR TITLE
fix filepath test when on windows

### DIFF
--- a/tests/testcases/core/domain/values/FilePathTest.php
+++ b/tests/testcases/core/domain/values/FilePathTest.php
@@ -48,7 +48,7 @@ class FilePathTest extends EE_UnitTestCase
         $filepath = new FilePath(__FILE__);
         $this->assertEquals(__FILE__, (string) $filepath);
         $this->assertEquals(
-             str_replace('\\', '/', EE_TESTS_DIR . 'testcases/core/domain/values/FilePathTest.php'),
+            str_replace('\\', '/', EE_TESTS_DIR . 'testcases/core/domain/values/FilePathTest.php'),
             str_replace('\\', '/', $filepath)
         );
     }

--- a/tests/testcases/core/domain/values/FilePathTest.php
+++ b/tests/testcases/core/domain/values/FilePathTest.php
@@ -48,8 +48,8 @@ class FilePathTest extends EE_UnitTestCase
         $filepath = new FilePath(__FILE__);
         $this->assertEquals(__FILE__, (string) $filepath);
         $this->assertEquals(
-            'This is located at ' . EE_TESTS_DIR . 'testcases/core/domain/values/FilePathTest.php',
-            "This is located at {$filepath}"
+             str_replace('\\', '/', EE_TESTS_DIR . 'testcases/core/domain/values/FilePathTest.php'),
+            str_replace('\\', '/', $filepath)
         );
     }
 


### PR DESCRIPTION


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
There is a unit test failure when ran from a windows machine because both forward and backslashes are used as directory separators.
## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
The unit test got fixed when ran from a Windows machine (not a linux virtual machine)

## Checklist

* [x] I have added a changelog entry for this pull request - packaged plugin is unaffected
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
