### PR TITLE
Fix the Dompdf integration so that it supports PHP version 7.2

### DIFF
--- a/core/third_party_libs/dompdf/include/block_frame_reflower.cls.php
+++ b/core/third_party_libs/dompdf/include/block_frame_reflower.cls.php
@@ -22,13 +22,13 @@ class Block_Frame_Reflower extends Frame_Reflower {
    * @var Block_Frame_Decorator
    */
   protected $_frame;
-  
+
   function __construct(Block_Frame_Decorator $frame) { parent::__construct($frame); }
 
   /**
    *  Calculate the ideal used value for the width property as per:
    *  http://www.w3.org/TR/CSS21/visudet.html#Computing_widths_and_margins
-   *  
+   *
    *  @param float $width
    *  @return array
    */
@@ -46,7 +46,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
     $left = $style->length_in_pt($style->left, $w);
     $right = $style->length_in_pt($style->right, $w);
-    
+
     // Handle 'auto' values
     $dims = array($style->border_left_width,
                   $style->border_right_width,
@@ -65,7 +65,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
       $absolute = false;
     }
 
-    $sum = $style->length_in_pt($dims, $w);
+    $sum = (float)$style->length_in_pt($dims, $w);
 
     // Compare to the containing block
     $diff = $w - $sum;
@@ -105,7 +105,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
           $width = $diff;
 
         } else if ( $left === "auto" ) {
-          
+
           if ( $lm === "auto" )
             $lm = 0;
           if ( $rm === "auto" )
@@ -151,7 +151,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
     return array("width"=> $width, "margin_left" => $lm, "margin_right" => $rm, "left" => $left, "right" => $right);
   }
 
-  /** 
+  /**
    * Call the above function, but resolve max/min widths
    * @return array
    */
@@ -159,11 +159,11 @@ class Block_Frame_Reflower extends Frame_Reflower {
     $frame = $this->_frame;
     $style = $frame->get_style();
     $cb = $frame->get_containing_block();
-    
+
     if ( $style->position === "fixed" ) {
       $cb = $frame->get_root()->get_containing_block();
     }
-    
+
     //if ( $style->position === "absolute" )
     //  $cb = $frame->find_positionned_parent()->get_containing_block();
 
@@ -196,24 +196,24 @@ class Block_Frame_Reflower extends Frame_Reflower {
     return array($width, $margin_left, $margin_right, $left, $right);
 
   }
-  
-  /** 
+
+  /**
    * Determine the unrestricted height of content within the block
-   * not by adding each line's height, but by getting the last line's position. 
+   * not by adding each line's height, but by getting the last line's position.
    * This because lines could have been pushed lower by a clearing element.
    * @return float
    */
   protected function _calculate_content_height() {
     $lines = $this->_frame->get_line_boxes();
-    
+
     $first_line = reset($lines);
     $last_line  = end($lines);
     $height = $last_line->y + $last_line->h - $first_line->y;
-    
+
     return $height;
   }
 
-  /** 
+  /**
    * Determine the frame's restricted height
    * @return array
    */
@@ -222,7 +222,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
     $style = $frame->get_style();
     $content_height = $this->_calculate_content_height();
     $cb = $frame->get_containing_block();
-    
+
     $height = $style->length_in_pt($style->height, $cb["h"]);
 
     $top    = $style->length_in_pt($style->top, $cb["h"]);
@@ -245,15 +245,15 @@ class Block_Frame_Reflower extends Frame_Reflower {
                     $style->margin_bottom !== "auto" ? $style->margin_bottom : 0,
                     $bottom !== "auto" ? $bottom : 0);
 
-      $sum = $style->length_in_pt($dims, $cb["h"]);
+      $sum = (float)$style->length_in_pt($dims, $cb["h"]);
 
-      $diff = $cb["h"] - $sum; 
+      $diff = $cb["h"] - $sum;
 
       if ( $diff > 0 ) {
 
         if ( $height === "auto" && $top === "auto" && $bottom === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -262,7 +262,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $height === "auto" && $top === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -272,7 +272,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $height === "auto" && $bottom === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -282,7 +282,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $top === "auto" && $bottom === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -291,7 +291,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $top === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -300,7 +300,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $height === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -309,7 +309,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
         } else if ( $bottom === "auto" ) {
 
-          if ( $margin_top === "auto" ) 
+          if ( $margin_top === "auto" )
             $margin_top = 0;
           if ( $margin_bottom === "auto" )
             $margin_bottom = 0;
@@ -321,7 +321,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
           if ( $style->overflow === "visible" ) {
 
             // set all autos to zero
-            if ( $margin_top === "auto" ) 
+            if ( $margin_top === "auto" )
               $margin_top = 0;
             if ( $margin_bottom === "auto" )
               $margin_bottom = 0;
@@ -341,13 +341,13 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
     } else {
 
-      // Expand the height if overflow is visible 
-      if ( $height === "auto" && $content_height > $height /* && $style->overflow === "visible" */) 
+      // Expand the height if overflow is visible
+      if ( $height === "auto" && $content_height > $height /* && $style->overflow === "visible" */)
         $height = $content_height;
 
       // FIXME: this should probably be moved to a seperate function as per
       // _calculate_restricted_width
-      
+
       // Only handle min/max height if the height is independent of the frame's content
       if ( !($style->overflow === "visible" ||
              ($style->overflow === "hidden" && $height === "auto")) ) {
@@ -396,7 +396,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
   protected function _text_align() {
     $style = $this->_frame->get_style();
     $w = $this->_frame->get_containing_block("w");
-    $width = $style->length_in_pt($style->width, $w);
+    $width = (float)$style->length_in_pt($style->width, $w);
     switch ($style->text_align) {
 
     default:
@@ -414,11 +414,11 @@ class Block_Frame_Reflower extends Frame_Reflower {
       foreach ($this->_frame->get_line_boxes() as $line) {
         // Move each child over by $dx
         $dx = $width - $line->w - $line->right;
-        
+
         foreach($line->get_frames() as $frame) {
           // Block frames are not aligned by text-align
           if ($frame instanceof Block_Frame_Decorator) continue;
-          
+
           $frame->set_position( $frame->get_position("x") + $dx );
         }
       }
@@ -429,30 +429,30 @@ class Block_Frame_Reflower extends Frame_Reflower {
       // We justify all lines except the last one
       $lines = $this->_frame->get_line_boxes(); // needs to be a variable (strict standards)
       $lines = array_splice($lines, 0, -1);
-      
+
       foreach($lines as $i => $line) {
         if ( $line->br ) {
           unset($lines[$i]);
         }
       }
-      
+
       // One space character's width. Will be used to get a more accurate spacing
       $space_width = Font_Metrics::get_text_width(" ", $style->font_family, $style->font_size);
-      
+
       foreach ($lines as $i => $line) {
         if ( $line->left ) {
           foreach($line->get_frames() as $frame) {
             if ( !$frame instanceof Text_Frame_Decorator )
               continue;
-  
+
             $frame->set_position( $frame->get_position("x") + $line->left );
           }
         }
-          
+
         // Only set the spacing if the line is long enough.  This is really
         // just an aesthetic choice ;)
         //if ( $line["left"] + $line["w"] + $line["right"] > self::MIN_JUSTIFY_WIDTH * $width ) {
-          
+
           // Set the spacing for each child
           if ( $line->wc > 1 )
             $spacing = ($width - ($line->left + $line->w + $line->right) + $space_width) / ($line->wc - 1);
@@ -463,16 +463,16 @@ class Block_Frame_Reflower extends Frame_Reflower {
           foreach($line->get_frames() as $frame) {
             if ( !$frame instanceof Text_Frame_Decorator )
               continue;
-              
+
             $text = $frame->get_text();
             $spaces = mb_substr_count($text, " ");
-            
-            $char_spacing = $style->length_in_pt($style->letter_spacing);
+
+            $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
             $_spacing = $spacing + $char_spacing;
-            
+
             $frame->set_position( $frame->get_position("x") + $dx );
             $frame->set_text_spacing($_spacing);
-            
+
             $dx += $spaces * $_spacing;
           }
 
@@ -488,30 +488,30 @@ class Block_Frame_Reflower extends Frame_Reflower {
       foreach ($this->_frame->get_line_boxes() as $line) {
         // Centre each line by moving each frame in the line by:
         $dx = ($width + $line->left - $line->w - $line->right ) / 2;
-        
+
         foreach ($line->get_frames() as $frame) {
           // Block frames are not aligned by text-align
           if ($frame instanceof Block_Frame_Decorator) continue;
-          
+
           $frame->set_position( $frame->get_position("x") + $dx );
         }
       }
       break;
     }
   }
-  
+
   /**
    * Align inline children vertically.
    * Aligns each child vertically after each line is reflowed
    */
   function vertical_align() {
-    
+
     $canvas = null;
-    
+
     foreach ( $this->_frame->get_line_boxes() as $line ) {
 
       $height = $line->h;
-    
+
       foreach ( $line->get_frames() as $frame ) {
         $style = $frame->get_style();
 
@@ -521,64 +521,64 @@ class Block_Frame_Reflower extends Frame_Reflower {
         // FIXME?
         if ( $this instanceof Table_Cell_Frame_Reflower )
           $align = $frame->get_frame()->get_style()->vertical_align;
-        else 
+        else
           $align = $frame->get_frame()->get_parent()->get_style()->vertical_align;
-          
+
         $frame_h = $frame->get_margin_height();
-        
+
         if ( !isset($canvas) ) {
           $canvas = $frame->get_root()->get_dompdf()->get_canvas();
         }
-        
+
         $baseline = $canvas->get_font_baseline($style->font_family, $style->font_size);
         $y_offset = 0;
-        
+
         switch ($align) {
           case "baseline":
             $y_offset = $height*0.8 - $baseline; // The 0.8 ratio is arbitrary until we find it's meaning
             break;
-    
+
           case "middle":
             $y_offset = ($height*0.8 - $baseline) / 2;
             break;
-    
+
           case "sub":
             $y_offset = 0.3 * $height;
             break;
-    
+
           case "super":
             $y_offset = -0.2 * $height;
             break;
-    
+
           case "text-top":
           case "top": // Not strictly accurate, but good enough for now
             break;
-    
+
           case "text-bottom":
           case "bottom":
             $y_offset = $height*0.8 - $baseline;
             break;
         }
-         
+
         if ( $y_offset ) {
           $frame->move(0, $y_offset);
         }
       }
     }
   }
-  
+
   function process_clear(Frame $child){
     if ( !DOMPDF_ENABLE_CSS_FLOAT ) {
       return;
     }
-    
+
     $child_style = $child->get_style();
     $root = $this->_frame->get_root();
-    
+
     // Handle "clear"
     if ( $child_style->clear !== "none" ) {
       $lowest_y = $root->get_lowest_float_offset($child);
-      
+
       // If a float is still applying, we handle it
       if ( $lowest_y ) {
         if ( $child->is_in_flow() ) {
@@ -587,43 +587,43 @@ class Block_Frame_Reflower extends Frame_Reflower {
           $line_box->left = 0;
           $line_box->right = 0;
         }
-        
+
         $child->move(0, $lowest_y - $child->get_position("y"));
       }
     }
   }
-  
+
   function process_float(Frame $child, $cb_x, $cb_w){
     if ( !DOMPDF_ENABLE_CSS_FLOAT ) {
       return;
     }
-    
+
     $child_style = $child->get_style();
     $root = $this->_frame->get_root();
-    
+
     // Handle "float"
     if ( $child_style->float !== "none" ) {
       $root->add_floating_frame($child);
-      
+
       // Remove next frame's beginning whitespace
       $next = $child->get_next_sibling();
       if ( $next && $next instanceof Text_Frame_Decorator) {
         $next->set_text(ltrim($next->get_text()));
       }
-      
+
       $line_box = $this->_frame->get_current_line_box();
       list($old_x, $old_y) = $child->get_position();
-      
+
       $float_x = $cb_x;
       $float_y = $old_y;
       $float_w = $child->get_margin_width();
-      
+
       if ( $child_style->clear === "none" ) {
         switch( $child_style->float ) {
-          case "left": 
+          case "left":
             $float_x += $line_box->left;
             break;
-          case "right": 
+          case "right":
             $float_x += ($cb_w - $line_box->right - $float_w);
             break;
         }
@@ -633,13 +633,13 @@ class Block_Frame_Reflower extends Frame_Reflower {
           $float_x += ($cb_w - $float_w);
         }
       }
-      
+
       $line_box->get_float_offsets();
-      
+
       if ( $child->_float_next_line ) {
         $float_y += $line_box->h;
       }
-      
+
       $child->set_position($float_x, $float_y);
       $child->move($float_x - $old_x, $float_y - $old_y, true);
     }
@@ -654,7 +654,7 @@ class Block_Frame_Reflower extends Frame_Reflower {
     // Bail if the page is full
     if ( $page->is_full() )
       return;
-      
+
     // Generated content
     $this->_set_content();
 
@@ -663,11 +663,11 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
     $style = $this->_frame->get_style();
     $cb = $this->_frame->get_containing_block();
-    
+
     if ( $style->position === "fixed" ) {
       $cb = $this->_frame->get_root()->get_containing_block();
     }
-    
+
     // Determine the constraints imposed by this frame: calculate the width
     // of the content area:
     list($w, $left_margin, $right_margin, $left, $right) = $this->_calculate_restricted_width();
@@ -678,25 +678,25 @@ class Block_Frame_Reflower extends Frame_Reflower {
     $style->margin_right = $right_margin."pt";
     $style->left = $left ."pt";
     $style->right = $right . "pt";
-    
+
     // Update the position
     $this->_frame->position();
     list($x, $y) = $this->_frame->get_position();
 
     // Adjust the first line based on the text-indent property
-    $indent = $style->length_in_pt($style->text_indent, $cb["w"]);
+    $indent = (float)$style->length_in_pt($style->text_indent, $cb["w"]);
     $this->_frame->increase_line_width($indent);
 
     // Determine the content edge
-    $top = $style->length_in_pt(array($style->margin_top,
+    $top = (float)$style->length_in_pt(array($style->margin_top,
                                       $style->padding_top,
                                       $style->border_top_width), $cb["h"]);
 
-    $bottom = $style->length_in_pt(array($style->border_bottom_width,
+    $bottom = (float)$style->length_in_pt(array($style->border_bottom_width,
                                          $style->margin_bottom,
                                          $style->padding_bottom), $cb["h"]);
 
-    $cb_x = $x + $left_margin + $style->length_in_pt(array($style->border_left_width, 
+    $cb_x = $x + (float)$left_margin + (float)$style->length_in_pt(array($style->border_left_width,
                                                            $style->padding_left), $cb["w"]);
 
     $cb_y = $y + $top;
@@ -705,26 +705,26 @@ class Block_Frame_Reflower extends Frame_Reflower {
 
     // Set the y position of the first line in this block
     $this->_frame->set_current_line($cb_y);
-        
+
     $this->_frame->get_current_line_box()->get_float_offsets();
-    
+
     // Set the containing blocks and reflow each child
     foreach ( $this->_frame->get_children() as $child ) {
-      
+
       // Bail out if the page is full
       if ( $page->is_full() )
         break;
-      
+
       $child->set_containing_block($cb_x, $cb_y, $w, $cb_h);
-      
+
       $this->process_clear($child);
-      
+
       $child->reflow($this->_frame);
-      
+
       // Don't add the child to the line if a page break has occurred
       if ( $page->check_page_break($child) )
         break;
-      
+
       $this->process_float($child, $cb_x, $w);
     }
 
@@ -735,9 +735,9 @@ class Block_Frame_Reflower extends Frame_Reflower {
     $style->margin_bottom = $margin_bottom;
     $style->top = $top;
     $style->bottom = $bottom;
-    
+
     $needs_reposition = ($style->position === "absolute" && ($style->right !== "auto" || $style->bottom !== "auto"));
-    
+
     // Absolute positioning measurement
     if ( $needs_reposition ) {
       $orig_style = $this->_frame->get_original_style();
@@ -748,14 +748,14 @@ class Block_Frame_Reflower extends Frame_Reflower {
         }
         $style->width = $width;
       }
-      
+
       $style->left = $orig_style->left;
       $style->right = $orig_style->right;
     }
 
     $this->_text_align();
     $this->vertical_align();
-    
+
     // Absolute positioning
     if ( $needs_reposition ) {
       list($x, $y) = $this->_frame->get_position();
@@ -763,10 +763,10 @@ class Block_Frame_Reflower extends Frame_Reflower {
       list($new_x, $new_y) = $this->_frame->get_position();
       $this->_frame->move($new_x-$x, $new_y-$y, true);
     }
-    
+
     if ( $block && $this->_frame->is_in_flow() ) {
       $block->add_frame_to_line($this->_frame);
-      
+
       // May be inline-block
       if ( $style->display === "block" ) {
         $block->add_line();

--- a/core/third_party_libs/dompdf/include/frame.cls.php
+++ b/core/third_party_libs/dompdf/include/frame.cls.php
@@ -20,7 +20,7 @@
  * @package dompdf
  */
 class Frame {
-  
+
   /**
    * The DOMNode object this frame represents
    *
@@ -40,7 +40,7 @@ class Frame {
    * Unique id counter
    */
   static /*protected*/ $ID_COUNTER = 0;
-  
+
   /**
    * This frame's calculated style
    *
@@ -55,14 +55,14 @@ class Frame {
    * @var Style
    */
   protected $_original_style;
-  
+
   /**
    * This frame's parent in the document tree.
    *
    * @var Frame
    */
   protected $_parent;
-  
+
   /**
    * This frame's children
    *
@@ -98,7 +98,7 @@ class Frame {
    * @var Frame
    */
   protected $_next_sibling;
-  
+
   /**
    * This frame's containing block (used in layout): array(x, y, w, h)
    *
@@ -113,7 +113,7 @@ class Frame {
    * @var array
    */
   protected $_position;
-  
+
   /**
    * Absolute opacity of this frame
    *
@@ -127,28 +127,28 @@ class Frame {
    * @var Frame_Decorator
    */
   protected $_decorator;
-  
+
   /**
    * This frame's containing line box
    * @var Line_Box
    */
   protected $_containing_line;
-  
+
   protected $_is_cache = array();
-  
+
   /**
    * Tells wether the frame was already pushed to the next page
    * @var bool
    */
   public $_already_pushed = false;
-  
+
   public $_float_next_line = false;
-  
+
   static $_ws_state = self::WS_SPACE;
-  
+
   const WS_TEXT = 1;
   const WS_SPACE = 2;
-  
+
   /**
    * Class destructor
    */
@@ -163,32 +163,32 @@ class Frame {
    */
   function __construct(DOMNode $node) {
     $this->_node = $node;
-      
+
     $this->_parent = null;
     $this->_first_child = null;
     $this->_last_child = null;
     $this->_prev_sibling = $this->_next_sibling = null;
-    
+
     $this->_style = null;
     $this->_original_style = null;
-    
+
     $this->_containing_block = array(
       "x" => null,
       "y" => null,
       "w" => null,
       "h" => null,
     );
-    
+
     $this->_containing_block[0] =& $this->_containing_block["x"];
     $this->_containing_block[1] =& $this->_containing_block["y"];
     $this->_containing_block[2] =& $this->_containing_block["w"];
     $this->_containing_block[3] =& $this->_containing_block["h"];
-    
+
     $this->_position = array(
       "x" => null,
       "y" => null,
     );
-    
+
     $this->_position[0] =& $this->_position["x"];
     $this->_position[1] =& $this->_position["y"];
 
@@ -197,28 +197,28 @@ class Frame {
 
     $this->set_id( self::$ID_COUNTER++ );
   }
-  
+
   // WIP : preprocessing to remove all the unused whitespace
   protected function ws_trim(){
     if ( $this->ws_keep() ) return;
-    
+
     switch(self::$_ws_state) {
-      case self::WS_SPACE: 
+      case self::WS_SPACE:
         $node = $this->_node;
-        
+
         if ( $node->nodeName === "#text" ) {
           $node->data = preg_replace("/[ \t\r\n\f]+/u", " ", $text);
-          
+
           // starts with a whitespace
           if ( isset($node->data[0]) && $node->data[0] === " " ) {
             $node->data = ltrim($node->data);
           }
-          
+
           // if not empty
           if ( $node->data !== "" ) {
             // change the current state (text)
             self::$_ws_state = self::WS_TEXT;
-          
+
             // ends with a whitespace
             if ( preg_match("/[ \t\r\n\f]+$/u", $node->data) ) {
               $node->data = ltrim($node->data);
@@ -226,31 +226,31 @@ class Frame {
           }
         }
       break;
-      
+
       case self::WS_TEXT:
     }
   }
-  
+
   protected function ws_keep(){
     $whitespace = $this->get_style()->white_space;
     return in_array($whitespace, array("pre", "pre-wrap", "pre-line"));
   }
-  
+
   protected function ws_is_text(){
     $node = $this->get_node();
-    
+
     if ($node->nodeName === "img") {
       return true;
     }
-    
+
     if ( !$this->is_in_flow() ) {
       return false;
     }
-    
+
     if ($this->is_text_node()) {
       return trim($node->nodeValue) !== "";
     }
-    
+
     return true;
   }
 
@@ -268,7 +268,7 @@ class Frame {
 
     // Remove this frame from the tree
     if ( $this->_prev_sibling ) {
-      $this->_prev_sibling->_next_sibling = $this->_next_sibling;      
+      $this->_prev_sibling->_next_sibling = $this->_next_sibling;
     }
 
     if ( $this->_next_sibling ) {
@@ -290,18 +290,18 @@ class Frame {
     $this->_style->dispose();
     $this->_style = null;
     unset($this->_style);
-    
+
     $this->_original_style->dispose();
     $this->_original_style = null;
     unset($this->_original_style);
-    
+
   }
 
   // Re-initialize the frame
   function reset() {
     $this->_position["x"] = null;
     $this->_position["y"] = null;
-    
+
     $this->_containing_block["x"] = null;
     $this->_containing_block["y"] = null;
     $this->_containing_block["w"] = null;
@@ -311,7 +311,7 @@ class Frame {
     unset($this->_style);
     $this->_style = clone $this->_original_style;
   }
-  
+
   //........................................................................
 
   // Accessor methods
@@ -319,82 +319,82 @@ class Frame {
    * @return DOMNode
    */
   function get_node() { return $this->_node; }
-  
+
   /**
    * @return string
    */
   function get_id() { return $this->_id; }
-  
+
   /**
    * @return Style
    */
   function get_style() { return $this->_style; }
-  
+
   /**
    * @return Style
    */
   function get_original_style() { return $this->_original_style; }
-  
+
   /**
    * @return Frame
    */
   function get_parent() { return $this->_parent; }
-  
+
   /**
    * @return Frame_Decorator
    */
   function get_decorator() { return $this->_decorator; }
-  
+
   /**
    * @return Frame
    */
   function get_first_child() { return $this->_first_child; }
-  
+
   /**
    * @return Frame
    */
   function get_last_child() { return $this->_last_child; }
-  
+
   /**
    * @return Frame
    */
   function get_prev_sibling() { return $this->_prev_sibling; }
-  
+
   /**
    * @return Frame
    */
   function get_next_sibling() { return $this->_next_sibling; }
-  
+
   /**
    * @return FrameList
    */
-  function get_children() { 
+  function get_children() {
     if ( isset($this->_frame_list) ) {
       return $this->_frame_list;
     }
-    
+
     $this->_frame_list = new FrameList($this);
-    return $this->_frame_list; 
+    return $this->_frame_list;
   }
-  
+
   // Layout property accessors
-  
-  /** 
+
+  /**
    * Containing block dimensions
-   * 
+   *
    * @param $i string The key of the wanted containing block's dimension (x, y, x, h)
    * @return array|float
    */
   function get_containing_block($i = null) {
     if ( isset($i) ) {
-      return $this->_containing_block[$i];  
-    }  
+      return $this->_containing_block[$i];
+    }
     return $this->_containing_block;
   }
-  
+
   /**
    * Block position
-   * 
+   *
    * @param $i string The key of the wanted position value (x, y)
    * @return array|float
    */
@@ -404,19 +404,19 @@ class Frame {
     }
     return $this->_position;
   }
-    
+
   //........................................................................
 
   /**
    * Return the height of the margin box of the frame, in pt.  Meaningless
    * unless the height has been calculated properly.
-   * 
+   *
    * @return float
    */
   function get_margin_height() {
     $style = $this->_style;
-    
-    return $style->length_in_pt(array(
+
+    return (float)$style->length_in_pt(array(
       $style->height,
       $style->margin_top,
       $style->margin_bottom,
@@ -430,12 +430,12 @@ class Frame {
   /**
    * Return the width of the margin box of the frame, in pt.  Meaningless
    * unless the width has been calculated properly.
-   * 
+   *
    * @return float
-   */ 
+   */
   function get_margin_width() {
     $style = $this->_style;
-    
+
     return $style->length_in_pt(array(
       $style->width,
       $style->margin_left,
@@ -446,10 +446,10 @@ class Frame {
       $style->padding_right
     ), $this->_containing_block["w"]);
   }
-  
+
   function get_break_margins(){
     $style = $this->_style;
-    
+
     return $style->length_in_pt(array(
       //$style->height,
       $style->margin_top,
@@ -463,23 +463,23 @@ class Frame {
 
   /**
    * Return the padding box (x,y,w,h) of the frame
-   * 
+   *
    * @return array
    */
   function get_padding_box() {
     $style = $this->_style;
     $cb = $this->_containing_block;
-    
+
     $x = $this->_position["x"] +
       $style->length_in_pt(array($style->margin_left,
                                  $style->border_left_width),
                            $cb["w"]);
-                           
+
     $y = $this->_position["y"] +
       $style->length_in_pt(array($style->margin_top,
                                  $style->border_top_width),
                            $cb["h"]);
-    
+
     $w = $style->length_in_pt(array($style->padding_left,
                                     $style->width,
                                     $style->padding_right),
@@ -496,17 +496,17 @@ class Frame {
                  3 => $h, "h" => $h);
   }
 
-  /** 
+  /**
    * Return the border box of the frame
-   * 
+   *
    * @return array
    */
   function get_border_box() {
     $style = $this->_style;
     $cb = $this->_containing_block;
-    
+
     $x = $this->_position["x"] + $style->length_in_pt($style->margin_left, $cb["w"]);
-                          
+
     $y = $this->_position["y"] + $style->length_in_pt($style->margin_top,  $cb["h"]);
 
     $w = $style->length_in_pt(array($style->border_left_width,
@@ -528,21 +528,21 @@ class Frame {
                  2 => $w, "w" => $w,
                  3 => $h, "h" => $h);
   }
-  
+
   function get_opacity($opacity = null) {
     if ( $opacity !== null ) {
       $this->set_opacity($opacity);
     }
     return $this->_opacity;
   }
-  
+
   /**
    * @return Line_Box
    */
   function &get_containing_line() {
     return $this->_containing_line;
   }
-  
+
   //........................................................................
 
   // Set methods
@@ -559,34 +559,34 @@ class Frame {
   function set_style(Style $style) {
     if ( is_null($this->_style) )
       $this->_original_style = clone $style;
-    
+
     //$style->set_frame($this);
     $this->_style = $style;
   }
-  
+
   function set_decorator(Frame_Decorator $decorator) {
     $this->_decorator = $decorator;
   }
-  
+
   function set_containing_block($x = null, $y = null, $w = null, $h = null) {
     if ( is_array($x) ){
       foreach($x as $key => $val){
         $$key = $val;
       }
     }
-    
+
     if (is_numeric($x)) {
       $this->_containing_block["x"] = $x;
     }
-    
+
     if (is_numeric($y)) {
       $this->_containing_block["y"] = $y;
     }
-    
+
     if (is_numeric($w)) {
       $this->_containing_block["w"] = $w;
     }
-    
+
     if (is_numeric($h)) {
       $this->_containing_block["h"] = $h;
     }
@@ -595,7 +595,7 @@ class Frame {
   function set_position($x = null, $y = null) {
     if ( is_array($x) )
       extract($x);
-    
+
     if ( is_numeric($x) ) {
       $this->_position["x"] = $x;
     }
@@ -604,105 +604,105 @@ class Frame {
       $this->_position["y"] = $y;
     }
   }
-  
+
   function set_opacity($opacity) {
     $parent = $this->get_parent();
     $base_opacity = (($parent && $parent->_opacity !== null) ? $parent->_opacity : 1.0);
     $this->_opacity = $base_opacity * $opacity;
   }
-  
+
   function set_containing_line(Line_Box $line) {
     $this->_containing_line = $line;
   }
 
   //........................................................................
-  
+
   /**
    * Tells if the frame is a text node
-   * @return bool 
+   * @return bool
    */
   function is_text_node() {
     if ( isset($this->_is_cache["text_node"]) ) {
       return $this->_is_cache["text_node"];
     }
-    
+
     return $this->_is_cache["text_node"] = ($this->get_node()->nodeName === "#text");
   }
-  
+
   function is_positionned() {
     if ( isset($this->_is_cache["positionned"]) ) {
       return $this->_is_cache["positionned"];
     }
-    
+
     $position = $this->get_style()->position;
-    
+
     return $this->_is_cache["positionned"] = in_array($position, Style::$POSITIONNED_TYPES);
   }
-  
+
   function is_absolute() {
     if ( isset($this->_is_cache["absolute"]) ) {
       return $this->_is_cache["absolute"];
     }
-    
+
     $position = $this->get_style()->position;
-   
+
     return $this->_is_cache["absolute"] = ($position === "absolute" || $position === "fixed");
   }
-  
+
   function is_block() {
     if ( isset($this->_is_cache["block"]) ) {
       return $this->_is_cache["block"];
     }
-    
+
     return $this->_is_cache["block"] = in_array($this->get_style()->display, Style::$BLOCK_TYPES);
   }
-  
+
   function is_in_flow() {
     if ( isset($this->_is_cache["in_flow"]) ) {
       return $this->_is_cache["in_flow"];
     }
-    
+
     return $this->_is_cache["in_flow"] = !(DOMPDF_ENABLE_CSS_FLOAT && $this->get_style()->float !== "none" || $this->is_absolute());
   }
-  
+
   function is_pre(){
     if ( isset($this->_is_cache["pre"]) ) {
       return $this->_is_cache["pre"];
     }
-    
+
     $white_space = $this->get_style()->white_space;
-   
+
     return $this->_is_cache["pre"] = in_array($white_space, array("pre", "pre-wrap"));
   }
-  
+
   function is_table(){
     if ( isset($this->_is_cache["table"]) ) {
       return $this->_is_cache["table"];
     }
-    
+
     $display = $this->get_style()->display;
-   
+
     return $this->_is_cache["table"] = in_array($display, Style::$TABLE_TYPES);
   }
-  
-  
+
+
   /**
    * Inserts a new child at the beginning of the Frame
-   * 
+   *
    * @param $child Frame The new Frame to insert
    * @param $update_node boolean Whether or not to update the DOM
-   */ 
+   */
   function prepend_child(Frame $child, $update_node = true) {
-    if ( $update_node ) 
+    if ( $update_node )
       $this->_node->insertBefore($child->_node, $this->_first_child ? $this->_first_child->_node : null);
 
     // Remove the child from its parent
     if ( $child->_parent )
       $child->_parent->remove_child($child, false);
-    
+
     $child->_parent = $this;
     $child->_prev_sibling = null;
-    
+
     // Handle the first child
     if ( !$this->_first_child ) {
       $this->_first_child = $child;
@@ -710,19 +710,19 @@ class Frame {
       $child->_next_sibling = null;
     } else {
       $this->_first_child->_prev_sibling = $child;
-      $child->_next_sibling = $this->_first_child;      
+      $child->_next_sibling = $this->_first_child;
       $this->_first_child = $child;
     }
   }
-    
+
   /**
    * Inserts a new child at the end of the Frame
-   * 
+   *
    * @param $child Frame The new Frame to insert
    * @param $update_node boolean Whether or not to update the DOM
-   */ 
+   */
   function append_child(Frame $child, $update_node = true) {
-    if ( $update_node ) 
+    if ( $update_node )
       $this->_node->appendChild($child->_node);
 
     // Remove the child from its parent
@@ -731,7 +731,7 @@ class Frame {
 
     $child->_parent = $this;
     $child->_next_sibling = null;
-    
+
     // Handle the first child
     if ( !$this->_last_child ) {
       $this->_first_child = $child;
@@ -742,15 +742,15 @@ class Frame {
       $child->_prev_sibling = $this->_last_child;
       $this->_last_child = $child;
     }
-  }  
-  
+  }
+
   /**
    * Inserts a new child immediately before the specified frame
-   * 
+   *
    * @param $new_child Frame The new Frame to insert
    * @param $ref Frame The Frame after the new Frame
    * @param $update_node boolean Whether or not to update the DOM
-   */ 
+   */
   function insert_child_before(Frame $new_child, Frame $ref, $update_node = true) {
     if ( $ref === $this->_first_child ) {
       $this->prepend_child($new_child, $update_node);
@@ -761,35 +761,35 @@ class Frame {
       $this->append_child($new_child, $update_node);
       return;
     }
-    
+
     if ( $ref->_parent !== $this )
       throw new DOMPDF_Exception("Reference child is not a child of this node.");
 
-    // Update the node    
+    // Update the node
     if ( $update_node )
       $this->_node->insertBefore($new_child->_node, $ref->_node);
 
     // Remove the child from its parent
     if ( $new_child->_parent )
       $new_child->_parent->remove_child($new_child, false);
-    
+
     $new_child->_parent = $this;
     $new_child->_next_sibling = $ref;
     $new_child->_prev_sibling = $ref->_prev_sibling;
 
     if ( $ref->_prev_sibling )
       $ref->_prev_sibling->_next_sibling = $new_child;
-    
+
     $ref->_prev_sibling = $new_child;
   }
-  
+
   /**
    * Inserts a new child immediately after the specified frame
-   * 
+   *
    * @param $new_child Frame The new Frame to insert
    * @param $ref Frame The Frame before the new Frame
    * @param $update_node boolean Whether or not to update the DOM
-   */ 
+   */
   function insert_child_after(Frame $new_child, Frame $ref, $update_node = true) {
     if ( $ref === $this->_last_child ) {
       $this->append_child($new_child, $update_node);
@@ -800,7 +800,7 @@ class Frame {
       $this->prepend_child($new_child, $update_node);
       return;
     }
-    
+
     if ( $ref->_parent !== $this )
       throw new DOMPDF_Exception("Reference child is not a child of this node.");
 
@@ -813,25 +813,25 @@ class Frame {
         $new_child->_node = $this->_node->appendChild($new_child);
       }
     }
-    
+
     // Remove the child from its parent
     if ( $new_child->_parent)
       $new_child->_parent->remove_child($new_child, false);
-    
+
     $new_child->_parent = $this;
     $new_child->_prev_sibling = $ref;
     $new_child->_next_sibling = $ref->_next_sibling;
 
-    if ( $ref->_next_sibling ) 
+    if ( $ref->_next_sibling )
       $ref->_next_sibling->_prev_sibling = $new_child;
 
     $ref->_next_sibling = $new_child;
   }
 
 
-  /** 
+  /**
    * Remove a child frame
-   * 
+   *
    * @param $child Frame
    * @param $update_node boolean Whether or not to remove the DOM node
    * @return Frame The removed child frame
@@ -842,7 +842,7 @@ class Frame {
 
     if ( $update_node )
       $this->_node->removeChild($child->_node);
-    
+
     if ( $child === $this->_first_child )
       $this->_first_child = $child->_next_sibling;
 
@@ -853,7 +853,7 @@ class Frame {
       $child->_prev_sibling->_next_sibling = $child->_next_sibling;
 
     if ( $child->_next_sibling )
-      $child->_next_sibling->_prev_sibling = $child->_prev_sibling;    
+      $child->_next_sibling->_prev_sibling = $child->_prev_sibling;
 
     $child->_next_sibling = null;
     $child->_prev_sibling = null;
@@ -869,13 +869,13 @@ class Frame {
 //     if ( $this->is_text_node() &&
 //          preg_replace("/\s/", "", $this->_node->data) === "" )
 //       return "";
-    
-    
+
+
     $str = "<b>" . $this->_node->nodeName . ":</b><br/>";
     //$str .= spl_object_hash($this->_node) . "<br/>";
     $str .= "Id: " .$this->get_id() . "<br/>";
     $str .= "Class: " .get_class($this) . "<br/>";
-    
+
     if ( $this->is_text_node() ) {
       $tmp = htmlspecialchars($this->_node->nodeValue);
       $str .= "<pre>'" .  mb_substr($tmp,0,70) .
@@ -884,7 +884,7 @@ class Frame {
       $tmp = htmlspecialchars($css_class);
       $str .= "CSS class: '$css_class'<br/>";
     }
-    
+
     if ( $this->_parent )
       $str .= "\nParent:" . $this->_parent->_node->nodeName .
         " (" . spl_object_hash($this->_parent->_node) . ") " .
@@ -910,7 +910,7 @@ class Frame {
     $str .= "\nContaining block: " . pre_r($this->_containing_block, true);
     $str .= "\nMargin width: " . pre_r($this->get_margin_width(), true);
     $str .= "\nMargin height: " . pre_r($this->get_margin_height(), true);
-    
+
     $str .= "\nStyle: <pre>". $this->_style->__toString() . "</pre>";
 
     if ( $this->_decorator instanceof Block_Frame_Decorator ) {
@@ -918,13 +918,13 @@ class Frame {
       foreach ($this->_decorator->get_line_boxes() as $line) {
         foreach ($line->get_frames() as $frame) {
           if ($frame instanceof Text_Frame_Decorator) {
-            $str .= "\ntext: ";          
+            $str .= "\ntext: ";
             $str .= "'". htmlspecialchars($frame->get_text()) ."'";
           } else {
             $str .= "\nBlock: " . $frame->get_node()->nodeName . " (" . spl_object_hash($frame->get_node()) . ")";
           }
         }
-        
+
         $str .=
           "\ny => " . $line->y . "\n" .
           "w => " . $line->w . "\n" .
@@ -939,7 +939,7 @@ class Frame {
       $str = strip_tags(str_replace(array("<br/>","<b>","</b>"),
                                     array("\n","",""),
                                     $str));
-    
+
     return $str;
   }
 }
@@ -958,7 +958,7 @@ class FrameList implements IteratorAggregate {
   function __construct($frame) { $this->_frame = $frame; }
   function getIterator() { return new FrameListIterator($this->_frame); }
 }
-  
+
 /**
  * Linked-list Iterator
  *
@@ -974,12 +974,12 @@ class FrameListIterator implements Iterator {
    * @var Frame
    */
   protected $_parent;
-  
+
   /**
    * @var Frame
    */
   protected $_cur;
-  
+
   /**
    * @var int
    */
@@ -991,7 +991,7 @@ class FrameListIterator implements Iterator {
     $this->_num = 0;
   }
 
-  function rewind() { 
+  function rewind() {
     $this->_cur = $this->_parent->get_first_child();
     $this->_num = 0;
   }
@@ -1002,9 +1002,9 @@ class FrameListIterator implements Iterator {
   function valid() {
     return isset($this->_cur);// && ($this->_cur->get_prev_sibling() === $this->_prev);
   }
-  
+
   function key() { return $this->_num; }
-  
+
   /**
    * @return Frame
    */
@@ -1018,7 +1018,7 @@ class FrameListIterator implements Iterator {
     $ret = $this->_cur;
     if ( !$ret )
       return null;
-    
+
     $this->_cur = $this->_cur->get_next_sibling();
     $this->_num++;
     return $ret;
@@ -1038,9 +1038,9 @@ class FrameTreeList implements IteratorAggregate {
    * @var Frame
    */
   protected $_root;
-  
+
   function __construct(Frame $root) { $this->_root = $root; }
-  
+
   /**
    * @return FrameTreeIterator
    */
@@ -1061,12 +1061,12 @@ class FrameTreeIterator implements Iterator {
    */
   protected $_root;
   protected $_stack = array();
-  
+
   /**
    * @var int
    */
   protected $_num;
-  
+
   function __construct(Frame $root) {
     $this->_stack[] = $this->_root = $root;
     $this->_num = 0;
@@ -1076,17 +1076,17 @@ class FrameTreeIterator implements Iterator {
     $this->_stack = array($this->_root);
     $this->_num = 0;
   }
-  
+
   /**
    * @return bool
    */
   function valid() { return count($this->_stack) > 0; }
-  
+
   /**
    * @return int
    */
   function key() { return $this->_num; }
-  
+
   /**
    * @var Frame
    */
@@ -1097,11 +1097,11 @@ class FrameTreeIterator implements Iterator {
    */
   function next() {
     $b = end($this->_stack);
-    
+
     // Pop last element
     unset($this->_stack[ key($this->_stack) ]);
     $this->_num++;
-    
+
     // Push all children onto the stack in reverse order
     if ( $c = $b->get_last_child() ) {
       $this->_stack[] = $c;

--- a/core/third_party_libs/dompdf/include/inline_renderer.cls.php
+++ b/core/third_party_libs/dompdf/include/inline_renderer.cls.php
@@ -14,7 +14,7 @@
  * @package dompdf
  */
 class Inline_Renderer extends Abstract_Renderer {
-  
+
   //........................................................................
 
   function render(Frame $frame) {
@@ -22,13 +22,13 @@ class Inline_Renderer extends Abstract_Renderer {
 
     if ( !$frame->get_first_child() )
       return; // No children, no service
-    
+
     // Draw the left border if applicable
     $bp = $style->get_border_properties();
-    $widths = array($style->length_in_pt($bp["top"]["width"]),
-                    $style->length_in_pt($bp["right"]["width"]),
-                    $style->length_in_pt($bp["bottom"]["width"]),
-                    $style->length_in_pt($bp["left"]["width"]));
+    $widths = array((float)$style->length_in_pt($bp["top"]["width"]),
+                    (float)$style->length_in_pt($bp["right"]["width"]),
+                    (float)$style->length_in_pt($bp["bottom"]["width"]),
+                    (float)$style->length_in_pt($bp["left"]["width"]));
 
     // Draw the background & border behind each child.  To do this we need
     // to figure out just how much space each child takes:
@@ -37,14 +37,14 @@ class Inline_Renderer extends Abstract_Renderer {
     $h = 0;
 //     $x += $widths[3];
 //     $y += $widths[0];
-    
+
     $this->_set_opacity( $frame->get_opacity( $style->opacity ) );
-    
+
     $first_row = true;
 
     foreach ($frame->get_children() as $child) {
       list($child_x, $child_y, $child_w, $child_h) = $child->get_padding_box();
-      
+
       if ( !is_null($w) && $child_x < $x + $w ) {
         //This branch seems to be supposed to being called on the first part
         //of an inline html element, and the part after the if clause for the
@@ -67,7 +67,7 @@ class Inline_Renderer extends Abstract_Renderer {
         if ( $first_row ) {
 
           if ( $bp["left"]["style"] !== "none" && $bp["left"]["color"] !== "transparent" && $bp["left"]["width"] > 0 ) {
-            $method = "_border_" . $bp["left"]["style"];            
+            $method = "_border_" . $bp["left"]["style"];
             $this->$method($x, $y, $h + $widths[0] + $widths[2], $bp["left"]["color"], $widths, "left");
           }
           $first_row = false;
@@ -78,7 +78,7 @@ class Inline_Renderer extends Abstract_Renderer {
           $method = "_border_" . $bp["top"]["style"];
           $this->$method($x, $y, $w + $widths[1] + $widths[3], $bp["top"]["color"], $widths, "top");
         }
-        
+
         if ( $bp["bottom"]["style"] !== "none" && $bp["bottom"]["color"] !== "transparent" && $bp["bottom"]["width"] > 0 ) {
           $method = "_border_" . $bp["bottom"]["style"];
           $this->$method($x, $y + $h + $widths[0] + $widths[2], $w + $widths[1] + $widths[3], $bp["bottom"]["color"], $widths, "bottom");
@@ -92,48 +92,48 @@ class Inline_Renderer extends Abstract_Renderer {
         else if ( $frame->get_parent()->get_node()->nodeName === "a" ){
           $link_node = $frame->get_parent()->get_node();
         }
-        
+
         if ( $link_node && $href = $link_node->getAttribute("href") ) {
           $this->_canvas->add_link($href, $x, $y, $w, $h);
         }
 
         $x = $child_x;
         $y = $child_y;
-        $w = $child_w;
-        $h = $child_h;
+        $w = (float)$child_w;
+        $h = (float)$child_h;
         continue;
       }
 
       if ( is_null($w) )
-        $w = $child_w;
+        $w = (float)$child_w;
       else
-        $w += $child_w;
-      
+        $w += (float)$child_w;
+
       $h = max($h, $child_h);
     }
 
-    
+
     // Handle the last child
-    if ( ($bg = $style->background_color) !== "transparent" ) 
+    if ( ($bg = $style->background_color) !== "transparent" )
       $this->_canvas->filled_rectangle( $x + $widths[3], $y + $widths[0], $w, $h, $bg);
 
     //On continuation lines (after line break) of inline elements, the style got copied.
     //But a non repeatable background image should not be repeated on the next line.
     //But removing the background image above has never an effect, and removing it below
     //removes it always, even on the initial line.
-    //Need to handle it elsewhere, e.g. on certain ...clone()... usages.    
+    //Need to handle it elsewhere, e.g. on certain ...clone()... usages.
     // Repeat not given: default is Style::__construct
     // ... && (!($repeat = $style->background_repeat) || $repeat === "repeat" ...
     //different position? $this->_background_image($url, $x, $y, $w, $h, $style);
-    if ( ($url = $style->background_image) && $url !== "none" )           
+    if ( ($url = $style->background_image) && $url !== "none" )
       $this->_background_image($url, $x + $widths[3], $y + $widths[0], $w, $h, $style);
-        
+
     // Add the border widths
-    $w += $widths[1] + $widths[3];
-    $h += $widths[0] + $widths[2];
+    $w += (float)$widths[1] + (float)$widths[3];
+    $h += (float)$widths[0] + (float)$widths[2];
 
     // make sure the border and background start inside the left margin
-    $left_margin = $style->length_in_pt($style->margin_left);
+    $left_margin = (float)$style->length_in_pt($style->margin_left);
     $x += $left_margin;
 
     // If this is the first row, draw the left border too
@@ -141,13 +141,13 @@ class Inline_Renderer extends Abstract_Renderer {
       $method = "_border_" . $bp["left"]["style"];
       $this->$method($x, $y, $h, $bp["left"]["color"], $widths, "left");
     }
-    
+
     // Draw the top & bottom borders
     if ( $bp["top"]["style"] !== "none" && $bp["top"]["color"] !== "transparent" && $widths[0] > 0 ) {
       $method = "_border_" . $bp["top"]["style"];
       $this->$method($x, $y, $w, $bp["top"]["color"], $widths, "top");
     }
-    
+
     if ( $bp["bottom"]["style"] !== "none" && $bp["bottom"]["color"] !== "transparent" && $widths[2] > 0 ) {
       $method = "_border_" . $bp["bottom"]["style"];
       $this->$method($x, $y + $h, $w, $bp["bottom"]["color"], $widths, "bottom");
@@ -165,22 +165,22 @@ class Inline_Renderer extends Abstract_Renderer {
     $link_node = null;
     if ( $frame->get_node()->nodeName === "a" ) {
       $link_node = $frame->get_node();
-      
+
       if ( ($name = $link_node->getAttribute("name")) || ($name = $link_node->getAttribute("id")) ) {
         $this->_canvas->add_named_dest($name);
       }
     }
-    
+
     if ( $frame->get_parent() && $frame->get_parent()->get_node()->nodeName === "a" ){
       $link_node = $frame->get_parent()->get_node();
     }
-    
+
     // Handle anchors & links
     if ( $link_node ) {
       if ( $href = $link_node->getAttribute("href") )
         $this->_canvas->add_link($href, $x, $y, $w, $h);
     }
-    
+
     if (DEBUG_LAYOUT && DEBUG_LAYOUT_INLINE) {
       $this->_debug_layout($child->get_border_box(), "blue");
       if (DEBUG_LAYOUT_PADDINGBOX) {

--- a/core/third_party_libs/dompdf/include/page_frame_decorator.cls.php
+++ b/core/third_party_libs/dompdf/include/page_frame_decorator.cls.php
@@ -42,10 +42,10 @@ class Page_Frame_Decorator extends Frame_Decorator {
    * @var Renderer
    */
   protected $_renderer;
-  
+
   /**
    * This page's floating frames
-   * 
+   *
    * @var array
    */
   protected $_floating_frames = array();
@@ -137,7 +137,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
   function in_nested_table() {
     return $this->_in_table > 1;
   }
-  
+
   /**
    * Check if a forced page break is required before $frame.  This uses the
    * frame's page_break_before property as well as the preceeding frame's
@@ -149,7 +149,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
    * @return bool true if a page break occured
    */
   function check_forced_page_break(Frame $frame) {
-      
+
     // Skip check if page is already split
     if ( $this->_page_full )
       return;
@@ -177,7 +177,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
       // $frame->style to the frame's orignal style.
       $frame->get_style()->page_break_before = "auto";
       $this->_page_full = true;
-      
+
       return true;
     }
 
@@ -188,7 +188,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
       $this->_page_full = true;
       return true;
     }
-    
+
     if( $prev && $prev->get_last_child() && $frame->get_node()->nodeName != "body" ) {
       $prev_last_child = $prev->get_last_child();
       if ( in_array($prev_last_child->get_style()->page_break_after, $page_breaks) ) {
@@ -206,16 +206,16 @@ class Page_Frame_Decorator extends Frame_Decorator {
   /**
    * Determine if a page break is allowed before $frame
    * http://www.w3.org/TR/CSS21/page.html#allowed-page-breaks
-   * 
+   *
    * In the normal flow, page breaks can occur at the following places:
-   * 
+   *
    *    1. In the vertical margin between block boxes. When a page
    *    break occurs here, the used values of the relevant
    *    'margin-top' and 'margin-bottom' properties are set to '0'.
    *    2. Between line boxes inside a block box.
    *
    * These breaks are subject to the following rules:
-   * 
+   *
    *   * Rule A: Breaking at (1) is allowed only if the
    *     'page-break-after' and 'page-break-before' properties of
    *     all the elements generating boxes that meet at this margin
@@ -247,7 +247,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
    * We will also allow breaks between table rows.  However, when
    * splitting a table, the table headers should carry over to the
    * next page (but they don't yet).
-   * 
+   *
    * @param Frame $frame the frame to check
    * @return bool true if a break is allowed, false otherwise
    */
@@ -413,30 +413,30 @@ class Page_Frame_Decorator extends Frame_Decorator {
    * @return Frame the frame following the page break
    */
   function check_page_break(Frame $frame) {
-    // Do not split if we have already or if the frame was already 
+    // Do not split if we have already or if the frame was already
     // pushed to the next page (prevents infinite loops)
     if ( $this->_page_full || $frame->_already_pushed ) {
       return false;
     }
-    
+
     // If the frame is absolute of fixed it shouldn't break
     $p = $frame;
     do {
       if ( $p->is_absolute() )
         return false;
     } while ( $p = $p->get_parent() );
-    
+
     $margin_height = $frame->get_margin_height();
-    
-    // FIXME If the row is taller than the page and 
+
+    // FIXME If the row is taller than the page and
     // if it the first of the page, we don't break
     if ( $frame->get_style()->display === "table-row" &&
-         !$frame->get_prev_sibling() && 
+         !$frame->get_prev_sibling() &&
          $margin_height > $this->get_margin_height() )
       return false;
 
     // Determine the frame's maximum y value
-    $max_y = $frame->get_position("y") + $margin_height;
+    $max_y = (float)$frame->get_position("y") + $margin_height;
 
     // If a split is to occur here, then the bottom margins & paddings of all
     // parents of $frame must fit on the page as well:
@@ -544,7 +544,7 @@ class Page_Frame_Decorator extends Frame_Decorator {
     $this->_page_full = true;
     $frame->_already_pushed = true;
     return true;
-    
+
   }
 
   //........................................................................
@@ -552,21 +552,21 @@ class Page_Frame_Decorator extends Frame_Decorator {
   function split($frame = null, $force_pagebreak = false) {
     // Do nothing
   }
-  
+
   /**
    * Add a floating frame
-   * 
+   *
    * @param $child Frame
    */
   function add_floating_frame(Frame $frame) {
     array_unshift($this->_floating_frames, $frame);
   }
-  
+
   /**
    * @return array
    */
-  function get_floating_frames() { 
-    return $this->_floating_frames; 
+  function get_floating_frames() {
+    return $this->_floating_frames;
   }
 
   public function remove_floating_frame($key) {
@@ -577,19 +577,19 @@ class Page_Frame_Decorator extends Frame_Decorator {
     $style = $child->get_style();
     $side = $style->clear;
     $float = $style->float;
-    
+
     $y = 0;
-    
+
     foreach($this->_floating_frames as $key => $frame) {
       if ( $side === "both" || $frame->get_style()->float === $side ) {
         $y = max($y, $frame->get_position("y") + $frame->get_margin_height());
-        
+
         if ( $float !== "none" ) {
           $this->remove_floating_frame($key);
         }
       }
     }
-    
+
     return $y;
   }
 

--- a/core/third_party_libs/dompdf/include/style.cls.php
+++ b/core/third_party_libs/dompdf/include/style.cls.php
@@ -21,7 +21,7 @@
  * @package dompdf
  */
 class Style {
-  
+
   const CSS_IDENTIFIER = "-?[_a-zA-Z]+[_a-zA-Z0-9-]*";
   const CSS_INTEGER    = "-?\d+";
 
@@ -38,7 +38,7 @@ class Style {
    * @var float
    */
   static $default_line_height = 1.2;
-  
+
   /**
    * Default "absolute" font sizes relative to the default font-size
    * http://www.w3.org/TR/css3-fonts/#font-size-the-font-size-property
@@ -53,7 +53,7 @@ class Style {
     "x-large"  => 1.5,   // 3/2
     "xx-large" => 2.0,   // 2/1
   );
-  
+
   /**
    * List of all inline types.  Should really be a constant.
    *
@@ -67,7 +67,7 @@ class Style {
    * @var array
    */
   static $BLOCK_TYPES = array("block", "inline-block", "table-cell", "list-item");
-  
+
   /**
    * List of all positionned types.  Should really be a constant.
    *
@@ -107,10 +107,10 @@ class Style {
    * @var array
    */
   static protected $_inherited = null;
-  
+
   /**
    * Caches method_exists result
-   * 
+   *
    * @var array<bool>
    */
   static protected $_methods_cache = array();
@@ -139,7 +139,7 @@ class Style {
    * @var array
    */
   protected $_prop_cache;
-  
+
   /**
    * Font size of parent element in document tree.  Used for relative font
    * size resolution.
@@ -147,19 +147,19 @@ class Style {
    * @var float
    */
   protected $_parent_font_size; // Font size of parent element
-  
+
   /**
    * @var Frame
    */
   protected $_frame;
-  
+
   /**
    * The origin of the style
-   * 
+   *
    * @var int
    */
   protected $_origin = Stylesheet::ORIG_AUTHOR;
-  
+
   // private members
   /**
    * True once the font size is resolved absolutely
@@ -167,7 +167,7 @@ class Style {
    * @var bool
    */
   private $__font_size_calculated; // Cache flag
-  
+
   /**
    * Class constructor
    *
@@ -180,12 +180,12 @@ class Style {
     $this->_origin = $origin;
     $this->_parent_font_size = null;
     $this->__font_size_calculated = false;
-    
+
     if ( !isset(self::$_defaults) ) {
-    
+
       // Shorthand
       $d =& self::$_defaults;
-    
+
       // All CSS 2.1 properties, and their default values
       $d["azimuth"] = "center";
       $d["background_attachment"] = "scroll";
@@ -313,7 +313,7 @@ class Style {
       $d["width"] = "auto";
       $d["word_spacing"] = "normal";
       $d["z_index"] = "auto";
-      
+
       // for @font-face
       $d["src"] = "";
       $d["unicode_range"] = "";
@@ -374,30 +374,30 @@ class Style {
   function dispose() {
     clear_object($this);
   }
-  
+
   function set_frame(Frame $frame) {
     $this->_frame = $frame;
   }
-  
+
   function get_frame() {
     return $this->_frame;
   }
-  
+
   function set_origin($origin) {
     $this->_origin = $origin;
   }
-  
+
   function get_origin() {
     return $this->_origin;
   }
-  
+
   /**
    * returns the {@link Stylesheet} this Style is associated with.
    *
    * @return Stylesheet
    */
   function get_stylesheet() { return $this->_stylesheet; }
-  
+
   /**
    * Converts any CSS length value into an absolute length in points.
    *
@@ -414,15 +414,15 @@ class Style {
    */
   function length_in_pt($length, $ref_size = null) {
     static $cache = array();
-    
+
     if ( !is_array($length) )
       $length = array($length);
 
     if ( !isset($ref_size) )
       $ref_size = self::$default_font_size;
-      
+
     $key = implode("@", $length)."/$ref_size";
-    
+
     if ( isset($cache[$key]) ) {
       return $cache[$key];
     }
@@ -432,7 +432,7 @@ class Style {
 
       if ( $l === "auto" )
         return "auto";
-      
+
       if ( $l === "none" )
         return "none";
 
@@ -441,9 +441,9 @@ class Style {
         $ret += $l;
         continue;
       }
-        
+
       if ( $l === "normal" ) {
-        $ret += $ref_size;
+        $ret += (float)$ref_size;
         continue;
       }
 
@@ -452,76 +452,76 @@ class Style {
         $ret += 0.5;
         continue;
       }
-      
+
       if ( $l === "medium" ) {
         $ret += 1.5;
         continue;
       }
-    
+
       if ( $l === "thick" ) {
         $ret += 2.5;
         continue;
       }
 
       if ( ($i = mb_strpos($l, "px"))  !== false ) {
-        $ret += ( mb_substr($l, 0, $i)  * 72 ) / DOMPDF_DPI;
+        $ret += ( (float)mb_substr($l, 0, $i)  * 72 ) / DOMPDF_DPI;
         continue;
       }
-      
+
       if ( ($i = mb_strpos($l, "pt"))  !== false ) {
-        $ret += mb_substr($l, 0, $i);
+        $ret += (float)mb_substr($l, 0, $i);
         continue;
       }
-      
+
       if ( ($i = mb_strpos($l, "%"))  !== false ) {
-        $ret += mb_substr($l, 0, $i)/100 * $ref_size;
+        $ret += (float)mb_substr($l, 0, $i)/100 * (float)$ref_size;
         continue;
       }
 
       if ( ($i = mb_strpos($l, "rem"))  !== false ) {
-        $ret += mb_substr($l, 0, $i) * $this->_stylesheet->get_dompdf()->get_tree()->get_root()->get_style()->font_size;
+        $ret += (float)mb_substr($l, 0, $i) * $this->_stylesheet->get_dompdf()->get_tree()->get_root()->get_style()->font_size;
         continue;
       }
 
       if ( ($i = mb_strpos($l, "em"))  !== false ) {
-        $ret += mb_substr($l, 0, $i) * $this->__get("font_size");
+        $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size");
         continue;
       }
-          
+
       if ( ($i = mb_strpos($l, "cm")) !== false ) {
-        $ret += mb_substr($l, 0, $i) * 72 / 2.54;
+        $ret += (float)mb_substr($l, 0, $i) * 72 / 2.54;
         continue;
       }
 
       if ( ($i = mb_strpos($l, "mm")) !== false ) {
-        $ret += mb_substr($l, 0, $i) * 72 / 25.4;
+        $ret += (float)mb_substr($l, 0, $i) * 72 / 25.4;
         continue;
       }
-      
+
       // FIXME: em:ex ratio?
       if ( ($i = mb_strpos($l, "ex"))  !== false ) {
-        $ret += mb_substr($l, 0, $i) * $this->__get("font_size") / 2;
+        $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size") / 2;
         continue;
       }
-      
+
       if ( ($i = mb_strpos($l, "in")) !== false ) {
-        $ret += mb_substr($l, 0, $i) * 72;
+        $ret += (float)mb_substr($l, 0, $i) * 72;
         continue;
       }
-          
+
       if ( ($i = mb_strpos($l, "pc")) !== false ) {
-        $ret += mb_substr($l, 0, $i) * 12;
+        $ret += (float)mb_substr($l, 0, $i) * 12;
         continue;
       }
-          
+
       // Bogus value
-      $ret += $ref_size;
+      $ret += (float)$ref_size;
     }
 
     return $cache[$key] = $ret;
   }
 
-  
+
   /**
    * Set inherited properties in this style using values in $parent
    *
@@ -531,7 +531,7 @@ class Style {
 
     // Set parent font size
     $this->_parent_font_size = $parent->get_font_size();
-    
+
     foreach (self::$_inherited as $prop) {
       //inherit the !important property also.
       //if local property is also !important, don't inherit.
@@ -548,7 +548,7 @@ class Style {
         $this->_props[$prop] = $parent->_props[$prop];
       }
     }
-      
+
     foreach (array_keys($this->_props) as $prop) {
       if ( $this->_props[$prop] === "inherit" ) {
         if ( isset($parent->_important_props[$prop]) ) {
@@ -568,10 +568,10 @@ class Style {
         $this->$prop = $parent->$prop;
       }
     }
-          
+
     return $this;
   }
-  
+
   /**
    * Override properties in this style with those in $style
    *
@@ -597,7 +597,7 @@ class Style {
     if ( isset($style->_props["font_size"]) )
       $this->__font_size_calculated = false;
   }
-  
+
   /**
    * Returns an array(r, g, b, "r"=> r, "g"=>g, "b"=>b, "hex"=>"#rrggbb")
    * based on the provided CSS colour value.
@@ -606,7 +606,7 @@ class Style {
    * @return array
    */
   function munge_colour($colour) { return CSS_Color::parse($colour); }
-  
+
   /**
    * Alias for {@link Style::munge_colour()}
    *
@@ -660,20 +660,20 @@ class Style {
   function __set($prop, $val) {
     $prop = str_replace("-", "_", $prop);
     $this->_prop_cache[$prop] = null;
-    
+
     if ( !isset(self::$_defaults[$prop]) ) {
       global $_dompdf_warnings;
       $_dompdf_warnings[] = "'$prop' is not a valid CSS2 property.";
       return;
     }
-    
+
     if ( $prop !== "content" && is_string($val) && strlen($val) > 5 && mb_strpos($val, "url") === false ) {
       $val = mb_strtolower(trim(str_replace(array("\n", "\t"), array(" "), $val)));
       $val = preg_replace("/([0-9]+) (pt|px|pc|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
     }
-    
+
     $method = "set_$prop";
-    
+
     if ( !isset(self::$_methods_cache[$method]) ) {
       self::$_methods_cache[$method] = method_exists($this, $method);
     }
@@ -703,7 +703,7 @@ class Style {
 
     if ( isset($this->_prop_cache[$prop]) && $this->_prop_cache[$prop] != null )
       return $this->_prop_cache[$prop];
-    
+
     $method = "get_$prop";
 
     // Fall back on defaults if property is not set
@@ -713,7 +713,7 @@ class Style {
     if ( !isset(self::$_methods_cache[$method]) ) {
       self::$_methods_cache[$method] = method_exists($this, $method);
     }
-    
+
     if ( self::$_methods_cache[$method] )
       return $this->_prop_cache[$prop] = $this->$method();
 
@@ -734,7 +734,7 @@ class Style {
    * @return string
    */
   function get_font_family() {
-  
+
     $DEBUGCSS=DEBUGCSS; //=DEBUGCSS; Allow override of global setting for ad hoc debug
 
     // Select the appropriate font.  First determine the subtype, then check
@@ -742,7 +742,7 @@ class Style {
 
     // Resolve font-weight
     $weight = $this->__get("font_weight");
-    
+
     if ( is_numeric($weight) ) {
 
       if ( $weight < 600 )
@@ -769,7 +769,7 @@ class Style {
       $subtype = "italic";
     else
       $subtype = "normal";
-    
+
     // Resolve the font family
     if ($DEBUGCSS) {
       print "<pre>[get_font_family:";
@@ -803,7 +803,7 @@ class Style {
       return $font;
     }
     throw new DOMPDF_Exception("Unable to find a suitable font replacement for: '" . $this->_props["font_family"] ."'");
-    
+
   }
 
   /**
@@ -816,15 +816,15 @@ class Style {
 
     if ( $this->__font_size_calculated )
       return $this->_props["font_size"];
-    
+
     if ( !isset($this->_props["font_size"]) )
       $fs = self::$_defaults["font_size"];
     else
       $fs = $this->_props["font_size"];
-    
+
     if ( !isset($this->_parent_font_size) )
       $this->_parent_font_size = self::$default_font_size;
-    
+
     switch ($fs) {
     case "xx-small":
     case "x-small":
@@ -839,24 +839,24 @@ class Style {
     case "smaller":
       $fs = 8/9 * $this->_parent_font_size;
       break;
-      
+
     case "larger":
       $fs = 6/5 * $this->_parent_font_size;
       break;
-      
+
     default:
       break;
     }
 
     // Ensure relative sizes resolve to something
     if ( ($i = mb_strpos($fs, "em")) !== false )
-      $fs = mb_substr($fs, 0, $i) * $this->_parent_font_size;
+      $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
 
     else if ( ($i = mb_strpos($fs, "ex")) !== false )
-      $fs = mb_substr($fs, 0, $i) * $this->_parent_font_size;
+      $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
 
     else
-      $fs = $this->length_in_pt($fs);
+      $fs = (float)$this->length_in_pt($fs);
 
     //see __set and __get, on all assignments clear cache!
     $this->_prop_cache["font_size"] = null;
@@ -894,13 +894,13 @@ class Style {
    */
   function get_line_height() {
     $line_height = $this->_props["line_height"];
-    
+
     if ( $line_height === "normal" )
       return self::$default_line_height * $this->get_font_size();
 
     if ( is_numeric($line_height) )
       return $this->length_in_pt( $line_height . "em", $this->get_font_size());
-    
+
     return $this->length_in_pt( $line_height, $this->get_font_size() );
   }
 
@@ -928,7 +928,7 @@ class Style {
   function get_background_color() {
     return $this->munge_color( $this->_props["background_color"] );
   }
-  
+
   /**
    * Returns the background position as an array
    *
@@ -975,26 +975,26 @@ class Style {
       case "left":
         $x = "0%";
         break;
-        
+
       case "right":
         $x = "100%";
         break;
-        
+
       case "top":
         $y = "0%";
         break;
-        
+
       case "bottom":
         $y = "100%";
         break;
-        
+
       case "center":
         if ( $tmp[0] === "left" || $tmp[0] === "right" || $tmp[0] === "center" )
           $y = "50%";
         else
           $x = "50%";
         break;
-        
+
       default:
         $y = $tmp[1];
         break;
@@ -1100,7 +1100,7 @@ class Style {
     }
     return $this->munge_color($this->_props["border_left_color"]);
   }
-  
+
   /**#@-*/
 
  /**#@+
@@ -1113,7 +1113,7 @@ class Style {
     $style = $this->__get("border_top_style");
     return $style !== "none" && $style !== "hidden" ? $this->length_in_pt($this->_props["border_top_width"]) : 0;
   }
-  
+
   function get_border_right_width() {
     $style = $this->__get("border_right_style");
     return $style !== "none" && $style !== "hidden" ? $this->length_in_pt($this->_props["border_right_width"]) : 0;
@@ -1165,7 +1165,7 @@ class Style {
    */
   protected function _get_border($side) {
     $color = $this->__get("border_" . $side . "_color");
-    
+
     return $this->__get("border_" . $side . "_width") . " " .
       $this->__get("border_" . $side . "_style") . " " . $color["hex"];
   }
@@ -1185,7 +1185,7 @@ class Style {
   function get_border_bottom() { return $this->_get_border("bottom"); }
   function get_border_left() { return $this->_get_border("left"); }
   /**#@-*/
-  
+
   /**
    * Returns the outline colour as an array
    *
@@ -1211,7 +1211,7 @@ class Style {
     $style = $this->__get("outline_style");
     return $style !== "none" && $style !== "hidden" ? $this->length_in_pt($this->_props["outline_width"]) : 0;
   }
-  
+
   /**#@+
    * Return full outline properties as a string
    *
@@ -1224,10 +1224,10 @@ class Style {
    */
   function get_outline() {
     $color = $this->__get("outline_color");
-    return 
-      $this->__get("outline_width") . " " . 
-      $this->__get("outline_style") . " " . 
-      $color["hex"]; 
+    return
+      $this->__get("outline_width") . " " .
+      $this->__get("outline_style") . " " .
+      $color["hex"];
   }
   /**#@-*/
 
@@ -1294,7 +1294,7 @@ class Style {
    */
   protected function _set_style_side_type($style,$side,$type,$val,$important) {
     $prop = $style.'_'.$side.$type;
-    
+
     if ( !isset($this->_important_props[$prop]) || $important) {
       //see __set and __get, on all assignments clear cache!
       $this->_prop_cache[$prop] = null;
@@ -1315,7 +1315,7 @@ class Style {
   protected function _set_style_type($style,$type,$val,$important) {
     $val = preg_replace("/\s*\,\s*/", ",", $val); // when rgb() has spaces
     $arr = explode(" ", $val);
-    
+
     switch (count($arr)) {
     case 1:
       $this->_set_style_sides_type($style,$arr[0],$arr[0],$arr[0],$arr[0],$type,$important);
@@ -1363,7 +1363,7 @@ class Style {
 
   protected function _image($val) {
     $DEBUGCSS=DEBUGCSS;
-    
+
     if ( mb_strpos($val, "url") === false ) {
       $path = "none"; //Don't resolve no image -> otherwise would prefix path and no longer recognize as none
     } else {
@@ -1455,7 +1455,7 @@ class Style {
   function set_background_repeat($val) {
     if ( is_null($val) )
       $val = self::$_defaults["background_repeat"];
-      
+
     //see __set and __get, on all assignments clear cache, not needed on direct set through __set
     $this->_prop_cache["background_repeat"] = null;
     $this->_props["background_repeat"] = $val;
@@ -1503,7 +1503,7 @@ class Style {
     $tmp = preg_replace("/\s*\,\s*/", ",", $val); // when rgb() has spaces
     $tmp = explode(" ", $tmp);
     $important = isset($this->_important_props["background"]);
-    
+
     foreach($tmp as $attr) {
       if (mb_substr($attr, 0, 3) === "url" || $attr === "none") {
         $this->_set_style("background_image", $this->_image($attr), $important);
@@ -1517,7 +1517,7 @@ class Style {
         $pos[] = $attr;
       }
     }
-    
+
     if (count($pos)) {
       $this->_set_style("background_position",implode(' ',$pos), $important);
     }
@@ -1642,7 +1642,7 @@ class Style {
     $this->_props["page_break_after"] = $break;
   }
   /**#@-*/
-    
+
   //........................................................................
 
   /**#@+
@@ -1666,7 +1666,7 @@ class Style {
   function set_margin_left($val) {
     $this->_set_style_side_width_important('margin','left',$val);
   }
-  
+
   function set_margin($val) {
     $val = str_replace("none", "0px", $val);
     $this->_set_style_type_important('margin','',$val);
@@ -1713,7 +1713,7 @@ class Style {
     $arr = explode(" ", $border_spec);
 
     // FIXME: handle partial values
- 
+
     //For consistency of individal and combined properties, and with ie8 and firefox3
     //reset all attributes, even if only partially given
     $this->_set_style_side_type('border',$side,'_style',self::$_defaults['border_'.$side.'_style'],$important);
@@ -1781,16 +1781,16 @@ class Style {
    */
   function set_outline($val) {
     $important = isset($this->_important_props["outline"]);
-    
+
     $props = array(
-      "outline_style", 
-      "outline_width", 
+      "outline_style",
+      "outline_width",
       "outline_color",
     );
-    
+
     foreach($props as $prop) {
       $_val = self::$_defaults[$prop];
-      
+
       if ( !isset($this->_important_props[$prop]) || $important) {
         //see __set and __get, on all assignments clear cache!
         $this->_prop_cache[$prop] = null;
@@ -1800,7 +1800,7 @@ class Style {
         $this->_props[$prop] = $_val;
       }
     }
-    
+
     $val = preg_replace("/\s*\,\s*/", ",", $val); // when rgb() has spaces
     $arr = explode(" ", $val);
     foreach ($arr as $value) {
@@ -1814,7 +1814,7 @@ class Style {
         $this->set_outline_color($value);
       }
     }
-    
+
     //see __set and __get, on all assignments clear cache, not needed on direct set through __set
     $this->_prop_cache["outline"] = null;
     $this->_props["outline"] = $val;
@@ -1874,12 +1874,12 @@ class Style {
     $arr = explode(" ", str_replace(",", " ", $val));
 
     static $types = array(
-      "disc", "circle", "square", 
+      "disc", "circle", "square",
       "decimal-leading-zero", "decimal", "1",
       "lower-roman", "upper-roman", "a", "A",
-      "lower-greek", 
-      "lower-latin", "upper-latin", 
-      "lower-alpha", "upper-alpha", 
+      "lower-greek",
+      "lower-latin", "upper-latin",
+      "lower-alpha", "upper-alpha",
       "armenian", "georgian", "hebrew",
       "cjk-ideographic", "hiragana", "katakana",
       "hiragana-iroha", "katakana-iroha", "none"
@@ -1901,7 +1901,7 @@ class Style {
       //and url exists, then url has precedence, otherwise fall back to list_style_type
       //Firefox is wrong here (list_style_image gets overwritten on explicite list_style_type)
       //Internet Explorer 7/8 and dompdf is right.
-       
+
       if (mb_substr($value, 0, 3) === "url") {
         $this->_set_style("list_style_image", $this->_image($value), $important);
         continue;
@@ -1918,22 +1918,22 @@ class Style {
     $this->_prop_cache["list_style"] = null;
     $this->_props["list_style"] = $val;
   }
-  
+
   function set_size($val) {
     $length_re = "/(\d+\s*(?:pt|px|pc|em|ex|in|cm|mm|%))/";
 
     $val = mb_strtolower($val);
-    
+
     if ( $val === "auto" ) {
       return;
     }
-        
+
     $parts = preg_split("/\s+/", $val);
-    
+
     $computed = array();
     if ( preg_match($length_re, $parts[0]) ) {
       $computed[] = $this->length_in_pt($parts[0]);
-      
+
       if ( isset($parts[1]) && preg_match($length_re, $parts[1]) ) {
         $computed[] = $this->length_in_pt($parts[1]);
       }
@@ -1943,7 +1943,7 @@ class Style {
     }
     elseif ( isset(CPDF_Adapter::$PAPER_SIZES[$parts[0]]) ) {
       $computed = array_slice(CPDF_Adapter::$PAPER_SIZES[$parts[0]], 2, 2);
-      
+
       if ( isset($parts[1]) && $parts[1] === "landscape" ) {
         $computed = array_reverse($computed);
       }
@@ -1951,10 +1951,10 @@ class Style {
     else {
       return;
     }
-    
+
     $this->_props["size"] = $computed;
   }
-  
+
   /**
    * Sets the CSS3 transform property
    *
@@ -1965,55 +1965,55 @@ class Style {
     $number   = "\s*([^,\s]+)\s*";
     $tr_value = "\s*([^,\s]+)\s*";
     $angle    = "\s*([^,\s]+(?:deg|rad)?)\s*";
-    
+
     if( !preg_match_all("/[a-z]+\([^\)]+\)/i", $val, $parts, PREG_SET_ORDER) ) {
       return;
     }
-    
+
     $functions = array(
       //"matrix"     => "\($number,$number,$number,$number,$number,$number\)",
-    
+
       "translate"  => "\($tr_value(?:,$tr_value)?\)",
       "translateX" => "\($tr_value\)",
       "translateY" => "\($tr_value\)",
-    
+
       "scale"      => "\($number(?:,$number)?\)",
       "scaleX"     => "\($number\)",
       "scaleY"     => "\($number\)",
-    
+
       "rotate"     => "\($angle\)",
-    
+
       "skew"       => "\($angle(?:,$angle)?\)",
       "skewX"      => "\($angle\)",
       "skewY"      => "\($angle\)",
     );
-    
+
     $transforms = array();
-    
+
     foreach($parts as $part) {
       $t = $part[0];
-      
+
       foreach($functions as $name => $pattern) {
         if (preg_match("/$name\s*$pattern/i", $t, $matches)) {
           $values = array_slice($matches, 1);
-          
+
           switch($name) {
             // <angle> units
             case "rotate":
             case "skew":
             case "skewX":
             case "skewY":
-              
+
               foreach($values as $i => $value) {
-                if ( strpos($value, "rad") ) 
+                if ( strpos($value, "rad") )
                   $values[$i] = rad2deg(floatval($value));
                 else
                   $values[$i] = floatval($value);
               }
-              
+
               switch($name) {
                 case "skew":
-                  if ( !isset($values[1]) ) 
+                  if ( !isset($values[1]) )
                     $values[1] = 0;
                 break;
                 case "skewX":
@@ -2026,65 +2026,65 @@ class Style {
                 break;
               }
             break;
-            
+
             // <translation-value> units
             case "translate":
-              $values[0] = $this->length_in_pt($values[0], $this->width);
-              
-              if ( isset($values[1]) ) 
-                $values[1] = $this->length_in_pt($values[1], $this->height);
+              $values[0] = $this->length_in_pt($values[0], (float)$this->width);
+
+              if ( isset($values[1]) )
+                $values[1] = $this->length_in_pt($values[1], (float)$this->height);
               else
                 $values[1] = 0;
             break;
-            
+
             case "translateX":
               $name = "translate";
-              $values = array($this->length_in_pt($values[0], $this->width), 0);
+              $values = array($this->length_in_pt($values[0], (float)$this->width), 0);
             break;
-            
+
             case "translateY":
               $name = "translate";
-              $values = array(0, $this->length_in_pt($values[0], $this->height));
+              $values = array(0, $this->length_in_pt($values[0], (float)$this->height));
             break;
-            
+
             // <number> units
             case "scale":
-              if ( !isset($values[1]) ) 
+              if ( !isset($values[1]) )
                 $values[1] = $values[0];
             break;
-            
+
             case "scaleX":
               $name = "scale";
               $values = array($values[0], 1.0);
             break;
-            
+
             case "scaleY":
               $name = "scale";
               $values = array(1.0, $values[0]);
             break;
           }
-          
+
           $transforms[] = array(
-            $name, 
+            $name,
             $values,
           );
         }
       }
     }
-    
+
     //see __set and __get, on all assignments clear cache, not needed on direct set through __set
     $this->_prop_cache["transform"] = null;
     $this->_props["transform"] = $transforms;
   }
-  
+
   function set__webkit_transform($val) {
     return $this->set_transform($val);
   }
-  
+
   function set__webkit_transform_origin($val) {
     return $this->set_transform_origin($val);
   }
-  
+
   /**
    * Sets the CSS3 transform-origin property
    *
@@ -2093,63 +2093,63 @@ class Style {
    */
   function set_transform_origin($val) {
     $values = preg_split("/\s+/", $val);
-    
+
     if ( count($values) === 0) {
       return;
     }
-    
+
     foreach($values as &$value) {
       if ( in_array($value, array("top", "left")) ) {
         $value = 0;
       }
-      
+
       if ( in_array($value, array("bottom", "right")) ) {
         $value = "100%";
       }
     }
-    
+
     if ( !isset($values[1]) ) {
       $values[1] = $values[0];
     }
-    
+
     //see __set and __get, on all assignments clear cache, not needed on direct set through __set
     $this->_prop_cache["transform_origin"] = null;
     $this->_props["transform_origin"] = $values;
   }
-  
+
   protected function parse_image_resolution($val) {
-    // If exif data could be get: 
+    // If exif data could be get:
     // $re = '/^\s*(\d+|normal|auto)(?:\s*,\s*(\d+|normal))?\s*$/';
-    
+
     $re = '/^\s*(\d+|normal|auto)\s*$/';
-    
+
     if ( !preg_match($re, $val, $matches) ) {
       return null;
     }
-    
+
     return $matches[1];
   }
-  
+
   // auto | normal | dpi
   function set_background_image_resolution($val) {
     $parsed = $this->parse_image_resolution($val);
-    
+
     $this->_prop_cache["background_image_resolution"] = null;
     $this->_props["background_image_resolution"] = $parsed;
   }
-  
+
   // auto | normal | dpi
   function set_image_resolution($val) {
     $parsed = $this->parse_image_resolution($val);
-    
+
     $this->_prop_cache["image_resolution"] = null;
     $this->_props["image_resolution"] = $parsed;
   }
-  
+
   function set__dompdf_background_image_resolution($val) {
     return $this->set_background_image_resolution($val);
   }
-  
+
   function set__dompdf_image_resolution($val) {
     return $this->set_image_resolution($val);
   }
@@ -2162,11 +2162,11 @@ class Style {
     $this->_prop_cache["z_index"] = null;
     $this->_props["z_index"] = $val;
   }
-  
+
   function set_counter_increment($val) {
     $val = trim($val);
     $value = null;
-    
+
     if ( in_array($val, array("none", "inherit")) ) {
       $value = $val;
     }

--- a/core/third_party_libs/dompdf/include/style.cls.php
+++ b/core/third_party_libs/dompdf/include/style.cls.php
@@ -780,8 +780,7 @@ class Style {
     reset($families);
 
     $font = null;
-    while ( current($families) ) {
-      list(,$family) = each($families);
+    foreach ($families as $family) {
       //remove leading and trailing string delimiters, e.g. on font names with spaces;
       //remove leading and trailing whitespace
       $family = trim($family, " \t\n\r\x0B\"'");

--- a/core/third_party_libs/dompdf/include/table_cell_frame_reflower.cls.php
+++ b/core/third_party_libs/dompdf/include/table_cell_frame_reflower.cls.php
@@ -44,21 +44,21 @@ class Table_Cell_Frame_Reflower extends Block_Frame_Reflower {
     //FIXME?
     $h = $this->_frame->get_containing_block("h");
 
-    $left_space = $style->length_in_pt(array($style->margin_left,
+    $left_space = (float)$style->length_in_pt(array($style->margin_left,
                                              $style->padding_left,
                                              $style->border_left_width),
                                        $w);
 
-    $right_space = $style->length_in_pt(array($style->padding_right,
+    $right_space = (float)$style->length_in_pt(array($style->padding_right,
                                               $style->margin_right,
                                               $style->border_right_width),
                                         $w);
 
-    $top_space = $style->length_in_pt(array($style->margin_top,
+    $top_space = (float)$style->length_in_pt(array($style->margin_top,
                                             $style->padding_top,
                                             $style->border_top_width),
                                       $h);
-    $bottom_space = $style->length_in_pt(array($style->margin_bottom,
+    $bottom_space = (float)$style->length_in_pt(array($style->margin_bottom,
                                                $style->padding_bottom,
                                                $style->border_bottom_width),
                                       $h);
@@ -69,31 +69,31 @@ class Table_Cell_Frame_Reflower extends Block_Frame_Reflower {
     $content_y = $line_y = $y + $top_space;
 
     // Adjust the first line based on the text-indent property
-    $indent = $style->length_in_pt($style->text_indent, $w);
+    $indent = (float)$style->length_in_pt($style->text_indent, $w);
     $this->_frame->increase_line_width($indent);
 
     // Set the y position of the first line in the cell
     $page = $this->_frame->get_root();
     $this->_frame->set_current_line($line_y);
-    
+
     // Set the containing blocks and reflow each child
     foreach ( $this->_frame->get_children() as $child ) {
-      
+
       if ( $page->is_full() )
         break;
-    
+
       $child->set_containing_block($content_x, $content_y, $cb_w, $h);
       $child->reflow($this->_frame);
-    
+
       $this->process_float($child, $x + $left_space, $w - $right_space - $left_space);
     }
 
     // Determine our height
-    $style_height = $style->length_in_pt($style->height, $h);
+    $style_height = (float)$style->length_in_pt($style->height, $h);
 
     $this->_frame->set_content_height($this->_calculate_content_height());
 
-    $height = max($style_height, $this->_frame->get_content_height());
+    $height = max($style_height, (float)$this->_frame->get_content_height());
 
     // Let the cellmap know our height
     $cell_height = $height / count($cells["rows"]);

--- a/core/third_party_libs/dompdf/include/text_frame_reflower.cls.php
+++ b/core/third_party_libs/dompdf/include/text_frame_reflower.cls.php
@@ -20,12 +20,12 @@ class Text_Frame_Reflower extends Frame_Reflower {
    * @var Block_Frame_Decorator
    */
   protected $_block_parent; // Nearest block-level ancestor
-  
+
   /**
    * @var Text_Frame_Decorator
    */
   protected $_frame;
-  
+
   public static $_whitespace_pattern = "/[ \t\r\n\f]+/u";
 
   function __construct(Text_Frame_Decorator $frame) { parent::__construct($frame); }
@@ -46,11 +46,11 @@ class Text_Frame_Reflower extends Frame_Reflower {
     $size = $style->font_size;
     $font = $style->font_family;
     $current_line = $this->_block_parent->get_current_line_box();
-    
+
     // Determine the available width
     $line_width = $this->_frame->get_containing_block("w");
     $current_line_width = $current_line->left + $current_line->w + $current_line->right;
-    
+
     $available_width = $line_width - $current_line_width;
 
     // split the text into words
@@ -58,19 +58,19 @@ class Text_Frame_Reflower extends Frame_Reflower {
     $wc = count($words);
 
     // Account for word-spacing
-    $word_spacing = $style->length_in_pt($style->word_spacing);
-    $char_spacing = $style->length_in_pt($style->letter_spacing);
+    $word_spacing = (float)$style->length_in_pt($style->word_spacing);
+    $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
 
     // Determine the frame width including margin, padding & border
     $text_width = Font_Metrics::get_text_width($text, $font, $size, $word_spacing, $char_spacing);
     $mbp_width =
-      $style->length_in_pt( array( $style->margin_left,
+      (float)$style->length_in_pt( array( $style->margin_left,
                                    $style->border_left_width,
                                    $style->padding_left,
                                    $style->padding_right,
                                    $style->border_right_width,
                                    $style->margin_right), $line_width );
-                                   
+
     $frame_width = $text_width + $mbp_width;
 
 // Debugging:
@@ -104,13 +104,13 @@ class Text_Frame_Reflower extends Frame_Reflower {
     }
 
     $break_word = ($style->word_wrap === "break-word");
-    
+
     // The first word has overflowed.   Force it onto the line
     if ( $current_line_width == 0 && $width == 0 ) {
-      
+
       $s = "";
       $last_width = 0;
-        
+
       if ( $break_word ) {
         for ( $j = 0; $j < strlen($word); $j++ ) {
           $s .= $word[$j];
@@ -118,11 +118,11 @@ class Text_Frame_Reflower extends Frame_Reflower {
           if ($_width > $available_width) {
             break;
           }
-          
+
           $last_width = $_width;
         }
       }
-      
+
       if ( $break_word && $last_width > 0 ) {
         $width += $last_width;
         $str .= substr($s, 0, -1);
@@ -178,7 +178,7 @@ class Text_Frame_Reflower extends Frame_Reflower {
       case "uppercase":  $text = mb_convert_case($text, MB_CASE_UPPER); break;
       case "lowercase":  $text = mb_convert_case($text, MB_CASE_LOWER); break;
     }
-    
+
     // Handle white-space property:
     // http://www.w3.org/TR/CSS21/text.html#propdef-white-space
     switch ($style->white_space) {
@@ -254,21 +254,21 @@ class Text_Frame_Reflower extends Frame_Reflower {
         // Layout the new line
         $this->_layout_line();
 
-      } 
-      
+      }
+
       else if ( $split < mb_strlen($frame->get_text()) ) {
         // split the line if required
         $frame->split_text($split);
 
         $t = $frame->get_text();
-        
+
         // Remove any trailing newlines
         if ( $split > 1 && $t[$split-1] === "\n" && !$frame->is_pre() )
           $frame->set_text( mb_substr($t, 0, -1) );
 
-        // Do we need to trim spaces on wrapped lines? This might be desired, however, we 
-        // can't trim the lines here or the layout will be affected if trimming the line 
-        // leaves enough space to fit the next word in the text stream (because pdf layout  
+        // Do we need to trim spaces on wrapped lines? This might be desired, however, we
+        // can't trim the lines here or the layout will be affected if trimming the line
+        // leaves enough space to fit the next word in the text stream (because pdf layout
         // is performed elsewhere).
         /*if (!$this->_frame->get_prev_sibling() && !$this->_frame->get_next_sibling()) {
           $t = $this->_frame->get_text();
@@ -289,19 +289,19 @@ class Text_Frame_Reflower extends Frame_Reflower {
       $t = $frame->get_text();
       $parent = $frame->get_parent();
       $is_inline_frame = get_class($parent) === 'Inline_Frame_Decorator';
-      
-      if ((!$is_inline_frame && !$frame->get_next_sibling()) || 
+
+      if ((!$is_inline_frame && !$frame->get_next_sibling()) ||
           ( $is_inline_frame && !$parent->get_next_sibling())) {
         $t = rtrim($t);
       }
-      
-      if ((!$is_inline_frame && !$frame->get_prev_sibling())/* || 
+
+      if ((!$is_inline_frame && !$frame->get_prev_sibling())/* ||
           ( $is_inline_frame && !$parent->get_prev_sibling())*/) { //  <span><span>A<span>B</span> C</span></span> fails (the whitespace is removed)
         $t = ltrim($t);
       }
-      
+
       $frame->set_text( $t );
-      
+
     }
 
     // Set our new width
@@ -314,7 +314,7 @@ class Text_Frame_Reflower extends Frame_Reflower {
     $frame = $this->_frame;
     $page = $frame->get_root();
     $page->check_forced_page_break($this->_frame);
-    
+
     if ( $page->is_full() )
       return;
 
@@ -327,11 +327,11 @@ class Text_Frame_Reflower extends Frame_Reflower {
 //           $frame->get_style()->white_space !== "pre-wrap") ) {
 //       $frame->set_text( ltrim( $frame->get_text() ) );
 //     }
-    
+
     $frame->position();
 
     $this->_layout_line();
-    
+
     if ( $block ) {
       $block->add_frame_to_line($frame);
     }
@@ -353,8 +353,8 @@ class Text_Frame_Reflower extends Frame_Reflower {
     $size = $style->font_size;
     $font = $style->font_family;
 
-    $word_spacing = $style->length_in_pt($style->word_spacing);
-    $char_spacing = $style->length_in_pt($style->letter_spacing);
+    $word_spacing = (float)$style->length_in_pt($style->word_spacing);
+    $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
 
     switch($style->white_space) {
 
@@ -416,8 +416,8 @@ class Text_Frame_Reflower extends Frame_Reflower {
     }
 
     $max = Font_Metrics::get_text_width($str, $font, $size, $word_spacing, $char_spacing);
-    
-    $delta = $style->length_in_pt(array($style->margin_left,
+
+    $delta = (float)$style->length_in_pt(array($style->margin_left,
                                         $style->border_left_width,
                                         $style->padding_left,
                                         $style->padding_right,

--- a/core/third_party_libs/dompdf/include/text_frame_reflower.cls.php
+++ b/core/third_party_libs/dompdf/include/text_frame_reflower.cls.php
@@ -370,16 +370,19 @@ class Text_Frame_Reflower extends Frame_Reflower {
       // faster than doing a single-pass character by character scan.  Heh,
       // yes I took the time to bench it ;)
       $words = array_flip(preg_split("/[\s-]+/u",$str, -1, PREG_SPLIT_DELIM_CAPTURE));
-      array_walk($words, create_function('&$val,$str',
-                                         '$val = Font_Metrics::get_text_width($str, "'.addslashes($font).'", '.$size.', '.$word_spacing.', '.$char_spacing.');'));
+      array_walk($words, function(&$val, $str) use ($font, $size, $word_spacing, $char_spacing) {
+        $val = Font_Metrics::get_text_width($str, $font, $size, $word_spacing, $char_spacing);
+      });
+
       arsort($words);
       $min = reset($words);
       break;
 
     case "pre":
       $lines = array_flip(preg_split("/\n/u", $str));
-      array_walk($lines, create_function('&$val,$str',
-                                         '$val = Font_Metrics::get_text_width($str, "'.addslashes($font).'", '.$size.', '.$word_spacing.', '.$char_spacing.');'));
+      array_walk($lines, function(&$val, $str) use ($font, $size, $word_spacing, $char_spacing) {
+        $val = Font_Metrics::get_text_width($str, $font, $size, $word_spacing, $char_spacing);
+      });
 
       arsort($lines);
       $min = reset($lines);
@@ -406,8 +409,9 @@ class Text_Frame_Reflower extends Frame_Reflower {
     case "pre-wrap":
       // Find the longest word (i.e. minimum length)
       $lines = array_flip(preg_split("/\n/", $text));
-      array_walk($lines, create_function('&$val,$str',
-                                         '$val = Font_Metrics::get_text_width($str, "'.$font.'", '.$size.', '.$word_spacing.', '.$char_spacing.');'));
+      array_walk($lines, function(&$val, $str) use ($font, $size, $word_spacing, $char_spacing) {
+        $val = Font_Metrics::get_text_width($str, $font, $size, $word_spacing, $char_spacing);
+      });
       arsort($lines);
       reset($lines);
       $str = key($lines);


### PR DESCRIPTION
## Problem this Pull Request solves
The Dompdf integration will invoke quite a few PHP7.1+ specific warnings like `A non-numeric value encountered...`, when run by php7.1+. It also uses a few deprecated methods.

Work in this PR is considered as a code refactoring for the Dompdf integration so that it's complaint with php version up to 7.2. In places where the change is required I mostly try to apply the same refactoring that was done in the newest version of Dompgf on that particular peace of code.

## How has this been tested
* [ ] While running your server on php7.2, try generating a PDF in any way possible. For example, try downloading a PDF of the order receipt after a successful event registration. There should be no PHP Warnings or Deprecated messages in the logs.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
