### PR TITLE
Bug/improve tickets on sale

### DIFF
--- a/core/db_classes/EE_Event.class.php
+++ b/core/db_classes/EE_Event.class.php
@@ -1161,6 +1161,23 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
+     * This returns the number of different ticket types currently on sale for this event.
+     *
+     * @return int
+     * @throws EE_Error
+     */
+    public function countTicketsOnSale()
+    {
+        $where = array(
+            'Datetime.EVT_ID' => $this->ID(),
+            'TKT_start_date'  => array('<', time()),
+            'TKT_end_date'    => array('>', time()),
+        );
+        return EEM_Ticket::instance()->count(array($where));
+    }
+
+
+    /**
      * This returns whether there are any tickets on sale for this event.
      *
      * @return bool true = YES tickets on sale.

--- a/core/db_classes/EE_Event.class.php
+++ b/core/db_classes/EE_Event.class.php
@@ -1185,16 +1185,7 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      */
     public function tickets_on_sale()
     {
-        $earliest_ticket = $this->get_ticket_with_earliest_start_time();
-        $latest_ticket = $this->get_ticket_with_latest_end_time();
-        if (! $latest_ticket instanceof EE_Ticket && ! $earliest_ticket instanceof EE_Ticket) {
-            return false;
-        }
-        // check on sale for these two tickets.
-        if ($latest_ticket->is_on_sale() || $earliest_ticket->is_on_sale()) {
-            return true;
-        }
-        return false;
+        return $this->countTicketsOnSale() > 0;
     }
 
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The problem this pull request attempts to solve is currently the tickets_on_sale() method ignores any and all ticket types that aren't the first to go on sale or the last to go on sale. 

Real world example: An event has a ticket where its sale end date is passed, a ticket that's currently on sale, and a ticket that is yet to go on sale. The current `tickets_on_sale()` method returns `false` with this scenario. 
## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
I reject the premise of your question. 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
This was tested by setting up an event as described above. Then I added:
```
if( !$event->tickets_on_sale() ) {
    continue;
}
```
to the Events table template add-ons template to see if the event would display in the list. The event does not display in the list when switched to Master. 

## Checklist
* [x] Darren actually wrote this code, I just did the pull request
* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
