### PR TITLE
Fixed URL validation

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -772,6 +772,11 @@ class EE_Dependency_Map
                 'EE_Registry' => EE_Dependency_Map::load_from_cache,
                 'EE_Config' => EE_Dependency_Map::load_from_cache
             ),
+            'EE_URL_Validation_Strategy' => array(
+                null,
+                null,
+                'EventEspresso\core\services\validators\URLValidator' => EE_Dependency_Map::load_from_cache
+            )
         );
     }
 

--- a/core/db_classes/EE_Question.class.php
+++ b/core/db_classes/EE_Question.class.php
@@ -614,7 +614,7 @@ class EE_Question extends EE_Soft_Delete_Base_Class implements EEI_Duplicatable
                 $result = new EE_Float_Input($input_constructor_args);
                 break;
             case EEM_Question::QST_type_url:
-                $input_constructor_args['validation_strategies'][] = LoaderFactory::getLoader()->load('EE_URL_Validation_Strategy');
+                $input_constructor_args['validation_strategies'][] = LoaderFactory::getLoader()->getShared('EE_URL_Validation_Strategy');
                 $result = new EE_Text_Input($input_constructor_args);
                 break;
             case EEM_Question::QST_type_year:

--- a/core/db_classes/EE_Question.class.php
+++ b/core/db_classes/EE_Question.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use EventEspresso\core\services\loaders\LoaderFactory;
+
 /**
  * EE_Question class
  *
@@ -612,7 +614,7 @@ class EE_Question extends EE_Soft_Delete_Base_Class implements EEI_Duplicatable
                 $result = new EE_Float_Input($input_constructor_args);
                 break;
             case EEM_Question::QST_type_url:
-                $input_constructor_args['validation_strategies'][] = new EE_URL_Validation_Strategy();
+                $input_constructor_args['validation_strategies'][] = LoaderFactory::getLoader()->load('EE_URL_Validation_Strategy');
                 $result = new EE_Text_Input($input_constructor_args);
                 break;
             case EEM_Question::QST_type_year:

--- a/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
@@ -25,7 +25,7 @@ class EE_Admin_File_Uploader_Input extends EE_Form_Input_Base
         $this->_set_display_strategy(new EE_Admin_File_Uploader_Display_Strategy());
         $this->_set_normalization_strategy(new EE_Text_Normalization());
         $this->_add_validation_strategy(
-            LoaderFactory::getLoader()->load(
+            LoaderFactory::getLoader()->getShared(
                 'EE_URL_Validation_Strategy',
                 array(
                     isset($input_settings['validation_error_message'])

--- a/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
@@ -1,4 +1,7 @@
 <?php
+
+use EventEspresso\core\services\loaders\LoaderFactory;
+
 /**
  * Class EE_Admin_File_Uploader_Input
  *
@@ -13,17 +16,23 @@ class EE_Admin_File_Uploader_Input extends EE_Form_Input_Base
 
     /**
      * @param array $input_settings
+     * @throws InvalidArgumentException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
     public function __construct($input_settings = array())
     {
         $this->_set_display_strategy(new EE_Admin_File_Uploader_Display_Strategy());
         $this->_set_normalization_strategy(new EE_Text_Normalization());
         $this->_add_validation_strategy(
-            new EE_URL_Validation_Strategy(
-                isset($input_settings['validation_error_message'])
-                    ? $input_settings['validation_error_message']
-                    : null,
-                true
+            LoaderFactory::getLoader()->load(
+                'EE_URL_Validation_Strategy',
+                array(
+                    isset($input_settings['validation_error_message'])
+                        ? $input_settings['validation_error_message']
+                        : null,
+                    true
+                )
             )
         );
         parent::__construct($input_settings);

--- a/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
@@ -1,4 +1,9 @@
 <?php
+
+use EventEspresso\core\services\loaders\CoreLoader;
+use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\validators\URLValidator;
+
 /**
  * Class EE_URL_Validation_Strategy
  *
@@ -17,11 +22,27 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
     protected $check_file_exists;
 
     /**
+     * @var URLValidator
+     */
+    protected $url_validator;
+
+    /**
      * @param null $validation_error_message
      * @param boolean $check_file_exists
+     * @param URLValidator $url_validator
+     * @throws InvalidArgumentException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function __construct($validation_error_message = null, $check_file_exists = false)
-    {
+    public function __construct(
+        $validation_error_message = null,
+        $check_file_exists = false,
+        URLValidator $url_validator = null
+    ) {
+        if (! $url_validator instanceof URLValidator) {
+            $url_validator = LoaderFactory::getLoader()->load('EventEspresso\core\services\validators\URLValidator');
+        }
+        $this->url_validator = $url_validator;
         if (! $validation_error_message) {
             $validation_error_message = __("Please enter a valid URL. Eg https://eventespresso.com", "event_espresso");
         }
@@ -41,7 +62,7 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
     public function validate($normalized_value)
     {
         if ($normalized_value) {
-            if (filter_var($normalized_value, FILTER_VALIDATE_URL) === false) {
+            if (! $this->url_validator->isValid($normalized_value)) {
                 throw new EE_Validation_Error($this->get_validation_error_message(), 'invalid_url');
             } elseif (apply_filters('FHEE__EE_URL_Validation_Strategy__validate__check_remote_file_exists', $this->check_file_exists, $this->_input)) {
                 if (! EEH_URL::remote_file_exists(

--- a/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/validation/EE_URL_Validation_Strategy.strategy.php
@@ -40,7 +40,7 @@ class EE_URL_Validation_Strategy extends EE_Validation_Strategy_Base
         URLValidator $url_validator = null
     ) {
         if (! $url_validator instanceof URLValidator) {
-            $url_validator = LoaderFactory::getLoader()->load('EventEspresso\core\services\validators\URLValidator');
+            $url_validator = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\validators\URLValidator');
         }
         $this->url_validator = $url_validator;
         if (! $validation_error_message) {

--- a/core/services/validators/URLValidator.php
+++ b/core/services/validators/URLValidator.php
@@ -21,7 +21,7 @@ class URLValidator
      */
     public function isValid($url)
     {
-        return filter_var($url, FILTER_VALIDATE_URL);
+        return filter_var($url, FILTER_VALIDATE_URL) !== false;
     }
 
 }

--- a/core/services/validators/URLValidator.php
+++ b/core/services/validators/URLValidator.php
@@ -14,14 +14,14 @@ namespace EventEspresso\core\services\validators;
 class URLValidator
 {
     /**
-     * Returns whether or not
+     * Returns whether or not the URL is valid
      * @since $VID:$
      * @param $url
      * @return boolean
      */
     public function isValid($url)
     {
-        return filter_var($url, FILTER_VALIDATE_URL) !== false;
+        return  esc_url_raw($url) === $url;
     }
 
 }

--- a/core/services/validators/URLValidator.php
+++ b/core/services/validators/URLValidator.php
@@ -1,5 +1,6 @@
 <?php
 namespace EventEspresso\core\services\validators;
+
 /**
  * Class URLValidator
  *
@@ -23,7 +24,6 @@ class URLValidator
     {
         return  esc_url_raw($url) === $url;
     }
-
 }
 // End of file URLValidator.php
 // Location: ${NAMESPACE}/URLValidator.php

--- a/core/services/validators/URLValidator.php
+++ b/core/services/validators/URLValidator.php
@@ -1,0 +1,29 @@
+<?php
+namespace EventEspresso\core\services\validators;
+/**
+ * Class URLValidator
+ *
+ * Replacement for `filter_var($url, FILTER_VALIDATE_URL)` because of all the problems mentioned on
+ * https://d-mueller.de/blog/why-url-validation-with-filter_var-might-not-be-a-good-idea/
+ *
+ * @package     Event Espresso
+ * @author         Mike Nelson
+ * @since         $VID:$
+ *
+ */
+class URLValidator
+{
+    /**
+     * Returns whether or not
+     * @since $VID:$
+     * @param $url
+     * @return boolean
+     */
+    public function isValid($url)
+    {
+        return filter_var($url, FILTER_VALIDATE_URL);
+    }
+
+}
+// End of file URLValidator.php
+// Location: ${NAMESPACE}/URLValidator.php

--- a/core/services/validators/URLValidator.php
+++ b/core/services/validators/URLValidator.php
@@ -5,7 +5,9 @@ namespace EventEspresso\core\services\validators;
  * Class URLValidator
  *
  * Replacement for `filter_var($url, FILTER_VALIDATE_URL)` because of all the problems mentioned on
- * https://d-mueller.de/blog/why-url-validation-with-filter_var-might-not-be-a-good-idea/
+ * https://d-mueller.de/blog/why-url-validation-with-filter_var-might-not-be-a-good-idea/.
+ * Why not just use `esc_url_raw()`? Yes, we could. But it's better to consolidate the validation logic in case it needs
+ * to be tweaked someday.
  *
  * @package     Event Espresso
  * @author         Mike Nelson

--- a/tests/testcases/core/libraries/form_sections/inputs/EE_Form_Input_Base_Test.php
+++ b/tests/testcases/core/libraries/form_sections/inputs/EE_Form_Input_Base_Test.php
@@ -189,7 +189,6 @@ class EE_Form_Input_Base_Test extends EE_UnitTestCase{
     /**
      * Tests that if `ignore_input` is provided, we get the null normalization and no validation strategies
      * @group 11380
-     * @group current
      */
 	public function testIgnoreInput() {
         $f = new EE_Form_Section_Proper(

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1013,7 +1013,6 @@ class Read_Test extends \EE_REST_TestCase
      * This was temporarily broken while working on 536, but no test picked up on it, so here's one that does.
      *
      * @group 536 see https://github.com/eventespresso/event-espresso-core/pull/536
-     * @group current
      * @throws \EE_Error
      */
     public function testHandleRequestGetAllVenues()

--- a/tests/testcases/core/services/validators/URLValidatorTest.php
+++ b/tests/testcases/core/services/validators/URLValidatorTest.php
@@ -6,7 +6,7 @@ use EventEspresso\core\services\validators\URLValidator;
 /**
  * Class URLValidatorTest
  *
- * Description
+ * Tests URLValidator, which is used by EE_URL_Validation_Strategy and potentially elsewhere
  *
  * @package     Event Espresso
  * @author         Mike Nelson

--- a/tests/testcases/core/services/validators/URLValidatorTest.php
+++ b/tests/testcases/core/services/validators/URLValidatorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class URLValidatorTest
+ *
+ * Description
+ *
+ * @package     Event Espresso
+ * @author         Mike Nelson
+ * @since         $VID:$
+ *
+ */
+class URLValidatorTest
+{
+
+
+}
+// End of file URLValidatorTest.php
+// Location: ${NAMESPACE}/URLValidatorTest.php

--- a/tests/testcases/core/services/validators/URLValidatorTest.php
+++ b/tests/testcases/core/services/validators/URLValidatorTest.php
@@ -1,4 +1,7 @@
 <?php
+namespace EventEspresso\tests\core\services\validators;
+use \EE_UnitTestCase;
+use EventEspresso\core\services\validators\URLValidator;
 
 /**
  * Class URLValidatorTest
@@ -10,8 +13,45 @@
  * @since         $VID:$
  *
  */
-class URLValidatorTest
+class URLValidatorTest extends EE_UnitTestCase
 {
+    /**
+     * @since $VID:$
+     * @return array {
+     * @type string $url
+     * @type boolean $should_be_valid
+     * }
+     */
+    public function urlsToTest()
+    {
+        return array(
+            'localhost' => array('http://localhost', true),
+            'http' => array('http://eventespresso.com', true),
+            'https' => array('https://eventespresso.com', true),
+            'underscore' => array('http://event_espresso.com', true),
+            'subsite' => array('http://dev.eventespresso.com', true),
+            'querystring' => array('http://foo.bar?foo=bar&other=thing', true),
+            'slashquerystring' => array('http://foob.bar/?foo=bar', true),
+            'port' => array('http://foo.bar:80', true),
+            'unicode' => array('http://스타벅스코리아.com', true),
+            'xss' => array('http://example.com/"><script>alert("xss")</script>', false),
+            'bad_scheme' => array('php://filter/read=convert.base64-encode/resource=/etc/passw', false),
+            'bad_scheme_2' => array('foo://bar', false),
+            'javascript' => array('javascript://test%0Aalert(321)', false),
+        );
+    }
+
+    /**
+     * @dataProvider urlsToTest
+     * @since $VID:$
+     * @group current
+     *
+     */
+    public function testIsValid($url, $should_be_valid)
+    {
+        $validator = new URLValidator();
+        $this->assertEquals($should_be_valid,$validator->isValid($url));
+    }
 
 
 }

--- a/tests/testcases/core/services/validators/URLValidatorTest.php
+++ b/tests/testcases/core/services/validators/URLValidatorTest.php
@@ -32,6 +32,8 @@ class URLValidatorTest extends EE_UnitTestCase
             'subsite' => array('http://dev.eventespresso.com', true),
             'querystring' => array('http://foo.bar?foo=bar&other=thing', true),
             'slashquerystring' => array('http://foob.bar/?foo=bar', true),
+            'with_path' => array('http://foo.bar/some/path', true),
+            'with_file' => array('http://foo.bar/some/file.txt', true),
             'port' => array('http://foo.bar:80', true),
             'unicode' => array('http://스타벅스코리아.com', true),
             'encoded_unicode' => array('http://%EC%8A%A4%ED%83%80%EB%B2%85%EC%8A%A4%EC%BD%94%EB%A6%AC%EC%95%84_foobar.com', true),
@@ -39,6 +41,8 @@ class URLValidatorTest extends EE_UnitTestCase
             'bad_scheme' => array('php://filter/read=convert.base64-encode/resource=/etc/passw', false),
             'bad_scheme_2' => array('foo://bar', false),
             'javascript' => array('javascript://test%0Aalert(321)', false),
+            'www' => array('www', false),
+            'relative_url' => array('some/path', false),
         );
     }
 

--- a/tests/testcases/core/services/validators/URLValidatorTest.php
+++ b/tests/testcases/core/services/validators/URLValidatorTest.php
@@ -34,6 +34,7 @@ class URLValidatorTest extends EE_UnitTestCase
             'slashquerystring' => array('http://foob.bar/?foo=bar', true),
             'port' => array('http://foo.bar:80', true),
             'unicode' => array('http://스타벅스코리아.com', true),
+            'encoded_unicode' => array('http://%EC%8A%A4%ED%83%80%EB%B2%85%EC%8A%A4%EC%BD%94%EB%A6%AC%EC%95%84_foobar.com', true),
             'xss' => array('http://example.com/"><script>alert("xss")</script>', false),
             'bad_scheme' => array('php://filter/read=convert.base64-encode/resource=/etc/passw', false),
             'bad_scheme_2' => array('foo://bar', false),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixed URL validation. Previously, URLs with underscores were considered invalid, and there may have even been some security issues (eg putting JS into URLs). That was because we were using `filter_var($url,FILTER_VALIDATE_URL)`, but now that we're using `esc_url_raw()` they seem to all be fixed.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create a question of type URL. Register for an event with it. URLs with underscores should be ok (they weren't before). But ones like `http://example.com/"><script>alert("xss")</script>`, `php://filter/read=convert.base64-encode/resource=/etc/passwd` and `foo://bar` should not be.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
