### PR TITLE
Restore trash/restore action for custom message template groups (fixes #922)

### DIFF
--- a/admin_pages/messages/Messages_Template_List_Table.class.php
+++ b/admin_pages/messages/Messages_Template_List_Table.class.php
@@ -171,13 +171,14 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
     {
         // Return the name contents
         return sprintf(
-            '%1$s <span style="color:silver">(id:%2$s)</span><br />%3$s',
+            '%1$s <span style="color:silver">(id:%2$s)</span><br />%3$s%4$s',
             /* $1%s */
             ucwords($item->messenger_obj()->label['singular']),
             /* $2%s */
             $item->GRP_ID(),
             /* %4$s */
-            $this->_get_context_links($item)
+            $this->_get_context_links($item),
+            $this->row_actions($this->_get_actions_for_messenger_column($item))
         );
     }
 
@@ -347,5 +348,19 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
         }
 
         return sprintf('<strong>%s:</strong> ', ucwords($c_label['plural'])) . implode(' | ', $ctxt);
+    }
+
+
+    /**
+     * Returns the actions for the messenger column.
+     *
+     * Note: Children classes may override this so do not remove it.
+     *
+     * @param EE_Message_Template_Group $item
+     * @return array
+     */
+    protected function _get_actions_for_messenger_column(EE_Message_Template_Group $item)
+    {
+        return [];
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

In #725, the trash and restore actions were accidentally removed as a part of that work. This pull restores them.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] Verify the trash and restore actions are now visible/usable for the Custom Message Template Groups.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
