### PR TITLE
Account for worse-case CSS word-break scenarios

### DIFF
--- a/modules/ticket_selector/assets/ticket_selector.css
+++ b/modules/ticket_selector/assets/ticket_selector.css
@@ -12,6 +12,11 @@
     width: 99%;
 }
 
+.tkt-slctr-tbl th,
+.tkt-slctr-tbl td { 
+	word-break: normal;
+}
+
 /* span.ui-icon { float:none !important; }*/
 .icon-right span.ui-icon {
 	margin: 0.7em 0.3em 0 0;


### PR DESCRIPTION
Themeforest themes yay


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Please see screenshots that explain:
![screen shot 2018-08-10 at 3 02 07 pm](https://user-images.githubusercontent.com/891156/43977667-cb62562e-9cb2-11e8-8270-f2d045db11a8.png)
![screen shot 2018-08-10 at 3 03 01 pm](https://user-images.githubusercontent.com/891156/43977685-dd3cb2fe-9cb2-11e8-99a5-2796cad1b0ff.png)



## How has this been tested
Browser tested across a few different themes

## Checklist

* [x] Suggested Changelog item: Account for worse-case CSS word-break scenarios
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
