### PR TITLE
show the pretty description of the venue, not the awful one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 ### Fixed
 - Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
-
+- Fixed venue description on event page so line breaks are shown properly ([612](https://github.com/eventespresso/event-espresso-core/pull/612))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/helpers/EEH_Venue_View.helper.php
+++ b/core/helpers/EEH_Venue_View.helper.php
@@ -231,7 +231,7 @@ class EEH_Venue_View extends EEH_Base
     {
         $venue = EEH_Venue_View::get_venue($VNU_ID);
         if ($venue instanceof EE_Venue) {
-            return$venue->description();
+            return $venue->get_pretty('VNU_desc');
         }
         return '';
     }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/507
Fixes venue description on event page so line breaks are shown properly.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
* [ ] Create a venue with a lot of line breaks in it. View it on the front-end. The line breaks should be preserved
* [ ] Assign the venue to an event and view the event. The line breaks in the venue description should still be there
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
