### PR TITLE
Fix: Don't add version string to asset source when hash name assets used

### DIFF
--- a/core/domain/values/assets/BrowserAsset.php
+++ b/core/domain/values/assets/BrowserAsset.php
@@ -111,6 +111,8 @@ abstract class BrowserAsset extends Asset
 
 
     /**
+     * @todo investigate why this isn't working as expected.  We're seeing `?ver=` strings output for the url path with
+     *       core version even though for built hash assets this should not be the case.
      * @return string
      * @throws InvalidDataTypeException
      */

--- a/tests/mocks/core/domain/DomainMock.php
+++ b/tests/mocks/core/domain/DomainMock.php
@@ -3,10 +3,13 @@
 namespace EventEspresso\tests\mocks\core\domain;
 
 use EventEspresso\core\domain\DomainBase;
+use EventEspresso\core\domain\values\FilePath;
+use EventEspresso\core\domain\values\Version;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidFilePathException;
+use InvalidArgumentException;
 
 defined('EVENT_ESPRESSO_VERSION') || exit;
-
-
 
 /**
  * Class DomainMock
@@ -14,15 +17,40 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  *
  * @package EventEspresso\tests\mocks\core\domain
  * @author  Brent Christensen
- * 
+ *
  */
 class DomainMock extends DomainBase
 {
+
+    /**
+     * DomainMock constructor.
+     *
+     * By default, is constructed the same way as normal DomainBase classes, however
+     * if no arguments are provided, then will construct a default for the purpose of mock.
+     *
+     * @param null $file_path
+     * @param null $version
+     * @throws InvalidDataTypeException
+     * @throws InvalidFilePathException
+     * @throws InvalidArgumentException
+     */
+    public function __construct($file_path = null, $version = null)
+    {
+        if ($file_path instanceof FilePath
+            && $version instanceof Version
+        ) {
+            parent::__construct($file_path, $version);
+        } else {
+            parent::__construct(
+                new FilePath(EE_TESTS_DIR . 'mocks/core/domain/DomainMock.php'),
+                Version::fromString('1.2.3.p')
+            );
+        }
+    }
+
 
     public function returnOhYeah()
     {
         return 'Oh Yeah';
     }
-
 }
-// Location: DomainMock.php

--- a/tests/testcases/core/domain/values/assets/JavascriptAssetTest.php
+++ b/tests/testcases/core/domain/values/assets/JavascriptAssetTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace EventEspresso\tests;
+
+use EventEspresso\core\domain\DomainInterface;
+use EventEspresso\core\domain\values\assets\JavascriptAsset;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidFilePathException;
+use EventEspresso\tests\mocks\core\domain\DomainMock;
+use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * JavascriptAssetTest
+ *
+ *
+ * @package EventEspresso\tests
+ * @author  Darren Ethier
+ * @since   $VID:$
+ */
+class JavascriptAssetTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var DomainInterface
+     */
+    private $domain_mock;
+
+    /**
+     * @var JavascriptAsset
+     */
+    private $js_asset;
+
+
+    /**
+     * @throws InvalidDataTypeException
+     * @throws InvalidFilePathException
+     * @throws InvalidArgumentException
+     */
+    public function setUp()
+    {
+        $this->domain_mock = new DomainMock();
+        $this->js_asset = $this->getAsset();
+    }
+
+
+    public function tearDown()
+    {
+        $this->domain_mock = null;
+        $this->js_asset = null;
+    }
+
+
+    private function getAsset(
+        $source = 'https://testurl.com/test.js',
+        $dependencies = array(),
+        $load_in_footer = true
+    ) {
+        return new JavascriptAsset(
+            'test-handle',
+            $source,
+            $dependencies,
+            $load_in_footer,
+            $this->domain_mock
+        );
+    }
+
+
+    public function testConstruct()
+    {
+        $this->assertEquals('test-handle', $this->js_asset->handle());
+        $this->assertEquals('https://testurl.com/test.js', $this->js_asset->source());
+        $this->assertEquals(array(), $this->js_asset->dependencies());
+        $this->assertTrue($this->js_asset->loadInFooter());
+    }
+
+
+    public function testRequiresTranslation()
+    {
+        $this->assertFalse($this->js_asset->requiresTranslation());
+        $this->js_asset->setRequiresTranslation();
+        $this->assertTrue($this->js_asset->requiresTranslation());
+    }
+
+
+    public function testHasInlineData()
+    {
+        $this->assertFalse($this->js_asset->hasInlineData());
+        $this->js_asset->setHasInlineData();
+        $this->assertTrue($this->js_asset->hasInlineData());
+    }
+
+
+    public function testInlineDataCallback()
+    {
+        $test_callback = function () {
+            return true;
+        };
+        $this->assertFalse($this->js_asset->hasInlineDataCallback());
+        $this->assertNull($this->js_asset->inlineDataCallback());
+        $this->assertFalse($this->js_asset->hasInlineData());
+
+        $this->js_asset->setInlineDataCallback($test_callback);
+        $this->assertTrue($this->js_asset->hasInlineDataCallback());
+        $this->assertEquals($test_callback, $this->js_asset->inlineDataCallback());
+        $this->assertTrue($this->js_asset->hasInlineData());
+    }
+
+
+    public function testIsBuiltDistributionSource()
+    {
+        $this->assertFalse($this->js_asset->isBuiltDistributionSource());
+
+        $asset = $this->getAsset('https://testurl.com/testjs.dist.js');
+        $this->assertTrue($asset->isBuiltDistributionSource());
+    }
+
+
+    public function testVersion()
+    {
+        // version for non built (or "dist") source with no set version
+        $this->assertEquals('1.2.3.p', $this->js_asset->version());
+
+        // version for explicitly set version
+        $this->js_asset->setVersion('4.5.6');
+        $this->assertEquals('4.5.6', $this->js_asset->version());
+
+        // version for built ('.dist.js') source.
+        $asset = $this->getAsset('https://testurl.com/testjs.dist.js');
+        $this->assertNull($asset->version());
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

We just noticed that when "built" (built meaning through our new asset build process) assets are enqueued they are getting the version string `?ver=4.9.xx` added to them and they should _not_ be.  Having the version string basically makes the hash in the asset name pointless. 

Some preliminary investigation points to `BrowserAsset::version()` being the potential culprit except that it appears to have conditionals that should correctly detect when an asset source has `.dist.js` or `.dist.css` in the string.  Still, that's the first place to check for fixing this.

Also in this pull I'll make sure there's adequate phpunit test coverage for this process and either add tests or update tests if necessary.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Wrote unit test coverage
* [x] verified the javascript/css loaded on the WP plugins page (which is impacted by these changes) still works as expected.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
