### PR TITLE
Add offers.availability to event structured data 

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -60,7 +60,7 @@ class EEH_Schema
                 EE_Registry::instance()->CFG->currency->dec_mrk,
                 EE_Registry::instance()->CFG->currency->thsnds
             );
-            switch($ticket->ticket_status()) {
+            switch ($ticket->ticket_status()) {
                 case 'TKO':
                     $availability = 'InStock';
                     break;

--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -60,6 +60,18 @@ class EEH_Schema
                 EE_Registry::instance()->CFG->currency->dec_mrk,
                 EE_Registry::instance()->CFG->currency->thsnds
             );
+            switch($ticket->ticket_status()) {
+                case 'TKO':
+                    $availability = 'InStock';
+                    break;
+                case 'TKS':
+                    $availability = 'SoldOut';
+                    break;
+                default:
+                    $availability = null;
+                    break;
+            }
+            $template_args['event_tickets'][ $ID ]['availability'] = $availability;
             unset($ticket);
         }
         $VNU_ID = espresso_venue_id();

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -32,10 +32,9 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
       "validThrough": "<?php echo $ticket['end_date']; ?>",
       "price": "<?php echo $ticket['price']; ?>",
       "priceCurrency": "<?php echo $currency; ?>"
-      <?php if (isset($ticket['availability'])) {
-         ?>,"availability": "http://schema.org/<?php echo $ticket['availability']; ?>"
-      <?php
-      } ?>
+        <?php if (isset($ticket['availability'])) {
+            ?>,"availability": "http://schema.org/<?php echo $ticket['availability']; ?>"
+        <?php } ?>
     }<?php
     if (is_array($event_tickets) && end($event_tickets) !== $ticket) {
             echo ',';

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -32,6 +32,10 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
       "validThrough": "<?php echo $ticket['end_date']; ?>",
       "price": "<?php echo $ticket['price']; ?>",
       "priceCurrency": "<?php echo $currency; ?>"
+      <?php if (isset($ticket['availability'])) {
+         ?>,"availability": "http://schema.org/<?php echo $ticket['availability']; ?>"
+      <?php
+      } ?>
     }<?php
     if (is_array($event_tickets) && end($event_tickets) !== $ticket) {
             echo ',';


### PR DESCRIPTION
This PR adds the `offers.availability` property if tickets are available or sold out. The following are the two applicable values for Event Espresso tickets:

https://schema.org/InStock
http://schema.org/SoldOut

(If one day EE adds the ability to do a true "pre-order" then we can add the PreOrder value too)



## Checklist


* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)

Testing notes:

Each ticket status should be tested:
On Sale, Archived, Sold Out, Pending, and Expired
The offers.availability property should be output for "On Sale" and "Sold Out" tickets only. 

This tool can be used to validate the structured data while testing:
https://search.google.com/structured-data/testing-tool/u/0/
