### PR TITLE
Namespace site license key request key (fixes #605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed Authorize.net AIM so payment currency is sent ([591](https://github.com/eventespresso/event-espresso-core/pull/591))
 - Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
 - Fixes a syntax issue inside `EE_Config::register_ee_widget()` ([608](https://github.com/eventespresso/event-espresso-core/pull/608))
+- Namespace `site-license-key` in requests (to `ee-site-license-key`) to hopefully fix issue some users see with multiple pue license key requests happening. ([633](https://github.com/eventespresso/event-espresso-core/pull/633))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed Authorize.net AIM so payment currency is sent ([591](https://github.com/eventespresso/event-espresso-core/pull/591))
 - Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
 - Fixes a syntax issue inside `EE_Config::register_ee_widget()` ([608](https://github.com/eventespresso/event-espresso-core/pull/608))
-- Namespace `site-license-key` in requests (to `ee-site-license-key`) to hopefully fix issue some users see with multiple pue license key requests happening. ([633](https://github.com/eventespresso/event-espresso-core/pull/633))
+- Namespaced `site-license-key` in requests (to `ee-site-license-key`) to hopefully fix issue some users see with multiple pue license key requests happening. ([633](https://github.com/eventespresso/event-espresso-core/pull/633))
 
 ### Changed
 

--- a/admin_pages/general_settings/OrganizationSettings.php
+++ b/admin_pages/general_settings/OrganizationSettings.php
@@ -392,8 +392,8 @@ class OrganizationSettings extends FormHandler
         }
 
         if (is_main_site()) {
-            $this->network_core_config->site_license_key = isset($form_data['site_license_key'])
-                ? sanitize_text_field($form_data['site_license_key'])
+            $this->network_core_config->site_license_key = isset($form_data['ee_site_license_key'])
+                ? sanitize_text_field($form_data['ee_site_license_key'])
                 : $this->network_core_config->site_license_key;
         }
         $this->organization_config->name = isset($form_data['organization_name'])
@@ -495,7 +495,7 @@ class OrganizationSettings extends FormHandler
     {
         $text_input = new EE_Text_Input(
             array(
-                'html_name' => 'site_license_key',
+                'html_name' => 'ee_site_license_key',
                 'html_id' => 'site_license_key',
                 'html_label_text' => esc_html__('Support License Key', 'event_espresso'),
                 /** phpcs:disable WordPress.WP.I18n.UnorderedPlaceholdersText */

--- a/core/domain/services/pue/Config.php
+++ b/core/domain/services/pue/Config.php
@@ -58,7 +58,7 @@ class Config
 
     public function optionKey()
     {
-        return 'site_license_key';
+        return 'ee_site_license_key';
     }
 
 

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1108,7 +1108,7 @@ class EE_Register_Addon implements EEI_Plugin_API
                         'apikey'            => EE_Registry::instance()->NET_CFG->core->site_license_key,
                         'lang_domain'       => 'event_espresso',
                         'checkPeriod'       => $settings['pue_options']['checkPeriod'],
-                        'option_key'        => 'site_license_key',
+                        'option_key'        => 'ee_site_license_key',
                         'options_page_slug' => 'event_espresso',
                         'plugin_basename'   => $settings['pue_options']['plugin_basename'],
                         // if use_wp_update is TRUE it means you want FREE versions of the plugin to be updated from WP

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1091,13 +1091,14 @@ class EE_Register_Addon implements EEI_Plugin_API
     {
         // load PUE client
         require_once EE_THIRD_PARTY . 'pue' . DS . 'pue-client.php';
+        $license_server = defined('PUE_UPDATES_ENDPOINT') ? PUE_UPDATES_ENDPOINT : 'https://eventespresso.com';
         // cycle thru settings
         foreach (self::$_settings as $settings) {
             if (! empty($settings['pue_options'])) {
                 // initiate the class and start the plugin update engine!
                 new PluginUpdateEngineChecker(
                     // host file URL
-                    'https://eventespresso.com',
+                    $license_server,
                     // plugin slug(s)
                     array(
                         'premium'    => array('p' => $settings['pue_options']['pue_plugin_slug']),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

See #605 for details.  Essentially, this pull request modifies the form name field used for the support/site license key on the general options page so that its namespaced a bit more.  Then in pue-client, rather than listening for `site-license-key` on requests, its listening for this new namespaced key (`ee-site-license-key`).

The original request key was a bit too generic and its feasible this resulted in pue triggering multiple requests to our server as a result of a plugin and/or theme also submitting `site-license-key` somewhere in a request as a key.

This pull request also fixes a small bug for registered EE add-ons which were not using the `PUE_UPDATES_ENDPOINT` constant if present.  This affected testing with that constant.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

I have yet found a way to reproduce the issue prompting #605 so there's no way currently for me to verify this actually fixes the issue some users report.  So testing has focused mainly on ensuring existing pue functionality is not broken.

* [x] Verify license key validation still works as expected on saving the General Options page.
* [x] Verify that license key validation for both ee core and any add-ons works as expected (in testing verify that you are able to download "updates" from staging.eventespresso.com).

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
