### PR TITLE
Fixed translated event taxonomy slugs so they stay valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
 - Fixes a syntax issue inside `EE_Config::register_ee_widget()` ([608](https://github.com/eventespresso/event-espresso-core/pull/608))
 - Fixed URL validation when URL was for a site denying access to our HTTP client ([628](https://github.com/eventespresso/event-espresso-core/pull/628))
+- Fixed translated event taxonomy slugs so they stay valid ([641](https://github.com/eventespresso/event-espresso-core/pull/641))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -866,7 +866,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
         $old_slug = EE_Registry::instance()->CFG->core->event_cpt_slug;
         EE_Registry::instance()->CFG->core->event_cpt_slug = empty($this->_req_data['event_cpt_slug'])
             ? EE_Registry::instance()->CFG->core->event_cpt_slug
-            : sanitize_title_with_dashes($this->_req_data['event_cpt_slug']);
+            : EEH_URL::slugify($this->_req_data['event_cpt_slug'], 'events');
         $what = 'Template Settings';
         $success = $this->_update_espresso_configuration(
             $what,

--- a/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
+++ b/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace EventEspresso\core\domain\entities\custom_post_types;
+use EEH_URL;
 
 /**
  * Class CustomTaxonomyDefinitions
@@ -46,10 +47,9 @@ class CustomTaxonomyDefinitions
                         'assign_terms' => 'ee_assign_event_category',
                     ),
                     'rewrite'           => array(
-                        'slug' => sanitize_title(
+                        'slug' => EEH_URL::slugify(
                             __('event-category', 'event_espresso'),
-                            'event-category',
-                            'save'
+                            'event-category'
                         )
                     ),
                 ),
@@ -68,10 +68,9 @@ class CustomTaxonomyDefinitions
                         'assign_terms' => 'ee_assign_venue_category',
                     ),
                     'rewrite'           => array(
-                        'slug' => sanitize_title(
+                        'slug' => EEH_URL::slugify(
                             __('venue-category', 'event_espresso'),
-                            'venue-category',
-                            'save'
+                            'venue-category'
                         )
                     ),
                 ),
@@ -90,10 +89,10 @@ class CustomTaxonomyDefinitions
                         'assign_terms' => 'ee_assign_event_type',
                     ),
                     'rewrite'      => array(
-                        'slug' => sanitize_title(
-                            __('event-type', 'event_espresso'),
-                            'event-type',
-                            'save'
+                        'slug' =>
+                            EEH_URL::slugify(
+                                __('event-type', 'event_espresso'),
+                                'event-type'
                         )
                     ),
                     'hierarchical' => true,

--- a/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
+++ b/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
@@ -45,7 +45,13 @@ class CustomTaxonomyDefinitions
                         'delete_terms' => 'ee_delete_event_category',
                         'assign_terms' => 'ee_assign_event_category',
                     ),
-                    'rewrite'           => array('slug' => esc_html__('event-category', 'event_espresso')),
+                    'rewrite'           => array(
+                        'slug' => sanitize_title(
+                            __('event-category', 'event_espresso'),
+                            'event-category',
+                            'save'
+                        )
+                    ),
                 ),
             ),
             'espresso_venue_categories' => array(
@@ -61,7 +67,13 @@ class CustomTaxonomyDefinitions
                         'delete_terms' => 'ee_delete_venue_category',
                         'assign_terms' => 'ee_assign_venue_category',
                     ),
-                    'rewrite'           => array('slug' => esc_html__('venue-category', 'event_espresso')),
+                    'rewrite'           => array(
+                        'slug' => sanitize_title(
+                            __('venue-category', 'event_espresso'),
+                            'venue-category',
+                            'save'
+                        )
+                    ),
                 ),
             ),
             'espresso_event_type'       => array(
@@ -77,7 +89,13 @@ class CustomTaxonomyDefinitions
                         'delete_terms' => 'ee_delete_event_type',
                         'assign_terms' => 'ee_assign_event_type',
                     ),
-                    'rewrite'      => array('slug' => esc_html__('event-type', 'event_espresso')),
+                    'rewrite'      => array(
+                        'slug' => sanitize_title(
+                            __('event-type', 'event_espresso'),
+                            'event-type',
+                            'save'
+                        )
+                    ),
                     'hierarchical' => true,
                 ),
             ),

--- a/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
+++ b/core/domain/entities/custom_post_types/CustomTaxonomyDefinitions.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace EventEspresso\core\domain\entities\custom_post_types;
+
 use EEH_URL;
 
 /**
@@ -89,10 +90,9 @@ class CustomTaxonomyDefinitions
                         'assign_terms' => 'ee_assign_event_type',
                     ),
                     'rewrite'      => array(
-                        'slug' =>
-                            EEH_URL::slugify(
-                                __('event-type', 'event_espresso'),
-                                'event-type'
+                        'slug' => EEH_URL::slugify(
+                            __('event-type', 'event_espresso'),
+                            'event-type'
                         )
                     ),
                     'hierarchical' => true,

--- a/core/helpers/EEH_URL.helper.php
+++ b/core/helpers/EEH_URL.helper.php
@@ -282,7 +282,8 @@ class EEH_URL
      * @param string $fallback
      * @return string which can be used in a URL
      */
-    public static function slugify($text, $fallback) {
+    public static function slugify($text, $fallback)
+    {
         // url decode after sanitizing title to restore unicode characters,
         // see https://github.com/eventespresso/event-espresso-core/issues/575
         return urldecode(

--- a/core/helpers/EEH_URL.helper.php
+++ b/core/helpers/EEH_URL.helper.php
@@ -283,6 +283,8 @@ class EEH_URL
      * @return string which can be used in a URL
      */
     public static function slugify($text, $fallback) {
+        // url decode after sanitizing title to restore unicode characters,
+        // see https://github.com/eventespresso/event-espresso-core/issues/575
         return urldecode(
             sanitize_title(
                 $text,

--- a/core/helpers/EEH_URL.helper.php
+++ b/core/helpers/EEH_URL.helper.php
@@ -270,4 +270,24 @@ class EEH_URL
         wp_safe_redirect($location, $status);
         exit($exit_notice);
     }
+
+    /**
+     * Slugifies text for usage in a URL.
+     *
+     * Currently, this isn't just calling `sanitize_title()` on it, because that percent-encodes unicode characters,
+     * and WordPress chokes on them when used as CPT and custom taxonomy slugs.
+     *
+     * @since $VID:$
+     * @param string $text
+     * @param string $fallback
+     * @return string which can be used in a URL
+     */
+    public static function slugify($text, $fallback) {
+        return urldecode(
+            sanitize_title(
+                $text,
+                $fallback
+            )
+        );
+    }
 }


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/574
Fixed translated event taxonomy slugs so they stay valid (ie, don't get any invalid characters that aren't permitted in a URL). I couldn't get the old slugs to work anyway (eg in French), so I don't think harm in this change. Also, I opted to have the translated slugs NOT include accents, as I couldn't the URLs to work when they had accents. (Plus this is what WP does with post slugs anyways, see https://wordpress.stackexchange.com/questions/310894/why-dont-wordpress-post-slugs-allow-accents?noredirect=1#comment459608_310894)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create an event category with the slug "sluggy", then go to `/event-category/sluggy`. Your event should appear in the list. Then switch the site language to French, and refresh permalinks. Then go to `/cas-category/sluggy` and your event should still appear
* [ ] With your site still in French, go to `/type-devenement/single-event`, it should show all events (FYI, the event type "single-event" isn't modifiable, but nor is it really used because we haven't told anyone about it)
* [ ] 

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
