### PR TITLE
Fixed EEM_Question filter name so it's not a duplicate of existing filter

### DIFF
--- a/core/db_models/EEM_Question.model.php
+++ b/core/db_models/EEM_Question.model.php
@@ -131,7 +131,7 @@ class EEM_Question extends EEM_Soft_Delete_Base
             )
         );
         $this->_question_descriptions = apply_filters(
-            'FHEE__EEM_Question__construct__allowed_question_types',
+            'FHEE__EEM_Question__construct__question_descriptions',
             array(
                 EEM_Question::QST_type_text => __('A single line text input field', 'event_espresso'),
                 EEM_Question::QST_type_textarea => __('A multi line text input field', 'event_espresso'),


### PR DESCRIPTION
## Problem this Pull Request solves
`EEM_Question::__construct()` contains the following two filters that are **BOTH** using `FHEE__EEM_Question__construct__allowed_question_types` for their name:

```php
$this->_allowed_question_types = apply_filters(
            'FHEE__EEM_Question__construct__allowed_question_types',
            array( /* array content */ )
        );
        $this->_question_descriptions = apply_filters(
            'FHEE__EEM_Question__construct__allowed_question_types',
            array( /* array content */ )
        );
```

This is super problematic because any changes made using that filter will affect both arrays of data.

This appears to have been introduced during a merge to master in this commit:
https://github.com/eventespresso/event-espresso-core/blob/c8ef5adedfadddc6793e6e3597d1c7fa6fa07661/core/db_models/EEM_Question.model.php

So fortunately it looks like it has never been an issue.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
