### PR TITLE
improper use of str_replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 ### Fixed
 - Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
-
+- Fixes a syntax issue inside `EE_Config::register_ee_widget()` ([608](https://github.com/eventespresso/event-espresso-core/pull/608))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -1052,7 +1052,7 @@ final class EE_Config implements ResettableInterface
         do_action('AHEE__EE_Config__register_widget__begin', $widget_path);
         $widget_ext = '.widget.php';
         // make all separators match
-        $widget_path = rtrim(str_replace('/\\', DS, $widget_path), DS);
+        $widget_path = rtrim(str_replace('\\', DS, $widget_path), DS);
         // does the file path INCLUDE the actual file name as part of the path ?
         if (strpos($widget_path, $widget_ext) !== false) {
             // grab and shortcode file name from directory name and break apart at dots


### PR DESCRIPTION
… for individual characters like other functions. This is how string are normalized throughout most of EE, and it works assuming DS continues to just be a slash


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
 Fixed a syntax issue inside `EE_Config::register_ee_widget()`.
Noticed this mistake while on an experimental branch of EE (it was causing an error which prevented EE from finding the promotion addon's widget). However, on EE master, this didn't present a problem so it's lower priority (kinda coincidentally, the details are a bit dizzying and I think beside the point). But we may as well fix it: we accidentally passed a list of characters to PHP `str_replace()` in the first argument... except it doesn't accept a string of characters (like some other methods do), it just accepts a single needle, or an array of needles.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] EE core widgets are still available and work
* [x] The promotion's widget is still available and works

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
