### PR TITLE
filter db engine when creating tables

### DIFF
--- a/core/services/database/TableManager.php
+++ b/core/services/database/TableManager.php
@@ -184,6 +184,12 @@ class TableManager extends \EE_Base
      */
     public function createTable($table_name, $create_sql, $engine = 'MyISAM')
     {
+        $engine = apply_filters(
+            'FHEE__EventEspresso__core__services__database__TableManager__createTable__engine',
+            $engine,
+            $table_name,
+            $create_sql
+        );
         // does $sql contain valid column information? ( LPT: https://regex101.com/ is great for working out regex patterns )
         if (preg_match('((((.*?))(,\s))+)', $create_sql, $valid_column_data)) {
             $table_name = $this->getTableAnalysis()->ensureTableNameHasPrefix($table_name);


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
This should allow site owners to change what database engine a table uses. This should help with https://github.com/eventespresso/EE4-Promotions/issues/6, allowing folks having this problem to switch their table to `MyISAM` instead of `InnoDB`.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
TBA

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
