### PR TITLE
Added logic to not adjust event subtotals for ticket scope promo line items

### DIFF
--- a/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
@@ -337,9 +337,12 @@ class EE_SPCO_Line_Item_Display_Strategy implements EEI_Line_Item_Display
         $html .= EEH_HTML::td($line_item->quantity(), '', 'item_l jst-rght');
         // $total = $line_item->total() * $line_item->quantity();
         $total = $line_item->total();
-        if (
-            isset($options['event_id'], $this->_events[ $options['event_id'] ])
-            && ! ($line_item->OBJ_type() === 'Promotion' && $line_item->parent()->OBJ_ID() !== $options['event_id'])
+        if (isset($options['event_id'], $this->_events[ $options['event_id'] ])
+            && ! ($line_item->OBJ_type() === 'Promotion'
+                && ! ($line_item->parent()->OBJ_type() === 'Event'
+                    && $line_item->parent()->OBJ_ID() === $options['event_id']
+                )
+            )
         ) {
             $this->_events[ $options['event_id'] ] += $total;
         }

--- a/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
@@ -337,7 +337,10 @@ class EE_SPCO_Line_Item_Display_Strategy implements EEI_Line_Item_Display
         $html .= EEH_HTML::td($line_item->quantity(), '', 'item_l jst-rght');
         // $total = $line_item->total() * $line_item->quantity();
         $total = $line_item->total();
-        if (isset($options['event_id'], $this->_events[ $options['event_id'] ])) {
+        if (
+            isset($options['event_id'], $this->_events[ $options['event_id'] ])
+            && ! ($line_item->OBJ_type() === 'Promotion' && $line_item->parent()->OBJ_ID() !== $options['event_id'])
+        ) {
             $this->_events[ $options['event_id'] ] += $total;
         }
         // total td


### PR DESCRIPTION
## Problem this Pull Request solves
plz see: https://github.com/eventespresso/EE4-Promotions/pull/15
In the above PR, I added some filters that facilitate the adding of ticket scope promotions, but that caused some issues with the line item display filters, so this tweak fixes things.

## How has this been tested
monkey based browser testing only