### PR TITLE
Fix "seperator" typo on Countries page

### DIFF
--- a/core/db_models/EEM_Country.model.php
+++ b/core/db_models/EEM_Country.model.php
@@ -33,8 +33,8 @@ class EEM_Country extends EEM_Base
 
     protected function __construct($timezone = null)
     {
-        $this->singular_item = __('Country', 'event_espresso');
-        $this->plural_item = __('Countries', 'event_espresso');
+        $this->singular_item = esc_html__('Country', 'event_espresso');
+        $this->plural_item = esc_html__('Countries', 'event_espresso');
 
 
         $this->_tables = array(
@@ -42,21 +42,21 @@ class EEM_Country extends EEM_Base
         );
         $this->_fields = array(
             'Country'=>array(
-                'CNT_active' => new EE_Boolean_Field('CNT_active', __('Country Appears in Dropdown Select Lists', 'event_espresso'), false, true),
-                'CNT_ISO'=> new EE_Primary_Key_String_Field('CNT_ISO', __('Country ISO Code', 'event_espresso')),
-                'CNT_ISO3'=>new EE_All_Caps_Text_Field('CNT_ISO3', __('Country ISO3 Code', 'event_espresso'), false, ''),
-                'RGN_ID'=>new EE_Integer_Field('RGN_ID', __('Region ID', 'event_espresso'), false, 0),// should be a foreign key, but no region table exists yet
-                'CNT_name'=>new EE_Plain_Text_Field('CNT_name', __('Country Name', 'event_espresso'), false, ''),
-                'CNT_cur_code'=>new EE_All_Caps_Text_Field('CNT_cur_code', __('Country Currency Code', 'event_espresso'), false),
-                'CNT_cur_single' => new EE_Plain_Text_Field('CNT_cur_single', __('Currency Name Singular', 'event_espresso'), false),
-                'CNT_cur_plural' => new EE_Plain_Text_Field('CNT_cur_plural', __('Currency Name Plural', 'event_espresso'), false),
-                'CNT_cur_sign' => new EE_Plain_Text_Field('CNT_cur_sign', __('Currency Sign', 'event_espresso'), false),
-                'CNT_cur_sign_b4' => new EE_Boolean_Field('CNT_cur_sign_b4', __('Currency Sign Before Number', 'event_espresso'), false, true),
-                'CNT_cur_dec_plc' => new EE_Integer_Field('CNT_cur_dec_plc', __('Currency Decimal Places', 'event_espresso'), false, 2),
-                'CNT_cur_dec_mrk' => new EE_Plain_Text_Field('CNT_cur_dec_mrk', __('Currency Decimal Mark', 'event_espresso'), false, '.'),
-                'CNT_cur_thsnds' => new EE_Plain_Text_Field('CNT_cur_thsnds', __('Currency Thousands Seperator', 'event_espresso'), false, ','),
-                'CNT_tel_code' => new EE_Plain_Text_Field('CNT_tel_code', __('Country Telephone Code', 'event_espresso'), false, ''),
-                'CNT_is_EU' => new EE_Boolean_Field('CNT_is_EU', __('Country is Member of EU', 'event_espresso'), false, false)
+                'CNT_active' => new EE_Boolean_Field('CNT_active', esc_html__('Country Appears in Dropdown Select Lists', 'event_espresso'), false, true),
+                'CNT_ISO'=> new EE_Primary_Key_String_Field('CNT_ISO', esc_html__('Country ISO Code', 'event_espresso')),
+                'CNT_ISO3'=>new EE_All_Caps_Text_Field('CNT_ISO3', esc_html__('Country ISO3 Code', 'event_espresso'), false, ''),
+                'RGN_ID'=>new EE_Integer_Field('RGN_ID', esc_html__('Region ID', 'event_espresso'), false, 0),// should be a foreign key, but no region table exists yet
+                'CNT_name'=>new EE_Plain_Text_Field('CNT_name', esc_html__('Country Name', 'event_espresso'), false, ''),
+                'CNT_cur_code'=>new EE_All_Caps_Text_Field('CNT_cur_code', esc_html__('Country Currency Code', 'event_espresso'), false),
+                'CNT_cur_single' => new EE_Plain_Text_Field('CNT_cur_single', esc_html__('Currency Name Singular', 'event_espresso'), false),
+                'CNT_cur_plural' => new EE_Plain_Text_Field('CNT_cur_plural', esc_html__('Currency Name Plural', 'event_espresso'), false),
+                'CNT_cur_sign' => new EE_Plain_Text_Field('CNT_cur_sign', esc_html__('Currency Sign', 'event_espresso'), false),
+                'CNT_cur_sign_b4' => new EE_Boolean_Field('CNT_cur_sign_b4', esc_html__('Currency Sign Before Number', 'event_espresso'), false, true),
+                'CNT_cur_dec_plc' => new EE_Integer_Field('CNT_cur_dec_plc', esc_html__('Currency Decimal Places', 'event_espresso'), false, 2),
+                'CNT_cur_dec_mrk' => new EE_Plain_Text_Field('CNT_cur_dec_mrk', esc_html__('Currency Decimal Mark', 'event_espresso'), false, '.'),
+                'CNT_cur_thsnds' => new EE_Plain_Text_Field('CNT_cur_thsnds', esc_html__('Currency Thousands Separator', 'event_espresso'), false, ','),
+                'CNT_tel_code' => new EE_Plain_Text_Field('CNT_tel_code', esc_html__('Country Telephone Code', 'event_espresso'), false, ''),
+                'CNT_is_EU' => new EE_Boolean_Field('CNT_is_EU', esc_html__('Country is Member of EU', 'event_espresso'), false, false)
             ));
         $this->_model_relations = array(
             'Attendee'=>new EE_Has_Many_Relation(),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
View the Event Espresso > General Settings > Countries page, all text should display as before, with the exception of the typo for "seperator" which is fixed in this branch. 
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
