### PR TITLE
update travis build to include php 7.3 (fixes #794)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,13 @@ before_script:
     # Install the specified version of PHPUnit depending on the PHP version:
     if [[ -n "$TRAVIS_PHP_VERSION" ]]; then
       case "$TRAVIS_PHP_VERSION" in
-        7.2|7.1|7.0|nightly)
+        7.3|7.2|7.1|7.0|nightly)
           echo "Using PHPUnit 6.1"
           composer global require "phpunit/phpunit=6.1.*"
           ;;
-        5.6|5.5|5.4|5.3)
+        5.6|5.5)
           echo "Using PHPUnit 4.8"
           composer global require "phpunit/phpunit=4.8.*"
-          ;;
-        5.2)
-          # Do nothing, use default PHPUnit 3.6.x
-          echo "Using default PHPUnit, hopefully 3.6"
           ;;
         *)
           echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
@@ -59,13 +55,13 @@ jobs:
   fast_finish: true
   allow_failures:
     - php: nightly
-    - php: 7.2
+    - php: 7.3
       env:
         - PHP_LINT=1
         - PHP_LINT_WITH_WARNINGS=yes
   include:
     - stage: test
-      php: 7.2
+      php: 7.3
       env:
         - PHP_LINT=1
         - PHP_LINT_WITH_WARNINGS=no
@@ -73,7 +69,7 @@ jobs:
         - composer install || exit 1
         - composer config-eventespressocs || exit 1
         - npm run lint-php:skip-warnings || exit 1
-    - php: 7.2
+    - php: 7.3
       env:
         - PHP_LINT=1
         - PHP_LINT_WITH_WARNINGS=yes
@@ -96,6 +92,7 @@ jobs:
         - LICENSE_CHECK=1
       script:
         - npm run lc || exit 1
+    - php: 7.3
     - php: 7.2
     - php: 7.1
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,14 @@ before_script:
     # Install the specified version of PHPUnit depending on the PHP version:
     if [[ -n "$TRAVIS_PHP_VERSION" ]]; then
       case "$TRAVIS_PHP_VERSION" in
-        7.3|7.2|7.1|7.0|nightly)
-          echo "Using PHPUnit 6.1"
-          composer global require "phpunit/phpunit=6.1.*"
+        7.3|nightly)
+          # when wp tests support phpunit 7 we'll update this.
+          echo "Using PHPUnit 6"
+          composer global require "phpunit/phpunit=6.5.*"
+          ;;
+        7.2|7.1|7.0)
+          echo "Using PHPUnit 6"
+          composer global require "phpunit/phpunit=6.5.*"
           ;;
         5.6|5.5)
           echo "Using PHPUnit 4.8"

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -1426,7 +1426,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
                             // right now we're only handling tickets here.
                             // Cause its expected that only tickets will have attendees right?
                             if (! $ticket instanceof EE_Ticket) {
-                                continue;
+                                break;
                             }
                             try {
                                 $event_name = $ticket->get_event_name();
@@ -1443,7 +1443,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
                             );
                             foreach ($registrations as $registration) {
                                 if (! $registration instanceof EE_Registration) {
-                                    continue;
+                                    break;
                                 }
                                 $this->_template_args['event_attendees'][ $registration->ID() ]['STS_ID']
                                     = $registration->status_ID();

--- a/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
@@ -11,6 +11,7 @@ if (! defined('EVENT_ESPRESSO_VERSION')) {
  * @subpackage            core
  * @author                Brent Christensen
  * @since                 4.8
+ * @group transactions_admin
  */
 class Transactions_Admin_Page_Test extends EE_UnitTestCase
 {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

PHP 7.3 stable was released at the beginning of December.  It's time to update our travis build to include that as a non-failing build so that we're ensuring EE runs well on PHP 7.3

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Verify things pass in travis
* [x] This does impact the single transaction details view in the admin.  Specifically the Attendees metabox in that view.  Ensure that all the attendees (and the relevant details loads the same as master on this branch).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
