### PR TITLE
dont say password required to view deleted tickets

### DIFF
--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -650,7 +650,8 @@ class Read extends Base
                 array(
                     0 => array(
                         $model->primary_key_name() => $db_row[ $model->get_primary_key_field()->get_qualified_column() ]
-                    )
+                    ),
+                    'default_where_conditions' => 'minimum'
                 ),
                 $rest_request
             );

--- a/tests/testcases/core/libraries/rest_api/controllers/ReadProtectedTest.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/ReadProtectedTest.php
@@ -54,7 +54,6 @@ class ReadProtectedTest extends EE_REST_TestCase
     /**
      * test get_all on a model with a password field, with no password provided.
      * @since 4.9.74.p
-     * @group current
      */
     public function testGetAllNoPassword()
     {
@@ -966,6 +965,127 @@ class ReadProtectedTest extends EE_REST_TestCase
     }
 
     /**
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    public function testGetRelatedDatetimesToTicketsNoPassword()
+    {
+        // Create a datetime, and event, that's not password protected.
+        $event = $this->new_model_obj_with_dependencies(
+            'Event',
+            array(
+                'status' => EEM_Event::post_status_publish
+            )
+        );
+        $dtt = $this->new_model_obj_with_dependencies(
+            'Datetime',
+            array(
+                'EVT_ID' => $event->ID()
+            )
+        );
+        // And create a ticket for it.
+        $tkt = $this->new_model_obj_with_dependencies('Ticket');
+        $dtt->_add_relation_to($tkt, 'Ticket');
+        $request = new WP_REST_Request(
+            'GET',
+            '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/datetimes/' . $dtt->ID() . '/tickets'
+        );
+        $response = rest_do_request($request);
+        $this->assertInstanceOf('WP_REST_Response', $response);
+        $data = $response->get_data();
+        $this->assertEquals(1, count($data));
+        $this->assertEquals($tkt->ID(),$data[0]['TKT_ID']);
+    }
+
+    /**
+     * * Verifies that if a ticket is archived, there is no erroneous requirement for a password (this was a problem
+     * at one point).
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    public function testGetRelatedDatetimesToTicketsDeletedNoPassword()
+    {
+        // Create a datetime, and event, that's not password protected.
+        $event = $this->new_model_obj_with_dependencies(
+            'Event',
+            array(
+                'status' => EEM_Event::post_status_publish
+            )
+        );
+        $dtt = $this->new_model_obj_with_dependencies(
+            'Datetime',
+            array(
+                'EVT_ID' => $event->ID()
+            )
+        );
+        // And create a ticket for it.
+        $tkt = $this->new_model_obj_with_dependencies(
+            'Ticket',
+            array(
+                'TKT_deleted' => true
+            )
+        );
+        $dtt->_add_relation_to($tkt, 'Ticket');
+        $request = new WP_REST_Request(
+            'GET',
+            '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/datetimes/' . $dtt->ID() . '/tickets'
+        );
+        $response = rest_do_request($request);
+        $this->assertInstanceOf('WP_REST_Response', $response);
+        $data = $response->get_data();
+        $this->assertEquals(1, count($data));
+        $this->assertEquals($tkt->ID(),$data[0]['TKT_ID']);
+    }
+
+    /**
+     * Verifies that if a datetime is trashed, there is no erroneous requirement for a password (this was a problem
+     * at one point).
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    public function testGetRelatedDatetimesDeletedToTicketsNoPassword()
+    {
+        // Create a datetime, and event, that's not password protected.
+        $event = $this->new_model_obj_with_dependencies(
+            'Event',
+            array(
+                'status' => EEM_Event::post_status_publish
+            )
+        );
+        $dtt = $this->new_model_obj_with_dependencies(
+            'Datetime',
+            array(
+                'EVT_ID' => $event->ID(),
+                'DTT_deleted' => true
+            )
+        );
+        // And create a ticket for it.
+        $tkt = $this->new_model_obj_with_dependencies('Ticket');
+        $dtt->_add_relation_to($tkt, 'Ticket');
+        $request = new WP_REST_Request(
+            'GET',
+            '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/datetimes/' . $dtt->ID() . '/tickets'
+        );
+        $response = rest_do_request($request);
+        $this->assertInstanceOf('WP_REST_Response', $response);
+        $data = $response->get_data();
+        $this->assertEquals(1, count($data));
+        $this->assertEquals($tkt->ID(),$data[0]['TKT_ID']);
+    }
+
+    /**
      * Test fetching an protected model, and including an  UNprotected model (venue to country), and no password is provided.
      * @since 4.9.74.p
      * @throws EE_Error
@@ -1403,7 +1523,6 @@ class ReadProtectedTest extends EE_REST_TestCase
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws ReflectionException
-     * @group current
      */
     public function testGetAllAdminRequestIndirectlyProtected()
     {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixed bug that erroneous required a password to view archived tickets.
Eg `/wp-json/ee/v4.8.36/datetimes/1/tickets` would return an error response if one of the datetimes' tickets were archived.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create an event, archive one of its tickets, then send a request to `wp-json/ee/v4.8.36/events/{event_id}/datetime?include=Ticket`. It shouldn't have an error.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
