### PR TITLE
Set light gray text to have minimum contrast ratio

### DIFF
--- a/core/templates/global_assets/css/espresso_default.css
+++ b/core/templates/global_assets/css/espresso_default.css
@@ -880,7 +880,7 @@ input.ee-register-button {
 	 color: #F8D755;
 }
 .lt-grey-text {
-	color: #A39D9C;
+	color: #767676;
 }
 .grey-text {
 	color: #888;
@@ -944,7 +944,7 @@ input.ee-register-button {
 }
 .currency-code {
 	font-size: .7em;
-	color: #a8a8a8;
+	color: #767676;
 	vertical-align: text-top;
 }
 

--- a/modules/single_page_checkout/css/single_page_checkout.css
+++ b/modules/single_page_checkout/css/single_page_checkout.css
@@ -10,7 +10,7 @@
 	padding: 0!important;
 	margin: .25em 0 !important;
 	line-height:1em;
-	color:#ccc;
+	color:#919191;
 	border: none!important;
 }
 .spco-steps-big-hdr {
@@ -456,7 +456,7 @@
 	clear: none;
 	margin:0;
 	/*text-align:right;*/
-	color:#ccc;
+	color:#919191;
 }
 .spco-payment-method-img {
 	float:left;


### PR DESCRIPTION
Event Espresso default styles should allow for passing WCAG 2 Color Contrast if white background. 


## How has this been tested
Browser testing, and https://webaim.org/resources/contrastchecker/

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
