### PR TITLE
Fixed URL validation when URL was for a site denying access to our HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed caching loader identifier ([610](https://github.com/eventespresso/event-espresso-core/pull/610))
 - Fixed Authorize.net AIM so payment currency is sent ([591](https://github.com/eventespresso/event-espresso-core/pull/591))
 - Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
-
+- Fixed URL validation when URL was for a site denying access to our HTTP client ([628](https://github.com/eventespresso/event-espresso-core/pull/628))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
@@ -18,7 +18,14 @@ class EE_Admin_File_Uploader_Input extends EE_Form_Input_Base
     {
         $this->_set_display_strategy(new EE_Admin_File_Uploader_Display_Strategy());
         $this->_set_normalization_strategy(new EE_Text_Normalization());
-        $this->_add_validation_strategy(new EE_URL_Validation_Strategy(isset($input_settings['validation_error_message']) ? $input_settings['validation_error_message'] : null));
+        $this->_add_validation_strategy(
+            new EE_URL_Validation_Strategy(
+                isset($input_settings['validation_error_message'])
+                    ? $input_settings['validation_error_message']
+                    : null,
+                true
+            )
+        );
         parent::__construct($input_settings);
     }
 }

--- a/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
@@ -12,13 +12,20 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
 {
 
     /**
-     * @param null $validation_error_message
+     * @var @boolean whether we should check if the file exists or not
      */
-    public function __construct($validation_error_message = null)
+    protected $check_file_exists;
+
+    /**
+     * @param null $validation_error_message
+     * @param boolean $check_file_exists
+     */
+    public function __construct($validation_error_message = null, $check_file_exists = false)
     {
         if (! $validation_error_message) {
             $validation_error_message = __("Please enter a valid URL. Eg https://eventespresso.com", "event_espresso");
         }
+        $this->check_file_exists = $check_file_exists;
         parent::__construct($validation_error_message);
     }
 
@@ -36,7 +43,7 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
         if ($normalized_value) {
             if (filter_var($normalized_value, FILTER_VALIDATE_URL) === false) {
                 throw new EE_Validation_Error($this->get_validation_error_message(), 'invalid_url');
-            } elseif (apply_filters('FHEE__EE_URL_Validation_Strategy__validate__check_remote_file_exists', false, $this->_input)) {
+            } elseif (apply_filters('FHEE__EE_URL_Validation_Strategy__validate__check_remote_file_exists', $this->check_file_exists, $this->_input)) {
                 if (! EEH_URL::remote_file_exists(
                     $normalized_value,
                     array(

--- a/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
@@ -36,7 +36,7 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
         if ($normalized_value) {
             if (filter_var($normalized_value, FILTER_VALIDATE_URL) === false) {
                 throw new EE_Validation_Error($this->get_validation_error_message(), 'invalid_url');
-            } else {
+            } elseif (apply_filters('FHEE__EE_URL_Validation_Strategy__validate__check_remote_file_exists', false, $this->_input)) {
                 if (! EEH_URL::remote_file_exists(
                     $normalized_value,
                     array(


### PR DESCRIPTION
…dd a filter in case someone really wants to enable it


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/618
Fixes URL validation when URL was for a site denying access to our HTTP client

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Add a URL question to a registration form and register with it. The site `https://www.njadvancemedia.com` should be considered valid, whereas `--!/!@#$%^&*()` should be invalid
* [x] Updating payment method BUTTON URLs should work the same as before (I'm open to changing that, but let's do it on a separate ticket)

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
