### PR TITLE
Turn off, but filter link to the "Failed Transactions" list table Fixes #737

### DIFF
--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -433,12 +433,33 @@ class Transactions_Admin_Page extends EE_Admin_Page
                 'label' => esc_html__('Abandoned Transactions', 'event_espresso'),
                 'count' => 0,
             ),
-            'failed'    => array(
+        );
+        if (
+            /**
+             * Filters whether a link to the "Failed Transactions" list table
+             * appears on the Transactions Admin Page list table.
+             * List display can be turned back on via the following:
+             * add_filter(
+             *     'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed',
+             *     '__return_true'
+             * );
+             *
+             * @since $VID:$
+             * @param boolean                 $display_failed_txns_list
+             * @param Transactions_Admin_Page $this
+             */
+        apply_filters(
+            'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed_txns_list',
+            false,
+            $this
+        )
+        ) {
+            $this->_views['failed'] = array(
                 'slug'  => 'failed',
                 'label' => esc_html__('Failed Transactions', 'event_espresso'),
                 'count' => 0,
-            ),
-        );
+            );
+        }
     }
 
 

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -434,8 +434,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
                 'count' => 0,
             ),
         );
-        if (
-            /**
+        if (/**
              * Filters whether a link to the "Failed Transactions" list table
              * appears on the Transactions Admin Page list table.
              * List display can be turned back on via the following:
@@ -448,11 +447,11 @@ class Transactions_Admin_Page extends EE_Admin_Page
              * @param boolean                 $display_failed_txns_list
              * @param Transactions_Admin_Page $this
              */
-        apply_filters(
-            'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed_txns_list',
-            false,
-            $this
-        )
+            apply_filters(
+                'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed_txns_list',
+                false,
+                $this
+            )
         ) {
             $this->_views['failed'] = array(
                 'slug'  => 'failed',

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -440,7 +440,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
              * appears on the Transactions Admin Page list table.
              * List display can be turned back on via the following:
              * add_filter(
-             *     'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed',
+             *     'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed_txns_list',
              *     '__return_true'
              * );
              *


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #737

Filters whether a link to the "Failed Transactions" list table appears on the Transactions Admin Page list table.
 display can be turned back on via the following:

```php
add_filter(
     'FHEE__Transactions_Admin_Page___set_list_table_views_default__display_failed',
     '__return_true'
);
```

## How has this been tested
browser based monkey testing


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
