### PR TITLE
Bug/rest api innaccessible related model causes error response

### DIFF
--- a/core/libraries/rest_api/controllers/model/Read.php
+++ b/core/libraries/rest_api/controllers/model/Read.php
@@ -981,18 +981,22 @@ class Read extends Base
                     )
                 );
                 if (! $included_items_protected) {
-                    $related_results = $this->getEntitiesFromRelationUsingModelQueryParams(
-                        $primary_model_query_params,
-                        $relation_obj,
-                        $pretend_related_request
-                    );
+                    try {
+                        $related_results = $this->getEntitiesFromRelationUsingModelQueryParams(
+                            $primary_model_query_params,
+                            $relation_obj,
+                            $pretend_related_request
+                        );
+                    } catch (RestException $e) {
+                        $related_results = null;
+                    }
                 } else {
                     // they're protected, hide them.
-                    $related_results = $relation_obj instanceof EE_Belongs_To_Relation ? null : array();
+                    $related_results = null;
                     $entity_array['_protected'][] = Read::getRelatedEntityName($relation_name, $relation_obj);
                 }
-                if ($related_results instanceof WP_Error) {
-                    $related_results = null;
+                if ($related_results instanceof WP_Error || $related_results === null) {
+                    $related_results = $relation_obj instanceof EE_Belongs_To_Relation ? null : array();
                 }
                 $entity_array[ Read::getRelatedEntityName($relation_name, $relation_obj) ] = $related_results;
             }

--- a/tests/testcases/core/libraries/rest_api/controllers/ReadProtectedTest.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/ReadProtectedTest.php
@@ -1319,7 +1319,7 @@ class ReadProtectedTest extends EE_REST_TestCase
     }
 
     /**
-     * Test fetching an protected model, and including an  UNprotected model (venue to country), and the wrong
+     * Test fetching an unprotected model, and including a protected model (country to venue), and the wrong
      * password is provided.
      * @since 4.9.74.p
      * @throws EE_Error
@@ -1349,7 +1349,9 @@ class ReadProtectedTest extends EE_REST_TestCase
         $response = rest_do_request($request);
         $this->assertInstanceOf('WP_REST_Response', $response);
         $data = $response->get_data();
-        $this->assertEquals('rest_post_incorrect_password', $data['code']);
+        $this->assertArrayNotHasKey('code', $data);
+        $this->assertEquals('CA', $data['CNT_ISO']);
+        $this->assertEquals(array(), $data['venues']);
     }
 
     /**

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1,13 +1,18 @@
 <?php
 namespace EventEspresso\core\libraries\rest_api\controllers\model;
 
+use EE_Error;
 use EE_REST_TestCase;
 use EED_Core_Rest_Api;
 use EEM_CPT_Base;
 use EEM_Event;
 use EventEspresso\core\domain\services\event\EventSpacesCalculator;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\libraries\rest_api\controllers\Base as Controller_Base;
 use EventEspresso\core\services\loaders\LoaderFactory;
+use InvalidArgumentException;
+use ReflectionException;
 use WP_REST_Request;
 
 if (! defined('EVENT_ESPRESSO_VERSION')) {
@@ -698,11 +703,11 @@ class Read_Test extends EE_REST_TestCase
 
     /**
      * @since 4.9.74.p
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \InvalidArgumentException
-     * @throws \ReflectionException
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function test_handle_request_get_one__registration_include_answers_and_question_bare_min_from_each()
     {
@@ -733,11 +738,11 @@ class Read_Test extends EE_REST_TestCase
 
     /**
      * @since 4.9.74.p
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \InvalidArgumentException
-     * @throws \ReflectionException
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function test_handle_request_get_one__doesnt_exist()
     {
@@ -936,7 +941,7 @@ class Read_Test extends EE_REST_TestCase
 
     /**
      * @group 536 see https://github.com/eventespresso/event-espresso-core/pull/536
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function testHandleRequestGetAllSoldOutEventsToo()
     {
@@ -990,7 +995,7 @@ class Read_Test extends EE_REST_TestCase
 
     /**
      * @group 536
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function testHandleRequestGetAllIncludeDatetimesToSoldOutEvents()
     {
@@ -1034,7 +1039,7 @@ class Read_Test extends EE_REST_TestCase
      * This was temporarily broken while working on 536, but no test picked up on it, so here's one that does.
      *
      * @group 536 see https://github.com/eventespresso/event-espresso-core/pull/536
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function testHandleRequestGetAllVenues()
     {
@@ -1076,7 +1081,7 @@ class Read_Test extends EE_REST_TestCase
      * Reproduces https://github.com/eventespresso/event-espresso-core/issues/845, which has been an often-recurring
      * regression.
      * @since 4.9.76.p
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function testHandleRequestGeAllTermRelationships()
     {
@@ -1375,6 +1380,50 @@ class Read_Test extends EE_REST_TestCase
             $data[0]['EVT_desc']['rendered'],
             $data[1]['EVT_desc']['rendered']
         );
+    }
+
+    /**
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function testHandleGetOneIncludeInnaccessibleModel()
+    {
+        // Create an event and some registrations
+        $e = $this->new_model_obj_with_dependencies(
+            'Event',
+            [
+                'status' => EEM_Event::post_status_publish
+            ]
+        );
+        $d = $this->new_model_obj_with_dependencies('Datetime');
+        $t = $this->new_model_obj_with_dependencies('Ticket');
+        $d->_add_relation_to($t, 'Ticket');
+        $r = $this->new_model_obj_with_dependencies(
+            'Registration',
+            [
+                'EVT_ID' => $e->ID(),
+                'TKT_ID' => $t->ID()
+            ]
+        );
+
+        // Request to include the registrations.
+        $request = new WP_REST_Request( 'GET', '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/events');
+        $request->set_query_params(
+            array(
+                'include' => 'Registration',
+            )
+        );
+        $response = rest_do_request($request);
+        $data = $response->get_data();
+
+        // The registrations should just be removed, we shouldn't have a big error response.
+        $this->assertArrayNotHasKey('code', $data);
+        $this->assertEquals($e->ID(), $data['EVT_ID']);
+        $this->assertIsNull($data['registrations']);
     }
 }
 // End of file Read_Test.php

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -1383,6 +1383,9 @@ class Read_Test extends EE_REST_TestCase
     }
 
     /**
+     * Reproduces https://github.com/eventespresso/event-espresso-core/issues/903
+     * where including an innaccessible model caused the entire request to fail instead
+     * of just swapping out the response for null.
      * @since $VID:$
      * @throws EE_Error
      * @throws InvalidDataTypeException
@@ -1411,7 +1414,7 @@ class Read_Test extends EE_REST_TestCase
         );
 
         // Request to include the registrations.
-        $request = new WP_REST_Request( 'GET', '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/events');
+        $request = new WP_REST_Request( 'GET', '/' . EED_Core_Rest_Api::ee_api_namespace . '4.8.36/events/' . $e->ID());
         $request->set_query_params(
             array(
                 'include' => 'Registration',
@@ -1423,7 +1426,7 @@ class Read_Test extends EE_REST_TestCase
         // The registrations should just be removed, we shouldn't have a big error response.
         $this->assertArrayNotHasKey('code', $data);
         $this->assertEquals($e->ID(), $data['EVT_ID']);
-        $this->assertIsNull($data['registrations']);
+        $this->assertEquals(array(), $data['registrations']);
     }
 }
 // End of file Read_Test.php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixed a bug where REST API requests returned an error when attempting to include an innaccessible model, instead of just replacing it with `null` or `[]`. See https://github.com/eventespresso/event-espresso-core/issues/903

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Unit tested
See testcase from https://github.com/eventespresso/event-espresso-core/issues/903

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
