### PR TITLE
don’t load our blocks framework if in Divi front-end editor context

### DIFF
--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1327,7 +1327,8 @@ final class EE_System implements ResettableInterface
      */
     private function canLoadBlocks()
     {
-        return function_exists('register_block_type')
+        return apply_filters('FHEE__EE_System__canLoadBlocks', true)
+               && function_exists('register_block_type')
                // don't load blocks if in the Divi page builder editor context
                // @see https://github.com/eventespresso/event-espresso-core/issues/814
                && ! $this->request->getRequestParam('et_fb', false);

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1175,7 +1175,7 @@ final class EE_System implements ResettableInterface
             try {
                 $this->loader->getShared('EventEspresso\core\services\assets\Registry');
                 $this->loader->getShared('EventEspresso\core\domain\services\assets\CoreAssetManager');
-                if (function_exists('register_block_type')) {
+                if ($this->canLoadBlocks()) {
                     $this->loader->getShared(
                         'EventEspresso\core\services\editor\BlockRegistrationManager'
                     );
@@ -1318,5 +1318,13 @@ final class EE_System implements ResettableInterface
     public function remove_pages_from_wp_list_pages($exclude_array)
     {
         return array_merge($exclude_array, $this->registry->CFG->core->get_critical_pages_array());
+    }
+
+    private function canLoadBlocks()
+    {
+        return function_exists('register_block_type')
+               // don't load blocks if in the Divi page builder editor context
+               // @see https://github.com/eventespresso/event-espresso-core/issues/814
+               && ! $this->request->getRequestParam('et_fb');
     }
 }

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1320,11 +1320,16 @@ final class EE_System implements ResettableInterface
         return array_merge($exclude_array, $this->registry->CFG->core->get_critical_pages_array());
     }
 
+
+    /**
+     * Return whether blocks can be registered/loaded or not.
+     * @return bool
+     */
     private function canLoadBlocks()
     {
         return function_exists('register_block_type')
                // don't load blocks if in the Divi page builder editor context
                // @see https://github.com/eventespresso/event-espresso-core/issues/814
-               && ! $this->request->getRequestParam('et_fb');
+               && ! $this->request->getRequestParam('et_fb', false);
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

See #814 for background.  Essentially this pull kills any php side block registration (and thus any asset loading) when the divi frontend editor is loading.  Divi uses a request parameter (`et_fb`) when in that view so its trivial for us to just use that to kill loading.

Brent, I don't generally like putting compatibility things for other plugins directly in our code like this, but in this case I'm _hoping_ that Divi gets on the ball and fixes the conflict issues on their end.  Essentially they are not accounting for the very real possibility that other plugins/themes could start using the WP core block api for loading react, lodash etc on the frontend (along with other `wp` packages). For now, we don't really care because divi doesn't really fully support GB anyways, they currently just _bypass_ the whole thing.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] tested against the issue reported in #814 with Divi loaded.
* [x] Ensured our assets still load on other non divi frontend editor routes.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
