### PR TITLE
Fixed the organization settings form so that the license key section is not being displayed on subsites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 ## [$VID:$]
 
+### Fixed
+
+- Fixed the organization settings form so that the license key section is not being displayed on subsites ([674](https://github.com/eventespresso/event-espresso-core/pull/674))
+
 ## [4.9.67.p]
 
 ### Fixed

--- a/admin_pages/general_settings/OrganizationSettings.php
+++ b/admin_pages/general_settings/OrganizationSettings.php
@@ -102,19 +102,6 @@ class OrganizationSettings extends FormHandler
                 'html_id'         => 'organization_settings',
                 'layout_strategy' => new EE_Admin_Two_Column_Layout(),
                 'subsections'     => array(
-                    'site_license_key_hdr' => new EE_Form_Section_HTML(
-                        EEH_HTML::h2(
-                            esc_html__('Your Event Espresso License Key', 'event_espresso')
-                            . ' '
-                            . EEH_HTML::span(
-                                EEH_Template::get_help_tab_link('site_license_key_info'),
-                                'help_tour_activation'
-                            ),
-                            '',
-                            'site-license-key-hdr'
-                        )
-                    ),
-                    'site_license_key'     => $this->getSiteLicenseKeyField(),
                     'contact_information_hdr'        => new EE_Form_Section_HTML(
                         EEH_HTML::h2(
                             esc_html__('Contact Information', 'event_espresso')
@@ -325,7 +312,24 @@ class OrganizationSettings extends FormHandler
         if (is_main_site()) {
             $form->add_subsections(
                 array(
-                    'uxip_optin_hdr'  => new EE_Form_Section_HTML(
+                    'site_license_key_hdr' => new EE_Form_Section_HTML(
+                        EEH_HTML::h2(
+                            esc_html__('Your Event Espresso License Key', 'event_espresso')
+                            . ' '
+                            . EEH_HTML::span(
+                                EEH_Template::get_help_tab_link('site_license_key_info'),
+                                'help_tour_activation'
+                            ),
+                            '',
+                            'site-license-key-hdr'
+                        )
+                    ),
+                    'site_license_key' => $this->getSiteLicenseKeyField()
+                )
+            );
+            $form->add_subsections(
+                array(
+                    'uxip_optin_hdr' => new EE_Form_Section_HTML(
                         $this->uxipOptinText()
                     ),
                     'ueip_optin' => new EE_Checkbox_Multi_Input(


### PR DESCRIPTION
## Problem this Pull Request solves
Resolves #661 

Work in this PR resolves an issue when the license key settings section was being displayed on subsites when on a multisite install.

## How has this been tested
* [x] Activate Event Espresso on a WP Multisite install. The "Your Event Espresso License Key" section under the General Settings >> Organization settings should be present on the main site, but not available on other subsites in the same network.
 
## Checklist

* [x] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
