### PR TITLE
Cast translated strings to strings before using as array keys

### DIFF
--- a/core/CPTs/EE_CPT_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Strategy.core.php
@@ -126,7 +126,7 @@ class EE_CPT_Strategy extends EE_Base
         $_CPT_endpoints = array();
         if (is_array($this->_CPTs)) {
             foreach ($this->_CPTs as $CPT_type => $CPT) {
-                $_CPT_endpoints [ $CPT['plural_slug'] ] = $CPT_type;
+                $_CPT_endpoints [ (string)$CPT['plural_slug'] ] = $CPT_type;
             }
         }
         return $_CPT_endpoints;

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -1267,7 +1267,7 @@ final class EE_Config implements ResettableInterface
             EE_Error::add_error($msg . '||' . $msg, __FILE__, __FUNCTION__, __LINE__);
             return false;
         }
-        EE_Config::$_module_route_map[ $key ][ $route ] = array('EED_' . $module, $method_name);
+        EE_Config::$_module_route_map[ (string)$key ][ (string)$route ] = array('EED_' . $module, $method_name);
         return true;
     }
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Compatibility with WP trac ticket: https://core.trac.wordpress.org/ticket/41305#comment:24

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Retest all the things

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
