### PR TITLE
Fixed null datetimes in REST API

### DIFF
--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -763,8 +763,8 @@ class EE_Datetime_Field extends EE_Model_Field_Base
         $default_raw = $this->get_default_value();
         if ($default_raw instanceof DateTime) {
             return $default_raw;
-        } elseif( is_null($default_raw)) {
-          return $default_raw;
+        } elseif (is_null($default_raw)) {
+            return $default_raw;
         } else {
             return new DbSafeDateTime(
                 $this->get_default_value(),

--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -750,6 +750,28 @@ class EE_Datetime_Field extends EE_Model_Field_Base
         }
     }
 
+    /**
+     * Gets the default datetime object from the field's default time
+     * @since $VID:$
+     * @return DbSafeDateTime|null
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    public function getDefaultDateTimeObj()
+    {
+        $default_raw = $this->get_default_value();
+        if ($default_raw instanceof DateTime) {
+            return $default_raw;
+        } elseif( is_null($default_raw)) {
+          return $default_raw;
+        } else {
+            return new DbSafeDateTime(
+                $this->get_default_value(),
+                EEH_DTT_Helper::get_valid_timezone_string($this->get_timezone())
+            );
+        }
+    }
 
     public function getSchemaDescription()
     {

--- a/core/libraries/rest_api/ModelDataTranslator.php
+++ b/core/libraries/rest_api/ModelDataTranslator.php
@@ -332,7 +332,9 @@ class ModelDataTranslator
                     )
                 );
             }
-            $new_value = mysql_to_rfc3339($new_value);
+            if ($new_value !== null) {
+                $new_value = mysql_to_rfc3339($new_value);
+            }
         } else {
             $new_value = $original_value;
         }

--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -689,7 +689,7 @@ class Read extends Base
             } elseif ($field_obj instanceof \EE_Datetime_Field) {
                 $field_value = $field_obj->prepare_for_set_from_db($field_value);
                 // if the value is null, but we're not supposed to permit null, then set to the field's default
-                if( is_null($field_value)) {
+                if (is_null($field_value)) {
                     $field_value = $field_obj->getDefaultDateTimeObj();
                 }
                 if (is_null($field_value)) {

--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -688,6 +688,10 @@ class Read extends Base
                 );
             } elseif ($field_obj instanceof \EE_Datetime_Field) {
                 $field_value = $field_obj->prepare_for_set_from_db($field_value);
+                // if the value is null, but we're not supposed to permit null, then set to the field's default
+                if( is_null($field_value)) {
+                    $field_value = $field_obj->getDefaultDateTimeObj();
+                }
                 if (is_null($field_value)) {
                     $gmt_date = $local_date = ModelDataTranslator::prepareFieldValuesForJson(
                         $field_obj,

--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -688,19 +688,29 @@ class Read extends Base
                 );
             } elseif ($field_obj instanceof \EE_Datetime_Field) {
                 $field_value = $field_obj->prepare_for_set_from_db($field_value);
-                $timezone = $field_value->getTimezone();
-                EEH_DTT_Helper::setTimezone($field_value, new DateTimeZone('UTC'));
-                $result[ $field_name . '_gmt' ] = ModelDataTranslator::prepareFieldValuesForJson(
-                    $field_obj,
-                    $field_value,
-                    $this->getModelVersionInfo()->requestedVersion()
-                );
-                EEH_DTT_Helper::setTimezone($field_value, $timezone);
-                $result[ $field_name ] = ModelDataTranslator::prepareFieldValuesForJson(
-                    $field_obj,
-                    $field_value,
-                    $this->getModelVersionInfo()->requestedVersion()
-                );
+                if (is_null($field_value)) {
+                    $gmt_date = $local_date = ModelDataTranslator::prepareFieldValuesForJson(
+                        $field_obj,
+                        $field_value,
+                        $this->getModelVersionInfo()->requestedVersion()
+                    );
+                } else {
+                    $timezone = $field_value->getTimezone();
+                    EEH_DTT_Helper::setTimezone($field_value, new DateTimeZone('UTC'));
+                    $gmt_date = ModelDataTranslator::prepareFieldValuesForJson(
+                        $field_obj,
+                        $field_value,
+                        $this->getModelVersionInfo()->requestedVersion()
+                    );
+                    EEH_DTT_Helper::setTimezone($field_value, $timezone);
+                    $local_date = ModelDataTranslator::prepareFieldValuesForJson(
+                        $field_obj,
+                        $field_value,
+                        $this->getModelVersionInfo()->requestedVersion()
+                    );
+                }
+                $result[ $field_name . '_gmt' ] = $gmt_date;
+                $result[ $field_name ] = $local_date;
             } else {
                 $result[ $field_name ] = $this->prepareFieldObjValueForJson($field_obj, $field_value);
             }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/630
Fixed null datetimes in REST API (before they threw a fatal error). If a datetime column has NULL for its value, the model's value will be null, and the REST API will also return null.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Activate the promotions add-on, and create a promotion with no start or end time. Then send an authenticated query to `GET /wp-json/ee/v4.8.36/promotions`. It should no longer have an error, instead the promotion's start and end times should be `null`
## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
