### PR TITLE
Fixed pue slug in the skeleton new payment method add-on

### DIFF
--- a/tests/mocks/addons/new-payment-method/EE_New_Payment_Method.class.php
+++ b/tests/mocks/addons/new-payment-method/EE_New_Payment_Method.class.php
@@ -36,7 +36,7 @@ Class  EE_New_Payment_Method extends EE_Addon {
 				'admin_callback' => 'additional_admin_hooks',
 				// if plugin update engine is being used for auto-updates. not needed if PUE is not being used.
 				'pue_options'			=> array(
-					'pue_plugin_slug' => 'espresso_new_payment_method',
+					'pue_plugin_slug' => 'eea-new-payment-method',
 					'plugin_basename' => EE_NEW_PAYMENT_METHOD_BASENAME,
 					'checkPeriod' => '24',
 					'use_wp_update' => FALSE,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/event-espresso-core/issues/694
Instead of having the default pue slug be `espresso_new_payment_method`, its `eea-new-payment-method`. I just checked and the renamer does successfully keep those dashes, so if you named the plugin `Foo_Bar`, the pue slug would be `eea-foo-bar`.
Alternatively we thought we could leave this blank, but I personally prefer having this default to the standard in order to reduce boilerplate we need to write.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [] I used the renamer (provided it with `?search=New_Payment_Method&replace=Foo_Bar`) and found the `pue_plugin_slug` was successfully renamed (to `eea-foo-bar`)

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
