### PR TITLE
imrprove recipient (context) links in message template list table (fixes #725)

### DIFF
--- a/admin_pages/messages/Messages_Template_List_Table.class.php
+++ b/admin_pages/messages/Messages_Template_List_Table.class.php
@@ -171,15 +171,13 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
     {
         // Return the name contents
         return sprintf(
-            '%1$s <span style="color:silver">(id:%2$s)</span><br />%3$s%4$s',
+            '%1$s <span style="color:silver">(id:%2$s)</span><br />%3$s',
             /* $1%s */
-            $this->_get_name_link_for_messenger($item),
+            ucwords($item->messenger_obj()->label['singular']),
             /* $2%s */
             $item->GRP_ID(),
             /* %4$s */
-            $this->_get_context_links($item),
-            /* $3%s */
-            $this->row_actions($this->_get_actions_for_messenger_column($item))
+            $this->_get_context_links($item)
         );
     }
 
@@ -327,7 +325,11 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
                               || ! $item->is_context_active($context)
                 ? ' mtp-inactive'
                 : '';
-            $context_title = ucwords($c_configs[ $context ]['label']);
+            $context_title = sprintf(
+                /* translators: Placeholder represents the context label. Example "Edit Event Admin" */
+                esc_html__('Edit %1$s', 'event_espresso'),
+                ucwords($c_configs[ $context ]['label'])
+            );
             $edit_link = EE_Admin_Page::add_query_args_and_nonce(
                 array(
                     'action'  => 'edit_message_template',
@@ -345,47 +347,5 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
         }
 
         return sprintf('<strong>%s:</strong> ', ucwords($c_label['plural'])) . implode(' | ', $ctxt);
-    }
-
-
-    /**
-     * Get the Name string from the messenger column (linked to edit if the context allows for that).
-     *
-     * @param EE_Message_Template_Group $item
-     * @return string
-     * @throws EE_Error
-     */
-    protected function _get_name_link_for_messenger(EE_Message_Template_Group $item)
-    {
-        $edit_url = $this->_get_edit_url($item);
-        return $edit_url
-            ? '<a href="' . $edit_url . '"'
-              . ' title="' . esc_attr__('Edit Template Group', 'event_espresso') . '">'
-              . ucwords($item->messenger_obj()->label['singular'])
-              . '</a>'
-            : ucwords($item->messenger_obj()->label['singular']);
-    }
-
-
-    /**
-     * Return the actions array for the messenger column.
-     *
-     * @param EE_Message_Template_Group $item
-     * @return array
-     * @throws EE_Error
-     */
-    protected function _get_actions_for_messenger_column(EE_Message_Template_Group $item)
-    {
-        $actions = array();
-        if ($edit_url = $this->_get_edit_url($item)) {
-            $actions = array(
-                'edit' => '<a href="' . $edit_url . '"'
-                          . ' class="' . $item->message_type() . '-edit-link"'
-                          . ' title="' . esc_attr__('Edit Template Group', 'event_espresso') . '">'
-                          . esc_html__('Edit', 'event_espresso')
-                          . '</a>',
-            );
-        }
-        return $actions;
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

See #725 for background.  This pull implements the suggested changes there to the context links in the Messenger column of the Message Template List Table in the admin.

Result:

![screenshot-of-changes](https://www.evernote.com/l/AAMKP9zL069NFZlCP0Uc3XlUyiAoaYH6Cg8B/image.png)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] Verified the links display as expected on the Default Message Templates tab of the messages admin (verified links worked)
* [ ] Same as above for the Custom Message Templates tab.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
