### PR TITLE
fix potential for PHP fatal in PHP7.2+ boxes

### DIFF
--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1083,6 +1083,7 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 );
             }
 
+            $existing_notices = is_array( $existing_notices ) ? $existing_notices : array();
 
             //k make sure there are no existing notices matching the incoming notices and only append new notices
             //(unless overwrite is set to true).


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

We got a [report](https://eventespresso.com/topic/urgent-ee-4-9-71p-is-producing-the-following-php-errors/) of the following fatal error from a customer:

```
PHP Fatal error: Cannot use string offset as an array in /[redacted]/wp-content/plugins/event-espresso-core-reg/core/third_party_libs/pue/pue-client.php on line 1114
```

The fix in this pull intends to the address the potential for this kind of fatal surfacing.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Verified that pue-client functionality is not borked by this change.  Essentially what we're going is ensuring that what is retrieved from the db is an array and if its not then discarding it and saving as an array.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
