### PR TITLE
Improve REST Schema to include missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ See [our documentation](https://github.com/eventespresso/event-espresso-core/blo
 
 - Fixed the organization settings form so that the license key section is not being displayed on subsites ([674](https://github.com/eventespresso/event-espresso-core/pull/674))
 
+### Changed
+
+- Improved REST Schema response to include missing fields (including `_calculated_fields`, `_links` and `link`)([680](https://github.com/eventespresso/event-espresso-core/pull/680))
+
 ## [4.9.67.p]
 
 ### Fixed

--- a/core/entities/models/JsonModelSchema.php
+++ b/core/entities/models/JsonModelSchema.php
@@ -190,30 +190,30 @@ class JsonModelSchema
                         ),
                         'readonly' => true
                     ),
-                    'additionalProperties' => array(
-                        'type' => 'array',
-                        'description' => esc_html(
-                            'Additional property keys are the link to relations resource collection.',
-                            'event_espresso'
-                        ),
-                        'items' => array(
-                            'type' => 'object',
-                            'properties' => array(
-                                'href' => array(
-                                    'description' => esc_html(
-                                        'Link to relations collection for this entity resource.',
-                                        'event_espresso'
-                                    ),
-                                    'type' => 'string',
-                                ),
-                                'single' => array(
-                                    'type' => 'boolean'
-                                )
-                            ),
-                            'additionalProperties' => false
-                        )
-                    )
                 ),
+                'additionalProperties' => array(
+                    'type' => 'array',
+                    'description' => esc_html(
+                        'Additional property keys are the link to relations resource collection.',
+                        'event_espresso'
+                    ),
+                    'items' => array(
+                        'type' => 'object',
+                        'properties' => array(
+                            'href' => array(
+                                'description' => esc_html(
+                                    'Link to relations collection for this entity resource.',
+                                    'event_espresso'
+                                ),
+                                'type' => 'string',
+                            ),
+                            'single' => array(
+                                'type' => 'boolean'
+                            )
+                        ),
+                        'additionalProperties' => false
+                    )
+                )
             ),
             '_calculated_fields' => $this->fields_calculator->getJsonSchemaForModel($this->model)
         );

--- a/core/entities/models/JsonModelSchema.php
+++ b/core/entities/models/JsonModelSchema.php
@@ -123,6 +123,45 @@ class JsonModelSchema
                 : EEH_Inflector::pluralize_and_lower($model_name);
             $schema['properties'][ $model_name_for_schema ] = $relation->getSchema();
             $schema['properties'][ $model_name_for_schema ]['relation_model'] = $model_name;
+
+            // links schema
+            $links_key = 'https://api.eventespresso.com/' . strtolower($model_name);
+            $schema['properties']['_links']['properties'][ $links_key ] = array(
+                'description' => esc_html__(
+                    'Array of objects describing the link(s) for this relation resource.',
+                    'event_espresso'
+                ),
+                'type' => 'array',
+                'readonly' => true,
+                'items' => array(
+                    'type' => 'object',
+                    'properties' => array(
+                        'href' => array(
+                            'type' => 'string',
+                            'description' => sprintf(
+                                // translators: placeholder is the model name for the relation.
+                                esc_html__(
+                                    'The link to the resource for the %s relation(s) to this entity',
+                                    'event_espresso'
+                                ),
+                                $model_name
+                            ),
+                        ),
+                        'single' => array(
+                            'type' => 'boolean',
+                            'description' => sprintf(
+                                // translators: placeholder is the model name for the relation.
+                                esc_html__(
+                                    'Whether or not there is only a single %s relation to this entity',
+                                    'event_espresso'
+                                ),
+                                $model_name
+                            ),
+                        ),
+                    ),
+                    'additionalProperties' => false
+                ),
+            );
         }
         return $schema;
     }
@@ -139,83 +178,63 @@ class JsonModelSchema
             '$schema'    => 'http://json-schema.org/draft-04/schema#',
             'title'      => $this->model->get_this_model_name(),
             'type'       => 'object',
-            'properties' => array(),
-            'link' => array(
-                'description' => esc_html__(
-                    'Link to event on WordPress site hosting events.',
-                    'event_espresso'
-                ),
-                'type' => 'string',
-                'readonly' => true,
-            ),
-            '_links' => array(
-                'description' => esc_html__(
-                    'Various links for resources related to the entity.',
-                    'event_espresso'
-                ),
-                'type' => 'object',
-                'readonly' => true,
-                'properties' => array(
-                    'self' => array(
-                        'description' => esc_html__(
-                            'Link to this entities resource.',
-                            'event_espresso'
-                        ),
-                        'type' => 'array',
-                        'items' => array(
-                            'type' => 'object',
-                            'properties' => array(
-                                'href' => array(
-                                    'type' => 'string',
-                                ),
-                            ),
-                            'additionalProperties' => false
-                        ),
-                        'readonly' => true
-                    ),
-                    'collection' => array(
-                        'description' => esc_html__(
-                            'Link to this entities collection resource.',
-                            'event_espresso'
-                        ),
-                        'type' => 'array',
-                        'items' => array(
-                            'type' => 'object',
-                            'properties' => array(
-                                'href' => array(
-                                  'type' => 'string'
-                                ),
-                            ),
-                            'additionalProperties' => false
-                        ),
-                        'readonly' => true
-                    ),
-                ),
-                'additionalProperties' => array(
-                    'type' => 'array',
-                    'description' => esc_html(
-                        'Additional property keys are the link to relations resource collection.',
+            'properties' => array(
+                'link' => array(
+                    'description' => esc_html__(
+                        'Link to event on WordPress site hosting events.',
                         'event_espresso'
                     ),
-                    'items' => array(
-                        'type' => 'object',
-                        'properties' => array(
-                            'href' => array(
-                                'description' => esc_html(
-                                    'Link to relations collection for this entity resource.',
-                                    'event_espresso'
-                                ),
-                                'type' => 'string',
+                    'type' => 'string',
+                    'readonly' => true,
+                ),
+                '_links' => array(
+                    'description' => esc_html__(
+                        'Various links for resources related to the entity.',
+                        'event_espresso'
+                    ),
+                    'type' => 'object',
+                    'readonly' => true,
+                    'properties' => array(
+                        'self' => array(
+                            'description' => esc_html__(
+                                'Link to this entities resource.',
+                                'event_espresso'
                             ),
-                            'single' => array(
-                                'type' => 'boolean'
-                            )
+                            'type' => 'array',
+                            'items' => array(
+                                'type' => 'object',
+                                'properties' => array(
+                                    'href' => array(
+                                        'type' => 'string',
+                                    ),
+                                ),
+                                'additionalProperties' => false
+                            ),
+                            'readonly' => true
                         ),
-                        'additionalProperties' => false
-                    )
-                )
+                        'collection' => array(
+                            'description' => esc_html__(
+                                'Link to this entities collection resource.',
+                                'event_espresso'
+                            ),
+                            'type' => 'array',
+                            'items' => array(
+                                'type' => 'object',
+                                'properties' => array(
+                                    'href' => array(
+                                        'type' => 'string'
+                                    ),
+                                ),
+                                'additionalProperties' => false
+                            ),
+                            'readonly' => true
+                        ),
+                    ),
+                    'additionalProperties' => false,
+                ),
+                '_calculated_fields' => $this->fields_calculator->getJsonSchemaForModel($this->model)
             ),
-            '_calculated_fields' => $this->fields_calculator->getJsonSchemaForModel($this->model)
+            'additionalProperties' => false,
         );
     }
 

--- a/core/entities/models/JsonModelSchema.php
+++ b/core/entities/models/JsonModelSchema.php
@@ -10,6 +10,7 @@ use EE_Foreign_Key_Field_Base;
 use EE_Model_Relation_Base;
 use EEH_Inflector;
 use EE_Belongs_To_Relation;
+use EventEspresso\core\libraries\rest_api\CalculatedModelFields;
 
 /**
  * This is used to generate an array that can be used to generate a schema for a given model.
@@ -25,24 +26,32 @@ class JsonModelSchema
 {
 
     /**
-     * @var \EEM_Base
+     * @var EEM_Base
      */
     protected $model;
 
     /**
+     * @var CalculatedModelFields
+     */
+    protected $fields_calculator;
+
+
+    /**
      * JsonModelSchema constructor.
      *
-     * @param \EEM_Base $model
+     * @param EEM_Base              $model
+     * @param CalculatedModelFields $fields_calculator
      */
-    public function __construct(EEM_Base $model)
+    public function __construct(EEM_Base $model, CalculatedModelFields $fields_calculator)
     {
         $this->model = $model;
+        $this->fields_calculator = $fields_calculator;
     }
+
 
     /**
      * Return the schema for a given model from a given model.
      *
-     * @param \EEM_Base $model
      * @return array
      */
     public function getModelSchema()
@@ -60,7 +69,8 @@ class JsonModelSchema
     /**
      * Get the schema for a given set of model fields.
      *
-     * @param \EE_Model_Field_Base[] $model_fields
+     * @param EE_Model_Field_Base[] $model_fields
+     * @param array                  $schema
      * @return array
      */
     public function getModelSchemaForFields(array $model_fields, array $schema)
@@ -99,6 +109,7 @@ class JsonModelSchema
      * Get the schema for a given set of model relations
      *
      * @param EE_Model_Relation_Base[] $relations_on_model
+     * @param array                    $schema
      * @return array
      */
     public function getModelSchemaForRelations(array $relations_on_model, array $schema)
@@ -120,7 +131,6 @@ class JsonModelSchema
     /**
      * Outputs the schema header for a model.
      *
-     * @param \EEM_Base $model
      * @return array
      */
     public function getInitialSchemaStructure()
@@ -130,6 +140,82 @@ class JsonModelSchema
             'title'      => $this->model->get_this_model_name(),
             'type'       => 'object',
             'properties' => array(),
+            'link' => array(
+                'description' => esc_html__(
+                    'Link to event on WordPress site hosting events.',
+                    'event_espresso'
+                ),
+                'type' => 'string',
+                'readonly' => true,
+            ),
+            '_links' => array(
+                'description' => esc_html__(
+                    'Various links for resources related to the entity.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'readonly' => true,
+                'properties' => array(
+                    'self' => array(
+                        'description' => esc_html__(
+                            'Link to this entities resource.',
+                            'event_espresso'
+                        ),
+                        'type' => 'array',
+                        'items' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'href' => array(
+                                    'type' => 'string',
+                                ),
+                            ),
+                            'additionalProperties' => false
+                        ),
+                        'readonly' => true
+                    ),
+                    'collection' => array(
+                        'description' => esc_html__(
+                            'Link to this entities collection resource.',
+                            'event_espresso'
+                        ),
+                        'type' => 'array',
+                        'items' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'href' => array(
+                                  'type' => 'string'
+                                ),
+                            ),
+                            'additionalProperties' => false
+                        ),
+                        'readonly' => true
+                    ),
+                    'additionalProperties' => array(
+                        'type' => 'array',
+                        'description' => esc_html(
+                            'Additional property keys are the link to relations resource collection.',
+                            'event_espresso'
+                        ),
+                        'items' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'href' => array(
+                                    'description' => esc_html(
+                                        'Link to relations collection for this entity resource.',
+                                        'event_espresso'
+                                    ),
+                                    'type' => 'string',
+                                ),
+                                'single' => array(
+                                    'type' => 'boolean'
+                                )
+                            ),
+                            'additionalProperties' => false
+                        )
+                    )
+                ),
+            ),
+            '_calculated_fields' => $this->fields_calculator->getJsonSchemaForModel($this->model)
         );
     }
 
@@ -137,7 +223,7 @@ class JsonModelSchema
     /**
      * Allows one to just use the object as a string to get the json.
      * eg.
-     * $json_schema = new JsonModelSchema(EEM_Event::instance());
+     * $json_schema = new JsonModelSchema(EEM_Event::instance(), new CalculatedModelFields);
      * echo $json_schema; //outputs the schema as a json formatted string.
      *
      * @return bool|false|mixed|string

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -162,6 +162,7 @@ class CalculatedModelFields
                 ? $this->mapping_schema[ $model->get_this_model_name() ]
                 : array(),
             'additionalProperties' => false,
+            'readonly' => true,
         );
     }
 

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -131,7 +131,7 @@ class CalculatedModelFields
      */
     public function getJsonSchemaForModel(EEM_Base $model)
     {
-        if( ! $this->mapping_schema) {
+        if (! $this->mapping_schema) {
             $this->generateNewMappingSchema();
         }
         return array(

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -152,9 +152,17 @@ class CalculatedModelFields
     public function getJsonSchemaForModel(EEM_Base $model)
     {
         $this->mapping();
-        return isset($this->mapping_schema[ $model->get_this_model_name() ])
-            ? $this->mapping_schema[ $model->get_this_model_name() ]
-            : array();
+        return array(
+            'description' => esc_html__(
+                'Available calculated fields for this model.  Fields are only present in the response if explicitly requested',
+                'event_espresso'
+            ),
+            'type' => 'object',
+            'properties' => isset($this->mapping_schema[ $model->get_this_model_name() ])
+                ? $this->mapping_schema[ $model->get_this_model_name() ]
+                : array(),
+            'additionalProperties' => false,
+        );
     }
 
 

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -69,7 +69,7 @@ class CalculatedModelFields
         foreach ($models_with_calculated_fields as $model_name) {
             $calculated_fields_classname = $namespace . $model_name;
             foreach (array_keys(call_user_func(array($calculated_fields_classname, 'schemaForCalculations'))) as $field_name) {
-                $mapping[$model_name][$field_name] = $calculated_fields_classname;
+                $mapping[ $model_name ][ $field_name ] = $calculated_fields_classname;
             }
         }
         return apply_filters(

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -132,7 +132,7 @@ class CalculatedModelFields
     public function getJsonSchemaForModel(EEM_Base $model)
     {
         if (! $this->mapping_schema) {
-            $this->generateNewMappingSchema();
+            $this->mapping_schema = $this->generateNewMappingSchema();
         }
         return array(
             'description' => esc_html__(

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -45,7 +45,6 @@ class CalculatedModelFields
     {
         if (! $this->mapping || $refresh) {
             $this->mapping = $this->generateNewMapping();
-            $this->mapping_schema = $this->generateNewMappingSchema();
         }
         return $this->mapping;
     }
@@ -87,7 +86,7 @@ class CalculatedModelFields
     protected function generateNewMappingSchema()
     {
         $schema_map = array();
-        foreach ($this->mapping as $map_model => $map_for_model) {
+        foreach ($this->mapping() as $map_model => $map_for_model) {
             /**
              * @var string $calculation_index
              * @var HasCalculationSchemaInterface $calculations_class
@@ -132,7 +131,9 @@ class CalculatedModelFields
      */
     public function getJsonSchemaForModel(EEM_Base $model)
     {
-        $this->mapping();
+        if( ! $this->mapping_schema) {
+            $this->generateNewMappingSchema();
+        }
         return array(
             'description' => esc_html__(
                 'Available calculated fields for this model.  Fields are only present in the response if explicitly requested',

--- a/core/libraries/rest_api/CalculatedModelFields.php
+++ b/core/libraries/rest_api/CalculatedModelFields.php
@@ -58,42 +58,23 @@ class CalculatedModelFields
      */
     protected function generateNewMapping()
     {
-        $rest_api_calculations_namespace = 'EventEspresso\core\libraries\rest_api\calculations\\';
-        $event_calculations_class = $rest_api_calculations_namespace . 'Event';
-        $datetime_calculations_class = $rest_api_calculations_namespace . 'Datetime';
-        $registration_class = $rest_api_calculations_namespace . 'Registration';
-        $attendee_class = $rest_api_calculations_namespace . 'Attendee';
+        $namespace = 'EventEspresso\core\libraries\rest_api\calculations\\';
+        $mapping = array();
+        $models_with_calculated_fields = array(
+            'Attendee',
+            'Datetime',
+            'Event',
+            'Registration'
+        );
+        foreach ($models_with_calculated_fields as $model_name) {
+            $calculated_fields_classname = $namespace . $model_name;
+            foreach (array_keys(call_user_func(array($calculated_fields_classname, 'schemaForCalculations'))) as $field_name) {
+                $mapping[$model_name][$field_name] = $calculated_fields_classname;
+            }
+        }
         return apply_filters(
             'FHEE__EventEspresso\core\libraries\rest_api\Calculated_Model_Fields__mapping',
-            array(
-                'Event'        => array(
-                    'optimum_sales_at_start'          => $event_calculations_class,
-                    'optimum_sales_now'               => $event_calculations_class,
-                    'spots_taken'                     => $event_calculations_class,
-                    'spots_taken_pending_payment'     => $event_calculations_class,
-                    'spaces_remaining'                => $event_calculations_class,
-                    'registrations_checked_in_count'  => $event_calculations_class,
-                    'registrations_checked_out_count' => $event_calculations_class,
-                    'image_thumbnail'                 => $event_calculations_class,
-                    'image_medium'                    => $event_calculations_class,
-                    'image_medium_large'              => $event_calculations_class,
-                    'image_large'                     => $event_calculations_class,
-                    'image_post_thumbnail'            => $event_calculations_class,
-                    'image_full'                      => $event_calculations_class,
-                ),
-                'Datetime'     => array(
-                    'spaces_remaining_considering_tickets' => $datetime_calculations_class,
-                    'registrations_checked_in_count'       => $datetime_calculations_class,
-                    'registrations_checked_out_count'      => $datetime_calculations_class,
-                    'spots_taken_pending_payment'          => $datetime_calculations_class,
-                ),
-                'Registration' => array(
-                    'datetime_checkin_stati' => $registration_class,
-                ),
-                'Attendee' => array(
-                    'user_avatar' => $attendee_class,
-                ),
-            )
+            $mapping
         );
     }
 

--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -7,7 +7,7 @@ use EE_Error;
 use EEM_Attendee;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
+use EventEspresso\core\libraries\rest_api\calculations\Base as AttendeeCalculationsBase;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use InvalidArgumentException;
 use WP_REST_Request;
@@ -20,7 +20,7 @@ use WP_REST_Request;
  * @author  Brent Christensen
  * @since   4.9.66.p
  */
-class Attendee extends Calculations_Base implements HasCalculationSchemaInterface
+class Attendee extends AttendeeCalculationsBase implements HasCalculationSchemaInterface
 {
 
     /**

--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -20,7 +20,7 @@ use WP_REST_Request;
  * @author  Brent Christensen
  * @since   4.9.66.p
  */
-class Attendee extends Calculations_Base
+class Attendee extends Calculations_Base implements HasCalculationSchemaInterface
 {
 
     /**
@@ -40,5 +40,40 @@ class Attendee extends Calculations_Base
         }
         $avatar = get_avatar_url($email_address);
         return $avatar ? $avatar : '';
+    }
+
+
+    /**
+     * Provides an array for all the calculations possible that outlines a json schema for those calculations.
+     * Array is indexed by calculation (snake case) and value is the schema for that calculation.
+     *
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculations()
+    {
+        return array(
+            'user_avatar' => array(
+                'description' => esc_html__(
+                    'The avatar url for the attendee (if available).',
+                    'event_espresso'
+                ),
+                'type' => 'string'
+            )
+        );
+    }
+
+
+    /**
+     * Returns the json schema for the given calculation index.
+     *
+     * @since $VID:$
+     * @param $calculation_index
+     * @return array
+     */
+    public static function schemaForCalculation($calculation_index)
+    {
+        $schema_map = self::schemaForCalculations();
+        return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -3,7 +3,7 @@
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
 use EventEspresso\core\libraries\rest_api\calculations\Base as AttendeeCalculationsBase;
-use EventEspresso\core\libraries\rest_api\controllers\model\Base;
+use EventEspresso\core\libraries\rest_api\controllers\model\Base as AttendeeControllerBase;
 use WP_REST_Request;
 
 /**
@@ -18,13 +18,13 @@ class Attendee extends AttendeeCalculationsBase implements HasCalculationSchemaI
 {
 
     /**
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array                  $wpdb_row
+     * @param WP_REST_Request        $request
+     * @param AttendeeControllerBase $controller
      * @since 4.9.66.p
      * @return string
      */
-    public static function userAvatar(array $wpdb_row, WP_REST_Request $request, Base $controller)
+    public static function userAvatar(array $wpdb_row, WP_REST_Request $request, AttendeeControllerBase $controller)
     {
         if (is_array($wpdb_row) && isset($wpdb_row['Attendee_Meta.ATT_email'])) {
             $email_address = $wpdb_row['Attendee_Meta.ATT_email'];
@@ -52,8 +52,8 @@ class Attendee extends AttendeeCalculationsBase implements HasCalculationSchemaI
                     'The avatar url for the attendee (if available).',
                     'event_espresso'
                 ),
-                'type' => 'string'
-            )
+                'type'        => 'string',
+            ),
         );
     }
 

--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -73,7 +73,7 @@ class Attendee extends Calculations_Base implements HasCalculationSchemaInterfac
      */
     public static function schemaForCalculation($calculation_index)
     {
-        $schema_map = self::schemaForCalculations();
+        $schema_map = Attendee::schemaForCalculations();
         return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -2,14 +2,8 @@
 
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
-use EE_Attendee;
-use EE_Error;
-use EEM_Attendee;
-use EventEspresso\core\exceptions\InvalidDataTypeException;
-use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as AttendeeCalculationsBase;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
-use InvalidArgumentException;
 use WP_REST_Request;
 
 /**

--- a/core/libraries/rest_api/calculations/Datetime.php
+++ b/core/libraries/rest_api/calculations/Datetime.php
@@ -220,7 +220,7 @@ class Datetime extends Calculations_Base implements HasCalculationSchemaInterfac
      */
     public static function schemaForCalculation($calculation_index)
     {
-        $schema_map = self::schemaForCalculations();
+        $schema_map = Datetime::schemaForCalculations();
         return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Datetime.php
+++ b/core/libraries/rest_api/calculations/Datetime.php
@@ -5,8 +5,8 @@ namespace EventEspresso\core\libraries\rest_api\calculations;
 use EE_Error;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
-use EventEspresso\core\libraries\rest_api\controllers\model\Base as Controller_Base;
+use EventEspresso\core\libraries\rest_api\calculations\Base as DatetimeCalculationBase;
+use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use EEM_Datetime;
 use EEM_Registration;
 use EE_Datetime;
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 use ReflectionException;
 use WP_REST_Request;
 
-class Datetime extends Calculations_Base implements HasCalculationSchemaInterface
+class Datetime extends DatetimeCalculationBase implements HasCalculationSchemaInterface
 {
 
     /**
@@ -25,7 +25,7 @@ class Datetime extends Calculations_Base implements HasCalculationSchemaInterfac
      * @see EE_Datetime::spaces_remaining( true )
      * @param array            $wpdb_row
      * @param WP_REST_Request $request
-     * @param Controller_Base  $controller
+     * @param Base  $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidDataTypeException
@@ -63,7 +63,7 @@ class Datetime extends Calculations_Base implements HasCalculationSchemaInterfac
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Controller_Base $controller
+     * @param Base $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -97,7 +97,7 @@ class Datetime extends Calculations_Base implements HasCalculationSchemaInterfac
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Controller_Base $controller
+     * @param Base $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -132,7 +132,7 @@ class Datetime extends Calculations_Base implements HasCalculationSchemaInterfac
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Controller_Base $controller
+     * @param Base $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException

--- a/core/libraries/rest_api/calculations/Datetime.php
+++ b/core/libraries/rest_api/calculations/Datetime.php
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 use ReflectionException;
 use WP_REST_Request;
 
-class Datetime extends Calculations_Base
+class Datetime extends Calculations_Base implements HasCalculationSchemaInterface
 {
 
     /**
@@ -166,5 +166,61 @@ class Datetime extends Calculations_Base
             'REG_ID',
             true
         );
+    }
+
+
+    /**
+     * Provides an array for all the calculations possible that outlines a json schema for those calculations.
+     * Array is indexed by calculation (snake case) and value is the schema for that calculation.
+     *
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculations()
+    {
+        return array(
+            'spaces_remaining_considering_tickets' => array(
+                'description' => esc_html__(
+                    'Calculates the total spaces available on the datetime, taking into account ticket limits too.',
+                    'event_espresso'
+                ),
+                'type' => 'number'
+            ),
+            'registrations_checked_in_count' => array(
+                'description' => esc_html__(
+                    'Counts registrations who have checked into this datetime.',
+                    'event_espresso'
+                ),
+                'type' => 'number'
+            ),
+            'registrations_checked_out_count' => array(
+                'description' => esc_html__(
+                    'Counts registrations who have checked out of this datetime.',
+                    'event_espresso'
+                ),
+                'type' => 'number'
+            ),
+            'spots_taken_pending_payment' => array(
+                'description' => esc_html__(
+                    'The count of pending-payment registrations for this event (regardless of how many datetimes each registration\'s ticket purchase is for',
+                    'event_espresso'
+                ),
+                'type' => 'number'
+            ),
+        );
+    }
+
+
+    /**
+     * Returns the json schema for the given calculation index.
+     *
+     * @param string $calculation_index
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculation($calculation_index)
+    {
+        $schema_map = self::schemaForCalculations();
+        return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Datetime.php
+++ b/core/libraries/rest_api/calculations/Datetime.php
@@ -2,11 +2,18 @@
 
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
+use EE_Error;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base as Controller_Base;
 use EEM_Datetime;
 use EEM_Registration;
 use EE_Datetime;
+use EventEspresso\core\libraries\rest_api\RestException;
+use InvalidArgumentException;
+use ReflectionException;
+use WP_REST_Request;
 
 class Datetime extends Calculations_Base
 {
@@ -17,10 +24,14 @@ class Datetime extends Calculations_Base
      *
      * @see EE_Datetime::spaces_remaining( true )
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Controller_Base  $controller
      * @return int
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public static function spacesRemainingConsideringTickets($wpdb_row, $request, $controller)
     {
@@ -31,37 +42,39 @@ class Datetime extends Calculations_Base
         }
         if ($dtt_obj instanceof EE_Datetime) {
             return $dtt_obj->spaces_remaining(true);
-        } else {
-            throw new \EE_Error(
-                sprintf(
-                    __(
-                    // @codingStandardsIgnoreStart
-                        'Cannot calculate spaces_remaining_considering_tickets because the datetime with ID %1$s (from database row %2$s) was not found',
-                        // @codingStandardsIgnoreEnd
-                        'event_espresso'
-                    ),
-                    $wpdb_row['Datetime.DTT_ID'],
-                    print_r($wpdb_row, true)
-                )
-            );
         }
+        throw new EE_Error(
+            sprintf(
+                __(
+                // @codingStandardsIgnoreStart
+                    'Cannot calculate spaces_remaining_considering_tickets because the datetime with ID %1$s (from database row %2$s) was not found',
+                    // @codingStandardsIgnoreEnd
+                    'event_espresso'
+                ),
+                $wpdb_row['Datetime.DTT_ID'],
+                print_r($wpdb_row, true)
+            )
+        );
     }
 
 
     /**
      * Counts registrations who have checked into this datetime
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Controller_Base  $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Controller_Base $controller
      * @return int
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\libraries\rest_api\RestException
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws RestException
      */
     public static function registrationsCheckedInCount($wpdb_row, $request, $controller)
     {
         if (! is_array($wpdb_row) || ! isset($wpdb_row['Datetime.DTT_ID'])) {
-            throw new \EE_Error(
+            throw new EE_Error(
                 sprintf(
                     __(
                     // @codingStandardsIgnoreStart
@@ -82,17 +95,20 @@ class Datetime extends Calculations_Base
     /**
      * Counts registrations who have checked out of this datetime
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Controller_Base  $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Controller_Base $controller
      * @return int
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\libraries\rest_api\RestException
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws RestException
      */
     public static function registrationsCheckedOutCount($wpdb_row, $request, $controller)
     {
         if (! is_array($wpdb_row) || ! isset($wpdb_row['Datetime.DTT_ID'])) {
-            throw new \EE_Error(
+            throw new EE_Error(
                 sprintf(
                     __(
                     // @codingStandardsIgnoreStart
@@ -114,17 +130,20 @@ class Datetime extends Calculations_Base
      * Counts the number of pending-payment registrations for this event (regardless
      * of how many datetimes each registrations' ticket purchase is for)
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Controller_Base  $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Controller_Base $controller
      * @return int
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\libraries\rest_api\RestException
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws RestException
      */
     public static function spotsTakenPendingPayment($wpdb_row, $request, $controller)
     {
         if (! is_array($wpdb_row) || ! isset($wpdb_row['Datetime.DTT_ID'])) {
-            throw new \EE_Error(
+            throw new EE_Error(
                 sprintf(
                     __(
                     // @codingStandardsIgnoreStart

--- a/core/libraries/rest_api/calculations/Datetime.php
+++ b/core/libraries/rest_api/calculations/Datetime.php
@@ -6,7 +6,7 @@ use EE_Error;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as DatetimeCalculationBase;
-use EventEspresso\core\libraries\rest_api\controllers\model\Base;
+use EventEspresso\core\libraries\rest_api\controllers\model\Base as DatetimeControllerBase;
 use EEM_Datetime;
 use EEM_Registration;
 use EE_Datetime;
@@ -25,7 +25,7 @@ class Datetime extends DatetimeCalculationBase implements HasCalculationSchemaIn
      * @see EE_Datetime::spaces_remaining( true )
      * @param array            $wpdb_row
      * @param WP_REST_Request $request
-     * @param Base  $controller
+     * @param DatetimeControllerBase  $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidDataTypeException
@@ -63,7 +63,7 @@ class Datetime extends DatetimeCalculationBase implements HasCalculationSchemaIn
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Base $controller
+     * @param DatetimeControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -97,7 +97,7 @@ class Datetime extends DatetimeCalculationBase implements HasCalculationSchemaIn
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Base $controller
+     * @param DatetimeControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -132,7 +132,7 @@ class Datetime extends DatetimeCalculationBase implements HasCalculationSchemaIn
      *
      * @param array           $wpdb_row
      * @param WP_REST_Request $request
-     * @param Base $controller
+     * @param DatetimeControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException

--- a/core/libraries/rest_api/calculations/Event.php
+++ b/core/libraries/rest_api/calculations/Event.php
@@ -24,7 +24,7 @@ use WP_REST_Request;
  * @subpackage
  * @author                Mike Nelson
  */
-class Event extends Calculations_Base
+class Event extends Calculations_Base implements HasCalculationSchemaInterface
 {
 
     /**
@@ -440,5 +440,150 @@ class Event extends Calculations_Base
     protected static function wpdbRowHasEventId($wpdb_row)
     {
         return (is_array($wpdb_row) && isset($wpdb_row['Event_CPT.ID']) && absint($wpdb_row['Event_CPT.ID']));
+    }
+
+
+    /**
+     * Provides an array for all the calculations possible that outlines a json schema for those calculations.
+     * Array is indexed by calculation (snake case) and value is the schema for that calculation.
+     *
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculations()
+    {
+        $image_object_properties = array(
+            'url' => array(
+                'type' => 'string'
+            ),
+            'width' => array(
+                'type' => 'number'
+            ),
+            'height' => array(
+                'type' => 'number'
+            ),
+            'generated' => array(
+                'type' => 'boolean'
+            )
+        );
+        return array(
+            'optimum_sales_at_start' => array(
+                'description' => esc_html__(
+                    'The total spaces on the event (not subtracting sales, but taking sales into account; so this is the optimum sales that CAN still be achieved.',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'optimum_sales_now' => array(
+                'description' => esc_html__(
+                    'The total spaces on the event (ignoring all sales; so this is the optimum sales that could have been achieved.',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'spaces_remaining' => array(
+                'description' => esc_html__(
+                    'The optimum_sales_number result, minus total sales so far.',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'spots_taken' => array(
+                'description' => esc_html__(
+                    'The number of approved registrations for this event (regardless of how many datetimes each registration\'s ticket purchase is for)',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'spots_taken_pending_payment' => array(
+                'description' => esc_html__(
+                    'The number of pending-payment registrations for this event (regardless of how many datetimes each registration\'s ticket purchase is for)',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'registrations_checked_in_count' => array(
+                'description' => esc_html__(
+                    'The count of all the registrations who have checked into one of this event\'s datetimes.',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'registrations_checked_out_count' => array(
+                'description' => esc_html__(
+                    'The count of all registrations who have checked out of one of this event\'s datetimes.',
+                    'event_espresso'
+                ),
+                'type' => 'number',
+            ),
+            'image_thumbnail' => array(
+                'description' => esc_html__(
+                    'The thumbnail image data.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            ),
+            'image_medium' => array(
+                'description' => esc_html__(
+                    'The medium image data.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            ),
+            'image_medium_large' => array(
+                'description' => esc_html__(
+                    'The medium-large image data.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            ),
+            'image_large' => array(
+                'description' => esc_html__(
+                    'The large image data.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            ),
+            'image_post_thumbnail' => array(
+                'description' => esc_html__(
+                    'The post-thumbnail image data.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            ),
+            'image_full' => array(
+                'description' => esc_html__(
+                    'The full size image data',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => $image_object_properties,
+                'additionalProperties' => false,
+            )
+        );
+    }
+
+
+    /**
+     * Returns the json schema for the given calculation index.
+     *
+     * @param $calculation_index
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculation($calculation_index)
+    {
+        $schema_map = self::schemaForCalculations();
+        return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Event.php
+++ b/core/libraries/rest_api/calculations/Event.php
@@ -6,7 +6,7 @@ use DomainException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
-use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
+use EventEspresso\core\libraries\rest_api\calculations\Base as EventCalculationBase;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use EventEspresso\core\libraries\rest_api\RestException;
 use EEM_Event;
@@ -24,7 +24,7 @@ use WP_REST_Request;
  * @subpackage
  * @author                Mike Nelson
  */
-class Event extends Calculations_Base implements HasCalculationSchemaInterface
+class Event extends EventCalculationBase implements HasCalculationSchemaInterface
 {
 
     /**

--- a/core/libraries/rest_api/calculations/Event.php
+++ b/core/libraries/rest_api/calculations/Event.php
@@ -583,7 +583,7 @@ class Event extends Calculations_Base implements HasCalculationSchemaInterface
      */
     public static function schemaForCalculation($calculation_index)
     {
-        $schema_map = self::schemaForCalculations();
+        $schema_map = Event::schemaForCalculations();
         return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Event.php
+++ b/core/libraries/rest_api/calculations/Event.php
@@ -2,6 +2,10 @@
 
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
+use DomainException;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use EventEspresso\core\libraries\rest_api\RestException;
@@ -9,6 +13,8 @@ use EEM_Event;
 use EE_Event;
 use EE_Error;
 use EEM_Registration;
+use InvalidArgumentException;
+use WP_REST_Request;
 
 /**
  * Class Event_Calculations
@@ -27,10 +33,15 @@ class Event extends Calculations_Base
      * See EE_Event::total_available_spaces( true );
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return int
      * @throws EE_Error
+     * @throws DomainException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
+     * @throws InvalidArgumentException
      */
     public static function optimumSalesAtStart($wpdb_row, $request, $controller)
     {
@@ -61,11 +72,16 @@ class Event extends Calculations_Base
      * sales that COULD have been achieved)
      * See EE_Event::total_available_spaces( true );
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int
+     * @throws DomainException
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      */
     public static function optimumSalesNow($wpdb_row, $request, $controller)
     {
@@ -95,11 +111,16 @@ class Event extends Calculations_Base
      * Like optimum_sales_now, but minus total sales so far.
      * See EE_Event::spaces_remaining_for_sale( true );
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int
+     * @throws DomainException
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      */
     public static function spacesRemaining($wpdb_row, $request, $controller)
     {
@@ -129,11 +150,14 @@ class Event extends Calculations_Base
      * Counts the number of approved registrations for this event (regardless
      * of how many datetimes each registrations' ticket purchase is for)
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public static function spotsTaken($wpdb_row, $request, $controller)
     {
@@ -167,11 +191,14 @@ class Event extends Calculations_Base
      * Counts the number of pending-payment registrations for this event (regardless
      * of how many datetimes each registrations' ticket purchase is for)
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      * @throws RestException
      */
     public static function spotsTakenPendingPayment($wpdb_row, $request, $controller)
@@ -207,11 +234,14 @@ class Event extends Calculations_Base
      * Counts all the registrations who have checked into one of this events' datetimes
      * See EE_Event::total_available_spaces( false );
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int|null if permission denied
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      * @throws RestException
      */
     public static function registrationsCheckedInCount($wpdb_row, $request, $controller)
@@ -238,11 +268,14 @@ class Event extends Calculations_Base
      * Counts all the registrations who have checked out of one of this events' datetimes
      * See EE_Event::total_available_spaces( false );
      *
-     * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
-     * @param Base             $controller
+     * @param array           $wpdb_row
+     * @param WP_REST_Request $request
+     * @param Base            $controller
      * @return int
      * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      * @throws RestException
      */
     public static function registrationsCheckedOutCount($wpdb_row, $request, $controller)
@@ -269,7 +302,7 @@ class Event extends Calculations_Base
      * Gets the thumbnail image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error
@@ -284,7 +317,7 @@ class Event extends Calculations_Base
      * Gets the medium image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error
@@ -299,7 +332,7 @@ class Event extends Calculations_Base
      * Gets the medium-large image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error
@@ -314,7 +347,7 @@ class Event extends Calculations_Base
      * Gets the large image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error
@@ -329,7 +362,7 @@ class Event extends Calculations_Base
      * Gets the post-thumbnail image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error
@@ -344,7 +377,7 @@ class Event extends Calculations_Base
      * Gets the full size image
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
      * @throws EE_Error

--- a/core/libraries/rest_api/calculations/Event.php
+++ b/core/libraries/rest_api/calculations/Event.php
@@ -7,7 +7,7 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as EventCalculationBase;
-use EventEspresso\core\libraries\rest_api\controllers\model\Base;
+use EventEspresso\core\libraries\rest_api\controllers\model\Base as EventControllerBase;
 use EventEspresso\core\libraries\rest_api\RestException;
 use EEM_Event;
 use EE_Event;
@@ -32,9 +32,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * sales into account; so this is the optimum sales that CAN still be achieved)
      * See EE_Event::total_available_spaces( true );
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws DomainException
@@ -72,9 +72,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * sales that COULD have been achieved)
      * See EE_Event::total_available_spaces( true );
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws DomainException
      * @throws EE_Error
@@ -111,9 +111,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * Like optimum_sales_now, but minus total sales so far.
      * See EE_Event::spaces_remaining_for_sale( true );
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws DomainException
      * @throws EE_Error
@@ -150,9 +150,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * Counts the number of approved registrations for this event (regardless
      * of how many datetimes each registrations' ticket purchase is for)
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -191,9 +191,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * Counts the number of pending-payment registrations for this event (regardless
      * of how many datetimes each registrations' ticket purchase is for)
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -234,9 +234,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * Counts all the registrations who have checked into one of this events' datetimes
      * See EE_Event::total_available_spaces( false );
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int|null if permission denied
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -268,9 +268,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
      * Counts all the registrations who have checked out of one of this events' datetimes
      * See EE_Event::total_available_spaces( false );
      *
-     * @param array           $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base            $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -301,9 +301,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the thumbnail image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -316,9 +316,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the medium image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -331,9 +331,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the medium-large image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -346,9 +346,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the large image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -361,9 +361,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the post-thumbnail image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -376,9 +376,9 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     /**
      * Gets the full size image
      *
-     * @param array            $wpdb_row
-     * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param array               $wpdb_row
+     * @param WP_REST_Request     $request
+     * @param EventControllerBase $controller
      * @return array
      * @throws EE_Error
      */
@@ -453,123 +453,123 @@ class Event extends EventCalculationBase implements HasCalculationSchemaInterfac
     public static function schemaForCalculations()
     {
         $image_object_properties = array(
-            'url' => array(
-                'type' => 'string'
+            'url'       => array(
+                'type' => 'string',
             ),
-            'width' => array(
-                'type' => 'number'
+            'width'     => array(
+                'type' => 'number',
             ),
-            'height' => array(
-                'type' => 'number'
+            'height'    => array(
+                'type' => 'number',
             ),
             'generated' => array(
-                'type' => 'boolean'
-            )
+                'type' => 'boolean',
+            ),
         );
         return array(
-            'optimum_sales_at_start' => array(
+            'optimum_sales_at_start'          => array(
                 'description' => esc_html__(
                     'The total spaces on the event (not subtracting sales, but taking sales into account; so this is the optimum sales that CAN still be achieved.',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'optimum_sales_now' => array(
+            'optimum_sales_now'               => array(
                 'description' => esc_html__(
                     'The total spaces on the event (ignoring all sales; so this is the optimum sales that could have been achieved.',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'spaces_remaining' => array(
+            'spaces_remaining'                => array(
                 'description' => esc_html__(
                     'The optimum_sales_number result, minus total sales so far.',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'spots_taken' => array(
+            'spots_taken'                     => array(
                 'description' => esc_html__(
                     'The number of approved registrations for this event (regardless of how many datetimes each registration\'s ticket purchase is for)',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'spots_taken_pending_payment' => array(
+            'spots_taken_pending_payment'     => array(
                 'description' => esc_html__(
                     'The number of pending-payment registrations for this event (regardless of how many datetimes each registration\'s ticket purchase is for)',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'registrations_checked_in_count' => array(
+            'registrations_checked_in_count'  => array(
                 'description' => esc_html__(
                     'The count of all the registrations who have checked into one of this event\'s datetimes.',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
             'registrations_checked_out_count' => array(
                 'description' => esc_html__(
                     'The count of all registrations who have checked out of one of this event\'s datetimes.',
                     'event_espresso'
                 ),
-                'type' => 'number',
+                'type'        => 'number',
             ),
-            'image_thumbnail' => array(
-                'description' => esc_html__(
+            'image_thumbnail'                 => array(
+                'description'          => esc_html__(
                     'The thumbnail image data.',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
             ),
-            'image_medium' => array(
-                'description' => esc_html__(
+            'image_medium'                    => array(
+                'description'          => esc_html__(
                     'The medium image data.',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
             ),
-            'image_medium_large' => array(
-                'description' => esc_html__(
+            'image_medium_large'              => array(
+                'description'          => esc_html__(
                     'The medium-large image data.',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
             ),
-            'image_large' => array(
-                'description' => esc_html__(
+            'image_large'                     => array(
+                'description'          => esc_html__(
                     'The large image data.',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
             ),
-            'image_post_thumbnail' => array(
-                'description' => esc_html__(
+            'image_post_thumbnail'            => array(
+                'description'          => esc_html__(
                     'The post-thumbnail image data.',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
             ),
-            'image_full' => array(
-                'description' => esc_html__(
+            'image_full'                      => array(
+                'description'          => esc_html__(
                     'The full size image data',
                     'event_espresso'
                 ),
-                'type' => 'object',
-                'properties' => $image_object_properties,
+                'type'                 => 'object',
+                'properties'           => $image_object_properties,
                 'additionalProperties' => false,
-            )
+            ),
         );
     }
 

--- a/core/libraries/rest_api/calculations/HasCalculationSchemaInterface.php
+++ b/core/libraries/rest_api/calculations/HasCalculationSchemaInterface.php
@@ -1,0 +1,27 @@
+<?php
+namespace EventEspresso\core\libraries\rest_api\calculations;
+
+/**
+ * Interface HasCalculationSchemaInterface
+ * This should be implemented by any calculation classes that expose a json schema.
+ *
+ * @author Darren Ethier
+ * @since  $VID:$
+ */
+interface HasCalculationSchemaInterface
+{
+    /**
+     * Provides an array for all the calculations possible that outlines a json schema for those calculations.
+     * Array is indexed by calculation (snake case) and value is the schema for that calculation.
+     * @return array
+     */
+    public static function schemaForCalculations();
+
+
+    /**
+     * Returns the json schema for the given calculation index.
+     * @param $calculation_index
+     * @return array
+     */
+    public static function schemaForCalculation($calculation_index);
+}

--- a/core/libraries/rest_api/calculations/Registration.php
+++ b/core/libraries/rest_api/calculations/Registration.php
@@ -6,7 +6,7 @@ use EE_Checkin;
 use EE_Error;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
+use EventEspresso\core\libraries\rest_api\calculations\Base as RegistrationCalculationBase;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use EEM_Registration;
 use EE_Registration;
@@ -21,7 +21,7 @@ use WP_REST_Request;
  * @subpackage
  * @author                Mike Nelson
  */
-class Registration extends Calculations_Base implements HasCalculationSchemaInterface
+class Registration extends RegistrationCalculationBase implements HasCalculationSchemaInterface
 {
 
     /**

--- a/core/libraries/rest_api/calculations/Registration.php
+++ b/core/libraries/rest_api/calculations/Registration.php
@@ -7,7 +7,7 @@ use EE_Error;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as RegistrationCalculationBase;
-use EventEspresso\core\libraries\rest_api\controllers\model\Base;
+use EventEspresso\core\libraries\rest_api\controllers\model\Base as RegistrationControllerBase;
 use EEM_Registration;
 use EE_Registration;
 use EEM_Datetime;
@@ -29,7 +29,7 @@ class Registration extends RegistrationCalculationBase implements HasCalculation
      *
      * @param array            $wpdb_row
      * @param WP_REST_Request $request
-     * @param Base             $controller
+     * @param RegistrationControllerBase $controller
      * @return array
      * @throws EE_Error
      * @throws InvalidDataTypeException

--- a/core/libraries/rest_api/calculations/Registration.php
+++ b/core/libraries/rest_api/calculations/Registration.php
@@ -125,7 +125,7 @@ class Registration extends Calculations_Base implements HasCalculationSchemaInte
      */
     public static function schemaForCalculation($calculation_index)
     {
-        $schema_map = self::schemaForCalculations();
+        $schema_map = Registration::schemaForCalculations();
         return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/calculations/Registration.php
+++ b/core/libraries/rest_api/calculations/Registration.php
@@ -3,11 +3,16 @@
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
 use EE_Checkin;
+use EE_Error;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\calculations\Base as Calculations_Base;
 use EventEspresso\core\libraries\rest_api\controllers\model\Base;
 use EEM_Registration;
 use EE_Registration;
 use EEM_Datetime;
+use InvalidArgumentException;
+use WP_REST_Request;
 
 /**
  * Class Registration
@@ -23,10 +28,13 @@ class Registration extends Calculations_Base
      * Calculates the checkin status for each datetime this registration has access to
      *
      * @param array            $wpdb_row
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param Base             $controller
      * @return array
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
      */
     public static function datetimeCheckinStati($wpdb_row, $request, $controller)
     {
@@ -37,7 +45,7 @@ class Registration extends Calculations_Base
         }
         if (! $reg instanceof EE_Registration
         ) {
-            throw new \EE_Error(
+            throw new EE_Error(
                 sprintf(
                     __(
                     // @codingStandardsIgnoreStart

--- a/core/libraries/rest_api/calculations/Registration.php
+++ b/core/libraries/rest_api/calculations/Registration.php
@@ -21,7 +21,7 @@ use WP_REST_Request;
  * @subpackage
  * @author                Mike Nelson
  */
-class Registration extends Calculations_Base
+class Registration extends Calculations_Base implements HasCalculationSchemaInterface
 {
 
     /**
@@ -84,5 +84,48 @@ class Registration extends Calculations_Base
             $checkin_stati[ $datetime_id ] = $status_pretty;
         }
         return $checkin_stati;
+    }
+
+
+    /**
+     * Provides an array for all the calculations possible that outlines a json schema for those calculations.
+     * Array is indexed by calculation (snake case) and value is the schema for that calculation.
+     *
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculations()
+    {
+        return array(
+            'datetime_checkin_stati' => array(
+                'description' => esc_html__(
+                    'Returns the checkin status for each datetime this registration has access to.',
+                    'event_espresso'
+                ),
+                'type' => 'object',
+                'properties' => array(),
+                'additionalProperties' => array(
+                    'description' => esc_html(
+                        'Keys are date-time ids and values are the check-in status',
+                        'event_espresso'
+                    ),
+                    'type' => 'string'
+                ),
+            ),
+        );
+    }
+
+
+    /**
+     * Returns the json schema for the given calculation index.
+     *
+     * @param $calculation_index
+     * @since $VID:$
+     * @return array
+     */
+    public static function schemaForCalculation($calculation_index)
+    {
+        $schema_map = self::schemaForCalculations();
+        return isset($schema_map[ $calculation_index ]) ? $schema_map[ $calculation_index ] : array();
     }
 }

--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -107,7 +107,7 @@ class Read extends Base
             }
             // get the model for this version
             $model = $controller->getModelVersionInfo()->loadModel($model_name);
-            $model_schema = new JsonModelSchema($model);
+            $model_schema = new JsonModelSchema($model, new CalculatedModelFields());
             return $model_schema->getModelSchemaForRelations(
                 $controller->getModelVersionInfo()->relationSettings($model),
                 $controller->customizeSchemaForRestResponse(

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1131,6 +1131,47 @@ class Read_Test extends \EE_REST_TestCase
         $this->assertEquals('EE_Has_Many_Relation', $datetimes_array['relation_type']);
         $this->assertArrayHasKey('readonly', $datetimes_array);
         $this->assertTrue($datetimes_array['readonly']);
+        // verify link item
+        $this->assertArrayHasKey('link', $data['schema']);
+        $link = $data['schema']['link'];
+        $this->assertArrayHasKey('type', $link);
+        $this->assertEquals('string', $link['type']);
+        // verify links item
+        $this->assertArrayHasKey('_links', $data['schema']);
+        $links = $data['schema']['_links'];
+        $this->assertEquals(
+            array('description', 'type', 'readonly', 'properties', 'additionalProperties'),
+            array_keys($links)
+        );
+        $this->assertEquals(
+            array('self', 'collection' ),
+            array_keys($links['properties'])
+        );
+        //verify _calculated_fields
+        $this->assertArrayHasKey('_calculated_fields', $data['schema']);
+        $calculated_fields = $data['schema']['_calculated_fields'];
+        $this->assertEquals(
+            array('description', 'type', 'properties', 'additionalProperties', 'readonly'),
+            array_keys($calculated_fields)
+        );
+        $this->assertEquals(
+            array(
+                'optimum_sales_at_start',
+                'optimum_sales_now',
+                'spots_taken',
+                'spots_taken_pending_payment',
+                'spaces_remaining',
+                'registrations_checked_in_count',
+                'registrations_checked_out_count',
+                'image_thumbnail',
+                'image_medium',
+                'image_medium_large',
+                'image_large',
+                'image_post_thumbnail',
+                'image_full',
+            ),
+            array_keys($calculated_fields['properties'])
+        );
     }
 
 

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1132,24 +1132,39 @@ class Read_Test extends \EE_REST_TestCase
         $this->assertArrayHasKey('readonly', $datetimes_array);
         $this->assertTrue($datetimes_array['readonly']);
         // verify link item
-        $this->assertArrayHasKey('link', $data['schema']);
-        $link = $data['schema']['link'];
+        $this->assertArrayHasKey('link', $data['schema']['properties']);
+        $link = $data['schema']['properties']['link'];
         $this->assertArrayHasKey('type', $link);
         $this->assertEquals('string', $link['type']);
         // verify links item
-        $this->assertArrayHasKey('_links', $data['schema']);
-        $links = $data['schema']['_links'];
+        $this->assertArrayHasKey('_links', $data['schema']['properties']);
+        $links = $data['schema']['properties']['_links'];
         $this->assertEquals(
             array('description', 'type', 'readonly', 'properties', 'additionalProperties'),
             array_keys($links)
         );
         $this->assertEquals(
-            array('self', 'collection' ),
+            array(
+                'self',
+                'collection',
+                'https://api.eventespresso.com/registration',
+                'https://api.eventespresso.com/datetime',
+                'https://api.eventespresso.com/question_group',
+                'https://api.eventespresso.com/venue',
+                'https://api.eventespresso.com/term_relationship',
+                'https://api.eventespresso.com/term_taxonomy',
+                'https://api.eventespresso.com/message_template_group',
+                'https://api.eventespresso.com/attendee',
+                'https://api.eventespresso.com/wp_user',
+                'https://api.eventespresso.com/post_meta',
+                'https://api.eventespresso.com/extra_meta',
+                'https://api.eventespresso.com/change_log',
+            ),
             array_keys($links['properties'])
         );
         //verify _calculated_fields
-        $this->assertArrayHasKey('_calculated_fields', $data['schema']);
-        $calculated_fields = $data['schema']['_calculated_fields'];
+        $this->assertArrayHasKey('_calculated_fields', $data['schema']['properties']);
+        $calculated_fields = $data['schema']['properties']['_calculated_fields'];
         $this->assertEquals(
             array('description', 'type', 'properties', 'additionalProperties', 'readonly'),
             array_keys($calculated_fields)

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1097,7 +1097,6 @@ class Read_Test extends \EE_REST_TestCase
      * This tests getting schema object returned for an options request on a valid collection endpoint.
      *
      * @group rest_schema_request
-     * @group current
      */
     public function test_handle_schema_request()
     {

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1097,6 +1097,7 @@ class Read_Test extends \EE_REST_TestCase
      * This tests getting schema object returned for an options request on a valid collection endpoint.
      *
      * @group rest_schema_request
+     * @group current
      */
     public function test_handle_schema_request()
     {
@@ -1158,9 +1159,9 @@ class Read_Test extends \EE_REST_TestCase
             array(
                 'optimum_sales_at_start',
                 'optimum_sales_now',
+                'spaces_remaining',
                 'spots_taken',
                 'spots_taken_pending_payment',
-                'spaces_remaining',
                 'registrations_checked_in_count',
                 'registrations_checked_out_count',
                 'image_thumbnail',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

The REST API JSON schema for resource endpoints is missing `link`, `_links`, and `_calculated_fields` from the response.  The work in this pull adds them.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Add unit tests and verified they passed.
* [x] Checked the schema endpoint for various resources (manual requests) and verified the response is as expected (ie. `OPTION http://ee.test/wp-json/ee/v4.8.36/events`)

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
