### PR TITLE
dont try to send messages while in full maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed an error when migrating from EE3 from attendee email index being too big ([611](https://github.com/eventespresso/event-espresso-core/pull/611))
 - Fixed venue description on event page so line breaks are shown properly ([612](https://github.com/eventespresso/event-espresso-core/pull/612))
 - Fixed caching loader identifier ([610](https://github.com/eventespresso/event-espresso-core/pull/610))
+- Fixed error when trying to send messages in full maintenance mode ([622](https://github.com/eventespresso/event-espresso-core/pull/622))
 
 ### Changed
 

--- a/core/libraries/messages/EE_Messages_Queue.lib.php
+++ b/core/libraries/messages/EE_Messages_Queue.lib.php
@@ -207,7 +207,9 @@ class EE_Messages_Queue
     public function get_to_send_batch_and_send()
     {
         $rate_limit = $this->get_rate_limit();
-        if ($rate_limit < 1 || $this->is_locked(EE_Messages_Queue::action_sending)) {
+        if ($rate_limit < 1
+            || $this->is_locked(EE_Messages_Queue::action_sending)
+            || ! EE_Maintenance_Mode::instance()->models_can_query()) {
             return false;
         }
 

--- a/core/libraries/messages/EE_Messages_Queue.lib.php
+++ b/core/libraries/messages/EE_Messages_Queue.lib.php
@@ -208,8 +208,7 @@ class EE_Messages_Queue
     {
         $rate_limit = $this->get_rate_limit();
         if ($rate_limit < 1
-            || $this->is_locked(EE_Messages_Queue::action_sending)
-            || ! EE_Maintenance_Mode::instance()->models_can_query()) {
+            || $this->is_locked(EE_Messages_Queue::action_sending)) {
             return false;
         }
 
@@ -348,13 +347,17 @@ class EE_Messages_Queue
 
 
     /**
-     * Returns whether batch methods are "locked" or not.
+     * Returns whether batch methods are "locked" or not, and if models an currently be used to query the database.
+     * Return true when batch methods should not be used; returns false when they can be.
      *
      * @param  string $type The type of lock being checked for.
      * @return bool
      */
     public function is_locked($type = EE_Messages_Queue::action_generating)
     {
+        if(! EE_Maintenance_Mode::instance()->models_can_query()){
+            return true;
+        }
         $lock = (int) get_option($this->_get_lock_key($type), 0);
         /**
          * This filters the default is_locked behaviour.

--- a/core/libraries/messages/EE_Messages_Queue.lib.php
+++ b/core/libraries/messages/EE_Messages_Queue.lib.php
@@ -355,7 +355,7 @@ class EE_Messages_Queue
      */
     public function is_locked($type = EE_Messages_Queue::action_generating)
     {
-        if(! EE_Maintenance_Mode::instance()->models_can_query()){
+        if (! EE_Maintenance_Mode::instance()->models_can_query()) {
             return true;
         }
         $lock = (int) get_option($this->_get_lock_key($type), 0);


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/500
Fixes error when trying to send messages in full maintenance mode.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] verify that when you register for an event, messages get sent out as normal
* [ ] see testing instructions from Tony on https://github.com/eventespresso/event-espresso-core/issues/500 (although I wasn't able to reproduce the original issue (I actually didn't never saw the messages code get called while in maintenance mode; possibly it got coincidentally fixed, but more likely I just can't reproduce)

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
