### PR TITLE
Add instanceof checks to avoid fatal errors on txn page

### DIFF
--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -470,7 +470,9 @@ class Transactions_Admin_Page extends EE_Admin_Page
         $this->_session = $this->_transaction instanceof EE_Transaction
             ? $this->_transaction->get('TXN_session_data')
             : null;
-        $this->_transaction->verify_abandoned_transaction_status();
+        if ($this->_transaction instanceof EE_Transaction) {
+            $this->_transaction->verify_abandoned_transaction_status();
+        }
 
         if (! $this->_transaction instanceof EE_Transaction) {
             $error_msg = sprintf(
@@ -685,6 +687,9 @@ class Transactions_Admin_Page extends EE_Admin_Page
 
         $this->_set_transaction_object();
 
+        if (! $this->_transaction instanceof EE_Transaction) {
+            return;
+        }
         $primary_registration = $this->_transaction->primary_registration();
         $attendee = $primary_registration instanceof EE_Registration
             ? $primary_registration->attendee()
@@ -845,6 +850,9 @@ class Transactions_Admin_Page extends EE_Admin_Page
 
         $this->_set_transaction_object();
 
+        if (! $this->_transaction instanceof EE_Transaction) {
+            return;
+        }
         add_meta_box(
             'edit-txn-details-mbox',
             esc_html__('Transaction Details', 'event_espresso'),


### PR DESCRIPTION
There were a number of fatal errors being thrown if I tried to view a txn that had been deleted (or supplied an invalid txn ID in the URL to the txn page). These additional checks avoid the fatal errors.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
