### PR TITLE
dont use expectException as thats new, instead use setExceptionExpect…

### DIFF
--- a/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
+++ b/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
@@ -143,7 +143,7 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
      */
     public function testPrepareConditionsQueryParamsForModelsUnprivilegedUseOfPassword()
     {
-        $this->expectException(RestException::class);
+        $this->setExceptionExpected(RestException::class);
         // you can't filter by password unless you're an admin
             ModelDataTranslator::prepareConditionsQueryParamsForModels(
                 array(


### PR DESCRIPTION
…ed shim


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Unit test failure from https://github.com/eventespresso/event-espresso-core/issues/812. Only affects unit tests.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Ran unit tests locally. Will run on travis.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
