### PR TITLE
Fixed fatal error and currency override on Countries settings page

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1055,30 +1055,45 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         $cols_n_values['CNT_name'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_name'])
             ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_name'])
             : null;
-        $cols_n_values['CNT_cur_code'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code'])
-            ? strtoupper(sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code']))
-            : 'USD';
-        $cols_n_values['CNT_cur_single'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single'])
-            : 'dollar';
-        $cols_n_values['CNT_cur_plural'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural'])
-            : 'dollars';
-        $cols_n_values['CNT_cur_sign'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign'])
-            : '$';
-        $cols_n_values['CNT_cur_sign_b4'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4'])
-            ? absint($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4'])
-            : true;
-        $cols_n_values['CNT_cur_dec_plc'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc'])
-            ? absint($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc'])
-            : 2;
-        $cols_n_values['CNT_cur_dec_mrk'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk'])
-            : '.';
-        $cols_n_values['CNT_cur_thsnds'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds'])
-            : ',';
+        if(isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code'])) {
+            $cols_n_values['CNT_cur_code'] = strtoupper(
+                sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code'])
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single'])) {
+            $cols_n_values['CNT_cur_single'] = sanitize_text_field(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single']
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural'])) {
+            $cols_n_values['CNT_cur_plural'] = sanitize_text_field(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural']
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign'])) {
+            $cols_n_values['CNT_cur_sign'] = sanitize_text_field(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign']);
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4'])) {
+            $cols_n_values['CNT_cur_sign_b4'] = absint(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4']
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc'])) {
+            $cols_n_values['CNT_cur_dec_plc'] = absint(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc']
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk'])) {
+            $cols_n_values['CNT_cur_dec_mrk'] = sanitize_text_field(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk']
+            );
+        }
+        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds'])) {
+            $cols_n_values['CNT_cur_thsnds'] = sanitize_text_field(
+                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds']
+            );
+        }
         $cols_n_values['CNT_tel_code'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_tel_code'])
             ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_tel_code'])
             : null;

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -564,6 +564,19 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
 
     /**
+     * @return string
+     */
+    protected function getCountryIsoForSite()
+    {
+        return isset(EE_Registry::instance()->CFG->organization->CNT_ISO)
+               && ! empty(EE_Registry::instance()->CFG->organization->CNT_ISO)
+            ? EE_Registry::instance()->CFG->organization->CNT_ISO
+            : 'US';
+    }
+
+
+
+    /**
      * Output Country Settings view.
      *
      * @throws DomainException
@@ -571,9 +584,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     protected function _country_settings()
     {
-        $CNT_ISO_for_site = isset(EE_Registry::instance()->CFG->organization->CNT_ISO)
-            ? EE_Registry::instance()->CFG->organization->CNT_ISO
-            : 'US';
+        $CNT_ISO_for_site = $this->getCountryIsoForSite();
         $CNT_ISO = isset($this->_req_data['country'])
             ? strtoupper(sanitize_text_field($this->_req_data['country']))
             : $CNT_ISO_for_site;
@@ -632,9 +643,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     public function display_country_settings($CNT_ISO = '')
     {
-        $CNT_ISO_for_site = isset(EE_Registry::instance()->CFG->organization->CNT_ISO)
-            ? EE_Registry::instance()->CFG->organization->CNT_ISO
-            : 'US';
+        $CNT_ISO_for_site = $this->getCountryIsoForSite();
 
         $CNT_ISO = isset($this->_req_data['country'])
             ? strtoupper(sanitize_text_field($this->_req_data['country']))


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #734 
The fatal error occurred when you would select nothing for a site country on the "Your Organization" tab in the General Settings, because we were only performing an `isset()` check for the `EE_Organization_Config->CNT_ISO` value on the "Countries" tab when deciding whether to use that value or the default. Since an empty string `""` is considered "set", we would then try to retrieve the country with an ISO value of "" and then access properties for the returned `EE_Country` object, which of course was actually null. Using an additional `empty()` check and then defaulting to `'US'` for the site country ISO when nothing is set prevents the error.

The second issue was that disabling the currency inputs removed them from the submitted form inputs and our logic for processing the forms would also perform an `isset()` check and then use default values if the form inputs were not found. Only setting and saving the currency settings when the inputs are detected solved this issue. Not sure how this one got past testing before because I know I had saved the inputs during my testing, so I must have just missed that the currency values were changing. 

OOOOOooo... I just realized why I never noticed this issue... I had selected "United States Minor Outlying Islands" as an alternate country to test that the currency settings were disabled, but that "country" setting obviously also uses "USD" for currency, so overriding "USD" with "USD" would be hard to notice :facepalm:

## How has this been tested
browser based monkey testing only

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
