### PR TITLE
Filter txn list table query params and allow for dynamic views

### DIFF
--- a/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
+++ b/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
@@ -148,8 +148,8 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
      */
     protected function _add_view_counts()
     {
-        foreach( $this->_views as $view) {
-            $this->_views[$view['slug']]['count'] = $this->_admin_page->get_transactions($this->_per_page, true, $view['slug']);
+        foreach ($this->_views as $view) { 
+            $this->_views[$view[ 'slug' ]][ 'count' ] = $this->_admin_page->get_transactions($this->_per_page, true, $view[ 'slug' ]);
         }
     }
 

--- a/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
+++ b/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
@@ -148,9 +148,9 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
      */
     protected function _add_view_counts()
     {
-        $this->_views['all']['count'] = $this->_admin_page->get_transactions($this->_per_page, true, 'all');
-        $this->_views['abandoned']['count'] = $this->_admin_page->get_transactions($this->_per_page, true, 'abandoned');
-        $this->_views['failed']['count'] = $this->_admin_page->get_transactions($this->_per_page, true, 'failed');
+        foreach( $this->_views as $view) {
+            $this->_views[$view['slug']]['count'] = $this->_admin_page->get_transactions($this->_per_page, true, $view['slug']);
+        }
     }
 
 

--- a/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
+++ b/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
@@ -148,8 +148,8 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
      */
     protected function _add_view_counts()
     {
-        foreach ($this->_views as $view) { 
-            $this->_views[$view[ 'slug' ]][ 'count' ] = $this->_admin_page->get_transactions($this->_per_page, true, $view[ 'slug' ]);
+        foreach ($this->_views as $view) {
+            $this->_views[ $view['slug'] ]['count'] = $this->_admin_page->get_transactions($this->_per_page, true, $view['slug']);
         }
     }
 

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -2479,7 +2479,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
         );
 
         $transactions = $count
-            ? $TXN->count(array($_where), 'TXN_ID', true)
+            ? $TXN->count(array($query_params[0]), 'TXN_ID', true)
             : $TXN->get_all($query_params);
 
         return $transactions;

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -2465,11 +2465,17 @@ class Transactions_Admin_Page extends EE_Admin_Page
             $_where['STS_ID*'] = array('!=', EEM_Transaction::abandoned_status_code);
         }
 
-        $query_params = array(
-            $_where,
-            'order_by'                 => array($orderby => $sort),
-            'limit'                    => $limit,
-            'default_where_conditions' => EEM_Base::default_where_conditions_this_only,
+        $query_params = apply_filters(
+            'FHEE__Transactions_Admin_Page___get_transactions_query_params',
+            array(
+                $_where,
+                'order_by'                 => array($orderby => $sort),
+                'limit'                    => $limit,
+                'default_where_conditions' => EEM_Base::default_where_conditions_this_only,
+            ),
+            $this->_req_data,
+            $view,
+            $count
         );
 
         $transactions = $count


### PR DESCRIPTION
## Problem this Pull Request solves
This branch filters the `$query_params` var used by the get_transaction method which pulls all of the transactions for the EE Transactions list table.

I added this to allow me to add an 'Incomplete' transactions view - http://take.ms/78cmZ

Whilst the list table views are already filtered, I couldn't find a way to add the count for my new custom view, so I've also updated the method used to add the counts so that it loops over all views set and adds the counts for each, meaning we can add and remove views without too much fuss.

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
Adding this filter to an add-on, for add-ons to use, makes the add-on unable to be an add-on :|

## How has this been tested
Use this branch and confirm that all of the counts and views are correct when you go to Event Espresso -> Transactions.

Add this snippet to your site: https://gist.github.com/Pebblo/f76f4b2ab766072de44bb8f333db146f

Refresh and check again, click on the new 'Incomplete Transactions' view and confirm all of your counts are still correct and also that the list now only shows incomplete transactions.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
