### PR TITLE
modify index column size on old data migration scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 ## [$VID:$]
 
 ### Fixed
-- Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
-
+- Fixed a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
+- Fixed an error when migrating from EE3 from attendee email index being too big ([611](https://github.com/eventespresso/event-espresso-core/pull/611))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
@@ -143,7 +143,7 @@ class EE_DMS_Core_4_1_0 extends EE_Data_Migration_Script_Base
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_fname (ATT_fname),
 								KEY ATT_lname (ATT_lname),
-								KEY ATT_email (ATT_email)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_is_new_in_this_version($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO VARCHAR(2) COLLATE utf8_bin NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
@@ -97,7 +97,7 @@ class EE_DMS_Core_4_2_0 extends EE_Data_Migration_Script_Base
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_fname (ATT_fname),
 								KEY ATT_lname (ATT_lname),
-								KEY ATT_email (ATT_email)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_should_exist_previously($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO VARCHAR(2) COLLATE utf8_bin NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
@@ -95,7 +95,7 @@ class EE_DMS_Core_4_3_0 extends EE_Data_Migration_Script_Base
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_fname (ATT_fname),
 								KEY ATT_lname (ATT_lname),
-								KEY ATT_email (ATT_email)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_should_exist_previously($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO VARCHAR(2) COLLATE utf8_bin NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
@@ -98,7 +98,7 @@ class EE_DMS_Core_4_5_0 extends EE_Data_Migration_Script_Base
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_fname (ATT_fname),
 								KEY ATT_lname (ATT_lname),
-								KEY ATT_email (ATT_email)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_should_exist_previously($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO VARCHAR(2) COLLATE utf8_bin NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
@@ -112,7 +112,7 @@ class EE_DMS_Core_4_6_0 extends EE_Data_Migration_Script_Base
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_fname (ATT_fname),
 								KEY ATT_lname (ATT_lname),
-								KEY ATT_email (ATT_email)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_should_exist_previously($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO VARCHAR(2) COLLATE utf8_bin NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
@@ -116,9 +116,7 @@ class EE_DMS_Core_4_8_0 extends EE_Data_Migration_Script_Base
 						ATT_phone varchar(45) DEFAULT NULL,
 							PRIMARY KEY  (ATTM_ID),
 								KEY ATT_ID (ATT_ID),
-								KEY ATT_email (ATT_email),
-								KEY ATT_lname (ATT_lname),
-								KEY ATT_fname (ATT_fname)";
+								KEY ATT_email (ATT_email(191))";
         $this->_table_is_changed_in_this_version($table_name, $sql, 'ENGINE=InnoDB ');
         $table_name = 'esp_country';
         $sql = "CNT_ISO varchar(2) collate utf8_bin NOT NULL,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/493
Fixes an error when migrating from EE3 from attendee email index being too big.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Setup a site in EE3 with some attendee. Deactivate EE3 and activate this version of EE4. Run the migrations. They should work fine

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
