### PR TITLE
Restored the ability to change PDF paper size

### DIFF
--- a/core/libraries/messages/messenger/EE_Pdf_messenger.class.php
+++ b/core/libraries/messages/messenger/EE_Pdf_messenger.class.php
@@ -334,6 +334,10 @@ class EE_Pdf_messenger extends EE_messenger
             $options->setFontDir(DOMPDF_FONT_DIR);
             $options->setFontCache(DOMPDF_FONT_DIR);
         }
+        // Allow changing the paper size.
+        if (defined('DOMPDF_DEFAULT_PAPER_SIZE')) {
+            $options->set('defaultPaperSize', DOMPDF_DEFAULT_PAPER_SIZE);
+        }
         $dompdf = new Dompdf\Dompdf($options);
         // Remove all spaces between HTML tags
         $content = preg_replace('/>\s+</', '><', $content);


### PR DESCRIPTION
## Problem this Pull Request solves
Resolves: #773 

This was accidentally removed in this commit: https://github.com/eventespresso/event-espresso-core/commit/b1dd7ca7bc8d3b90e45cb22c213d0c5d3eb9504a

## How has this been tested
* [x] Download a PDF invoice that was generated after a registration it should have the default letter size (8.5"x11").
* [x] Now put this in your `wp-config.php` file: `define('DOMPDF_DEFAULT_PAPER_SIZE', 'ledger');` and try downloading the same invoice. The paper size should be different - 17"x11".

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
