### PR TITLE
Increase default time on normalizing invalid dates

### DIFF
--- a/core/domain/entities/DbSafeDateTime.php
+++ b/core/domain/entities/DbSafeDateTime.php
@@ -146,7 +146,7 @@ class DbSafeDateTime extends DateTime
     {
         return str_replace(
             array('-0001-11-29', '-0001-11-30', '0000-00-00'),
-            '0000-01-01',
+            '0000-01-03',
             $date_string
         );
     }

--- a/tests/testcases/core/domain/entities/DbSafeDateTimeTest.php
+++ b/tests/testcases/core/domain/entities/DbSafeDateTimeTest.php
@@ -62,7 +62,7 @@ class DbSafeDateTimeTest extends EE_UnitTestCase
         $this->assertInstanceOf('DateTime', $db_safe_datetime);
         // ensures date has been coerced to something more valid.
         $this->assertEquals(
-            '0000-01-01 00:00:00.000000',
+            '0000-01-03 00:00:00.000000',
             $db_safe_datetime->format('Y-m-d H:i:s.u')
         );
     }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

The problem with using `0000-01-01` is that if a DateTime is created in UTC and then the timezone is set to something that has a negative offset, the date will get set back before `0000-00-00` and thus end up as something like `-001-12-31`.  To prevent any possibility of this happening its better to set the default to the third day.

See #743 for context

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

I don't think this needs a full round of testing because #743 took care of that.  This simply bumps up the day value from `01` to `03` so the change is fairly minimal.

A phpunit test was updated to adjust the expectation and impacted systems are covered by phpunit tests.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
