### PR TITLE
 Change the default per_page value for list tables to 20 (fixes #723)

### DIFF
--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -207,7 +207,7 @@ abstract class EE_Admin_List_Table extends WP_List_Table
         $this->_screen = $this->_admin_page->get_current_page() . '_' . $this->_admin_page->get_current_view();
         $this->_yes_no = array(__('No', 'event_espresso'), __('Yes', 'event_espresso'));
 
-        $this->_per_page = $this->get_items_per_page($this->_screen . '_per_page', 10);
+        $this->_per_page = $this->get_items_per_page($this->_screen . '_per_page', 20);
 
         $this->_setup_data();
         $this->_add_view_counts();

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -3686,7 +3686,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
             ),
             'default' => (int) apply_filters(
                 'FHEE__EE_Admin_Page___per_page_screen_options__default',
-                10
+                20
             ),
             'option'  => $this->_current_page . '_' . $this->_current_view . '_per_page',
         );


### PR DESCRIPTION
## Problem this Pull Request solves

This changes the default for `_per_page` property on all EE list tables to 20 (see #723 for background)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] Visit various EE list tables and verify there are 20 items in the list table.  Open up screen options and verify the value in the pagination field is 20.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
