### PR TITLE
if there is a custom session save handler, and it causes a fatal erro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 ### Fixed
 - Fixes a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))
 - Fixed venue description on event page so line breaks are shown properly ([612](https://github.com/eventespresso/event-espresso-core/pull/612))
+- Fixed a fatal error when there is an invalid session save handler, like on Pantheon servers ([615](https://github.com/eventespresso/event-espresso-core/pull/615))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/EE_Session.core.php
+++ b/core/EE_Session.core.php
@@ -565,7 +565,7 @@ class EE_Session implements SessionIdentifierInterface
         // check that session has started
         if (session_id() === '') {
             // starts a new session if one doesn't already exist, or re-initiates an existing one
-            if(ini_get('session.save_handler') === 'user') {
+            if (ini_get('session.save_handler') === 'user') {
                 $this->checkCustomSessionSaveHandler();
             } else {
                 session_start();

--- a/core/EE_Session.core.php
+++ b/core/EE_Session.core.php
@@ -6,6 +6,7 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\InvalidSessionDataException;
 use EventEspresso\core\services\cache\CacheStorageInterface;
+use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\request\RequestInterface;
 
 /**
@@ -564,7 +565,11 @@ class EE_Session implements SessionIdentifierInterface
         // check that session has started
         if (session_id() === '') {
             // starts a new session if one doesn't already exist, or re-initiates an existing one
-            session_start();
+            if(ini_get('session.save_handler') === 'user') {
+                $this->checkCustomSessionSaveHandler();
+            } else {
+                session_start();
+            }
         }
         $this->status = EE_Session::STATUS_OPEN;
         // get our modified session ID
@@ -606,6 +611,68 @@ class EE_Session implements SessionIdentifierInterface
         // make event espresso session data available to plugin
         $this->_session_data = array_merge($this->_session_data, $session_data);
         return true;
+    }
+
+    /**
+     * Handles a fatal error that can occur while starting the session because of an invalid session handler.
+     * This fatal error happens regularly on Pantheon's servers, see https://github.com/eventespresso/event-espresso-core/issues/494.
+     * This function keeps track of whether we know the custom session handler works or not. If it does, uses the session
+     * normally.
+     * If we don't know if the custom session save handler works, sets an option before starting the session, and
+     * removes it afterwards. This way, if there is a fatal error starting the session, we'll know during the next
+     * request, and avoid calling the session. Instead, we'll give a helpful error message and suggest how to fix the problem.
+     * Lastly, we need to allow the admin to indicate when they've fixed the problem, so we can try using EE's session
+     * again. For that, we give them a link with "ee_retry_session" in it. When they visit a page with that querystring
+     * variable, we set ourselves up to retry using the session on the next request, and do a redirect.
+     * @since $VID:$
+     */
+    private function checkCustomSessionSaveHandler()
+    {
+        if (get_option('ee_custom_session_save_handler_proven_ok', false)) {
+            // we've already tried it on a previous request. The custom save handler works. Don't worry
+            session_start();
+        } else {
+            // we haven't successfully tried the session handler yet.
+            // Check if we had a fatal error last time while trying it
+            if (get_option('ee_custom_session_save_handler_died', false)) {
+                $request = LoaderFactory::getLoader()->load('EventEspresso\core\services\request\Request');
+                if ($request->requestParamIsSet('ee_retry_session')) {
+                    delete_option('ee_custom_session_save_handler_died');
+                    // remove "ee_retry_session", otherwise, if the problem still isn't fixed, we'll just keep getting
+                    // the fatal error over and over. Better to remove it and redirect, and try on the next request
+                    wp_redirect(
+                        remove_query_arg(array('ee_retry_session'), EEH_URL::current_url())
+                    );
+                    die;
+                } else {
+                    // apparently, last time we tried using the custom session save handler, there was a fatal
+                    // so don't try it
+                    // just show a message to users that can fix it. Otherwise, try to hobble along without the session
+                    if (current_user_can('install_plugins')) {
+                        EE_Error::add_error(
+                            sprintf(
+                                esc_html__('It appears there was a fatal error while starting the session, so Event Espresso is not able to process registrations normally. Some hosting companies, like Pantheon, require an extra plugin for Event Espresso to work. Please install the %1$sWordPress Native PHP Sessions plugin%2$s, then %3$sclick here to check if the problem is resolved.%2$s', 'event_espresso'),
+                                '<a href="https://wordpress.org/plugins/wp-native-php-sessions/">',
+                                '</a>',
+                                '<a href="' . add_query_arg(array('ee_retry_session' => true), EEH_URL::current_url()) . '">'
+                            ),
+                            __FILE__,
+                            __FUNCTION__,
+                            __LINE__
+                        );
+                    }
+                }
+            } else {
+                // there is no record of having a fatal error while trying the custom session save handler
+                // so let's try it
+                // there is a custom session save handler. Proceed with caution
+                update_option('ee_custom_session_save_handler_died', '1');
+                // hold your breath, if the custom session save handler might cause a fatal here...
+                session_start();
+                // phew! we made it! the custom session handler is a-ok
+                update_option('ee_custom_session_save_handler_proven_ok', '1');
+            }
+        }
     }
 
 


### PR DESCRIPTION
…r, avoid starting the session and inform admins of the problem and offer a solution. Once they have fixed the problem, allow them to retry the session again


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/494
Fixes a fatal error when there is an invalid session save handler, like on Pantheon servers.
Well, detects when there is a fatal error (I don't think we can avoid the fatal error initially) and avoids calling the session code that triggers the fatal error on subsequent requests; and then instructs the admin how to fix the error. See https://drive.google.com/file/d/11HYwn-dG6XPvJB26-AcCXfa54VZx4xVo/view for the current UX.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with 
automated tests are preferred. -->
* [ ] Try registering for an event on a "normal" server (not pantheon). It should work normally
* [ ] Add `ini_set('session.save_handler', 'user');` to the top of your `wp-config.php` file, or use a pantheon server. You will still get the fatal error once. Sorry. But the next request will give you a helpful error message, but otherwise WordPress will work normally...
* [ ] Click the link that says "click here to check if the problem is resolved." first. You should get the fatal error again once, then this same page again.
* [ ] Log out and visit the front-end. You should get a helpful error message that won't scare average users.
* [ ] Log in again. Follow the link in the error message to the plugin Pantheon created to fix the issue. Install it. Then click "click here to check if the problem is resolved." again. Everything should work fine again.

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
