### PR TITLE
Change Google map image to map link in default email templates, resolves #383

### DIFF
--- a/caffeinated/core/libraries/messages/defaults/default/email_registration_event_list_attendee.template.php
+++ b/caffeinated/core/libraries/messages/defaults/default/email_registration_event_list_attendee.template.php
@@ -47,7 +47,7 @@
                         <li>[VENUE_ADDRESS]</li>
                         <li>[VENUE_CITY]</li>
                         <li>[VENUE_STATE], [VENUE_ZIP]</li>
-                        <li>[GOOGLE_MAP_IMAGE]</li>
+                        <li>[GOOGLE_MAP_LINK]</li>
                     </ul>
                     <!-- social &#038; contact -->
                     <table class="social" width="100%" bgcolor="">

--- a/core/libraries/messages/defaults/default/email_registration_event_list.template.php
+++ b/core/libraries/messages/defaults/default/email_registration_event_list.template.php
@@ -48,7 +48,7 @@
                             <li>[VENUE_ADDRESS]</li>
                             <li>[VENUE_CITY]</li>
                             <li>[VENUE_STATE], [VENUE_ZIP]</li>
-                            <li>[GOOGLE_MAP_IMAGE]</li>
+                            <li>[GOOGLE_MAP_LINK]</li>
                         </ul>
                         <table class="social" width="100%" bgcolor="">
                             <tbody>

--- a/core/libraries/messages/defaults/default/email_registration_event_list_primary_attendee.template.php
+++ b/core/libraries/messages/defaults/default/email_registration_event_list_primary_attendee.template.php
@@ -38,7 +38,7 @@
                             <li>[VENUE_ADDRESS]</li>
                             <li>[VENUE_CITY]</li>
                             <li>[VENUE_STATE], [VENUE_ZIP]</li>
-                            <li>[GOOGLE_MAP_IMAGE]</li>
+                            <li>[GOOGLE_MAP_LINK]</li>
                         </ul>
                         <table class="social" width="100%" bgcolor="">
                             <tbody>


### PR DESCRIPTION
Include a link to a google map in place of an image of a google map in default email templates. This is a simple change, but we might want to change how the links are displayed (maybe use some link text and use the map URL shortcode instead)? 

Open to suggestions!


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
