### PR TITLE
Fix incorrect dependency on `wp-api-request` in our asset registration

### DIFF
--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -252,7 +252,7 @@ class CoreAssetManager extends AssetManager
             array(
                 CoreAssetManager::JS_HANDLE_VENDOR,
                 'wp-data',
-                'wp-api-request',
+                'wp-api-fetch',
                 CoreAssetManager::JS_HANDLE_VALUE_OBJECTS
             )
         )


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Josh discovered today that running the latest version of the Gutenberg plugin (4.5.1) against WordPress 4.9.8 was producing errors in the Event Attendees block usage.  I discovered that the same errors (although a different error stack in development mode) could be reproduced with the GB plugin active against WP 5.0beta5.

The error traced the incorrect listing of the `wp-api-request` script handle as a dependency when it should be `wp-api-fetch`.  GB recently made some changes to how dependencies are loaded that exposed this as it was a "happy-accident" things worked due to the `wp.apiFetch` script just happening to be loaded before our data stores needing it.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

There were no changes in javascript and this was easily verified as fixing the issue both in my environment and Josh also verified the same fix addressed the errors he was seeing in his environment as well.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
