### PR TITLE
Add shim for get_user_locale

### DIFF
--- a/core/wordpress-shims.php
+++ b/core/wordpress-shims.php
@@ -93,3 +93,17 @@ if (! function_exists('wp_scripts_get_suffix')) {
         return $suffixes['suffix'];
     }
 }
+
+if (! function_exists('get_user_locale')) {
+    /**
+     * Shim for get_user_locale that was added in WP 4.7.0
+     *
+     * @param int $user_id
+     * @return string
+     * @since $VID:$
+     */
+    function get_user_locale($user_id = 0)
+    {
+        return get_locale();
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

Fatal errors are being reported for usage of this function in EE on WP versions earlier than 4.7.0.  Since we still support WP 4.5.0+ we should have a shim for this function.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] I tested to ensure there is no unusual behaviour with WP version 5.0.RC1 (which would be cover any WP version > 4.7).  If there was a problem it would surface in some sort of error fairly quickly.
* [x] I have not tested personally, but should be verified that this fixes issues on WP versions < 4.7 (any wp version less would do).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
