### PR TITLE
Avoid fatal error when invalid ID is in ticket selector shortcode fixes #655

### DIFF
--- a/core/domain/entities/shortcodes/EspressoTicketSelector.php
+++ b/core/domain/entities/shortcodes/EspressoTicketSelector.php
@@ -71,21 +71,31 @@ class EspressoTicketSelector extends EspressoShortcode
         $event_id = isset($event_id) ? $event_id : 0;
         $event = EE_Registry::instance()->load_model('Event')->get_one_by_ID($event_id);
         if (! $event instanceof EE_Event) {
-            new ExceptionStackTraceDisplay(
-                new InvalidArgumentException(
-                    sprintf(
-                        esc_html__(
-                            'A valid Event ID is required to use the "%1$s" shortcode.%4$sAn Event with an ID of "%2$s" could not be found.%4$sPlease verify that the shortcode added to this post\'s content includes an "%3$s" argument and that it\'s value corresponds to a valid Event ID.',
-                            'event_espresso'
-                        ),
-                        $this->getTag(),
-                        $event_id,
-                        'event_id',
-                        '<br />'
+            if (current_user_can('edit_pages') && WP_DEBUG === true ) {
+                new ExceptionStackTraceDisplay(
+                    new InvalidArgumentException(
+                        sprintf(
+                            esc_html__(
+                                'A valid Event ID is required to use the "%1$s" shortcode.%4$sAn Event with an ID of "%2$s" could not be found.%4$sPlease verify that the shortcode added to this post\'s content includes an "%3$s" argument and that its value corresponds to a valid Event ID.',
+                                'event_espresso'
+                            ),
+                            $this->getTag(),
+                            $event_id,
+                            'event_id',
+                            '<br />'
+                        )
                     )
-                )
-            );
-            return '';
+                ); 
+                return;
+            } else {
+                return sprintf(
+                    esc_html__(
+                        'An Event with an ID of "%s" could not be found. Please contact the event administrator for assistance.',
+                        'event_espresso'
+                    ),
+                    $event_id
+                );
+            }  
         }
         ob_start();
         do_action('AHEE_event_details_before_post', $event_id);

--- a/core/domain/entities/shortcodes/EspressoTicketSelector.php
+++ b/core/domain/entities/shortcodes/EspressoTicketSelector.php
@@ -2,11 +2,16 @@
 
 namespace EventEspresso\core\domain\entities\shortcodes;
 
+use EE_Error;
 use EE_Event;
 use EE_Registry;
 use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\shortcodes\EspressoShortcode;
+use Exception;
 use InvalidArgumentException;
+use ReflectionException;
 
 /**
  * Class EspressoTicketSelector
@@ -64,6 +69,11 @@ class EspressoTicketSelector extends EspressoShortcode
      * @param array $attributes
      * @return string
      * @throws InvalidArgumentException
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function processShortcode($attributes = array())
     {
@@ -71,7 +81,7 @@ class EspressoTicketSelector extends EspressoShortcode
         $event_id = isset($event_id) ? $event_id : 0;
         $event = EE_Registry::instance()->load_model('Event')->get_one_by_ID($event_id);
         if (! $event instanceof EE_Event) {
-            if (current_user_can('edit_pages') && WP_DEBUG === true ) {
+            if (WP_DEBUG === true && current_user_can('edit_pages')) {
                 new ExceptionStackTraceDisplay(
                     new InvalidArgumentException(
                         sprintf(
@@ -85,17 +95,16 @@ class EspressoTicketSelector extends EspressoShortcode
                             '<br />'
                         )
                     )
-                ); 
-                return;
-            } else {
-                return sprintf(
-                    esc_html__(
-                        'An Event with an ID of "%s" could not be found. Please contact the event administrator for assistance.',
-                        'event_espresso'
-                    ),
-                    $event_id
                 );
-            }  
+                return '';
+            }
+            return sprintf(
+                esc_html__(
+                    'An Event with an ID of "%s" could not be found. Please contact the event administrator for assistance.',
+                    'event_espresso'
+                ),
+                $event_id
+            );
         }
         ob_start();
         do_action('AHEE_event_details_before_post', $event_id);


### PR DESCRIPTION
Fixes issue #655 Only throw exception if WP_DEBUG is true and current user has the ability to edit the page

Otherwise just print a message.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See issue #655 

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
put ticket selector shortcodes on posts & pages, some with valid IDs and some with invalid IDs. Viewed the page with WP_DEBUG set to true and set to false. Viewed the page while logged in and viewed the page while logged out. 
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
