### PR TITLE
include button source on ALL paypal express API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 ### Added
 
 - Added support for Indian Rupees currency (INR) to PayPal Espresso and Pro ([593](https://github.com/eventespresso/event-espresso-core/pull/593)) 
-
+- Added BUTTONSOURCE on all PayPal Express API calls. ([627](https://github.com/eventespresso/event-espresso-core/pull/627))
 ### Fixed
 
 - Fixed a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))

--- a/payment_methods/Paypal_Express/EEG_Paypal_Express.gateway.php
+++ b/payment_methods/Paypal_Express/EEG_Paypal_Express.gateway.php
@@ -181,8 +181,6 @@ class EEG_Paypal_Express extends EE_Offsite_Gateway
             // Buyer does not need to create a PayPal account to check out.
             // This is referred to as PayPal Account Optional.
             'SOLUTIONTYPE'                   => 'Sole',
-            // EE will blow up if you change this
-            'BUTTONSOURCE'                   => 'EventEspresso_SP',
             // Locale of the pages displayed by PayPal during Express Checkout.
             'LOCALECODE'                     => $locale[1]
         );
@@ -303,8 +301,6 @@ class EEG_Paypal_Express extends EE_Offsite_Gateway
                     'PAYMENTREQUEST_0_PAYMENTACTION' => 'Sale',
                     'PAYMENTREQUEST_0_AMT'           => $payment->amount(),
                     'PAYMENTREQUEST_0_CURRENCYCODE'  => $payment->currency_code(),
-                    // EE will blow up if you change this
-                    'BUTTONSOURCE'                   => 'EventEspresso_SP',
                 );
                  // Include itemized list.
                 $itemized_list = $this->itemize_list(
@@ -566,10 +562,12 @@ class EEG_Paypal_Express extends EE_Offsite_Gateway
     public function _ppExpress_request($request_params, $request_text, $payment)
     {
         $request_dtls = array(
-            'VERSION'   => '204.0',
-            'USER'      => urlencode($this->_api_username),
-            'PWD'       => urlencode($this->_api_password),
+            'VERSION' => '204.0',
+            'USER' => urlencode($this->_api_username),
+            'PWD' => urlencode($this->_api_password),
             'SIGNATURE' => urlencode($this->_api_signature),
+            // EE will blow up if you change this
+            'BUTTONSOURCE' => 'EventEspresso_SP',
         );
         $dtls = array_merge($request_dtls, $request_params);
         $this->_log_clean_request($dtls, $payment, $request_text . ' Request');


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Add `BUTTONSOURCE` on all PayPal Express API calls.

Requestedb y Nathanial Sanders from PayPal as it will help with analysis.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Make a payment with PayPal Express. It should work fine
* [x] Look at the payment logs. All the log entries where the top-level name is either "Do Payment Request", or "Customer Details Request" or "Payment Token Request" should have the `BUTTONSOURCE` parameter set

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
