### PR TITLE
Fixed fatal by using loader instead of direct instantiation of REST controller

### DIFF
--- a/core/libraries/form_sections/inputs/EE_Select_Ajax_Model_Rest_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Select_Ajax_Model_Rest_Input.input.php
@@ -1,5 +1,9 @@
 <?php
+
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\ModelDataTranslator;
+use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
  * EE_Select_Ajax_Model_Rest_Input
@@ -34,7 +38,6 @@ class EE_Select_Ajax_Model_Rest_Input extends EE_Form_Input_With_Options_Base
     protected $_extra_select_columns = array();
 
 
-
     /**
      * @param array $input_settings     {
      * @type string $model_name         the name of model to be used for searching, both via the REST API and server-side model queries
@@ -48,7 +51,11 @@ class EE_Select_Ajax_Model_Rest_Input extends EE_Form_Input_With_Options_Base
      * @type array  $select2_args       arguments to be passed directly into the select2's JS constructor
      *                                  }
      *                                  And the arguments accepted by EE_Form_Input_With_Options_Base
-     * @throws \EE_Error
+     * }
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public function __construct($input_settings = array())
     {
@@ -94,7 +101,9 @@ class EE_Select_Ajax_Model_Rest_Input extends EE_Form_Input_With_Options_Base
             )
         );
         // get resource endpoint
-        $rest_controller = new EventEspresso\core\libraries\rest_api\controllers\model\Read();
+        $rest_controller = LoaderFactory::getLoader()->getNew(
+            'EventEspresso\core\libraries\rest_api\controllers\model\Read'
+        );
         $rest_controller->setRequestedVersion(EED_Core_Rest_Api::latest_rest_api_version());
         $default_select2_args = array(
             'ajax' => array(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->


## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/689
Fixed fatal error using Ajax Select inputs (used by Attendee Mover Add-on). This was fixed by using the Loader to load the Rest Read controller, instead of direct instantiation.
This error was just recently introduced because we changed the Rest Read controller to require injecting a dependency, but missed the fact it needed to be injected here. (I did a search through EE and the add-ons I have locally and didn't find any other direct instantiation.)

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
Although the error has only been reproduced with the Attendee Mover add-on active, the code needing to be fixed is in core. (The Attendee Mover add-on just calls it; it's otherwise unused.)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Activate Attendee Mover Add-on. Go to the registrations list table, and select to move a registration. On master you'd get a fatal error here, but not on this branch.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
