### PR TITLE
Use the correct path for PayPalSettingsForm namespace. Fixes #905

### DIFF
--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -1,6 +1,6 @@
 <?php
 
-use EventEspresso\caffeinated\payment_methods\PayPal_Pro\forms\PayPalProSettingsForm;
+use EventEspresso\caffeinated\payment_methods\Paypal_Pro\forms\PayPalProSettingsForm;
 
 /**
  * EEPMT_Paypal_Pro


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Uses correct path for PayPalSettingsForm namespace, see #905

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
Can I have a question on sport, please?

## How has this been tested
Changed char, checked no more fatal.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
