### PR TITLE
Switch away from @eventespresso/i18n and use @wordpress/i18n directly (wip)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,8 @@ const autoprefixer = require( 'autoprefixer' );
 const externals = {
 	jquery: 'jQuery',
 	'@eventespresso/eejs': 'eejs',
+	// @todo need to switch away from doing this and give it the same treatment
+	// as I did for other js libraries bundled with WP 5.0.
 	'@eventespresso/i18n': 'eejs.i18n',
 	'@wordpress/api-request': 'wp.apiRequest',
 	'@wordpress/data': 'wp.data',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

A while ago, I started using `@eventespresso/i18n` as a way to get around the fact that we started using wp.i18n functionality in environments that may not have `wp.i18n` so it was a way to ensure we could just use it anywhere (basically `eejs.i18n` is just a wrapper around the `@wordpress/i18n` package).

However, now that the release of WP5.0 is imminent, I think it'd be better for long term maintenance if we start using `@wordpress/i18n` everywhere instead and I can just give it the same treatment that I did for bundled vendor scripts in WordPress (such as `react`).  So essentially just copying the `wp.i18n` package into the `assets/vendors` directory and registering it on the `wpi18n` handle if its not already registered in WP.

**Note:** this is not an urgent requirement and can be done "whenever".  It's more of an optimization thing (and reduces maintenance overhead).  When I implement, I can just alias `@eventespresso/i18n` to the `wp.i18n` external instead of `eejs.i18n`.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] Verify no js unit-tests fail (indicating configuration problems)
* [ ] Verify files build successfully
* [ ] Verify existing GB blocks and react apps (plugins deactivation modal) still work as expected on the newly built files.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
