### PR TITLE
if no data was processed set the csv_data var to an empty array

### DIFF
--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -191,6 +191,7 @@ class RegistrationsReport extends JobHandlerFile
             \EEH_Export::write_data_array_to_csv($job_parameters->extra_datum('filepath'), $csv_data, false);
             $units_processed = count($csv_data);
         } else {
+            $csv_data = array();
             $units_processed = 0;
         }
         $job_parameters->mark_processed($units_processed);


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes a warning when generating a registration report with no registrations in it.
See https://github.com/eventespresso/eventsmart.com-website/issues/253

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] With `WP_DEBUG=true`, generate a filtered registration report that you know will have NO registration in it (eg a report for "today's" registrations, if you haven't made any today). On master there would be a warning in `debug.log`, but on this branch there is none.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
