### PR TITLE
Added ‘format: money’ to schema for EE_Money_Field fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Added support for Indian Rupees currency (INR) to PayPal Espresso and Pro ([593](https://github.com/eventespresso/event-espresso-core/pull/593)) 
 - Added BUTTONSOURCE on all PayPal Express API calls. ([627](https://github.com/eventespresso/event-espresso-core/pull/627))
 - Added foreign keys to REST API responses ([639](https://github.com/eventespresso/event-espresso-core/pull/639))
+- Added `format:money` to money field schemas in json-schema ([644](https://github.com/eventespresso/event-espresso-core/pull/644))
+
 ### Fixed
 
 - Fixed a fatal error while using many page builder plugins resulting from template tags only being loaded on the front-end([600](https://github.com/eventespresso/event-espresso-core/pull/600))

--- a/core/db_models/fields/EE_Money_Field.php
+++ b/core/db_models/fields/EE_Money_Field.php
@@ -83,14 +83,15 @@ class EE_Money_Field extends EE_Float_Field
                     __('%s - the raw value as it exists in the database as a simple float.', 'event_espresso'),
                     $this->get_nicename()
                 ),
-                'type' => 'number'
+                'type' => 'number',
             ),
             'pretty' => array(
                 'description' =>  sprintf(
                     __('%s - formatted for display in the set currency and decimal places.', 'event_espresso'),
                     $this->get_nicename()
                 ),
-                'type' => 'string'
+                'type' => 'string',
+                'format' => 'money'
             )
         );
     }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

For our javascript model entities (see #637), we're using the json-schema provided by our REST endpoint to generate the model entity constructors that automatically validate incoming data against the schema.  One thing we'd like to do is internally in these model entities, convert the raw value to a `moment` instance for datetime fields and to a `money` vo instance (for money fields).  For DateTime fields we are able to use the `format` key on the schema to know its "type".  However, there's no current way to know that an `integer` or `number` type in the schema represents a "money" value.  

This pull proposes adding `format:money` to the `EE_Money_Field` schema so that clients can derive that the value is derived from that field.  

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Tested via checking the response on a schema request for money fields.  There should be a `format:money` property on the `properties.pretty` element.  So for example the schema for registrations would have the following object in its schema:

```json
"REG_paid" : {
    "properties": {
         "pretty": {
            "format": "money"
         }
    }
}
```

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
