### PR TITLE
Fet/use indexes to decide habtm join table behaviour

### DIFF
--- a/core/db_models/EEM_Datetime_Ticket.model.php
+++ b/core/db_models/EEM_Datetime_Ticket.model.php
@@ -42,11 +42,20 @@ class EEM_Datetime_Ticket extends EEM_Base
         );
         // this model is generally available for reading
         $path_to_event = 'Datetime.Event';
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'DTT_ID',
+                    'TKT_ID'
+                ]
+            )
+        ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_delete ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event, EEM_Base::caps_edit);
         $this->model_chain_to_password = $path_to_event;
+
         parent::__construct($timezone);
     }
 }

--- a/core/db_models/EEM_Event_Message_Template.model.php
+++ b/core/db_models/EEM_Event_Message_Template.model.php
@@ -42,10 +42,19 @@ class EEM_Event_Message_Template extends EEM_Base
             'Message_Template_Group'=>new EE_Belongs_To_Relation()
         );
         $path_to_event = 'Event';
+        $this->_indexes = [
+        'fks' => new EE_Unique_Index(
+            [
+                'EMT_ID',
+                'EVT_ID'
+            ]
+        )
+    ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_delete ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event, EEM_Base::caps_edit);
+
         parent::__construct($timezone);
     }
 

--- a/core/db_models/EEM_Event_Message_Template.model.php
+++ b/core/db_models/EEM_Event_Message_Template.model.php
@@ -43,13 +43,13 @@ class EEM_Event_Message_Template extends EEM_Base
         );
         $path_to_event = 'Event';
         $this->_indexes = [
-        'fks' => new EE_Unique_Index(
-            [
-                'EMT_ID',
-                'EVT_ID'
-            ]
-        )
-    ];
+            'fks' => new EE_Unique_Index(
+                [
+                    'EMT_ID',
+                    'EVT_ID'
+                ]
+            )
+        ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);

--- a/core/db_models/EEM_Event_Question_Group.model.php
+++ b/core/db_models/EEM_Event_Question_Group.model.php
@@ -35,7 +35,8 @@ class EEM_Event_Question_Group extends EEM_Base
             'fks' => new EE_Unique_Index(
                 [
                     'EVT_ID',
-                    'QSG_ID'
+                    'QSG_ID',
+                    'EQG_primary'
                 ]
             )
         ];

--- a/core/db_models/EEM_Event_Question_Group.model.php
+++ b/core/db_models/EEM_Event_Question_Group.model.php
@@ -31,6 +31,14 @@ class EEM_Event_Question_Group extends EEM_Base
         );
         // this model is generally available for reading
         $path_to_event = 'Event';
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'EVT_ID',
+                    'QSG_ID'
+                ]
+            )
+        ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);

--- a/core/db_models/EEM_Event_Venue.model.php
+++ b/core/db_models/EEM_Event_Venue.model.php
@@ -32,6 +32,14 @@ class EEM_Event_Venue extends EEM_Base
         );
         // this model is generally available for reading
         $path_to_event = 'Event';
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'EVT_ID',
+                    'VNU_ID'
+                ]
+            )
+        ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
         $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);

--- a/core/db_models/EEM_Question_Group_Question.model.php
+++ b/core/db_models/EEM_Question_Group_Question.model.php
@@ -48,6 +48,14 @@ class EEM_Question_Group_Question extends EEM_Base
         $this->_cap_restriction_generators[ EEM_Base::caps_delete ] = new EE_Restriction_Generator_Reg_Form('Question_Group.QSG_system');
         // use the caps for question groups
         $this->_caps_slug = 'question_groups';
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'QSG_ID',
+                    'QST_ID'
+                ]
+            )
+        ];
         parent::__construct($timezone);
     }
 }

--- a/core/db_models/EEM_Registration_Payment.model.php
+++ b/core/db_models/EEM_Registration_Payment.model.php
@@ -39,6 +39,14 @@ class EEM_Registration_Payment extends EEM_Base
             'Registration'  => new EE_Belongs_To_Relation(),
             'Payment'       => new EE_Belongs_To_Relation(),
         );
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'REG_ID',
+                    'PAY_ID'
+                ]
+            )
+        ];
 
         parent::__construct($timezone);
     }

--- a/core/db_models/EEM_Ticket_Price.model.php
+++ b/core/db_models/EEM_Ticket_Price.model.php
@@ -41,6 +41,14 @@ class EEM_Ticket_Price extends EEM_Base
             'Price'=>new EE_Belongs_To_Relation()
         );
         $this->_model_chain_to_wp_user = 'Ticket';
+        $this->_indexes = [
+            'fks' => new EE_Unique_Index(
+                [
+                    'TKT_ID',
+                    'PRC_ID'
+                ]
+            )
+        ];
         $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Default_Public('Ticket.TKT_is_default', 'Ticket.Datetime.Event');
         // account for default tickets in the caps
         $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Default_Protected('Ticket.TKT_is_default', 'Ticket.Datetime.Event');

--- a/core/db_models/relations/EE_HABTM_Relation.php
+++ b/core/db_models/relations/EE_HABTM_Relation.php
@@ -199,7 +199,7 @@ class EE_HABTM_Relation extends EE_Model_Relation_Base
         } else {
             $this->get_join_model()->update(
                 $all_fields,
-                array($foreign_keys)
+                array($uniqueness_fields)
             );
         }
         return $other_model_obj;

--- a/core/db_models/relations/EE_HABTM_Relation.php
+++ b/core/db_models/relations/EE_HABTM_Relation.php
@@ -177,7 +177,7 @@ class EE_HABTM_Relation extends EE_Model_Relation_Base
         }
 
         $indexes = $this->get_join_model()->unique_indexes();
-        if ($indexes) {
+        if (! empty($indexes)) {
             $unique_index = reset($indexes);
             $uniqueness_fields = array_intersect_key(
                 $all_fields,

--- a/core/db_models/relations/EE_HABTM_Relation.php
+++ b/core/db_models/relations/EE_HABTM_Relation.php
@@ -176,7 +176,7 @@ class EE_HABTM_Relation extends EE_Model_Relation_Base
             $all_fields = array_merge($foreign_keys, $parsed_query);
         }
 
-        $indexes = $this->get_join_model()->unique_indexes();
+        $indexes = $this->get_join_model()->indexes();
         if (! empty($indexes)) {
             $unique_index = reset($indexes);
             $uniqueness_fields = array_intersect_key(

--- a/core/db_models/relations/EE_HABTM_Relation.php
+++ b/core/db_models/relations/EE_HABTM_Relation.php
@@ -176,7 +176,20 @@ class EE_HABTM_Relation extends EE_Model_Relation_Base
             $all_fields = array_merge($foreign_keys, $parsed_query);
         }
 
-        $existing_entry_in_join_table = $this->get_join_model()->get_one(array($all_fields));
+        $indexes = $this->get_join_model()->unique_indexes();
+        if ($indexes) {
+            $unique_index = reset($indexes);
+            $uniqueness_fields = array_intersect_key(
+                $all_fields,
+                $unique_index->fields()
+            );
+        } else {
+            // If no unique index was defined on the model, in order to be backward compatible, use all its fields
+            // for evaluating uniqueness.
+            $uniqueness_fields = $all_fields;
+        }
+
+        $existing_entry_in_join_table = $this->get_join_model()->get_one(array($uniqueness_fields));
         // If there is already an entry in the join table, indicating a relationship, update it instead of adding a
         // new row.
         // Again, if you want more sophisticated logic or insertions (handling more columns than just 2 foreign keys to

--- a/core/db_models/relations/EE_HABTM_Relation.php
+++ b/core/db_models/relations/EE_HABTM_Relation.php
@@ -176,7 +176,7 @@ class EE_HABTM_Relation extends EE_Model_Relation_Base
             $all_fields = array_merge($foreign_keys, $parsed_query);
         }
 
-        $existing_entry_in_join_table = $this->get_join_model()->get_one(array($foreign_keys));
+        $existing_entry_in_join_table = $this->get_join_model()->get_one(array($all_fields));
         // If there is already an entry in the join table, indicating a relationship, update it instead of adding a
         // new row.
         // Again, if you want more sophisticated logic or insertions (handling more columns than just 2 foreign keys to

--- a/tests/testcases/core/db_classes/EE_Base_Class_Test.php
+++ b/tests/testcases/core/db_classes/EE_Base_Class_Test.php
@@ -241,9 +241,6 @@ class EE_Base_Class_Test extends EE_UnitTestCase
             'Question_Group',
             array('QGQ_order' => $second_join_entry_order)
         );
-        $this->markTestIncomplete(
-            'This was reverted in order to fix https://github.com/eventespresso/event-espresso-core/issues/873'
-        );
         $this->assertEquals(
             1,
             EEM_Question_Group_Question::instance()->count(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Restores the behaviour from https://github.com/eventespresso/event-espresso-core/pull/798 (which limits there to only being one join table entry for the foreign keys) but only for the join models that expect that behaviour (other models allow duplicates based on foreign keys).

WIP!

### Exterior behaviour
This means join tables can either impose a uniqueness constraint based on foreign keys, or not. If a model defines a unique index/combined key (that is, a set of fields that must be globally unique for that model) then the `EE_HABTM_Relation` will respect that when adding a relation (instead of inserting a new entry, it will update the existing one). 
However, if a model doesn't define a unique index, the default is to to allow duplicate join table entries. (We could have the opposite be the default, but this is most backward compatible IMO).

### Implementation details
This primarily means join models should define a `EE_Unique_Index` that lists the fields that make the combined key. Those that don't get the old behaviour (which allowed duplicates).

### Up for debate
The main disadvantage is that there's no way for REST API clients to know which behaviour to expect. We should expose that either in the `/resources` endpoint, or somehow in the schema.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Not yet tested.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
