### PR TITLE
Fixed HTML encoded character in Alan Islands name being saved to the DB

### DIFF
--- a/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
@@ -603,7 +603,7 @@ class EE_DMS_Core_4_8_0 extends EE_Data_Migration_Script_Base
         // CNT_ISO, CNT_ISO3, RGN_ID, CNT_name, CNT_cur_code, CNT_cur_single, CNT_cur_plural, CNT_cur_sign, CNT_cur_sign_b4, CNT_cur_dec_plc, CNT_tel_code, CNT_is_EU, CNT_active
         // ('AD', 'AND', 0, 'Andorra', 'EUR', 'Euro', 'Euros', '€', 1, 2, '+376', 0, 0),
         $newer_countries = array(
-            array('AX', 'ALA', 0, '&#197;land Islands', 'EUR', 'Euro', 'Euros', '€', 1, 2, '+358', 1, 0),
+            array('AX', 'ALA', 0, 'Åland Islands', 'EUR', 'Euro', 'Euros', '€', 1, 2, '+358', 1, 0),
             array('BL', 'BLM', 0, 'Saint Barthelemy', 'EUR', 'Euro', 'Euros', '€', 1, 2, '+590', 1, 0),
             array('CW', 'CUW', 0, 'Curacao', 'ANG', 'Guilder', 'Guilders', 'ƒ', 1, 2, '+599', 1, 0),
             array('GG', 'GGY', 0, 'Guernsey', 'EUR', 'Euro', 'Euros', '€', 1, 2, '+44', 0, 0),


### PR DESCRIPTION
… for the country name too


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/666
Fixed Åland Islands not appearing properly in the countries dropdown list (until it was saved) for new installs of EE. Currently, this does not fix it for existing EE sites (that would require a DB query which might be overkill?)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] On a new install of EE, check go to general settings then countries page, then view Aland Islands from the dropdown list. It should look good

## Checklist
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
