### PR TITLE
Fix caching loader identifier

### DIFF
--- a/core/bootstrap_espresso.php
+++ b/core/bootstrap_espresso.php
@@ -85,6 +85,10 @@ function bootstrap_espresso()
             'EEH_Array',
             EE_CORE . 'helpers' . DS . 'EEH_Array.helper.php'
         );
+        espresso_load_required(
+            'EE_Base',
+            EE_CORE . 'EE_Base.core.php'
+        );
         // instantiate and configure PSR4 autoloader
         espresso_load_required(
             'Psr4Autoloader',

--- a/core/services/loaders/CachingLoader.php
+++ b/core/services/loaders/CachingLoader.php
@@ -95,13 +95,17 @@ class CachingLoader extends CachingLoaderDecorator
     /**
      * @param FullyQualifiedName|string $fqcn
      * @param mixed                     $object
+     * @param array                     $arguments
      * @return bool
      * @throws InvalidArgumentException
      */
-    public function share($fqcn, $object)
+    public function share($fqcn, $object, array $arguments = array())
     {
         if ($object instanceof $fqcn) {
-            return $this->cache->add($object, md5($fqcn));
+            return $this->cache->add(
+                $object,
+                $this->object_identifier->getIdentifier($fqcn, $arguments)
+            );
         }
         throw new InvalidArgumentException(
             sprintf(

--- a/tests/testcases/core/services/loaders/CachingLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CachingLoaderTest.php
@@ -135,7 +135,49 @@ class CachingLoaderTest extends EE_UnitTestCase
         $this->assertNotEquals(spl_object_hash($object9), spl_object_hash(self::$loader->load($fqcn9)));
     }
 
-
-
+    /**
+     * @since $VID:$
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws \PHPUnit\Framework\AssertionFailedError
+     */
+    public function testShare()
+    {
+        // turn caching on again
+        add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false', 10);
+        // create a context object
+        $context1 = new EventEspresso\core\domain\entities\contexts\Context('testShare', 'we are testing the share method');
+        // share it but don't pass any arguments
+        $added = self::$loader->share('EventEspresso\core\domain\entities\contexts\Context', $context1);
+        $this->assertTrue($added);
+        $object1 = self::$loader->load(
+            'EventEspresso\core\domain\entities\contexts\Context',
+            array('testShare', 'we are testing the share method')
+        );
+        $this->assertEquals(spl_object_hash($object1), spl_object_hash($context1));
+        // create another context object
+        $context2 = new EventEspresso\core\domain\entities\contexts\Context('testShare2', 'we are testing the share method again');
+        // share it but pass an array of its arguments
+        $added2 = self::$loader->share(
+            'EventEspresso\core\domain\entities\contexts\Context',
+            $context2,
+            array('testShare2', 'we are testing the share method again')
+        );
+        $this->assertTrue($added2);
+        // just load using FQCN... should match object 1
+        $not_object2 = self::$loader->load(
+            'EventEspresso\core\domain\entities\contexts\Context',
+            array('testShare', 'we are testing the share method')
+        );
+        $this->assertNotEquals(spl_object_hash($not_object2), spl_object_hash($context2));
+        // because it's context 1
+        $this->assertEquals(spl_object_hash($not_object2), spl_object_hash($context1));
+        // now load using arguments
+        $object2 = self::$loader->load(
+            'EventEspresso\core\domain\entities\contexts\Context',
+            array('testShare2', 'we are testing the share method again')
+        );
+        $this->assertEquals(spl_object_hash($object2), spl_object_hash($context2));
+    }
 }
 // Location: testcases/core/services/loaders/CachingLoaderTest.php

--- a/tests/testcases/core/services/loaders/CachingLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CachingLoaderTest.php
@@ -146,17 +146,20 @@ class CachingLoaderTest extends EE_UnitTestCase
         // turn caching on again
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false', 10);
         // create a context object
-        $context1 = new EventEspresso\core\domain\entities\contexts\Context('testShare', 'we are testing the share method');
+        $context1 = new EventEspresso\core\domain\entities\contexts\Context(
+            'testShare',
+            'we are testing the share method'
+        );
         // share it but don't pass any arguments
         $added = self::$loader->share('EventEspresso\core\domain\entities\contexts\Context', $context1);
         $this->assertTrue($added);
-        $object1 = self::$loader->load(
-            'EventEspresso\core\domain\entities\contexts\Context',
-            array('testShare', 'we are testing the share method')
-        );
+        $object1 = self::$loader->load('EventEspresso\core\domain\entities\contexts\Context');
         $this->assertEquals(spl_object_hash($object1), spl_object_hash($context1));
         // create another context object
-        $context2 = new EventEspresso\core\domain\entities\contexts\Context('testShare2', 'we are testing the share method again');
+        $context2 = new EventEspresso\core\domain\entities\contexts\Context(
+            'testShare2',
+            'we are testing the share method again'
+        );
         // share it but pass an array of its arguments
         $added2 = self::$loader->share(
             'EventEspresso\core\domain\entities\contexts\Context',
@@ -165,10 +168,7 @@ class CachingLoaderTest extends EE_UnitTestCase
         );
         $this->assertTrue($added2);
         // just load using FQCN... should match object 1
-        $not_object2 = self::$loader->load(
-            'EventEspresso\core\domain\entities\contexts\Context',
-            array('testShare', 'we are testing the share method')
-        );
+        $not_object2 = self::$loader->load('EventEspresso\core\domain\entities\contexts\Context');
         $this->assertNotEquals(spl_object_hash($not_object2), spl_object_hash($context2));
         // because it's context 1
         $this->assertEquals(spl_object_hash($not_object2), spl_object_hash($context1));


### PR DESCRIPTION
## Problem this Pull Request solves
Basically the `EventEspresso\core\services\loaders\CachingLoader::share()` method was not employing the same method to generate object identifiers for cached classes as was being used in `EventEspresso\core\services\loaders\CachingLoader::load()`. The result was that manually cached classes might not be found and a new instance would be generated.

## How has this been tested
in usage only

