### PR TITLE
Fixed Datetime Filter Radio Input Values Fixes #785

### DIFF
--- a/modules/ticket_selector/assets/ticket_selector.js
+++ b/modules/ticket_selector/assets/ticket_selector.js
@@ -57,7 +57,7 @@ jQuery(document).ready(function ($) {
                         active_rows++;
                     } else {
 						$ticket_selector_row.addClass( 'ee-hidden-ticket-tr' );
-						$qty_input = $ticket_selector_row.find(
+						var $qty_input = $ticket_selector_row.find(
 							'.ticket-selector-tbl-qty-slct'
 						);
 						// set qty to zero for non-radio inputs

--- a/modules/ticket_selector/assets/ticket_selector.js
+++ b/modules/ticket_selector/assets/ticket_selector.js
@@ -56,7 +56,14 @@ jQuery(document).ready(function ($) {
                         $ticket_selector_row.removeClass('ee-hidden-ticket-tr');
                         active_rows++;
                     } else {
-                        $ticket_selector_row.addClass('ee-hidden-ticket-tr').find('.ticket-selector-tbl-qty-slct').val(0);
+						$ticket_selector_row.addClass( 'ee-hidden-ticket-tr' );
+						$qty_input = $ticket_selector_row.find(
+							'.ticket-selector-tbl-qty-slct'
+						);
+						// set qty to zero for non-radio inputs
+						if ( $qty_input.attr( 'type' ) !== 'radio' ) {
+							$qty_input.val( 0 );
+						}
                     }
                 });
             }


### PR DESCRIPTION
## Problem this Pull Request solves
plz see #785

## How has this been tested
Monkey based browser testing 

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
