### PR TITLE
Add EE to block categories before tests run - wip

### DIFF
--- a/assets/src/blocks/event-attendees/test/index.js
+++ b/assets/src/blocks/event-attendees/test/index.js
@@ -2,11 +2,18 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
+import { getCategories, setCategories } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import EventAttendeesEditor from '../edit';
+
+beforeAll( () => {
+	const categories = getCategories();
+	categories.push( { slug: 'event-espresso', title: 'Event Espresso' } );
+	setCategories( categories );
+} );
 
 describe( 'EventAttendeesEditor Block', () => {
 	test( 'block edit matches snapshot', () => {
@@ -14,3 +21,5 @@ describe( 'EventAttendeesEditor Block', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 } );
+
+// location: /assets/src/blocks/event-attendees/test/index.js


### PR DESCRIPTION
## Problem this Pull Request solves
does what the title says. Wasn't *really* needed since we aren't testing the full block, but wanted to add this in before I forgot about it since it's likely we will need this kind of logic for other blocks. I was thinking this could maybe be moved to another file that can then be loaded by test files that need it.

## How has this been tested
via unit tests

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
