### PR TITLE
introduce default date coercing

### DIFF
--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -573,17 +573,11 @@ class EE_Datetime_Field extends EE_Model_Field_Base
         if (empty($datetime_string)) {
             $DateTime = new DbSafeDateTime(\EE_Datetime_Field::now, $this->get_UTC_DateTimeZone());
         } else {
-            $DateTime = DateTime::createFromFormat(
+            $DateTime = DbSafeDateTime::createFromFormat(
                 EE_Datetime_Field::mysql_timestamp_format,
                 $datetime_string,
                 $this->get_UTC_DateTimeZone()
             );
-            if ($DateTime instanceof \DateTime) {
-                $DateTime = new DbSafeDateTime(
-                    $DateTime->format(\EE_Datetime_Field::mysql_timestamp_format),
-                    $this->get_UTC_DateTimeZone()
-                );
-            }
         }
 
         if (! $DateTime instanceof DbSafeDateTime) {

--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -659,13 +659,7 @@ class EE_Datetime_Field extends EE_Model_Field_Base
         // create the DateTime object.
         $format = $this->_date_format . ' ' . $this->_time_format;
         try {
-            $DateTime = DateTime::createFromFormat($format, $date_string, $this->_DateTimeZone);
-            if ($DateTime instanceof DateTime) {
-                $DateTime = new DbSafeDateTime(
-                    $DateTime->format(\EE_Datetime_Field::mysql_timestamp_format),
-                    $this->_DateTimeZone
-                );
-            }
+            $DateTime = DbSafeDateTime::createFromFormat($format, $date_string, $this->_DateTimeZone);
             if (! $DateTime instanceof DbSafeDateTime) {
                 throw new EE_Error(
                     sprintf(

--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -111,12 +111,7 @@ class DbSafeDateTime extends DateTime
      */
     public function __wakeup()
     {
-        $this->_datetime_string = str_replace(
-            array('-0001-11-29', '-0001-11-30'),
-            '0000-00-00',
-            $this->_datetime_string
-        );
-        $date = DateTime::createFromFormat(
+        $date = self::createFromFormat(
             DbSafeDateTime::db_safe_timestamp_format,
             $this->_datetime_string
         );
@@ -143,6 +138,21 @@ class DbSafeDateTime extends DateTime
 
 
     /**
+     * Normalizes incoming date string so that it is a bit more stable for use.
+     * @param string $date_string
+     * @return string
+     */
+    public static function normalizeInvalidDate($date_string)
+    {
+        return str_replace(
+            array('-0001-11-29', '-0001-11-30', '0000-00-00'),
+            '0000-01-01',
+            $date_string
+        );
+    }
+
+
+    /**
      * Creates a DbSafeDateTime from ye old DateTime
      *
      * @param DateTime $datetime
@@ -154,6 +164,22 @@ class DbSafeDateTime extends DateTime
             $datetime->format(\EE_Datetime_Field::mysql_timestamp_format),
             new DateTimeZone($datetime->format('e'))
         );
+    }
+
+
+    /**
+     * Parse a string into a new DateTime object according to the specified format
+     *
+     * @param string       $format   Format accepted by date().
+     * @param string       $time     String representing the time.
+     * @param DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+     * @return DateTime|boolean
+     * @link https://php.net/manual/en/datetime.createfromformat.php
+     */
+    public static function createFromFormat($format, $time, $timezone = null)
+    {
+        $time = self::normalizeInvalidDate($time);
+        return parent::createFromFormat($format, $time, $timezone);
     }
 
 

--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -176,7 +176,7 @@ class DbSafeDateTime extends DateTime
      * @return DateTime|boolean
      * @link https://php.net/manual/en/datetime.createfromformat.php
      */
-    public static function createFromFormat($format, $time, $timezone = null)
+    public static function createFromFormat($format, $time, DateTimeZone $timezone = null)
     {
         $time = self::normalizeInvalidDate($time);
         return parent::createFromFormat($format, $time, $timezone);

--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -179,7 +179,10 @@ class DbSafeDateTime extends DateTime
     public static function createFromFormat($format, $time, $timezone = null)
     {
         $time = self::normalizeInvalidDate($time);
-        $DateTime = parent::createfromFormat($format, $time, $timezone);
+        // Various php versions handle the third argument differently.  This conditional accounts for that.
+        $DateTime = $timezone === null
+            ? parent::createFromFormat($format, $time)
+            : parent::createFromFormat($format, $time, $timezone);
         return $DateTime instanceof DateTime
             ? self::createFromDateTime($DateTime)
             : $DateTime;

--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -176,7 +176,7 @@ class DbSafeDateTime extends DateTime
      * @return DateTime|boolean
      * @link https://php.net/manual/en/datetime.createfromformat.php
      */
-    public static function createFromFormat($format, $time, DateTimeZone $timezone = null)
+    public static function createFromFormat($format, $time, $timezone = null)
     {
         $time = self::normalizeInvalidDate($time);
         return parent::createFromFormat($format, $time, $timezone);

--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -173,13 +173,16 @@ class DbSafeDateTime extends DateTime
      * @param string       $format   Format accepted by date().
      * @param string       $time     String representing the time.
      * @param DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
-     * @return DateTime|boolean
+     * @return DbSafeDateTime|boolean
      * @link https://php.net/manual/en/datetime.createfromformat.php
      */
     public static function createFromFormat($format, $time, $timezone = null)
     {
         $time = self::normalizeInvalidDate($time);
-        return parent::createFromFormat($format, $time, $timezone);
+        $DateTime = parent::createfromFormat($format, $time, $timezone);
+        return $DateTime instanceof DateTime
+            ? self::createFromDateTime($DateTime)
+            : $DateTime;
     }
 
 

--- a/tests/testcases/core/domain/entities/DbSafeDateTimeTest.php
+++ b/tests/testcases/core/domain/entities/DbSafeDateTimeTest.php
@@ -60,20 +60,10 @@ class DbSafeDateTimeTest extends EE_UnitTestCase
         unlink($log_file);
         $db_safe_datetime = unserialize($serialized_datetime);
         $this->assertInstanceOf('DateTime', $db_safe_datetime);
-        // still vot a valid date, but at least this won't cause additional errors
+        // ensures date has been coerced to something more valid.
         $this->assertEquals(
-            '-0001-11-30 00:00:00.000000',
-            $db_safe_datetime->format('Y-m-d H:i:s.u')
-        );
-        // and just verify that nothing changed
-        $this->assertEquals(
-            $empty_datetime->format('Y-m-d H:i:s.u'),
+            '0000-01-01 00:00:00.000000',
             $db_safe_datetime->format('Y-m-d H:i:s.u')
         );
     }
-
-
-
 }
-// end of file DbSafeDateTimeTest.php
-// Location: /tests/testcases/core/domain/entities/DbSafeDateTimeTest.php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Creating a DateTime (or DbSafeDateTime) object with `0000-00-00 00:00:00` results in a internal timestamp of `-0001-11-30 00:00:00.000000`.  This results in potential downstream problems when we go to output this because even when you output back to mysql date format you’ll get `-0001-11-30 00:00:00` which is DIFFERENT than what was sent in.

To resolve this, if we coerce those date and time strings to `0000-01-01 00:00:00` it will result in an internal timestamp of `0000-01-01 00:00:00.000000` which is better because it represents a more legible value as well as is consistent with what the object was created with.

Downstream this is more friendly when dates are converted to ISO strings to pass along on REST api packages etc.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

This pretty much impacts anywhere dates are displayed, so along with existing phpunit tests (which shouldn't break), testing should just involve interacting with any EE functionality that touches upon dates and make sure there is no funkiness.  Funkiness would be things like:

- errors displayed
- unexpected dates or date changes

Any issues with the changes I made should show up right away.

Our automated tests in travis should also reveal any issues across the php versions we support with this change.

Note: see also https://wiki.php.net/rfc/parameter-no-type-variance which allows us to override `DateTime::createFromFormat` with confidence with regards to cross version PHP compat.

## Checklist

* [ ] I have added a changelog entry for this pull request
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is Maintenance Mode (MM2 especially disallows usage of models)
