### PR TITLE
Fixed warning during admin registration

### DIFF
--- a/modules/messages/EED_Messages.module.php
+++ b/modules/messages/EED_Messages.module.php
@@ -630,7 +630,7 @@ class EED_Messages extends EED_Module
         if (is_admin() && ! EE_FRONT_AJAX) {
             // make sure appropriate admin params are set for sending messages
             if (empty($_REQUEST['txn_reg_status_change']['send_notifications'])
-                | ! absint($_REQUEST['txn_reg_status_change']['send_notifications'])
+                || ! absint($_REQUEST['txn_reg_status_change']['send_notifications'])
             ) {
                 // no messages sent please.
                 return false;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/604
Fixed a warning that appeared during admin registration when messages were deactivated.
The old logic was good but there was just a character (`|`) missing. The old logic worked, it just had a warning.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Turn on WP_DEBUG, and register for an event from the admin, and UNcheck the sending of messages. The registration should be created fine

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
