### PR TITLE
Add checkin model to `@eventespresso/model` bundle

### DIFF
--- a/assets/src/components/form/select/build-options.js
+++ b/assets/src/components/form/select/build-options.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, isFunction, isUndefined, reduce } from 'lodash';
+import { isEmpty, isFunction, isUndefined, reduce, isArray } from 'lodash';
 import warning from 'warning';
 
 /**
@@ -46,7 +46,18 @@ const buildOptions = (
 		return [];
 	}
 	// if requested mapSelection exists then use that
-	const map = optionsEntityMap[ mapSelection ];
+	let map = optionsEntityMap[ mapSelection ];
+
+	// if map is function then simply pass through entities to that function
+	if ( isFunction( map ) ) {
+		const options = map( entities );
+		if ( isArray( options ) ) {
+			return options;
+		}
+		// set map to empty object because the function on it returned something
+		// other than an array
+		map = {};
+	}
 	return ! isEmpty( map ) ?
 		reduce(
 			entities,

--- a/assets/src/components/form/select/build-options.js
+++ b/assets/src/components/form/select/build-options.js
@@ -57,6 +57,12 @@ const buildOptions = (
 		// set map to empty object because the function on it returned something
 		// other than an array
 		map = {};
+		warning(
+			false,
+			'The optionsEntityMap for ' + mapSelection + 'was a function but' +
+			' it did not return an array of options.  Make sure the function' +
+			' returns an array of simple objects with label and value keys.'
+		);
 	}
 	return ! isEmpty( map ) ?
 		reduce(

--- a/assets/src/data/model/checkin/constants.js
+++ b/assets/src/data/model/checkin/constants.js
@@ -1,0 +1,16 @@
+/**
+ * External imports
+ */
+import { values } from 'lodash';
+
+export const MODEL_NAME = 'checkin';
+
+export const CHECKIN_STATUS_ID = {
+	STATUS_CHECKED_OUT: 0,
+	STATUS_CHECKED_IN: 1,
+	STATUS_CHECKED_NEVER: 2,
+};
+
+export const CHECKIN_STATUS_IDS = values(
+	CHECKIN_STATUS_ID
+);

--- a/assets/src/data/model/checkin/index.js
+++ b/assets/src/data/model/checkin/index.js
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './query';

--- a/assets/src/data/model/checkin/query.js
+++ b/assets/src/data/model/checkin/query.js
@@ -3,7 +3,7 @@
  */
 import { isUndefined } from 'lodash';
 import PropTypes from 'prop-types';
-import { prettyStatus } from '@eventespresso/model';
+import { prettyStatus } from '../status';
 
 /**
  * Internal imports

--- a/assets/src/data/model/checkin/query.js
+++ b/assets/src/data/model/checkin/query.js
@@ -1,0 +1,146 @@
+/**
+ * External imports
+ */
+import { isUndefined } from 'lodash';
+import PropTypes from 'prop-types';
+import { prettyStatus } from '@eventespresso/model';
+
+/**
+ * Internal imports
+ */
+import {
+	getQueryString as baseGetQueryString,
+	QUERY_ORDER_DESC,
+	ALLOWED_ORDER_VALUES,
+} from '../base';
+import * as checkinStatus from './constants';
+
+/**
+ * Described attributes for this model
+ * @type {{attributes: *}}
+ */
+export const queryDataTypes = {
+	forDatetimeId: PropTypes.number,
+	forEventId: PropTypes.number,
+	forRegistrationId: PropTypes.number,
+	forTicketId: PropTypes.number,
+	forStatusId: PropTypes.oneOf( checkinStatus.CHECKIN_STATUS_IDS ),
+	queryData: PropTypes.shape( {
+		limit: PropTypes.number,
+		orderBy: PropTypes.oneOf( [
+			'CHK_ID',
+			'REG_ID',
+			'CHK_timestamp',
+			'DTT_ID',
+		] ),
+		order: PropTypes.oneOf( ALLOWED_ORDER_VALUES ),
+	} ),
+};
+
+export const optionsEntityMap = {
+	default: () => {
+		return [
+			{
+				label: prettyStatus(
+					checkinStatus.CHECKIN_STATUS_ID.STATUS_CHECKED_OUT
+				),
+				value: checkinStatus.CHECKIN_STATUS_ID.STATUS_CHECKED_OUT,
+			},
+			{
+				label: prettyStatus(
+					checkinStatus.CHECKIN_STATUS_ID.STATUS_CHECKED_IN
+				),
+				value: checkinStatus.CHECKIN_STATUS_ID.STATUS_CHECKED_IN,
+			},
+		];
+	},
+};
+
+/**
+ * Default attributes for this model
+ * @type {
+ * 	{
+ * 		attributes: {
+ * 			limit: number,
+ * 			orderBy: string,
+ * 			order: string,
+ *   	}
+ *   }
+ * }
+ */
+export const defaultQueryData = {
+	queryData: {
+		limit: 100,
+		orderBy: 'CHK_timestamp',
+		order: QUERY_ORDER_DESC,
+	},
+};
+
+/**
+ * Used to map an orderBy string to the actual value used in a REST query from
+ * the context of a registration.
+ *
+ * @param {string} orderBy
+ *
+ * @return { string } Returns an actual orderBy string for the REST query for
+ *                      the provided alias
+ */
+export const mapOrderBy = ( orderBy ) => {
+	const orderByMap = {
+		timestamp: 'CHK_timestamp',
+		id: 'CHK_ID',
+	};
+	return isUndefined( orderByMap[ orderBy ] ) ?
+		orderBy :
+		orderByMap[ orderBy ];
+};
+
+/**
+ * Builds where conditions for an registrations endpoint request
+ *
+ * @param {number} forDatetimeId    	ID of Event to retrieve registrations for
+ * @param {number} forEventId    ID of Attendee to retrieve registrations for
+ * @param {number} forRegistrationId ID of Transaction to retrieve registrations for
+ * @param {number} forTicketId 		ID of Ticket to retrieve registrations for
+ * @param {string} forStatusId 		ID of Status to retrieve registrations for
+ * @return {string}                	The assembled where conditions.
+ */
+export const whereConditions = ( {
+	forDatetimeId = 0,
+	forEventId = 0,
+	forRegistrationId = 0,
+	forTicketId = 0,
+	forStatusId = '',
+} ) => {
+	const where = [];
+	forEventId = parseInt( forEventId, 10 );
+	if ( forEventId !== 0 && ! isNaN( forEventId ) ) {
+		where.push( 'where[Registration.EVT_ID]=' + forEventId );
+	}
+	forDatetimeId = parseInt( forDatetimeId, 10 );
+	if ( forDatetimeId !== 0 && ! isNaN( forDatetimeId ) ) {
+		where.push( 'where[DTT_ID]=' + forDatetimeId );
+	}
+	forRegistrationId = parseInt( forRegistrationId, 10 );
+	if ( forRegistrationId !== 0 && ! isNaN( forRegistrationId ) ) {
+		where.push( 'where[REG_ID]=' + forRegistrationId );
+	}
+	forTicketId = parseInt( forTicketId, 10 );
+	if ( forTicketId !== 0 && ! isNaN( forTicketId ) ) {
+		where.push( 'where[Registration.TKT_ID]=' + forTicketId );
+	}
+	if ( forStatusId !== '' && forStatusId !== null ) {
+		where.push( 'where[CHK_in]=' + forStatusId );
+	}
+	return where.join( '&' );
+};
+
+/**
+ * Return a query string for use by a REST request given a set of queryData.
+ * @param { Object } queryData
+ * @return { string }  Returns the query string.
+ */
+export const getQueryString = ( queryData = {} ) => {
+	queryData = { ...defaultQueryData.queryData, ...queryData };
+	return baseGetQueryString( queryData, whereConditions, mapOrderBy );
+};

--- a/assets/src/data/model/checkin/test/query.js
+++ b/assets/src/data/model/checkin/test/query.js
@@ -20,7 +20,7 @@ describe( 'mapOrderBy()', () => {
 
 describe( 'whereConditions()', () => {
 	it( 'returns expected default for empty object passed in', () => {
-		expect( whereConditions( {} ) ).toEqual('');
+		expect( whereConditions( {} ) ).toEqual( '' );
 	} );
 	it( 'returns expected string for values passed in', () => {
 		const testObject = {

--- a/assets/src/data/model/checkin/test/query.js
+++ b/assets/src/data/model/checkin/test/query.js
@@ -1,0 +1,49 @@
+import {
+	mapOrderBy,
+	whereConditions,
+	getQueryString,
+} from '../query';
+import { CHECKIN_STATUS_ID } from '../constants';
+
+describe( 'mapOrderBy()', () => {
+	it( 'correctly maps incoming values to the correct expectation', () => {
+		const incomingToExpectedMap = {
+			timestamp: 'CHK_timestamp',
+			id: 'CHK_ID',
+		};
+		for ( const incomingOrderBy in incomingToExpectedMap ) {
+			const expectedValue = incomingToExpectedMap[ incomingOrderBy ];
+			expect( mapOrderBy( incomingOrderBy ) ).toEqual( expectedValue );
+		}
+	} );
+} );
+
+describe( 'whereConditions()', () => {
+	it( 'returns expected default for empty object passed in', () => {
+		expect( whereConditions( {} ) ).toEqual('');
+	} );
+	it( 'returns expected string for values passed in', () => {
+		const testObject = {
+			forDatetimeId: 10,
+			forEventId: 20,
+			forRegistrationId: 15,
+			forTicketId: 3,
+			forStatusId: CHECKIN_STATUS_ID.STATUS_CHECKED_IN,
+		};
+		expect( whereConditions( testObject ) ).toEqual(
+			'where[Registration.EVT_ID]=20' +
+			'&where[DTT_ID]=10' +
+			'&where[REG_ID]=15' +
+			'&where[Registration.TKT_ID]=3' +
+			'&where[CHK_in]=' + CHECKIN_STATUS_ID.STATUS_CHECKED_IN
+		);
+	} );
+} );
+
+describe( 'getQueryString', () => {
+	it( 'returns expected default for no arguments passed in', () => {
+		expect( getQueryString() ).toEqual(
+			'limit=100&order=DESC&order_by=CHK_timestamp'
+		);
+	} );
+} );

--- a/assets/src/data/model/models.js
+++ b/assets/src/data/model/models.js
@@ -3,5 +3,12 @@ import * as eventModel from './event';
 import * as registrationModel from './registration';
 import * as statusModel from './status';
 import * as ticketModel from './ticket';
-
-export { dateTimeModel, eventModel, registrationModel, statusModel, ticketModel };
+import * as checkInModel from './checkin';
+export {
+	dateTimeModel,
+	eventModel,
+	registrationModel,
+	statusModel,
+	ticketModel,
+	checkInModel,
+};

--- a/assets/src/data/model/models.js
+++ b/assets/src/data/model/models.js
@@ -5,10 +5,10 @@ import * as statusModel from './status';
 import * as ticketModel from './ticket';
 import * as checkInModel from './checkin';
 export {
+	checkInModel,
 	dateTimeModel,
 	eventModel,
 	registrationModel,
 	statusModel,
 	ticketModel,
-	checkInModel,
 };

--- a/assets/src/data/model/status/helpers.js
+++ b/assets/src/data/model/status/helpers.js
@@ -221,12 +221,12 @@ const STATUS_TRANSLATION_MAP_DATETIME = {
  */
 const STATUS_TRANSLATION_MAP_CHECKIN = {
 	[ CHECKIN_STATUS_ID.STATUS_CHECKED_IN ]: new Label(
-		__( 'check in', 'event_espresso' ),
-		__( 'checked in', 'event_espresso' )
+		__( 'check-in', 'event_espresso' ),
+		__( 'check-ins', 'event_espresso' )
 	),
 	[ CHECKIN_STATUS_ID.STATUS_CHECKED_OUT ]: new Label(
-		__( 'check out', 'event_espresso' ),
-		__( 'checked out', 'event_espresso' )
+		__( 'check-out', 'event_espresso' ),
+		__( 'check-outs', 'event_espresso' )
 	),
 	[ CHECKIN_STATUS_ID.STATUS_CHECKED_NEVER ]: Label.fromSameSingleAndPlural(
 		__( 'never checked in', 'event_espresso' )

--- a/assets/src/data/model/status/helpers.js
+++ b/assets/src/data/model/status/helpers.js
@@ -6,6 +6,7 @@ import Label from '../../../vo/label';
 import { EVENT_STATUS_ID } from '../event';
 import { TICKET_STATUS_ID } from '../ticket';
 import { DATETIME_STATUS_ID } from '../datetime';
+import { CHECKIN_STATUS_ID } from '../checkin';
 
 /**
  * External imports
@@ -214,6 +215,25 @@ const STATUS_TRANSLATION_MAP_DATETIME = {
 };
 
 /**
+ * Translation map for checkin statuses
+ *
+ * @type {{}}
+ */
+const STATUS_TRANSLATION_MAP_CHECKIN = {
+	[ CHECKIN_STATUS_ID.STATUS_CHECKED_IN ]: new Label(
+		__( 'check in', 'event_espresso' ),
+		__( 'checked in', 'event_espresso' )
+	),
+	[ CHECKIN_STATUS_ID.STATUS_CHECKED_OUT ]: new Label(
+		__( 'check out', 'event_espresso' ),
+		__( 'checked out', 'event_espresso' )
+	),
+	[ CHECKIN_STATUS_ID.STATUS_CHECKED_NEVER ]: Label.fromSameSingleAndPlural(
+		__( 'never checked in', 'event_espresso' )
+	),
+};
+
+/**
  * Combined translation map for all statuses.
  * @type {{}}
  */
@@ -226,6 +246,7 @@ const STATUS_TRANSLATION_MAP_ALL = {
 	...STATUS_TRANSLATION_MAP_EVENT,
 	...STATUS_TRANSLATION_MAP_TICKET,
 	...STATUS_TRANSLATION_MAP_DATETIME,
+	...STATUS_TRANSLATION_MAP_CHECKIN,
 	[ status.UNKNOWN_STATUS_ID ]: Label.fromSameSingleAndPlural(
 		__( 'unknown', 'event_espresso' )
 	),

--- a/docs/AA--Javascript-in-EE/eejs-module.md
+++ b/docs/AA--Javascript-in-EE/eejs-module.md
@@ -123,5 +123,6 @@ This property exposes all the model javascript interfaces for EE models. This be
 | registrationModel | A module containing all model related interfaces for the Registration model.
 | statusModel | A module containing all model related interfaces for the Status model.
 | ticketModel | A module containing all model related interfaces for the Ticket model.
+| checkInModel | A module containing all model related interfaces for the Checkin model.
 
 Note: The list of exposed models will be added to over time so the above list may be out of date. You can find all the models and their exposed interfaces [here](../../../assets/src/data/model/)

--- a/tests/javascript-config/unit/jest.config.json
+++ b/tests/javascript-config/unit/jest.config.json
@@ -10,6 +10,7 @@
 	"moduleNameMapper": {
 		"@eventespresso\\/(eejs)": "assets/src/$1",
 		"@eventespresso\/helpers": "assets/src/data/helpers",
+		"@eventespresso\/model": "assets/src/data/model",
 		"@eventespresso\/vo": "assets/src/vo",
 		"tinymce": "<rootDir>/tests/javascript-config/unit/mocks/tinymce",
 		"@wordpress/i18n": "<rootDir>/tests/javascript-config/unit/mocks/i18n",


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

This pull add the *Checkin* model to `@eventespresso/model` module.  Along with this:

- `buildOptions` in `build-options.js` has been tweaked so the `optionsEntityMap` passed by the model can provide a function for the `mapSelection` to build the options instead of just the map.  This was added in case there are specific types of option arrays a model wants to build.  The new checkin model is using this for its `default` options map.
- jest config has been tweaked so that it `@eventespresso/model` usage is correctly mapped to the model package.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] unit test coverage

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
