### PR TITLE
Disable the file exists check for image URLs in the admin

### DIFF
--- a/admin_pages/payments/Payments_Admin_Page.core.php
+++ b/admin_pages/payments/Payments_Admin_Page.core.php
@@ -258,7 +258,6 @@ class Payments_Admin_Page extends EE_Admin_Page
          * recheck here.
          */
         EE_Registry::instance()->load_lib('Payment_Method_Manager');
-        EEM_Payment_Method::instance()->verify_button_urls();
         // setup tabs, one for each payment method type
         $tabs = array();
         $payment_methods = array();

--- a/admin_pages/payments/Payments_Admin_Page.core.php
+++ b/admin_pages/payments/Payments_Admin_Page.core.php
@@ -258,6 +258,7 @@ class Payments_Admin_Page extends EE_Admin_Page
          * recheck here.
          */
         EE_Registry::instance()->load_lib('Payment_Method_Manager');
+        EEM_Payment_Method::instance()->verify_button_urls();
         // setup tabs, one for each payment method type
         $tabs = array();
         $payment_methods = array();

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -264,9 +264,15 @@ class EEM_Payment_Method extends EEM_Base
         $payment_methods = is_array($payment_methods) ? $payment_methods : $this->get_all_active(EEM_Payment_Method::scope_cart);
         foreach ($payment_methods as $payment_method) {
             try {
-                // If there is really no button URL at all, reset it to the default.
+                // If there is really no button URL at all, or if the button URLs still point to decaf folder even
+                // though this is a caffeinated install, reset it to the default.
                 $current_button_url = $payment_method->button_url();
-                if (empty($current_button_url)) {
+                if (empty($current_button_url)
+                || (
+                        strpos($current_button_url, 'decaf') !== false
+                        && strpos($payment_method->type_obj()->default_button_url(), 'decaf') === false
+                    )
+                ) {
                     $payment_method->save(
                         [
                             'PMD_button_url' => $payment_method->type_obj()->default_button_url()

--- a/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Admin_File_Uploader_Input.input.php
@@ -31,7 +31,7 @@ class EE_Admin_File_Uploader_Input extends EE_Form_Input_Base
                     isset($input_settings['validation_error_message'])
                         ? $input_settings['validation_error_message']
                         : null,
-                    true
+                    false
                 )
             )
         );


### PR DESCRIPTION
We get so many issues with this file exists check that I've just completely disabled it for now.

If this needs further investigation for a better/proper fix can we please just put this pull request through to disable the check until we get time to do so as we keep running into the same old validation check error in General Settings and/or Payment Methods.

If someone wants to break there images by adding URL's that aren't valid lets roll with that for now.

## Testing Checklist
* [x] Do a fresh install of EE (or just reset your current EE via the maintenance page). The payment method's button images should be set properly as usual.
* [x] Purposefully set a payment method's image to something that doesn't exist. It won't be automatically fixed. (Because we can't rely on the server to correctly identify when a URL is valid or not, and so we usually shouldn't automatically fix ostensibly "broken" image URLs)
* [x] Purposefully set a payment method's image to a blank string. It should get reset to the default button URL again.
* [x] Go to general settings and purposefully set the logo image to something non-existent. It should be saved without a problem.
* [x] Delete all EE4 data. Install EE4 **decaf**. Notice the payment method button URLs point to files inside `event-espresso-decaf`. Then deactivate decaff and delete it. Activate caffeinated. Visit the payment methods page. The button URLs should have automatically been updated to the EE caff folder (it, not be broken)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
