### PR TITLE
Added a filter so the system status page's content can be modified

### DIFF
--- a/core/db_models/EEM_System_Status.model.php
+++ b/core/db_models/EEM_System_Status.model.php
@@ -38,7 +38,9 @@ class EEM_System_Status
      */
     public function get_system_stati()
     {
-        return array(
+        return apply_filters(
+            'FHEE__EEM_System_Status__get_system_stati',
+            array(
                 'ee_version'=>$this->get_ee_version(),
                 'ee_activation_history'=>$this->get_ee_activation_history(),
                 'ee_config'=>$this->get_ee_config(),
@@ -52,6 +54,8 @@ class EEM_System_Status
                 'php_version'=>$this->php_version(),
                 'php.ini_settings'=>$this->get_php_ini_all(),
                 'php_info'=>$this->get_php_info(),
+            ),
+            $this
         );
     }
     /**


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Added a filter so the system status page's content can be modified.
While debugging https://github.com/eventespresso/eventsmart.com-website/issues/108 I found myself wanting some more info from a site. I could dig around directly in the DB and write custom scripts, but I thought it would be handy if add-ons (like the saas add-ons) could add more info to the system status page. Whatever info we might think helpful when debugging issues on that site. (In my particular case, I want to see exactly what add-ons are actually still registered and their versions; right now it's not very accessible).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Just verify the normal system status page didn't get broken

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
