### PR TITLE
Added foreign keys to REST API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 - Added support for Indian Rupees currency (INR) to PayPal Espresso and Pro ([593](https://github.com/eventespresso/event-espresso-core/pull/593)) 
 - Added BUTTONSOURCE on all PayPal Express API calls. ([627](https://github.com/eventespresso/event-espresso-core/pull/627))
+- Added foreign keys to REST API responses ([639](https://github.com/eventespresso/event-espresso-core/pull/639))
 ### Fixed
 
 - Fixed a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))

--- a/core/libraries/rest_api/ModelVersionInfo.php
+++ b/core/libraries/rest_api/ModelVersionInfo.php
@@ -331,7 +331,7 @@ class ModelVersionInfo
     {
         return apply_filters(
             'FHEE__Controller_Model_Read_fields_ignored',
-            array('EE_Foreign_Key_Field_Base', 'EE_Any_Foreign_Model_Name_Field')
+            array()
         );
     }
 

--- a/docs/C--REST-API/rest-api-changelog.md
+++ b/docs/C--REST-API/rest-api-changelog.md
@@ -3,6 +3,9 @@
 
 This is a log of client-facing changes made to the EE4 REST API (ie, changes to internal implementations aren't listed here, just changes that affect consumers of the API). For a complete list of changes to EE4, please see [the EE4 changelog](https://eventespresso.com/wiki/ee4-changelog/)
 
+## 4.9.66
+- Added foreign keys to REST API responses
+
 ## 4.9.38
 - Added support for `POST`ing, `PUT`ing, and `DELETE`ing EE4 model data
 - PHP objects in JSON responses are replaced with JSON objects with properties "error_code" and "error_message"
@@ -21,5 +24,3 @@ This is a log of client-facing changes made to the EE4 REST API (ie, changes to 
 
 ## 4.8.40
 - Added calculated field "datetime_checkin_stati" on registration resources onto 4.8.36 endpoint. See [the calculated fields reference page](https://github.com/eventespresso/event-espresso-core/blob/master/docs/C--REST-API/ee4-rest-api-calculated-fields-reference.md) for more info
-
-

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -422,6 +422,7 @@ class Read_Test extends \EE_REST_TestCase
                 ),
                 'EVT_slug'                        => $event->get('EVT_slug'),
                 'EVT_short_desc'                  => $event->get('EVT_short_desc'),
+                'EVT_wp_user'                     => $event->get('EVT_wp_user'),
                 'parent'                          => $event->get('parent'),
                 'EVT_order'                       => $event->get('EVT_order'),
                 'status'                          => array(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/636
Added foreign keys to REST API responses, whereas they were previously removed (because it was "more RESTy... although we were constantly struggling with it). 


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Send a request to `wp-json/ee/v4.8.36/datetimes`. Notice that `EVT_ID` should now be included in the response for each datetime. 
* [x] Try `wp-json/ee/v4.8.36/datetimes?include=EVT_ID`, it should return a list of datetimes with their associated `EVT_ID`s

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
