### PR TITLE
Fixes the 1-click upgrade from Decaf so that a prompt to upgrade is displayed when a correct support key is entered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 - Fixed DuplicateCollectionIdentifierException errors when converting old PersistentAdminNotice Fixes ([505](https://github.com/eventespresso/event-espresso-core/pull/505))
 - Fixes a syntax issue inside `EE_Config::register_ee_widget()` ([608](https://github.com/eventespresso/event-espresso-core/pull/608))
 - Fixed URL validation when URL was for a site denying access to our HTTP client ([628](https://github.com/eventespresso/event-espresso-core/pull/628))
+- Fixed the 1-click upgrade from Decaf so that a prompt to upgrade is displayed when a correct support key is entered ([647](https://github.com/eventespresso/event-espresso-core/pull/647))
 ### Changed
 
 - Updated js build process to use Babel 7 ([578](https://github.com/eventespresso/event-espresso-core/pull/578))

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -943,7 +943,7 @@ if (! class_exists('PluginUpdateEngineChecker')):
                     && ! $this->_is_premium
                     && ! $this->_is_prerelease
                     && $this->_is_freerelease
-                    && false !== stripos(
+                    && false === stripos(
                         $this->api_secret_key,
                         'FREE'
                     )


### PR DESCRIPTION
## Problem this Pull Request solves
This fixes #609 
A prompt to upgrade to Caffeinated from Decaf was not being displayed when a valid support key was entered. Work here should fix that.

## How has this been tested
* [x] Install and activate EE4 decaf (it should include the same changes done here). Then save the General Settings page with the correct support key in place. A prompt (as an admin notification) to upgrade should be displayed.

## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
