### PR TITLE
Move commands and handlers from `core/services/commands` to `core/domain/services/commands` and the logic in the classes in `core/domain/services/registration` into the new Command Handlers

### DIFF
--- a/core/EE_Deprecated.core.php
+++ b/core/EE_Deprecated.core.php
@@ -1053,15 +1053,15 @@ add_action(
 );
 
 add_filter(
-	'FHEE_EventEspresso_core_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
+	'FHEE_EventEspresso_core_domain_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
 	function($existing_attendee, $registration, $attendee_data) {
 		if ( ! has_filter( 'FHEE_EE_Single_Page_Checkout__save_registration_items__find_existing_attendee' )) {
 			return $existing_attendee;
 		}
 		deprecated_espresso_action_or_filter_doing_it_wrong(
 			'FHEE_EE_Single_Page_Checkout__save_registration_items__find_existing_attendee',
-			'FHEE_EventEspresso_core_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
-			'\EventEspresso\core\services\commands\attendee\CreateAttendeeCommandHandler::findExistingAttendee()',
+			'FHEE_EventEspresso_core_domain_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
+			'\EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommandHandler::findExistingAttendee()',
 			'4.9.34',
 			'5.0.0',
 			'filter'

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -267,6 +267,8 @@ final class EE_System implements ResettableInterface
      * create and cache the CommandBus, and also add middleware
      * The CapChecker middleware requires the use of EE_Capabilities
      * which is why we need to load the CommandBus after Caps are set up
+     * CommandBus middleware operate FIFO - First In First Out
+     * so LocateMovedCommands will run first in order to return any new commands
      *
      * @return void
      * @throws EE_Error
@@ -280,6 +282,7 @@ final class EE_System implements ResettableInterface
                 apply_filters(
                     'FHEE__EE_Load_Espresso_Core__handle_request__CommandBus_middleware',
                     array(
+                        $this->loader->getShared('EventEspresso\core\services\commands\middleware\LocateMovedCommands'),
                         $this->loader->getShared('EventEspresso\core\services\commands\middleware\CapChecker'),
                         $this->loader->getShared('EventEspresso\core\services\commands\middleware\AddActionHook'),
                     )

--- a/core/domain/services/commands/attendee/CreateAttendeeCommand.php
+++ b/core/domain/services/commands/attendee/CreateAttendeeCommand.php
@@ -1,0 +1,92 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\attendee;
+
+use EE_Registration;
+use EventEspresso\core\domain\services\capabilities\CapCheck;
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\domain\services\capabilities\PublicCapabilities;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\services\commands\Command;
+use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
+
+defined('EVENT_ESPRESSO_VERSION') || exit;
+
+
+
+/**
+ * Class CreateAttendeeCommand
+ * DTO for passing data to a CreateAttendeeCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         $VID:$
+ */
+class CreateAttendeeCommand extends Command implements CommandRequiresCapCheckInterface
+{
+
+    /**
+     * array of details where keys are names of EEM_Attendee model fields
+     *
+     * @var array $attendee_details
+     */
+    protected $attendee_details;
+
+    /**
+     * an existing registration to associate this attendee with
+     *
+     * @var EE_Registration $registration
+     */
+    protected $registration;
+
+
+
+    /**
+     * CreateAttendeeCommand constructor.
+     *
+     * @param array            $attendee_details
+     * @param EE_Registration $registration
+     */
+    public function __construct(array $attendee_details, EE_Registration $registration)
+    {
+        $this->attendee_details = $attendee_details;
+        $this->registration = $registration;
+    }
+
+
+
+    /**
+     * @return array
+     */
+    public function attendeeDetails()
+    {
+        return $this->attendee_details;
+    }
+
+
+
+    /**
+     * @return EE_Registration
+     */
+    public function registration()
+    {
+        return $this->registration;
+    }
+
+
+
+    /**
+     * @return CapCheckInterface
+     * @throws InvalidDataTypeException
+     */
+    public function getCapCheck()
+    {
+        // need cap for non-AJAX admin requests
+        if (! (defined('DOING_AJAX') && DOING_AJAX) && is_admin()) {
+            return new CapCheck('ee_edit_contacts', 'create_new_contact');
+        }
+        return new PublicCapabilities('', 'create_new_contact');
+    }
+
+
+
+}

--- a/core/domain/services/commands/attendee/CreateAttendeeCommand.php
+++ b/core/domain/services/commands/attendee/CreateAttendeeCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\attendee;
 
 use EE_Registration;
@@ -39,19 +40,17 @@ class CreateAttendeeCommand extends Command implements CommandRequiresCapCheckIn
     protected $registration;
 
 
-
     /**
      * CreateAttendeeCommand constructor.
      *
-     * @param array            $attendee_details
+     * @param array           $attendee_details
      * @param EE_Registration $registration
      */
     public function __construct(array $attendee_details, EE_Registration $registration)
     {
         $this->attendee_details = $attendee_details;
-        $this->registration = $registration;
+        $this->registration     = $registration;
     }
-
 
 
     /**
@@ -63,7 +62,6 @@ class CreateAttendeeCommand extends Command implements CommandRequiresCapCheckIn
     }
 
 
-
     /**
      * @return EE_Registration
      */
@@ -71,7 +69,6 @@ class CreateAttendeeCommand extends Command implements CommandRequiresCapCheckIn
     {
         return $this->registration;
     }
-
 
 
     /**
@@ -86,7 +83,4 @@ class CreateAttendeeCommand extends Command implements CommandRequiresCapCheckIn
         }
         return new PublicCapabilities('', 'create_new_contact');
     }
-
-
-
 }

--- a/core/domain/services/commands/attendee/CreateAttendeeCommandHandler.php
+++ b/core/domain/services/commands/attendee/CreateAttendeeCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\attendee;
+namespace EventEspresso\core\domain\services\commands\attendee;
 
 use EE_Attendee;
 use EE_Error;
@@ -104,7 +104,7 @@ class CreateAttendeeCommandHandler extends CommandHandler {
 			);
 		}
 		return apply_filters(
-			'FHEE_EventEspresso_core_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
+			'FHEE_EventEspresso_core_domain_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
 			$existing_attendee,
 			$registration,
 			$attendee_data
@@ -163,5 +163,3 @@ class CreateAttendeeCommandHandler extends CommandHandler {
 
 
 }
-// End of file CreateAttendeeCommandHandler.php
-// Location: EventEspresso\core\services\commands\attendee/CreateAttendeeCommandHandler.php

--- a/core/domain/services/commands/attendee/CreateAttendeeCommandHandler.php
+++ b/core/domain/services/commands/attendee/CreateAttendeeCommandHandler.php
@@ -1,15 +1,17 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\attendee;
 
 use EE_Attendee;
 use EE_Error;
 use EE_Registration;
 use EEM_Attendee;
+use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-defined( 'EVENT_ESPRESSO_VERSION' ) || exit;
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 
@@ -21,145 +23,145 @@ defined( 'EVENT_ESPRESSO_VERSION' ) || exit;
  * @author        Brent Christensen
  * @since         $VID:$
  */
-class CreateAttendeeCommandHandler extends CommandHandler {
+class CreateAttendeeCommandHandler extends CommandHandler
+{
+
+    /**
+     * @var EEM_Attendee $attendee_model
+     */
+    protected $attendee_model;
 
 
-	/**
-	 * @var EEM_Attendee $attendee_model
-	 */
-	protected $attendee_model;
-
-
-
-	/**
-	 * @param EEM_Attendee $attendee_model
-	 */
-	public function __construct(EEM_Attendee $attendee_model ) {
+    /**
+     * @param EEM_Attendee $attendee_model
+     */
+    public function __construct(EEM_Attendee $attendee_model)
+    {
         $this->attendee_model = $attendee_model;
-	}
+    }
 
 
+    /**
+     * @param CommandInterface $command
+     * @return EE_Attendee
+     * @throws EE_Error
+     * @throws InvalidEntityException
+     * @throws EntityNotFoundException
+     */
+    public function handle(CommandInterface $command)
+    {
+        /** @var CreateAttendeeCommand $command */
+        if (! $command instanceof CreateAttendeeCommand) {
+            throw new InvalidEntityException(get_class($command), 'CreateAttendeeCommand');
+        }
+        // have we met before?
+        $attendee = $this->findExistingAttendee(
+            $command->registration(),
+            $command->attendeeDetails()
+        );
+        // did we find an already existing record for this attendee ?
+        if ($attendee instanceof EE_Attendee) {
+            $attendee = $this->updateExistingAttendeeData(
+                $attendee,
+                $command->attendeeDetails()
+            );
+        } else {
+            $attendee = $this->createNewAttendee(
+                $command->registration(),
+                $command->attendeeDetails()
+            );
+        }
+        return $attendee;
+    }
 
-	/**
-	 * @param CommandInterface $command
-	 * @return EE_Attendee
-	 * @throws EE_Error
-	 * @throws InvalidEntityException
-	 */
-	public function handle( CommandInterface $command ) {
-		/** @var CreateAttendeeCommand $command */
-		if ( ! $command instanceof CreateAttendeeCommand ) {
-			throw new InvalidEntityException( get_class( $command ), 'CreateAttendeeCommand' );
-		}
-		// have we met before?
-		$attendee = $this->findExistingAttendee(
-			$command->registration(),
-			$command->attendeeDetails()
-		);
-		// did we find an already existing record for this attendee ?
-		if ( $attendee instanceof EE_Attendee ) {
-			$attendee = $this->updateExistingAttendeeData(
-				$attendee,
-				$command->attendeeDetails()
-			);
-		} else {
-			$attendee = $this->createNewAttendee(
-				$command->registration(),
-				$command->attendeeDetails()
-			);
-		}
-		return $attendee;
-	}
 
-
-
-	/**
-	 * find_existing_attendee
-	 *
-	 * @param EE_Registration $registration
-	 * @param  array           $attendee_data
-	 * @return EE_Attendee
-	 */
-	private function findExistingAttendee( EE_Registration $registration, array $attendee_data ) {
-		$existing_attendee = null;
-		// does this attendee already exist in the db ?
+    /**
+     * find_existing_attendee
+     *
+     * @param EE_Registration $registration
+     * @param  array          $attendee_data
+     * @return EE_Attendee
+     * @throws EE_Error
+     */
+    private function findExistingAttendee(EE_Registration $registration, array $attendee_data)
+    {
+        $existing_attendee = null;
+        // does this attendee already exist in the db ?
         // we're searching using a combination of first name, last name, AND email address
-		$ATT_fname = ! empty( $attendee_data['ATT_fname'] )
-			? $attendee_data['ATT_fname']
-			: '';
-		$ATT_lname = ! empty( $attendee_data['ATT_lname'] )
-			? $attendee_data['ATT_lname']
-			: '';
-		$ATT_email = ! empty( $attendee_data['ATT_email'] )
-			? $attendee_data['ATT_email']
-			: '';
-		// but only if those have values
-		if ( $ATT_fname && $ATT_lname && $ATT_email ) {
-			$existing_attendee = $this->attendee_model->find_existing_attendee(
-				array(
-					'ATT_fname' => $ATT_fname,
-					'ATT_lname' => $ATT_lname,
-					'ATT_email' => $ATT_email
-				)
-			);
-		}
-		return apply_filters(
-			'FHEE_EventEspresso_core_domain_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
-			$existing_attendee,
-			$registration,
-			$attendee_data
-		);
-	}
+        $ATT_fname = ! empty($attendee_data['ATT_fname'])
+            ? $attendee_data['ATT_fname']
+            : '';
+        $ATT_lname = ! empty($attendee_data['ATT_lname'])
+            ? $attendee_data['ATT_lname']
+            : '';
+        $ATT_email = ! empty($attendee_data['ATT_email'])
+            ? $attendee_data['ATT_email']
+            : '';
+        // but only if those have values
+        if ($ATT_fname && $ATT_lname && $ATT_email) {
+            $existing_attendee = $this->attendee_model->find_existing_attendee(
+                array(
+                    'ATT_fname' => $ATT_fname,
+                    'ATT_lname' => $ATT_lname,
+                    'ATT_email' => $ATT_email,
+                )
+            );
+        }
+        return apply_filters(
+            'FHEE_EventEspresso_core_domain_services_commands_attendee_CreateAttendeeCommandHandler__findExistingAttendee__existing_attendee',
+            $existing_attendee,
+            $registration,
+            $attendee_data
+        );
+    }
 
 
-
-	/**
-	 * _update_existing_attendee_data
-	 * in case it has changed since last time they registered for an event
-	 *
-	 * @param EE_Attendee $existing_attendee
-	 * @param  array       $attendee_data
-	 * @return EE_Attendee
-	 * @throws EE_Error
-	 */
-	private function updateExistingAttendeeData( EE_Attendee $existing_attendee, array $attendee_data ) {
-		// first remove fname, lname, and email from attendee data
+    /**
+     * _update_existing_attendee_data
+     * in case it has changed since last time they registered for an event
+     *
+     * @param EE_Attendee $existing_attendee
+     * @param  array      $attendee_data
+     * @return EE_Attendee
+     * @throws EE_Error
+     */
+    private function updateExistingAttendeeData(EE_Attendee $existing_attendee, array $attendee_data)
+    {
+        // first remove fname, lname, and email from attendee data
         // because these properties will be exactly the same as the returned attendee object,
         // since they were used in the query to get the attendee object in the first place
-		$dont_set = array( 'ATT_fname', 'ATT_lname', 'ATT_email' );
-		// now loop thru what's left and add to attendee CPT
-		foreach ( $attendee_data as $property_name => $property_value ) {
-			if (
-				! in_array( $property_name, $dont_set, true )
-				&& $this->attendee_model->has_field( $property_name )
-			) {
-				$existing_attendee->set( $property_name, $property_value );
-			}
-		}
-		// better save that now
-		$existing_attendee->save();
-		return $existing_attendee;
-	}
+        $dont_set = array('ATT_fname', 'ATT_lname', 'ATT_email');
+        // now loop thru what's left and add to attendee CPT
+        foreach ($attendee_data as $property_name => $property_value) {
+            if (
+                ! in_array($property_name, $dont_set, true)
+                && $this->attendee_model->has_field($property_name)
+            ) {
+                $existing_attendee->set($property_name, $property_value);
+            }
+        }
+        // better save that now
+        $existing_attendee->save();
+        return $existing_attendee;
+    }
 
 
-
-	/**
-	 * create_new_attendee
-	 *
-	 * @param EE_Registration $registration
-	 * @param  array           $attendee_data
-	 * @return EE_Attendee
-	 * @throws EE_Error
-	 */
-	private function createNewAttendee( EE_Registration $registration, array $attendee_data ) {
-		// create new attendee object
-		$new_attendee = EE_Attendee::new_instance( $attendee_data );
-		// set author to event creator
-		$new_attendee->set( 'ATT_author', $registration->event()->wp_user() );
-		$new_attendee->save();
-		return $new_attendee;
-	}
-
-
-
+    /**
+     * create_new_attendee
+     *
+     * @param EE_Registration $registration
+     * @param  array          $attendee_data
+     * @return EE_Attendee
+     * @throws EE_Error
+     * @throws EntityNotFoundException
+     */
+    private function createNewAttendee(EE_Registration $registration, array $attendee_data)
+    {
+        // create new attendee object
+        $new_attendee = EE_Attendee::new_instance($attendee_data);
+        // set author to event creator
+        $new_attendee->set('ATT_author', $registration->event()->wp_user());
+        $new_attendee->save();
+        return $new_attendee;
+    }
 }

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
@@ -2,10 +2,7 @@
 
 namespace EventEspresso\core\domain\services\commands\registration;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
@@ -1,0 +1,22 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class CancelRegistrationAndTicketLineItemCommand
+ * DTO for passing data to a CancelRegistrationAndTicketLineItemCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CancelRegistrationAndTicketLineItemCommand extends SingleRegistrationCommand
+{
+
+}

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
-
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
@@ -1,12 +1,20 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
+use EE_Error;
 use EventEspresso\core\domain\services\ticket\CancelTicketLineItemService;
+use EventEspresso\core\exceptions\EntityNotFoundException;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
+use InvalidArgumentException;
+use ReflectionException;
+use RuntimeException;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+if (! defined('EVENT_ESPRESSO_VERSION')) {
     exit('No direct script access allowed');
 }
 
@@ -23,12 +31,10 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
 class CancelRegistrationAndTicketLineItemCommandHandler extends CommandHandler
 {
 
-
     /**
      * @var CancelTicketLineItemService $cancel_ticket_line_item_service
      */
     private $cancel_ticket_line_item_service;
-
 
 
     /**
@@ -42,15 +48,22 @@ class CancelRegistrationAndTicketLineItemCommandHandler extends CommandHandler
     }
 
 
-
     /**
-     * @param \EventEspresso\core\services\commands\CommandInterface $command
+     * @param CommandInterface $command
      * @return boolean
+     * @throws InvalidEntityException
+     * @throws EE_Error
+     * @throws EntityNotFoundException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws RuntimeException
      */
     public function handle(CommandInterface $command)
     {
         /** @var CancelRegistrationAndTicketLineItemCommand $command */
-        if ( ! $command instanceof CancelRegistrationAndTicketLineItemCommand) {
+        if (! $command instanceof CancelRegistrationAndTicketLineItemCommand) {
             throw new InvalidEntityException(get_class($command), 'CancelRegistrationAndTicketLineItemCommand');
         }
         $registration = $command->registration();
@@ -60,7 +73,4 @@ class CancelRegistrationAndTicketLineItemCommandHandler extends CommandHandler
         $registration->save();
         return true;
     }
-
-
-
 }

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\registration;
+namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\domain\services\ticket\CancelTicketLineItemService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -64,5 +64,3 @@ class CancelRegistrationAndTicketLineItemCommandHandler extends CommandHandler
 
 
 }
-// End of file CancelRegistrationAndTicketLineItemCommandHandler.php
-// Location: /CancelRegistrationAndTicketLineItemCommandHandler.php

--- a/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/registration/CancelRegistrationAndTicketLineItemCommandHandler.php
@@ -14,10 +14,7 @@ use InvalidArgumentException;
 use ReflectionException;
 use RuntimeException;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
+use EE_Registration;
 use EventEspresso\core\services\commands\Command;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -20,55 +22,47 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class CopyRegistrationDetailsCommand extends Command
 {
 
+    /**
+     * @var EE_Registration $target_registration
+     */
+    private $target_registration;
 
-	/**
-	 * @var \EE_Registration $target_registration
-	 */
-	private $target_registration;
-
-
-	/**
-	 * @var \EE_Registration $registration_to_copy
-	 */
-	private $registration_to_copy;
+    /**
+     * @var EE_Registration $registration_to_copy
+     */
+    private $registration_to_copy;
 
 
-
-	/**
-	 * CopyRegistrationDetailsCommand constructor.
-	 *
-	 * @param \EE_Registration    $target_registration
-	 * @param \EE_Registration    $registration_to_copy
-	v
-	 */
-	public function __construct(
-		\EE_Registration $target_registration,
-		\EE_Registration $registration_to_copy
-	) {
-		$this->target_registration = $target_registration;
-		$this->registration_to_copy = $registration_to_copy;
-	}
-
+    /**
+     * CopyRegistrationDetailsCommand constructor.
+     *
+     * @param EE_Registration $target_registration
+     * @param EE_Registration $registration_to_copy
+    v
+     */
+    public function __construct(
+        EE_Registration $target_registration,
+        EE_Registration $registration_to_copy
+    ) {
+        $this->target_registration  = $target_registration;
+        $this->registration_to_copy = $registration_to_copy;
+    }
 
 
-	/**
-	 * @return \EE_Registration
-	 */
-	public function targetRegistration() {
-		return $this->target_registration;
-	}
+    /**
+     * @return EE_Registration
+     */
+    public function targetRegistration()
+    {
+        return $this->target_registration;
+    }
 
 
-
-	/**
-	 * @return \EE_Registration
-	 */
-	public function registrationToCopy() {
-		return $this->registration_to_copy;
-	}
-
-
-
+    /**
+     * @return EE_Registration
+     */
+    public function registrationToCopy()
+    {
+        return $this->registration_to_copy;
+    }
 }
-// End of file CopyRegistrationDetailsCommand.php
-// Location: /CopyRegistrationDetailsCommand.php

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
@@ -1,0 +1,74 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+use EventEspresso\core\services\commands\Command;
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class CopyRegistrationDetailsCommand
+ * DTO for passing data to a CopyRegistrationDetailsCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CopyRegistrationDetailsCommand extends Command
+{
+
+
+	/**
+	 * @var \EE_Registration $target_registration
+	 */
+	private $target_registration;
+
+
+	/**
+	 * @var \EE_Registration $registration_to_copy
+	 */
+	private $registration_to_copy;
+
+
+
+	/**
+	 * CopyRegistrationDetailsCommand constructor.
+	 *
+	 * @param \EE_Registration    $target_registration
+	 * @param \EE_Registration    $registration_to_copy
+	v
+	 */
+	public function __construct(
+		\EE_Registration $target_registration,
+		\EE_Registration $registration_to_copy
+	) {
+		$this->target_registration = $target_registration;
+		$this->registration_to_copy = $registration_to_copy;
+	}
+
+
+
+	/**
+	 * @return \EE_Registration
+	 */
+	public function targetRegistration() {
+		return $this->target_registration;
+	}
+
+
+
+	/**
+	 * @return \EE_Registration
+	 */
+	public function registrationToCopy() {
+		return $this->registration_to_copy;
+	}
+
+
+
+}
+// End of file CopyRegistrationDetailsCommand.php
+// Location: /CopyRegistrationDetailsCommand.php

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommand.php
@@ -5,10 +5,7 @@ namespace EventEspresso\core\domain\services\commands\registration;
 use EE_Registration;
 use EventEspresso\core\services\commands\Command;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
@@ -7,10 +7,7 @@ use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
@@ -62,5 +62,3 @@ class CopyRegistrationDetailsCommandHandler extends CommandHandler
 
 
 }
-// End of file CopyRegistrationDetailsCommandHandler.php
-// Location: /CopyRegistrationDetailsCommandHandler.php

--- a/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
+++ b/core/domain/services/commands/registration/CopyRegistrationDetailsCommandHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\services\commands\registration;
 
 use EventEspresso\core\domain\services\registration\CopyRegistrationService;
@@ -6,7 +7,7 @@ use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+if (! defined('EVENT_ESPRESSO_VERSION')) {
     exit('No direct script access allowed');
 }
 
@@ -24,12 +25,10 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
 class CopyRegistrationDetailsCommandHandler extends CommandHandler
 {
 
-
     /**
      * @var CopyRegistrationService $copy_registration_service
      */
     private $copy_registration_service;
-
 
 
     /**
@@ -43,15 +42,15 @@ class CopyRegistrationDetailsCommandHandler extends CommandHandler
     }
 
 
-
     /**
-     * @param \EventEspresso\core\services\commands\CommandInterface $command
+     * @param CommandInterface $command
      * @return boolean
+     * @throws InvalidEntityException
      */
     public function handle(CommandInterface $command)
     {
         /** @var CopyRegistrationDetailsCommand $command */
-        if ( ! $command instanceof CopyRegistrationDetailsCommand) {
+        if (! $command instanceof CopyRegistrationDetailsCommand) {
             throw new InvalidEntityException(get_class($command), 'CopyRegistrationDetailsCommand');
         }
         return $this->copy_registration_service->copyRegistrationDetails(
@@ -59,6 +58,4 @@ class CopyRegistrationDetailsCommandHandler extends CommandHandler
             $command->registrationToCopy()
         );
     }
-
-
 }

--- a/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
@@ -2,10 +2,7 @@
 
 namespace EventEspresso\core\domain\services\commands\registration;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
@@ -1,0 +1,23 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class CopyRegistrationPaymentsCommand
+ * DTO for passing data to a CopyRegistrationPaymentsCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CopyRegistrationPaymentsCommand extends CopyRegistrationDetailsCommand
+{
+
+}
+// End of file CopyRegistrationPaymentsCommand.php
+// Location: /CopyRegistrationPaymentsCommand.php

--- a/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
+++ b/core/domain/services/commands/registration/CopyRegistrationPaymentsCommand.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -19,5 +20,3 @@ class CopyRegistrationPaymentsCommand extends CopyRegistrationDetailsCommand
 {
 
 }
-// End of file CopyRegistrationPaymentsCommand.php
-// Location: /CopyRegistrationPaymentsCommand.php

--- a/core/domain/services/commands/registration/CopyRegistrationPaymentsCommandHandler.php
+++ b/core/domain/services/commands/registration/CopyRegistrationPaymentsCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\registration;
+namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\domain\services\registration\CopyRegistrationService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -64,5 +64,3 @@ class CopyRegistrationPaymentsCommandHandler extends CommandHandler
 
 
 }
-// End of file CopyRegistrationPaymentsCommandHandler.php
-// Location: /CopyRegistrationPaymentsCommandHandler.php

--- a/core/domain/services/commands/registration/CopyRegistrationPaymentsCommandHandler.php
+++ b/core/domain/services/commands/registration/CopyRegistrationPaymentsCommandHandler.php
@@ -44,10 +44,10 @@ class CopyRegistrationPaymentsCommandHandler extends CommandHandler
     }
 
 
-
     /**
-     * @param \EventEspresso\core\services\commands\CommandInterface $command
+     * @param CommandInterface $command
      * @return boolean
+     * @throws InvalidEntityException
      */
     public function handle(CommandInterface $command)
     {

--- a/core/domain/services/commands/registration/CreateRegistrationCommand.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommand.php
@@ -15,10 +15,7 @@ use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\Command;
 use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CreateRegistrationCommand.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
 use EE_Error;
@@ -9,11 +10,12 @@ use EE_Transaction;
 use EEM_Registration;
 use EventEspresso\core\domain\services\capabilities\CapCheck;
 use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\Command;
 use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+if (! defined('EVENT_ESPRESSO_VERSION')) {
     exit('No direct script access allowed');
 }
 
@@ -86,11 +88,11 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
         $reg_status = EEM_Registration::status_id_incomplete,
         EE_Ticket $ticket = null
     ) {
-        $this->transaction = $transaction;
+        $this->transaction      = $transaction;
         $this->ticket_line_item = $ticket_line_item;
-        $this->reg_count = absint($reg_count);
-        $this->reg_group_size = absint($reg_group_size);
-        $this->reg_status = $reg_status;
+        $this->reg_count        = absint($reg_count);
+        $this->reg_group_size   = absint($reg_group_size);
+        $this->reg_status       = $reg_status;
         // grab the related ticket object for this line_item if one wasn't already supplied
         $this->ticket = $ticket instanceof EE_Ticket ? $ticket : $this->ticket_line_item->ticket();
         if (! $this->ticket instanceof EE_Ticket) {
@@ -106,19 +108,17 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     }
 
 
-
     /**
-     * @return \EventEspresso\core\domain\services\capabilities\CapCheckInterface
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @return CapCheckInterface
+     * @throws InvalidDataTypeException
      */
     public function getCapCheck()
     {
-        if ( ! $this->cap_check instanceof CapCheckInterface) {
+        if (! $this->cap_check instanceof CapCheckInterface) {
             return new CapCheck('ee_edit_registrations', 'create_new_registration');
         }
         return $this->cap_check;
     }
-
 
 
     /**
@@ -130,7 +130,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     }
 
 
-
     /**
      * @return EE_Ticket
      */
@@ -138,7 +137,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     {
         return $this->ticket;
     }
-
 
 
     /**
@@ -150,7 +148,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     }
 
 
-
     /**
      * @return int
      */
@@ -158,7 +155,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     {
         return $this->reg_count;
     }
-
 
 
     /**
@@ -170,7 +166,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     }
 
 
-
     /**
      * @return string
      */
@@ -180,7 +175,6 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     }
 
 
-
     /**
      * @return EE_Registration
      */
@@ -188,9 +182,5 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
     {
         return $this->registration;
     }
-
-
-
 }
-// End of file CreateRegistrationCommand.php
-// Location: /CreateRegistrationCommand.php
+

--- a/core/domain/services/commands/registration/CreateRegistrationCommand.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommand.php
@@ -1,0 +1,196 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+use EE_Error;
+use EE_Line_Item;
+use EE_Registration;
+use EE_Ticket;
+use EE_Transaction;
+use EEM_Registration;
+use EventEspresso\core\domain\services\capabilities\CapCheck;
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\exceptions\InvalidEntityException;
+use EventEspresso\core\services\commands\Command;
+use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
+
+if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
+}
+
+
+
+/**
+ * Class CreateRegistrationCommand
+ * DTO for passing data to a CreateRegistrationCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CreateRegistrationCommand extends Command implements CommandRequiresCapCheckInterface
+{
+
+    /**
+     * @var EE_Transaction $transaction
+     */
+    private $transaction;
+
+    /**
+     * @var EE_Ticket $ticket
+     */
+    private $ticket;
+
+    /**
+     * @var EE_Line_Item $ticket_line_item
+     */
+    private $ticket_line_item;
+
+    /**
+     * @var int $reg_count
+     */
+    private $reg_count;
+
+    /**
+     * @var int $reg_group_size
+     */
+    private $reg_group_size;
+
+    /**
+     * @var string $reg_status
+     */
+    private $reg_status;
+
+    /**
+     * @var EE_Registration $registration
+     */
+    protected $registration;
+
+
+    /**
+     * CreateRegistrationCommand constructor.
+     *
+     * @param EE_Transaction $transaction
+     * @param EE_Line_Item   $ticket_line_item
+     * @param int            $reg_count
+     * @param int            $reg_group_size
+     * @param string         $reg_status
+     * @param EE_Ticket|null $ticket
+     * @throws InvalidEntityException
+     * @throws EE_Error
+     */
+    public function __construct(
+        EE_Transaction $transaction,
+        EE_Line_Item $ticket_line_item,
+        $reg_count = 1,
+        $reg_group_size = 0,
+        $reg_status = EEM_Registration::status_id_incomplete,
+        EE_Ticket $ticket = null
+    ) {
+        $this->transaction = $transaction;
+        $this->ticket_line_item = $ticket_line_item;
+        $this->reg_count = absint($reg_count);
+        $this->reg_group_size = absint($reg_group_size);
+        $this->reg_status = $reg_status;
+        // grab the related ticket object for this line_item if one wasn't already supplied
+        $this->ticket = $ticket instanceof EE_Ticket ? $ticket : $this->ticket_line_item->ticket();
+        if (! $this->ticket instanceof EE_Ticket) {
+            throw new InvalidEntityException(
+                is_object($this->ticket) ? get_class($this->ticket) : gettype($this->ticket),
+                'EE_Ticket',
+                sprintf(
+                    esc_html__('Line item %s did not contain a valid ticket', 'event_espresso'),
+                    $ticket_line_item->ID()
+                )
+            );
+        }
+    }
+
+
+
+    /**
+     * @return \EventEspresso\core\domain\services\capabilities\CapCheckInterface
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     */
+    public function getCapCheck()
+    {
+        if ( ! $this->cap_check instanceof CapCheckInterface) {
+            return new CapCheck('ee_edit_registrations', 'create_new_registration');
+        }
+        return $this->cap_check;
+    }
+
+
+
+    /**
+     * @return EE_Transaction
+     */
+    public function transaction()
+    {
+        return $this->transaction;
+    }
+
+
+
+    /**
+     * @return EE_Ticket
+     */
+    public function ticket()
+    {
+        return $this->ticket;
+    }
+
+
+
+    /**
+     * @return EE_Line_Item
+     */
+    public function ticketLineItem()
+    {
+        return $this->ticket_line_item;
+    }
+
+
+
+    /**
+     * @return int
+     */
+    public function regCount()
+    {
+        return $this->reg_count;
+    }
+
+
+
+    /**
+     * @return int
+     */
+    public function regGroupSize()
+    {
+        return $this->reg_group_size;
+    }
+
+
+
+    /**
+     * @return string
+     */
+    public function regStatus()
+    {
+        return $this->reg_status;
+    }
+
+
+
+    /**
+     * @return EE_Registration
+     */
+    public function registration()
+    {
+        return $this->registration;
+    }
+
+
+
+}
+// End of file CreateRegistrationCommand.php
+// Location: /CreateRegistrationCommand.php

--- a/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
@@ -10,10 +10,7 @@ use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 use OutOfRangeException;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\registration;
+namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\domain\services\registration\CreateRegistrationService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -71,5 +71,3 @@ class CreateRegistrationCommandHandler extends CommandHandler
 
 
 }
-// End of file CreateRegistrationCommandHandler.php
-// Location: /CreateRegistrationCommandHandler.php

--- a/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
+++ b/core/domain/services/commands/registration/CreateRegistrationCommandHandler.php
@@ -1,12 +1,16 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
+use EE_Error;
 use EventEspresso\core\domain\services\registration\CreateRegistrationService;
 use EventEspresso\core\exceptions\InvalidEntityException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
+use OutOfRangeException;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+if (! defined('EVENT_ESPRESSO_VERSION')) {
     exit('No direct script access allowed');
 }
 
@@ -29,7 +33,6 @@ class CreateRegistrationCommandHandler extends CommandHandler
     private $registration_service;
 
 
-
     /**
      * Command constructor
      *
@@ -41,19 +44,18 @@ class CreateRegistrationCommandHandler extends CommandHandler
     }
 
 
-
     /**
      * @param  CommandInterface $command
      * @return mixed
-     * @throws \OutOfRangeException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\exceptions\InvalidEntityException
+     * @throws OutOfRangeException
+     * @throws UnexpectedEntityException
+     * @throws EE_Error
+     * @throws InvalidEntityException
      */
     public function handle(CommandInterface $command)
     {
         /** @var CreateRegistrationCommand $command */
-        if ( ! $command instanceof CreateRegistrationCommand) {
+        if (! $command instanceof CreateRegistrationCommand) {
             throw new InvalidEntityException(get_class($command), 'CreateRegistrationCommand');
         }
         // now create a new registration for the ticket
@@ -67,7 +69,4 @@ class CreateRegistrationCommandHandler extends CommandHandler
             $command->regStatus()
         );
     }
-
-
-
 }

--- a/core/domain/services/commands/registration/SingleRegistrationCommand.php
+++ b/core/domain/services/commands/registration/SingleRegistrationCommand.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\services\commands\Command;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -20,35 +21,29 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 abstract class SingleRegistrationCommand extends Command
 {
 
-
-	/**
-	 * @var \EE_Registration $registration
-	 */
-	private $registration;
-
+    /**
+     * @var \EE_Registration $registration
+     */
+    private $registration;
 
 
-	/**
-	 * CancelRegistrationAndTicketLineItemCommand constructor.
-	 *
-	 * @param \EE_Registration    $registration
-	 */
-	public function __construct(
-		\EE_Registration $registration
-	) {
-		$this->registration = $registration;
-	}
+    /**
+     * CancelRegistrationAndTicketLineItemCommand constructor.
+     *
+     * @param \EE_Registration $registration
+     */
+    public function __construct(
+        \EE_Registration $registration
+    ) {
+        $this->registration = $registration;
+    }
 
 
-
-	/**
-	 * @return \EE_Registration
-	 */
-	public function registration()
-	{
-		return $this->registration;
-	}
-
+    /**
+     * @return \EE_Registration
+     */
+    public function registration()
+    {
+        return $this->registration;
+    }
 }
-// End of file SingleRegistrationCommand.php
-// Location: /SingleRegistrationCommand.php

--- a/core/domain/services/commands/registration/SingleRegistrationCommand.php
+++ b/core/domain/services/commands/registration/SingleRegistrationCommand.php
@@ -4,10 +4,7 @@ namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\services\commands\Command;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/SingleRegistrationCommand.php
+++ b/core/domain/services/commands/registration/SingleRegistrationCommand.php
@@ -1,0 +1,54 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+use EventEspresso\core\services\commands\Command;
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class SingleRegistrationCommand
+ * DTO for passing data a single EE_Registration object to a CommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+abstract class SingleRegistrationCommand extends Command
+{
+
+
+	/**
+	 * @var \EE_Registration $registration
+	 */
+	private $registration;
+
+
+
+	/**
+	 * CancelRegistrationAndTicketLineItemCommand constructor.
+	 *
+	 * @param \EE_Registration    $registration
+	 */
+	public function __construct(
+		\EE_Registration $registration
+	) {
+		$this->registration = $registration;
+	}
+
+
+
+	/**
+	 * @return \EE_Registration
+	 */
+	public function registration()
+	{
+		return $this->registration;
+	}
+
+}
+// End of file SingleRegistrationCommand.php
+// Location: /SingleRegistrationCommand.php

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
@@ -2,10 +2,7 @@
 
 namespace EventEspresso\core\domain\services\commands\registration;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
@@ -1,0 +1,24 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\registration;
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class UpdateRegistrationAndTransactionAfterChangeCommand
+ * DTO for passing data to a UpdateRegistrationAndTransactionAfterChangeCommandHandler
+ *
+ * @package       Event Espresso
+
+*@author        Brent Christensen
+ * @since         $VID:$
+ */
+class UpdateRegistrationAndTransactionAfterChangeCommand extends SingleRegistrationCommand
+{
+
+}
+// End of file UpdateRegistrationAndTransactionAfterChangeCommand.php
+// Location: /UpdateRegistrationAndTransactionAfterChangeCommand.php

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -12,13 +13,10 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * DTO for passing data to a UpdateRegistrationAndTransactionAfterChangeCommandHandler
  *
  * @package       Event Espresso
-
-*@author        Brent Christensen
+ * @author        Brent Christensen
  * @since         $VID:$
  */
 class UpdateRegistrationAndTransactionAfterChangeCommand extends SingleRegistrationCommand
 {
 
 }
-// End of file UpdateRegistrationAndTransactionAfterChangeCommand.php
-// Location: /UpdateRegistrationAndTransactionAfterChangeCommand.php

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
@@ -7,10 +7,7 @@ use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\domain\services\registration\UpdateRegistrationService;
@@ -6,8 +7,8 @@ use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -23,43 +24,38 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class UpdateRegistrationAndTransactionAfterChangeCommandHandler extends CommandHandler
 {
 
-
-	/**
-	 * @var UpdateRegistrationService $update_registration_service
-	 */
-	private $update_registration_service;
-
+    /**
+     * @var UpdateRegistrationService $update_registration_service
+     */
+    private $update_registration_service;
 
 
-	/**
-	 * Command constructor
-	 *
-	 * @param UpdateRegistrationService $update_registration_service
-	 */
-	public function __construct(
-		UpdateRegistrationService $update_registration_service
-	) {
-		$this->update_registration_service = $update_registration_service;
-	}
+    /**
+     * Command constructor
+     *
+     * @param UpdateRegistrationService $update_registration_service
+     */
+    public function __construct(
+        UpdateRegistrationService $update_registration_service
+    ) {
+        $this->update_registration_service = $update_registration_service;
+    }
 
 
-
-	/**
-	 * @param \EventEspresso\core\services\commands\CommandInterface $command
-	 * @return boolean
-	 */
-	public function handle( CommandInterface $command )
-	{
-		/** @var UpdateRegistrationAndTransactionAfterChangeCommand $command */
-		if ( ! $command instanceof UpdateRegistrationAndTransactionAfterChangeCommand ) {
-			throw new InvalidEntityException(
-				get_class($command),
-				'UpdateRegistrationAndTransactionAfterChangeCommand'
-			);
-		}
-		return $this->update_registration_service->updateRegistrationAndTransaction($command->registration());
-	}
-
-
-
+    /**
+     * @param CommandInterface $command
+     * @return boolean
+     * @throws InvalidEntityException
+     */
+    public function handle(CommandInterface $command)
+    {
+        /** @var UpdateRegistrationAndTransactionAfterChangeCommand $command */
+        if (! $command instanceof UpdateRegistrationAndTransactionAfterChangeCommand) {
+            throw new InvalidEntityException(
+                get_class($command),
+                'UpdateRegistrationAndTransactionAfterChangeCommand'
+            );
+        }
+        return $this->update_registration_service->updateRegistrationAndTransaction($command->registration());
+    }
 }

--- a/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
+++ b/core/domain/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\registration;
+namespace EventEspresso\core\domain\services\commands\registration;
 
 use EventEspresso\core\domain\services\registration\UpdateRegistrationService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -63,5 +63,3 @@ class UpdateRegistrationAndTransactionAfterChangeCommandHandler extends CommandH
 
 
 }
-// End of file UpdateRegistrationAndTransactionAfterChangeCommandHandler.php
-// Location: /UpdateRegistrationAndTransactionAfterChangeCommandHandler.php

--- a/core/domain/services/commands/ticket/CancelTicketLineItemCommand.php
+++ b/core/domain/services/commands/ticket/CancelTicketLineItemCommand.php
@@ -1,0 +1,141 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\ticket;
+
+use EventEspresso\core\services\commands\Command;
+
+if ( ! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
+}
+
+
+
+/**
+ * Class CancelTicketLineItemCommand
+ * DTO for passing data to CancelTicketLineItemCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CancelTicketLineItemCommand extends Command
+{
+
+
+    /**
+     * @var \EE_Transaction $transaction
+     */
+    private $transaction;
+
+    /**
+     * @var \EE_Ticket $ticket
+     */
+    private $ticket;
+
+    /**
+     * @var \EE_Line_Item $ticket_line_item
+     */
+    protected $ticket_line_item;
+
+    /**
+     * @var int $quantity
+     */
+    protected $quantity;
+
+
+
+    /**
+     * @param \EE_Registration $registration
+     * @param int              $quantity
+     */
+    public static function fromRegistration(\EE_Registration $registration, $quantity = 1)
+    {
+        new self(
+            $registration->transaction(),
+            $registration->ticket(),
+            1,
+            $registration->ticket_line_item()
+        );
+    }
+
+
+
+    /**
+     * @param \EE_Line_Item $ticket_line_item
+     * @param int           $quantity
+     */
+    public static function fromTicketLineItem(
+        \EE_Line_Item $ticket_line_item,
+        $quantity = 1
+    ) {
+        new self(
+            $ticket_line_item->transaction(),
+            $ticket_line_item->ticket(),
+            $quantity,
+            $ticket_line_item
+        );
+    }
+
+
+
+    /**
+     * CancelTicketLineItemCommand constructor.
+     *
+     * @param \EE_Transaction $transaction
+     * @param \EE_Ticket      $ticket
+     * @param int             $quantity
+     * @param \EE_Line_Item   $ticket_line_item
+     */
+    public function __construct(
+        \EE_Transaction $transaction,
+        \EE_Ticket $ticket,
+        $quantity = 1,
+        \EE_Line_Item $ticket_line_item = null
+    ) {
+        $this->transaction = $transaction;
+        $this->ticket = $ticket;
+        $this->quantity = min(1, absint($quantity));
+        $this->ticket_line_item = $ticket_line_item;
+    }
+
+
+
+    /**
+     * @return \EE_Transaction
+     */
+    public function transaction()
+    {
+        return $this->transaction;
+    }
+
+
+
+    /**
+     * @return \EE_Ticket
+     */
+    public function ticket()
+    {
+        return $this->ticket;
+    }
+
+
+
+    /**
+     * @return \EE_Line_Item
+     */
+    public function ticketLineItem()
+    {
+        return $this->ticket_line_item;
+    }
+
+
+
+    /**
+     * @return int
+     */
+    public function quantity()
+    {
+        return $this->quantity;
+    }
+
+
+}

--- a/core/domain/services/commands/ticket/CancelTicketLineItemCommand.php
+++ b/core/domain/services/commands/ticket/CancelTicketLineItemCommand.php
@@ -1,11 +1,16 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\ticket;
 
+use EE_Error;
+use EE_Line_Item;
+use EE_Registration;
+use EE_Ticket;
+use EE_Transaction;
+use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\services\commands\Command;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 
@@ -20,19 +25,18 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
 class CancelTicketLineItemCommand extends Command
 {
 
-
     /**
-     * @var \EE_Transaction $transaction
+     * @var EE_Transaction $transaction
      */
     private $transaction;
 
     /**
-     * @var \EE_Ticket $ticket
+     * @var EE_Ticket $ticket
      */
     private $ticket;
 
     /**
-     * @var \EE_Line_Item $ticket_line_item
+     * @var EE_Line_Item $ticket_line_item
      */
     protected $ticket_line_item;
 
@@ -42,12 +46,13 @@ class CancelTicketLineItemCommand extends Command
     protected $quantity;
 
 
-
     /**
-     * @param \EE_Registration $registration
-     * @param int              $quantity
+     * @param EE_Registration $registration
+     * @param int             $quantity
+     * @throws EE_Error
+     * @throws EntityNotFoundException
      */
-    public static function fromRegistration(\EE_Registration $registration, $quantity = 1)
+    public static function fromRegistration(EE_Registration $registration, $quantity = 1)
     {
         new self(
             $registration->transaction(),
@@ -58,13 +63,13 @@ class CancelTicketLineItemCommand extends Command
     }
 
 
-
     /**
-     * @param \EE_Line_Item $ticket_line_item
-     * @param int           $quantity
+     * @param EE_Line_Item $ticket_line_item
+     * @param int          $quantity
+     * @throws EE_Error
      */
     public static function fromTicketLineItem(
-        \EE_Line_Item $ticket_line_item,
+        EE_Line_Item $ticket_line_item,
         $quantity = 1
     ) {
         new self(
@@ -76,31 +81,29 @@ class CancelTicketLineItemCommand extends Command
     }
 
 
-
     /**
      * CancelTicketLineItemCommand constructor.
      *
-     * @param \EE_Transaction $transaction
-     * @param \EE_Ticket      $ticket
-     * @param int             $quantity
-     * @param \EE_Line_Item   $ticket_line_item
+     * @param EE_Transaction $transaction
+     * @param EE_Ticket      $ticket
+     * @param int            $quantity
+     * @param EE_Line_Item   $ticket_line_item
      */
     public function __construct(
-        \EE_Transaction $transaction,
-        \EE_Ticket $ticket,
+        EE_Transaction $transaction,
+        EE_Ticket $ticket,
         $quantity = 1,
-        \EE_Line_Item $ticket_line_item = null
+        EE_Line_Item $ticket_line_item = null
     ) {
-        $this->transaction = $transaction;
-        $this->ticket = $ticket;
-        $this->quantity = min(1, absint($quantity));
+        $this->transaction      = $transaction;
+        $this->ticket           = $ticket;
+        $this->quantity         = min(1, absint($quantity));
         $this->ticket_line_item = $ticket_line_item;
     }
 
 
-
     /**
-     * @return \EE_Transaction
+     * @return EE_Transaction
      */
     public function transaction()
     {
@@ -108,9 +111,8 @@ class CancelTicketLineItemCommand extends Command
     }
 
 
-
     /**
-     * @return \EE_Ticket
+     * @return EE_Ticket
      */
     public function ticket()
     {
@@ -118,15 +120,13 @@ class CancelTicketLineItemCommand extends Command
     }
 
 
-
     /**
-     * @return \EE_Line_Item
+     * @return EE_Line_Item
      */
     public function ticketLineItem()
     {
         return $this->ticket_line_item;
     }
-
 
 
     /**
@@ -136,6 +136,4 @@ class CancelTicketLineItemCommand extends Command
     {
         return $this->quantity;
     }
-
-
 }

--- a/core/domain/services/commands/ticket/CancelTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/ticket/CancelTicketLineItemCommandHandler.php
@@ -1,15 +1,14 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\ticket;
 
 use EventEspresso\core\domain\services\ticket\CancelTicketLineItemService;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
+use RuntimeException;
 
-if ( ! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**
@@ -26,12 +25,10 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
 class CancelTicketLineItemCommandHandler extends CommandHandler
 {
 
-
     /**
      * @var CancelTicketLineItemService $cancel_ticket_line_item_service
      */
     private $cancel_ticket_line_item_service;
-
 
 
     /**
@@ -45,15 +42,16 @@ class CancelTicketLineItemCommandHandler extends CommandHandler
     }
 
 
-
     /**
-     * @param \EventEspresso\core\services\commands\CommandInterface $command
+     * @param CommandInterface $command
      * @return mixed
+     * @throws InvalidEntityException
+     * @throws RuntimeException
      */
     public function handle(CommandInterface $command)
     {
         /** @var CancelTicketLineItemCommand $command */
-        if ( ! $command instanceof CancelTicketLineItemCommand) {
+        if (! $command instanceof CancelTicketLineItemCommand) {
             throw new InvalidEntityException(get_class($command), 'CancelTicketLineItemCommand');
         }
         return $this->cancel_ticket_line_item_service->cancel(
@@ -63,6 +61,4 @@ class CancelTicketLineItemCommandHandler extends CommandHandler
             $command->ticketLineItem()
         );
     }
-
-
 }

--- a/core/domain/services/commands/ticket/CancelTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/ticket/CancelTicketLineItemCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\ticket;
+namespace EventEspresso\core\domain\services\commands\ticket;
 
 use EventEspresso\core\domain\services\ticket\CancelTicketLineItemService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -66,5 +66,3 @@ class CancelTicketLineItemCommandHandler extends CommandHandler
 
 
 }
-// End of file CancelTicketLineItemCommandHandler.php
-// Location: /CancelTicketLineItemCommandHandler.php

--- a/core/domain/services/commands/ticket/CreateTicketLineItemCommand.php
+++ b/core/domain/services/commands/ticket/CreateTicketLineItemCommand.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\ticket;
 
+use EE_Line_Item;
+use EE_Ticket;
+use EE_Transaction;
 use EventEspresso\core\services\commands\Command;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
-}
-
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 /**
@@ -20,81 +21,77 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class CreateTicketLineItemCommand extends Command
 {
 
+    /**
+     * @var EE_Transaction $transaction
+     */
+    private $transaction;
 
-	/**
-	 * @var \EE_Transaction $transaction
-	 */
-	private $transaction;
+    /**
+     * @var EE_Ticket $ticket
+     */
+    private $ticket;
 
-	/**
-	 * @var \EE_Ticket $ticket
-	 */
-	private $ticket;
+    /**
+     * @var int $quantity
+     */
+    private $quantity = 1;
 
-	/**
-	 * @var int $quantity
-	 */
-	private $quantity = 1;
-
-	/**
-	 * @var \EE_Line_Item $ticket_line_item
-	 */
-	protected $ticket_line_item;
-
+    /**
+     * @var EE_Line_Item $ticket_line_item
+     */
+    protected $ticket_line_item;
 
 
-	/**
-	 * CreateTicketLineItemCommand constructor.
-	 *
-	 * @param \EE_Transaction     $transaction
-	 * @param \EE_Ticket          $ticket
-	 * @param int                 $quantity
-	 */
-	public function __construct(
-		\EE_Transaction $transaction,
-		\EE_Ticket $ticket,
-		$quantity = 1
-	) {
-		$this->transaction = $transaction;
-		$this->ticket = $ticket;
-		$this->quantity = $quantity;
-	}
+    /**
+     * CreateTicketLineItemCommand constructor.
+     *
+     * @param EE_Transaction $transaction
+     * @param EE_Ticket      $ticket
+     * @param int             $quantity
+     */
+    public function __construct(
+        EE_Transaction $transaction,
+        EE_Ticket $ticket,
+        $quantity = 1
+    ) {
+        $this->transaction = $transaction;
+        $this->ticket      = $ticket;
+        $this->quantity    = $quantity;
+    }
 
 
-
-	/**
-	 * @return \EE_Transaction
-	 */
-	public function transaction() {
-		return $this->transaction;
-	}
-
-
-
-	/**
-	 * @return \EE_Ticket
-	 */
-	public function ticket() {
-		return $this->ticket;
-	}
+    /**
+     * @return EE_Transaction
+     */
+    public function transaction()
+    {
+        return $this->transaction;
+    }
 
 
-
-	/**
-	 * @return int
-	 */
-	public function quantity() {
-		return $this->quantity;
-	}
-
-
-
-	/**
-	 * @return \EE_Line_Item
-	 */
-	public function ticketLineItem() {
-		return $this->ticket_line_item;
-	}
+    /**
+     * @return EE_Ticket
+     */
+    public function ticket()
+    {
+        return $this->ticket;
+    }
 
 
+    /**
+     * @return int
+     */
+    public function quantity()
+    {
+        return $this->quantity;
+    }
+
+
+    /**
+     * @return EE_Line_Item
+     */
+    public function ticketLineItem()
+    {
+        return $this->ticket_line_item;
+    }
 }

--- a/core/domain/services/commands/ticket/CreateTicketLineItemCommand.php
+++ b/core/domain/services/commands/ticket/CreateTicketLineItemCommand.php
@@ -1,0 +1,100 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\ticket;
+
+use EventEspresso\core\services\commands\Command;
+
+if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
+	exit( 'No direct script access allowed' );
+}
+
+
+
+/**
+ * Class CreateTicketLineItemCommand
+ * DTO for passing data to CreateTicketLineItemCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         4.9.0
+ */
+class CreateTicketLineItemCommand extends Command
+{
+
+
+	/**
+	 * @var \EE_Transaction $transaction
+	 */
+	private $transaction;
+
+	/**
+	 * @var \EE_Ticket $ticket
+	 */
+	private $ticket;
+
+	/**
+	 * @var int $quantity
+	 */
+	private $quantity = 1;
+
+	/**
+	 * @var \EE_Line_Item $ticket_line_item
+	 */
+	protected $ticket_line_item;
+
+
+
+	/**
+	 * CreateTicketLineItemCommand constructor.
+	 *
+	 * @param \EE_Transaction     $transaction
+	 * @param \EE_Ticket          $ticket
+	 * @param int                 $quantity
+	 */
+	public function __construct(
+		\EE_Transaction $transaction,
+		\EE_Ticket $ticket,
+		$quantity = 1
+	) {
+		$this->transaction = $transaction;
+		$this->ticket = $ticket;
+		$this->quantity = $quantity;
+	}
+
+
+
+	/**
+	 * @return \EE_Transaction
+	 */
+	public function transaction() {
+		return $this->transaction;
+	}
+
+
+
+	/**
+	 * @return \EE_Ticket
+	 */
+	public function ticket() {
+		return $this->ticket;
+	}
+
+
+
+	/**
+	 * @return int
+	 */
+	public function quantity() {
+		return $this->quantity;
+	}
+
+
+
+	/**
+	 * @return \EE_Line_Item
+	 */
+	public function ticketLineItem() {
+		return $this->ticket_line_item;
+	}
+
+
+}

--- a/core/domain/services/commands/ticket/CreateTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/ticket/CreateTicketLineItemCommandHandler.php
@@ -1,14 +1,16 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\ticket;
 
+use EE_Error;
+use EE_Line_Item;
 use EventEspresso\core\domain\services\ticket\CreateTicketLineItemService;
 use EventEspresso\core\exceptions\InvalidEntityException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
-}
+defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
 
@@ -23,45 +25,41 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class CreateTicketLineItemCommandHandler extends CommandHandler
 {
 
-
-	/**
-	 * @var CreateTicketLineItemService $factory
-	 */
-	private $factory;
-
+    /**
+     * @var CreateTicketLineItemService $factory
+     */
+    private $factory;
 
 
-	/**
-	 * Command constructor
-	 *
-	 * @param CreateTicketLineItemService $factory
-	 */
-	public function __construct(CreateTicketLineItemService $factory) {
-		$this->factory = $factory;
-	}
+    /**
+     * Command constructor
+     *
+     * @param CreateTicketLineItemService $factory
+     */
+    public function __construct(CreateTicketLineItemService $factory)
+    {
+        $this->factory = $factory;
+    }
 
 
-
-	/**
-	 * @param \EventEspresso\core\services\commands\CommandInterface $command
-	 * @return \EE_Line_Item
-	 * @throws \EventEspresso\core\exceptions\InvalidEntityException
-	 * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
-	 * @throws \EE_Error
-	 */
-	public function handle( CommandInterface $command ) {
-		/** @var CreateTicketLineItemCommand $command */
-		if ( ! $command instanceof CreateTicketLineItemCommand ) {
-			throw new InvalidEntityException( get_class( $command ), 'CreateTicketLineItemCommand' );
-		}
-		// create new line item for ticket
-		return $this->factory->create(
-			$command->transaction(),
-			$command->ticket(),
-			$command->quantity()
-		);
-	}
-
-
-
+    /**
+     * @param CommandInterface $command
+     * @return EE_Line_Item
+     * @throws InvalidEntityException
+     * @throws UnexpectedEntityException
+     * @throws EE_Error
+     */
+    public function handle(CommandInterface $command)
+    {
+        /** @var CreateTicketLineItemCommand $command */
+        if (! $command instanceof CreateTicketLineItemCommand) {
+            throw new InvalidEntityException(get_class($command), 'CreateTicketLineItemCommand');
+        }
+        // create new line item for ticket
+        return $this->factory->create(
+            $command->transaction(),
+            $command->ticket(),
+            $command->quantity()
+        );
+    }
 }

--- a/core/domain/services/commands/ticket/CreateTicketLineItemCommandHandler.php
+++ b/core/domain/services/commands/ticket/CreateTicketLineItemCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\ticket;
+namespace EventEspresso\core\domain\services\commands\ticket;
 
 use EventEspresso\core\domain\services\ticket\CreateTicketLineItemService;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -65,5 +65,3 @@ class CreateTicketLineItemCommandHandler extends CommandHandler
 
 
 }
-// End of file CreateTicketLineItemCommandHandler.php
-// Location: /CreateTicketLineItemCommandHandler.php

--- a/core/domain/services/commands/transaction/CreateTransactionCommand.php
+++ b/core/domain/services/commands/transaction/CreateTransactionCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\transaction;
 
 use EE_Checkout;
@@ -35,7 +36,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     protected $transaction_details;
 
 
-
     /**
      * CreateTransactionCommand constructor.
      *
@@ -44,10 +44,9 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
      */
     public function __construct(EE_Checkout $checkout = null, array $transaction_details = array())
     {
-        $this->checkout = $checkout;
+        $this->checkout            = $checkout;
         $this->transaction_details = $transaction_details;
     }
-
 
 
     /**
@@ -66,7 +65,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     }
 
 
-
     /**
      * @return EE_Checkout
      */
@@ -76,7 +74,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     }
 
 
-
     /**
      * @return array
      */
@@ -84,7 +81,4 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     {
         return $this->transaction_details;
     }
-
-
-
 }

--- a/core/domain/services/commands/transaction/CreateTransactionCommand.php
+++ b/core/domain/services/commands/transaction/CreateTransactionCommand.php
@@ -1,0 +1,90 @@
+<?php
+namespace EventEspresso\core\domain\services\commands\transaction;
+
+use EE_Checkout;
+use EventEspresso\core\domain\services\capabilities\CapCheck;
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\domain\services\capabilities\PublicCapabilities;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\services\commands\Command;
+use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
+
+defined('EVENT_ESPRESSO_VERSION') || exit;
+
+
+
+/**
+ * Class CreateTransactionCommand
+ * DTO for passing data to a CreateTransactionCommandHandler
+ *
+ * @package       Event Espresso
+ * @author        Brent Christensen
+ * @since         $VID:$
+ */
+class CreateTransactionCommand extends Command implements CommandRequiresCapCheckInterface
+{
+
+    /**
+     * @var EE_Checkout $checkout
+     */
+    protected $checkout;
+
+    /**
+     * @var array $transaction_details
+     */
+    protected $transaction_details;
+
+
+
+    /**
+     * CreateTransactionCommand constructor.
+     *
+     * @param EE_Checkout $checkout
+     * @param array       $transaction_details
+     */
+    public function __construct(EE_Checkout $checkout = null, array $transaction_details = array())
+    {
+        $this->checkout = $checkout;
+        $this->transaction_details = $transaction_details;
+    }
+
+
+
+    /**
+     * @return CapCheckInterface
+     * @throws InvalidDataTypeException
+     */
+    public function getCapCheck()
+    {
+        // need cap for non-AJAX admin requests
+        if (! (defined('DOING_AJAX') && DOING_AJAX) && is_admin()) {
+            // there's no specific caps for editing/creating transactions,
+            // so that's why we are using ee_edit_registrations
+            return new CapCheck('ee_edit_registrations', 'create_new_transaction');
+        }
+        return new PublicCapabilities('', 'create_new_transaction');
+    }
+
+
+
+    /**
+     * @return EE_Checkout
+     */
+    public function checkout()
+    {
+        return $this->checkout;
+    }
+
+
+
+    /**
+     * @return array
+     */
+    public function transactionDetails()
+    {
+        return $this->transaction_details;
+    }
+
+
+
+}

--- a/core/domain/services/commands/transaction/CreateTransactionCommandHandler.php
+++ b/core/domain/services/commands/transaction/CreateTransactionCommandHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace EventEspresso\core\services\commands\transaction;
+namespace EventEspresso\core\domain\services\commands\transaction;
 
 use EE_Checkout;
 use EE_Error;
@@ -67,5 +67,3 @@ class CreateTransactionCommandHandler extends CommandHandler
 
 
 }
-// End of file CreateTransactionCommandHandler.php
-// Location: EventEspresso\core\services\commands\transaction/CreateTransactionCommandHandler.php

--- a/core/domain/services/commands/transaction/CreateTransactionCommandHandler.php
+++ b/core/domain/services/commands/transaction/CreateTransactionCommandHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\domain\services\commands\transaction;
 
 use EE_Checkout;
@@ -6,9 +7,12 @@ use EE_Error;
 use EE_Line_Item;
 use EE_Transaction;
 use EEH_Line_Item;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\commands\CommandHandler;
 use EventEspresso\core\services\commands\CommandInterface;
+use InvalidArgumentException;
 
 defined('EVENT_ESPRESSO_VERSION') || exit;
 
@@ -25,12 +29,14 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
 class CreateTransactionCommandHandler extends CommandHandler
 {
 
-
     /**
      * @param CommandInterface $command
      * @return mixed
      * @throws EE_Error
      * @throws InvalidEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
      */
     public function handle(CommandInterface $command)
     {
@@ -39,14 +45,14 @@ class CreateTransactionCommandHandler extends CommandHandler
             throw new InvalidEntityException(get_class($command), 'CreateTransactionCommand');
         }
         $transaction_details = $command->transactionDetails();
-        $cart_total = null;
+        $cart_total          = null;
         if ($command->checkout() instanceof EE_Checkout) {
             // ensure cart totals have been calculated
             $command->checkout()->cart->get_grand_total()->recalculate_total_including_taxes();
             // grab the cart grand total
-            $cart_total = $command->checkout()->cart->get_cart_grand_total();
+            $cart_total                           = $command->checkout()->cart->get_cart_grand_total();
             $transaction_details['TXN_reg_steps'] = $command->checkout()->initialize_txn_reg_steps_array();
-            $transaction_details['TXN_total'] = $cart_total > 0 ? $cart_total : 0;
+            $transaction_details['TXN_total']     = $cart_total > 0 ? $cart_total : 0;
         }
         // create new TXN and save it so it has an ID
         $transaction = EE_Transaction::new_instance($transaction_details);
@@ -64,6 +70,4 @@ class CreateTransactionCommandHandler extends CommandHandler
         $cart_total->save_this_and_descendants_to_txn($transaction->ID());
         return $transaction;
     }
-
-
 }

--- a/core/services/commands/attendee/CreateAttendeeCommand.php
+++ b/core/services/commands/attendee/CreateAttendeeCommand.php
@@ -17,6 +17,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  * Class CreateAttendeeCommand
  * DTO for passing data to a CreateAttendeeCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         $VID:$

--- a/core/services/commands/middleware/LocateMovedCommands.php
+++ b/core/services/commands/middleware/LocateMovedCommands.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace EventEspresso\core\services\commands\middleware;
+
+use Closure;
+use EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand;
+use EventEspresso\core\domain\services\commands\registration\CancelRegistrationAndTicketLineItemCommand;
+use EventEspresso\core\domain\services\commands\registration\CopyRegistrationDetailsCommand;
+use EventEspresso\core\domain\services\commands\registration\CopyRegistrationPaymentsCommand;
+use EventEspresso\core\domain\services\commands\registration\CreateRegistrationCommand;
+use EventEspresso\core\domain\services\commands\registration\UpdateRegistrationAndTransactionAfterChangeCommand;
+use EventEspresso\core\domain\services\commands\ticket\CancelTicketLineItemCommand;
+use EventEspresso\core\domain\services\commands\ticket\CreateTicketLineItemCommand;
+use EventEspresso\core\services\commands\transaction\CreateTransactionCommand;
+use EventEspresso\core\services\commands\CommandInterface;
+use EventEspresso\core\services\commands\attendee\CreateAttendeeCommand as OldCreateAttendeeCommand;
+use EventEspresso\core\services\commands\registration\CancelRegistrationAndTicketLineItemCommand as OldCancelRegistrationAndTicketLineItemCommand;
+use EventEspresso\core\services\commands\registration\CopyRegistrationDetailsCommand as OldCopyRegistrationDetailsCommand;
+use EventEspresso\core\services\commands\registration\CopyRegistrationPaymentsCommand as OldCopyRegistrationPaymentsCommand;
+use EventEspresso\core\services\commands\registration\CreateRegistrationCommand as OldCreateRegistrationCommand;
+use EventEspresso\core\services\commands\registration\UpdateRegistrationAndTransactionAfterChangeCommand as OldUpdateRegistrationAndTransactionAfterChangeCommand;
+use EventEspresso\core\services\commands\ticket\CancelTicketLineItemCommand as OldCancelTicketLineItemCommand;
+use EventEspresso\core\services\commands\ticket\CreateTicketLineItemCommand as OldCreateTicketLineItemCommand;
+use EventEspresso\core\services\commands\transaction\CreateTransactionCommand as OldCreateTransactionCommand;
+
+defined('EVENT_ESPRESSO_VERSION') || exit;
+
+
+
+/**
+ * Class LocateMovedCommands
+ * Determines if incoming command has been moved to a new location,
+ * and if so, instantiates the new command and returns that instead of the old command
+ *
+ * @package EventEspresso\core\services\commands\middleware
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class LocateMovedCommands implements CommandBusMiddlewareInterface
+{
+
+    /**
+     * @param CommandInterface $command
+     * @param Closure          $next
+     * @return mixed
+     */
+    public function handle(CommandInterface $command, Closure $next)
+    {
+        $command_class = get_class($command);
+        switch ($command_class) {
+            case 'EventEspresso\core\services\commands\attendee\CreateAttendeeCommand' :
+                $command = $this->getCreateAttendeeCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\registration\CancelRegistrationAndTicketLineItemCommand' :
+                $command = $this->getCancelRegistrationAndTicketLineItemCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\registration\CopyRegistrationDetailsCommand' :
+                $command = $this->getCopyRegistrationDetailsCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\registration\CopyRegistrationPaymentsCommand' :
+                $command = $this->getCopyRegistrationPaymentsCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\registration\CreateRegistrationCommand' :
+                $command = $this->getCreateRegistrationCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\registration\UpdateRegistrationAndTransactionAfterChangeCommand' :
+                $command = $this->getUpdateRegistrationAndTransactionAfterChangeCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\ticket\CancelTicketLineItemCommand' :
+                $command = $this->getCancelTicketLineItemCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\ticket\CreateTicketLineItemCommand' :
+                $command = $this->getCreateTicketLineItemCommand($command);
+                break;
+            case 'EventEspresso\core\services\commands\transaction\CreateTransactionCommand' :
+                $command = $this->getCreateTransactionCommand($command);
+                break;
+        }
+        return $next($command);
+    }
+
+
+    /**
+     * @param OldCreateAttendeeCommand|CommandInterface $command
+     * @return CreateAttendeeCommand|OldCreateAttendeeCommand
+     */
+    private function getCreateAttendeeCommand(OldCreateAttendeeCommand $command)
+    {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CreateAttendeeCommand(
+                $command->attendeeDetails(),
+                $command->registration()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldCancelRegistrationAndTicketLineItemCommand|CommandInterface $command
+     * @return CancelRegistrationAndTicketLineItemCommand|OldCancelRegistrationAndTicketLineItemCommand
+     */
+    private function getCancelRegistrationAndTicketLineItemCommand(
+        OldCancelRegistrationAndTicketLineItemCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CancelRegistrationAndTicketLineItemCommand($command->registration())
+            : $command;
+    }
+
+
+    /**
+     * @param OldCopyRegistrationDetailsCommand|CommandInterface $command
+     * @return CopyRegistrationDetailsCommand|OldCopyRegistrationDetailsCommand
+     */
+    private function getCopyRegistrationDetailsCommand(
+        OldCopyRegistrationDetailsCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CopyRegistrationDetailsCommand(
+                $command->targetRegistration(),
+                $command->registrationToCopy()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldCopyRegistrationPaymentsCommand|CommandInterface $command
+     * @return CopyRegistrationPaymentsCommand|OldCopyRegistrationPaymentsCommand
+     */
+    private function getCopyRegistrationPaymentsCommand(
+        OldCopyRegistrationPaymentsCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CopyRegistrationPaymentsCommand(
+                $command->targetRegistration(),
+                $command->registrationToCopy()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldCreateRegistrationCommand|CommandInterface $command
+     * @return CreateRegistrationCommand|OldCreateRegistrationCommand
+     */
+    private function getCreateRegistrationCommand(
+        OldCreateRegistrationCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CreateRegistrationCommand(
+                $command->transaction(),
+                $command->ticketLineItem(),
+                $command->regCount(),
+                $command->regGroupSize(),
+                $command->regStatus(),
+                $command->ticket()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldUpdateRegistrationAndTransactionAfterChangeCommand|CommandInterface $command
+     * @return UpdateRegistrationAndTransactionAfterChangeCommand|OldUpdateRegistrationAndTransactionAfterChangeCommand
+     */
+    private function getUpdateRegistrationAndTransactionAfterChangeCommand(
+        OldUpdateRegistrationAndTransactionAfterChangeCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new UpdateRegistrationAndTransactionAfterChangeCommand($command->registration())
+            : $command;
+    }
+
+
+    /**
+     * @param OldCancelTicketLineItemCommand|CommandInterface $command
+     * @return CancelTicketLineItemCommand|OldCancelTicketLineItemCommand
+     */
+    private function getCancelTicketLineItemCommand(
+        OldCancelTicketLineItemCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CancelTicketLineItemCommand(
+                $command->transaction(),
+                $command->ticket(),
+                $command->quantity(),
+                $command->ticketLineItem()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldCreateTicketLineItemCommand|CommandInterface $command
+     * @return CreateTicketLineItemCommand|OldCreateTicketLineItemCommand
+     */
+    private function getCreateTicketLineItemCommand(
+        OldCreateTicketLineItemCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CreateTicketLineItemCommand(
+                $command->transaction(),
+                $command->ticket(),
+                $command->quantity()
+            )
+            : $command;
+    }
+
+
+    /**
+     * @param OldCreateTransactionCommand|CommandInterface $command
+     * @return CreateTransactionCommand|OldCreateTransactionCommand
+     */
+    private function getCreateTransactionCommand(
+        OldCreateTransactionCommand $command
+    ) {
+        return class_exists('EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand')
+            ? new CreateTransactionCommand(
+                $command->checkout(),
+                $command->transactionDetails()
+            )
+            : $command;
+    }
+}

--- a/core/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
+++ b/core/services/commands/registration/CancelRegistrationAndTicketLineItemCommand.php
@@ -12,13 +12,14 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class CancelRegistrationAndTicketLineItemCommand
  * DTO for passing data to a CancelRegistrationAndTicketLineItemCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0
  */
 class CancelRegistrationAndTicketLineItemCommand extends SingleRegistrationCommand
 {
-	
+
 }
 // End of file CancelRegistrationAndTicketLineItemCommand.php
 // Location: /CancelRegistrationAndTicketLineItemCommand.php

--- a/core/services/commands/registration/CopyRegistrationDetailsCommand.php
+++ b/core/services/commands/registration/CopyRegistrationDetailsCommand.php
@@ -13,6 +13,7 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class CopyRegistrationDetailsCommand
  * DTO for passing data to a CopyRegistrationDetailsCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/registration/CopyRegistrationPaymentsCommand.php
+++ b/core/services/commands/registration/CopyRegistrationPaymentsCommand.php
@@ -11,6 +11,7 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class CopyRegistrationPaymentsCommand
  * DTO for passing data to a CopyRegistrationPaymentsCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/registration/CreateRegistrationCommand.php
+++ b/core/services/commands/registration/CreateRegistrationCommand.php
@@ -22,6 +22,7 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
  * Class CreateRegistrationCommand
  * DTO for passing data to a CreateRegistrationCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/registration/SingleRegistrationCommand.php
+++ b/core/services/commands/registration/SingleRegistrationCommand.php
@@ -13,6 +13,7 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class SingleRegistrationCommand
  * DTO for passing data a single EE_Registration object to a CommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
+++ b/core/services/commands/registration/UpdateRegistrationAndTransactionAfterChangeCommand.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace EventEspresso\core\services\commands\registration;
 
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
 }
 
 
@@ -11,9 +12,9 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class UpdateRegistrationAndTransactionAfterChangeCommand
  * DTO for passing data to a UpdateRegistrationAndTransactionAfterChangeCommandHandler
  *
+ * @deprecated    4.9.54
  * @package       Event Espresso
-
-*@author        Brent Christensen
+ * @author        Brent Christensen
  * @since         $VID:$
  */
 class UpdateRegistrationAndTransactionAfterChangeCommand extends SingleRegistrationCommand

--- a/core/services/commands/ticket/CancelTicketLineItemCommand.php
+++ b/core/services/commands/ticket/CancelTicketLineItemCommand.php
@@ -13,6 +13,7 @@ if ( ! defined('EVENT_ESPRESSO_VERSION')) {
  * Class CancelTicketLineItemCommand
  * DTO for passing data to CancelTicketLineItemCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/ticket/CreateTicketLineItemCommand.php
+++ b/core/services/commands/ticket/CreateTicketLineItemCommand.php
@@ -13,6 +13,7 @@ if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * Class CreateTicketLineItemCommand
  * DTO for passing data to CreateTicketLineItemCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         4.9.0

--- a/core/services/commands/transaction/CreateTransactionCommand.php
+++ b/core/services/commands/transaction/CreateTransactionCommand.php
@@ -18,6 +18,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  * Class CreateTransactionCommand
  * DTO for passing data to a CreateTransactionCommandHandler
  *
+ * @deprecated 4.9.54
  * @package       Event Espresso
  * @author        Brent Christensen
  * @since         $VID:$

--- a/core/services/commands/transaction/CreateTransactionCommand.php
+++ b/core/services/commands/transaction/CreateTransactionCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventEspresso\core\services\commands\transaction;
 
 use EE_Checkout;
@@ -35,7 +36,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     protected $transaction_details;
 
 
-
     /**
      * CreateTransactionCommand constructor.
      *
@@ -44,10 +44,9 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
      */
     public function __construct(EE_Checkout $checkout = null, array $transaction_details = array())
     {
-        $this->checkout = $checkout;
+        $this->checkout            = $checkout;
         $this->transaction_details = $transaction_details;
     }
-
 
 
     /**
@@ -66,7 +65,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     }
 
 
-
     /**
      * @return EE_Checkout
      */
@@ -76,7 +74,6 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     }
 
 
-
     /**
      * @return array
      */
@@ -84,9 +81,4 @@ class CreateTransactionCommand extends Command implements CommandRequiresCapChec
     {
         return $this->transaction_details;
     }
-
-
-
 }
-// End of file CreateTransactionCommand.php
-// Location: EventEspresso\core\services\commands\transaction/CreateTransactionCommand.php


### PR DESCRIPTION
See https://events.codebasehq.com/projects/event-espresso/tickets/11214 for backstory.

tldr; it looks like what's left to do is the reg services still need to be moved to handlers