### PR TITLE
use default_avatar option instead of hardcoding in “Mystery Man”

### DIFF
--- a/core/libraries/rest_api/calculations/Attendee.php
+++ b/core/libraries/rest_api/calculations/Attendee.php
@@ -30,7 +30,7 @@ class Attendee extends AttendeeCalculationsBase
             $email_address = $wpdb_row['Attendee_Meta.ATT_email'];
         }
         if (empty($email_address)) {
-            return get_avatar_url('', array('default' => 'mm', 'force_default' => true));
+            return get_avatar_url('', array('force_default' => true));
         }
         $avatar = get_avatar_url($email_address);
         return $avatar ? $avatar : '';

--- a/ui/blocks/event-attendees.php
+++ b/ui/blocks/event-attendees.php
@@ -16,7 +16,6 @@
                 ? get_avatar_url(
                     $attendee->email(),
                     array(
-                        'default' => 'mm',
                         'width'   => $attributes['avatarSize'],
                         'height'  => $attributes['avatarSize']
                     )


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
I found that the live preview within the editor used what's set for the `default_avatar` option, but the front end of the site always used "Mystery Man" as a fallback if no Gravatar was registered for the email address.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Used WP5's editor, and added an attendee block. Compared the live preview in the editor to the front end page. 
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
