### PR TITLE
Fixed error in Authorize.net AIM when some non-ascii characters were used

### DIFF
--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -21,7 +21,6 @@ class EE_PMT_Aim extends EE_PMT_Base
     {
         $this->_setup_properties();
         parent::__construct($pm_instance);
-        $this->_gateway->set_unsupported_character_remover(new \EventEspresso\core\services\formatters\AsciiOnly());
     }
     
     /**

--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -21,7 +21,7 @@ class EE_PMT_Aim extends EE_PMT_Base
     {
         $this->_setup_properties();
         parent::__construct($pm_instance);
-        $this->_gateway->set_unsupported_character_remover(new \EventEspresso\core\services\formatters\Windows1252());
+        $this->_gateway->set_unsupported_character_remover(new \EventEspresso\core\services\formatters\AsciiOnly());
     }
     
     /**

--- a/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
+++ b/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
@@ -75,7 +75,7 @@
         <?php _e('Change the image that is used for this payment gateway.', 'event_espresso'); ?>
     </li>
     <li>
-        <strong><?php esc_html_e('Note About Special Characters','event_espresso' );?></strong>
-        <?php esc_html_e('If your event name, ticket name or ticket description contain special characters (eg emojis, foreign language characters, or curly quotes) they will be removed when sent to Authorize.net. This is because Authorize.net doesn\'t support them.','event_espresso' );?></li>
+        <strong><?php esc_html_e('Note About Special Characters', 'event_espresso');?></strong>
+        <?php esc_html_e('If your event name, ticket name or ticket description contain special characters (eg emojis, foreign language characters, or curly quotes) they will be removed when sent to Authorize.net. This is because Authorize.net doesn\'t support them.', 'event_espresso');?></li>
     </li>
 </ul>

--- a/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
+++ b/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
@@ -74,4 +74,8 @@
         <strong><?php _e('Button Image URL', 'event_espresso'); ?></strong><br/>
         <?php _e('Change the image that is used for this payment gateway.', 'event_espresso'); ?>
     </li>
+    <li>
+        <strong><?php esc_html_e('Note About Special Characters','event_espresso' );?></strong>
+        <?php esc_html_e('If your event name, ticket name or ticket description contain special characters (eg emojis, foreign language characters, or curly quotes) they will be removed when sent to Authorize.net. This is because Authorize.net doesn\'t support them.','event_espresso' );?></li>
+    </li>
 </ul>

--- a/core/services/payment_methods/gateways/GatewayDataFormatterInterface.php
+++ b/core/services/payment_methods/gateways/GatewayDataFormatterInterface.php
@@ -71,5 +71,4 @@ interface GatewayDataFormatterInterface
      * @return string
      */
     public function formatCurrency($amount);
-
 }

--- a/core/services/payment_methods/gateways/GatewayDataFormatterInterface.php
+++ b/core/services/payment_methods/gateways/GatewayDataFormatterInterface.php
@@ -71,4 +71,5 @@ interface GatewayDataFormatterInterface
      * @return string
      */
     public function formatCurrency($amount);
+
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/662
Fixed error in Authorize.net AIM when some non-ascii characters were used. Previously, we were just converting the UTF8 strings to CP1252 (see https://events.codebasehq.com/projects/event-espresso/tickets/10298), and that seemed to work, but some characters, like a single curly quote, were still producing problems. So this fix is to just remove ALL non-ascii characters from the data sent to AIM.
(Note: the user also suggested removing HTML and warning about that. I think that will require a little bit more work so I'll do that on a separate ticket)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create an event whose name, ticket names or ticket descriptions have all manner of non-ascii characters, like emojis, single curly quotes, and whatever else you can think of. Register for that event and pay with AIM. It should work fine.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
