### PR TITLE
Fix session not saving after clearing notices Fixes #770

### DIFF
--- a/core/EE_Session.core.php
+++ b/core/EE_Session.core.php
@@ -398,7 +398,7 @@ class EE_Session implements SessionIdentifierInterface
             EE_Session::SAVE_STATE_CLEAN,
             EE_Session::SAVE_STATE_DIRTY,
         ];
-        if(! in_array($save_state, $valid_save_states, true)) {
+        if (! in_array($save_state, $valid_save_states, true)) {
             $save_state = EE_Session::SAVE_STATE_DIRTY;
         }
         $this->save_state = $save_state;
@@ -955,7 +955,6 @@ class EE_Session implements SessionIdentifierInterface
                        || ! empty($this->_session_data['ee_notices']['success'])
                    )
                );
-
     }
 
 

--- a/core/EE_Session.core.php
+++ b/core/EE_Session.core.php
@@ -384,6 +384,12 @@ class EE_Session implements SessionIdentifierInterface
 
 
     /**
+     * Marks whether the session data has been updated or not.
+     * Valid options are:
+     *      EE_Session::SAVE_STATE_CLEAN - session data remains unchanged and updating is not necessary
+     *      EE_Session::SAVE_STATE_DIRTY - session data has changed since last save and needs to be updated
+     * default value is EE_Session::SAVE_STATE_DIRTY
+     *
      * @param string $save_state
      */
     public function setSaveState($save_state = EE_Session::SAVE_STATE_DIRTY)
@@ -938,15 +944,18 @@ class EE_Session implements SessionIdentifierInterface
     private function sessionHasStuffWorthSaving()
     {
         return $this->save_state === EE_Session::SAVE_STATE_DIRTY
-            || $this->cart() instanceof EE_Cart
-            || (
-                isset($this->_session_data['ee_notices'])
-                && (
-                    ! empty($this->_session_data['ee_notices']['attention'])
-                    || !empty($this->_session_data['ee_notices']['errors'])
-                    || !empty($this->_session_data['ee_notices']['success'])
-                )
-            );
+               // we may want to eventually remove the following
+               // on the assumption that the above check is enough
+               || $this->cart() instanceof EE_Cart
+               || (
+                   isset($this->_session_data['ee_notices'])
+                   && (
+                       ! empty($this->_session_data['ee_notices']['attention'])
+                       || ! empty($this->_session_data['ee_notices']['errors'])
+                       || ! empty($this->_session_data['ee_notices']['success'])
+                   )
+               );
+
     }
 
 


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #770

In #652 a method was added to the session for not only checking whether the session contained an active cart but also whether notices had been added and if so, would ensure that the session data was saved. The issue that we missed was that this made it impossible to clear notices from the session, because this new check would return that there was nothing worth saving and so session updating was aborted. So frontend notices saved to a user's session would reappear on every page load.

This branch introduces a way to track the session save state, using a property and two class constants. Whenever session data changes, the save state is toggled from clean to dirty, which can then be checked prior to updating. This should be a much more robust and fool-proof way to check for changes.

## How has this been tested
browser based monkey testing only

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
