### PR TITLE
Added InvalidArgumentError Exception

### DIFF
--- a/assets/src/eejs/exceptions/index.js
+++ b/assets/src/eejs/exceptions/index.js
@@ -1,2 +1,3 @@
 export { default as Exception } from './general';
 export { default as InvalidSchema } from './invalid-schema';
+export { default as InvalidArgument } from './invalid-argument';

--- a/assets/src/eejs/exceptions/invalid-argument.js
+++ b/assets/src/eejs/exceptions/invalid-argument.js
@@ -1,13 +1,12 @@
 /**
  * InvalidArgument
- * Usage: throw new eejs.InvalidArgument('some message', [parameter, argument])
+ * Usage: throw new eejs.InvalidArgument('some message'[, argument])
  *
  * Typically this error is thrown when a function or method is called with an
  * invalid argument for a given parameter.  It could still be the right type
  * but its an unexpected value.
  *
  * @param {string} msg
- * @param {string} parameter Optional, the name of the parameter.
  * @param {mixed} argument Optional, the argument that caused the error.
  */
 export default class InvalidArgument extends Error {
@@ -17,7 +16,6 @@ export default class InvalidArgument extends Error {
 			Error.captureStackTrace( this, InvalidArgument );
 		}
 		this.message = 'Invalid argument provided.' + this.message;
-		this.parameter = args[ 1 ] || '';
-		this.argument = args[ 2 ] || null;
+		this.argument = args[ 1 ] || null;
 	}
 }

--- a/assets/src/eejs/exceptions/invalid-argument.js
+++ b/assets/src/eejs/exceptions/invalid-argument.js
@@ -15,7 +15,9 @@ export default class InvalidArgument extends Error {
 		if ( Error.captureStackTrace ) {
 			Error.captureStackTrace( this, InvalidArgument );
 		}
-		this.message = 'Invalid argument provided.' + this.message;
+		this.message = this.message !== '' ?
+			'Invalid argument provided. ' + this.message :
+		'Invalid argument provided.';
 		this.argument = args[ 1 ] || null;
 	}
 }

--- a/assets/src/eejs/exceptions/invalid-argument.js
+++ b/assets/src/eejs/exceptions/invalid-argument.js
@@ -17,7 +17,7 @@ export default class InvalidArgument extends Error {
 		}
 		this.message = this.message !== '' ?
 			'Invalid argument provided. ' + this.message :
-		'Invalid argument provided.';
+			'Invalid argument provided.';
 		this.argument = args[ 1 ] || null;
 	}
 }

--- a/assets/src/eejs/exceptions/invalid-argument.js
+++ b/assets/src/eejs/exceptions/invalid-argument.js
@@ -1,0 +1,23 @@
+/**
+ * InvalidArgument
+ * Usage: throw new eejs.InvalidArgument('some message', [parameter, argument])
+ *
+ * Typically this error is thrown when a function or method is called with an
+ * invalid argument for a given parameter.  It could still be the right type
+ * but its an unexpected value.
+ *
+ * @param {string} msg
+ * @param {string} parameter Optional, the name of the parameter.
+ * @param {mixed} argument Optional, the argument that caused the error.
+ */
+export default class InvalidArgument extends Error {
+	constructor( ...args ) {
+		super( ...args );
+		if ( Error.captureStackTrace ) {
+			Error.captureStackTrace( this, InvalidArgument );
+		}
+		this.message = 'Invalid argument provided.' + this.message;
+		this.parameter = args[ 1 ] || '';
+		this.argument = args[ 2 ] || null;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

This pull adds a `InvalidArgument` exception for use when asserting whether arguments provided to a function or class method are valid.  The argument might still be the right expected type but not be the expected value.

For example, in the DateTime value object I'm writing, I want to assert the the provided timezone string is a valid timezone string (and parseable via the library in use for manipulating dates and times).  For the assertion method, I want to throw `InvalidArgument` when the timezone string is not valid.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Verify no existing tests are broken

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
