### PR TITLE
Improve PhpStorm code assistance on aliased javascript imports

### DIFF
--- a/docs/A--Best-Practices/code-style-tools-resources.md
+++ b/docs/A--Best-Practices/code-style-tools-resources.md
@@ -19,8 +19,8 @@ composer run-script config-eventespressocs
  npm run lint-php
  ```
  
- ## IDE Setup
+## PhpStorm Setup
  
- To set up PHPStorm, you can [refer to their documentation](https://www.jetbrains.com/phpstorm/help/using-php-code-sniffer-tool.html) for setting up the PHP Code Sniffer tool.  During the installation you will select the `EventEspresso` standard from the PHP Code Sniffer Validation inspection options.  
+ To set up PHPStorm, you can [refer to their documentation](https://www.jetbrains.com/phpstorm/help/using-php-code-sniffer-tool.html) for setting up the PHP Code Sniffer tool.  During the installation you will select the `EventEspresso` standard from the PHP Code Sniffer Validation inspection options.
  
  As well, for additional PHPStorm based linting and auto-code formatting, you can import the [EE Code Styles](https://github.com/eventespresso/project-configuration/tree/master/phpstorm/code-styles) package.  This helps you follow the standards as you are writing code rather than having things linted for you after the fact.

--- a/docs/A--Best-Practices/javascript-coding-assistance-in-phpstorm.md
+++ b/docs/A--Best-Practices/javascript-coding-assistance-in-phpstorm.md
@@ -1,0 +1,28 @@
+## Javascript Code Assistance in PHPStorm
+
+Out of the box PhpStorm does really well with javascript code assistance (code completion tools, goto etc). However EE javascript has a webpack configuration setup where we export some of our modules to a `eejs` global and alias that as an external in our modules.  For example:
+
+```js
+module.exports({
+    externals: {
+        '@eventespresso/eejs' : 'eejs',
+        '@eventespresso/validators': 'eejs.validators',
+    }
+});
+```
+
+The unfortunate side effect of this is that whenever we reference one of these "external" mapped aliased imports in our modules, PhpStorm doesn't know where to find it because by default it looks in `node_modules` for imports.  So for example something like this isn't resolved by PhpStorm's indexing:
+
+```js
+import { isSchema } from '@eventespresso/validators'
+```
+
+Fortunately, there's a solution!  In the root folder of event-espresso-core, I've added a _pseudo_ webpack config (pseudo in that it's not used in actually building any files) that simply has a map of aliases.  PhpStorm can be configured to point to a specific webpack config file and if there's an `alias` entry in it, it uses that to figure out what aliased imports point to.
+
+So all you need to do is go to the PhpStorm preferences settings. Navigate to `Languages and Frameworks > Javascript > Webpack` and set the path to the webpack config file to `phpstorm-webpack.config.js` in the Event Espresso plugin root folder. It'll look something like this:
+
+![screenshot for phpstorm config](https://www.evernote.com/l/AAP1MBPNsc9F_5H0B8YFBEkr0INkSFT6OAEB/image.png)
+
+Once you've done that, click apply.  You _may_ need to restart phpstorm so that a re-index is done to pick up the aliases.
+
+With that in place, you'll now get code assistance for all the aliased imports!

--- a/phpstorm-webpack.config.js
+++ b/phpstorm-webpack.config.js
@@ -1,0 +1,19 @@
+const path = require( 'path' );
+
+const assets = 'assets/src/';
+
+const aliases = {
+	'@eventespresso/eejs': path.resolve( __dirname, assets + 'eejs' ),
+	'@eventespresso/i18n': '@wordpress/i18n',
+	'@eventespresso/validators': path.resolve( __dirname, assets + 'eejs/validators' ),
+	'@eventespresso/helpers': path.resolve( __dirname, assets + 'data/helpers' ),
+	'@eventespresso/model': path.resolve( __dirname, assets + 'data/model' ),
+	'@eventespresso/value-objects': path.resolve( __dirname, assets + 'vo' ),
+	'@eventespresso/higher-order-components': path.resolve( __dirname, assets + 'higher-order-components' ),
+	'@eventespresso/components': path.resolve( __dirname, assets + 'components' ),
+};
+module.exports = {
+	resolve: {
+		alias: aliases,
+	},
+};


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

PHPStorm doesn't provide code assistance for any imports we use in our js modules that are configured in webpack to point to externals.  For example in webpack, `@eventespresso/components` points to `eejs.components`.  This means that whenever we use something like this in our modules, PhpStorm doesn't know how to resolve it and thus we don't get things like code completion etc for that import:

```
import { isSchema } from '@eventespresso/validators';
```

This pull fixes that by exposing a special `phpstorm-webpack.config.js` file that is not used in any builds, but configured specifically to help PHPStorm with resolving aliased imports.

Included documentation in the commit provides instructions on how to implement.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

I've got this setup in my PhpStorm setup and it seems to work swimmingly.  The only issue I see is that it's not handling an alias to another package (eg. `@eventespresso/i18n` -> `@wordpress/i18n`).  That shouldn't be an issue eventually anyways because I'm opening another pull to just start using `@wordpress/i18n`.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
