### PR TITLE
Fix DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes #505

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed venue description on event page so line breaks are shown properly ([612](https://github.com/eventespresso/event-espresso-core/pull/612))
 - Fixed `espresso_event_tickets_available()` so it echoes out the tickets when default arguments are provided ([619](https://github.com/eventespresso/event-espresso-core/pull/619))
 - Fixed caching loader identifier ([610](https://github.com/eventespresso/event-espresso-core/pull/610))
+- Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
 
 ### Changed
 

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -658,7 +658,7 @@ class EE_Dependency_Map
             'EventEspresso\core\services\notifications\PersistentAdminNoticeManager'                                      => array(
                 null,
                 'EventEspresso\core\domain\services\capabilities\CapabilitiesChecker' => EE_Dependency_Map::load_from_cache,
-                'EE_Request'                                                          => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'                         => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\core\services\licensing\LicenseService'                                                        => array(
                 'EventEspresso\core\domain\services\pue\Stats'  => EE_Dependency_Map::load_from_cache,

--- a/core/domain/entities/notifications/PersistentAdminNotice.php
+++ b/core/domain/entities/notifications/PersistentAdminNotice.php
@@ -9,6 +9,7 @@ use EventEspresso\core\domain\services\capabilities\RequiresCapCheckInterface;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\collections\Collection;
+use EventEspresso\core\services\collections\DuplicateCollectionIdentifierException;
 use EventEspresso\core\services\notifications\PersistentAdminNoticeManager;
 use Exception;
 
@@ -289,6 +290,7 @@ class PersistentAdminNotice implements RequiresCapCheckInterface
      * @param Collection $persistent_admin_notice_collection
      * @throws InvalidEntityException
      * @throws InvalidDataTypeException
+     * @throws DuplicateCollectionIdentifierException
      */
     public function registerPersistentAdminNotice(Collection $persistent_admin_notice_collection)
     {

--- a/core/services/notifications/PersistentAdminNoticeManager.php
+++ b/core/services/notifications/PersistentAdminNoticeManager.php
@@ -152,7 +152,7 @@ class PersistentAdminNoticeManager
                             $details['cap_context'],
                             $details['dismissed']
                         ),
-                        $name
+                        sanitize_key($name)
                     );
                 } else {
                     try {
@@ -166,7 +166,7 @@ class PersistentAdminNoticeManager
                                 '',
                                 empty($details)
                             ),
-                            $name
+                            sanitize_key($name)
                         );
                     } catch (Exception $e) {
                         EE_Error::add_error($e->getMessage(), __FILE__, __FUNCTION__, __LINE__);

--- a/core/services/notifications/PersistentAdminNoticeManager.php
+++ b/core/services/notifications/PersistentAdminNoticeManager.php
@@ -4,7 +4,6 @@ namespace EventEspresso\core\services\notifications;
 
 use DomainException;
 use EE_Error;
-use EE_Request;
 use EventEspresso\core\domain\entities\notifications\PersistentAdminNotice;
 use EventEspresso\core\domain\services\capabilities\CapabilitiesChecker;
 use EventEspresso\core\exceptions\InsufficientPermissionsException;
@@ -15,6 +14,7 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\collections\Collection;
 use EventEspresso\core\services\collections\DuplicateCollectionIdentifierException;
 use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\request\RequestInterface;
 use Exception;
 use InvalidArgumentException;
 
@@ -52,7 +52,7 @@ class PersistentAdminNoticeManager
     private $capabilities_checker;
 
     /**
-     * @var EE_Request $request
+     * @var RequestInterface $request
      */
     private $request;
 
@@ -62,10 +62,10 @@ class PersistentAdminNoticeManager
      *
      * @param string              $return_url where to  redirect to after dismissing notices
      * @param CapabilitiesChecker $capabilities_checker
-     * @param EE_Request          $request
+     * @param RequestInterface          $request
      * @throws InvalidDataTypeException
      */
-    public function __construct($return_url = '', CapabilitiesChecker $capabilities_checker, EE_Request $request)
+    public function __construct($return_url = '', CapabilitiesChecker $capabilities_checker, RequestInterface $request)
     {
         $this->setReturnUrl($return_url);
         $this->capabilities_checker = $capabilities_checker;
@@ -306,7 +306,7 @@ class PersistentAdminNoticeManager
      */
     public function dismissNotice($pan_name = '', $purge = false, $return = false)
     {
-        $pan_name = $this->request->get('ee_nag_notice', $pan_name);
+        $pan_name = $this->request->getRequestParam('ee_nag_notice', $pan_name);
         $this->notice_collection = $this->getPersistentAdminNoticeCollection();
         if (! empty($pan_name) && $this->notice_collection->has($pan_name)) {
             /** @var PersistentAdminNotice $persistent_admin_notice */
@@ -318,7 +318,7 @@ class PersistentAdminNoticeManager
         if ($return) {
             return;
         }
-        if ($this->request->ajax) {
+        if ($this->request->isAjax()) {
             // grab any notices and concatenate into string
             echo wp_json_encode(
                 array(
@@ -331,7 +331,7 @@ class PersistentAdminNoticeManager
         EE_Error::get_notices(false, true);
         wp_safe_redirect(
             urldecode(
-                $this->request->get('return_url', '')
+                $this->request->getRequestParam('return_url', '')
             )
         );
     }

--- a/core/services/notifications/PersistentAdminNoticeManager.php
+++ b/core/services/notifications/PersistentAdminNoticeManager.php
@@ -13,6 +13,7 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\collections\Collection;
+use EventEspresso\core\services\collections\DuplicateCollectionIdentifierException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use Exception;
 use InvalidArgumentException;
@@ -97,6 +98,7 @@ class PersistentAdminNoticeManager
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
      * @throws DomainException
+     * @throws DuplicateCollectionIdentifierException
      */
     protected function getPersistentAdminNoticeCollection()
     {
@@ -118,11 +120,11 @@ class PersistentAdminNoticeManager
      * @throws InvalidEntityException
      * @throws DomainException
      * @throws InvalidDataTypeException
+     * @throws DuplicateCollectionIdentifierException
      */
     protected function retrieveStoredNotices()
     {
         $persistent_admin_notices = get_option(PersistentAdminNoticeManager::WP_OPTION_KEY, array());
-        // \EEH_Debug_Tools::printr($persistent_admin_notices, '$persistent_admin_notices', __FILE__, __LINE__);
         if (! empty($persistent_admin_notices)) {
             foreach ($persistent_admin_notices as $name => $details) {
                 if (is_array($details)) {
@@ -198,6 +200,7 @@ class PersistentAdminNoticeManager
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidEntityException
+     * @throws DuplicateCollectionIdentifierException
      */
     public function displayNotices()
     {
@@ -295,6 +298,11 @@ class PersistentAdminNoticeManager
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
      * @throws DomainException
+     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
+     * @throws DuplicateCollectionIdentifierException
      */
     public function dismissNotice($pan_name = '', $purge = false, $return = false)
     {
@@ -336,6 +344,7 @@ class PersistentAdminNoticeManager
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidEntityException
+     * @throws DuplicateCollectionIdentifierException
      */
     public function saveNotices()
     {
@@ -370,6 +379,7 @@ class PersistentAdminNoticeManager
      * @throws InvalidDataTypeException
      * @throws InvalidEntityException
      * @throws InvalidInterfaceException
+     * @throws DuplicateCollectionIdentifierException
      */
     public function registerAndSaveNotices()
     {
@@ -389,6 +399,7 @@ class PersistentAdminNoticeManager
      * @throws InvalidEntityException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
+     * @throws DuplicateCollectionIdentifierException
      */
     public static function loadRegisterAndSaveNotices()
     {


### PR DESCRIPTION
## Problem this Pull Request solves
Plz see #505

So the problem was that `PersistentAdminNotice` uses the WordPress `sanitize_key()` function when setting the notice's name property upon construction. 
The name is later used during notice self registration to determine if it has already been added to the `PersistentAdminNotice` Collection or not. 

The actual problem was that when first registering notices that have been retrieved from the database, we were using the raw notice name from the WP option when adding the notices to the Collection. So in the case of the "New State" data notices, a notice name like `"CA-AB"` would get used as the object identifier in the Collection, but then the `PersistentAdminNotice` would sanitize that upon construction and convert it to `"ca-ab"`. Then when self registering, that notice would check for `"ca-ab"` in the Collection, which would return `false`, because that notice had been added using  `"CA-AB"` as the identifier, and attempt to add itself to the Collection which would generate the exception.

The simple simple fix is to perform the same sanitization on notice names from the db before using them as Collection identifiers.

## How has this been tested
locally using data from issue/505

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
