### PR TITLE
Up the requirements in the readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: eventespresso, sethshoultes, garthkoyle, pebblo, nerrad, mnelson4, lorenzocaum, charliespider, builtbynorthby
 Donate link: https://eventespresso.com/pricing/?ee_ver=ee4&utm_source=wordpress_org&utm_medium=link&utm_campaign=ee4_decaf_plugin_donate_link&utm_content=Donate+link
 Tags: event registration, ticketing, online registration, ticket sales, event booking, event management, event manager, class booking, booking, class registration, conference registration, events calendar, events planner, event ticketing, registration, registration form, training, event, events, online event registration
-Requires at least: 4.1
+Requires at least: 4.5
 Requires PHP Version: 5.4
 Tested up to: 5.0
 Stable tag: 4.9.72.decaf


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

On WordPress.org I noticed this today in the listing for our decaf plugin:

![screenshot](https://www.evernote.com/l/AAONAdY3bSZH-ITbDsjKcc8E68tLRBJMcXEB/image.png)

However, our [requirements page](https://eventespresso.com/requirements/) lists EE4 as requiring WordPress 4.5.  This pull thus updates the readme.txt to make it consistent with what we publish on the main website.

I've submitted this as a pull on the off chance decaf has a different requirement level than caf that I was not aware of.  If the pull is okay it can just be merged right into master.
