### PR TITLE
Improve `Registry::pushData` (fixes #855)

### DIFF
--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -245,12 +245,16 @@ class Registry
     /**
      * Similar to addData except this allows for users to push values to an existing key where the values on key are
      * elements in an array.
-     * When you use this method, the value you include will be appended to the end of an array on $key.
-     * So if the $key was 'test' and you added a value of 'my_data' then it would be represented in the javascript
+     *
+     * When you use this method, the value you include will be merged with the array on $key.
+     * So if the $key was 'test' and you added a value of ['my_data'] then it would be represented in the javascript
      * object like this, eejs.data.test = [ my_data,
      * ]
-     * If there has already been a scalar value attached to the data object given key, then
+     * If there has already been a scalar value attached to the data object given key (via addData for instance), then
      * this will throw an exception.
+     *
+     * Caution: Only add data using this method if you are okay with the potential for additional data added on the same
+     * key potentially overriding the existing data on merge (specifically with associative arrays).
      *
      * @param string       $key   Key to attach data to.
      * @param string|array $value Value being registered.
@@ -276,7 +280,11 @@ class Registry
                 )
             );
         }
-        $this->jsdata[ $key ][] = $value;
+        if ( ! isset( $this->jsdata[ $key ] ) ) {
+            $this->jsdata[ $key ] = is_array($value) ? $value : [$value];
+        } else {
+            $this->jsdata[ $key ] = array_merge( $this->jsdata[$key], (array) $value);
+        }
     }
 
 

--- a/tests/testcases/core/services/assets/RegistryTest.php
+++ b/tests/testcases/core/services/assets/RegistryTest.php
@@ -114,6 +114,38 @@ class RegistryTest extends EE_UnitTestCase
     }
 
 
+    public function pushDataWithArrayProvider() {
+        return [
+            'initial creation of dataset when it does not exist' => [ 'test', 'foo', [ 'foo' ] ],
+            'adding a string to existing dataset' => [ 'test', 'bar', [ 'foo', 'bar' ] ],
+            'adding an array to existing dataset' => [ 'test', [ 'howdy', 'there' ], [ 'foo', 'bar', 'howdy', 'there' ] ]
+        ];
+    }
+
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testPushDataWithArrayAddingData()
+    {
+        foreach ($this->pushDataWithArrayProvider() as $test_description => $test_data) {
+            list($key, $value, $expected) = $test_data;
+            $this->registry->pushData($key, $value);
+            $this->assertEquals($expected, $this->registry->getData($key), $test_description);
+        }
+    }
+
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testPushDataExceptionWhenExistingDataIsScalar()
+    {
+        $this->registry->addData( 'test', 'foo' );
+        $this->registry->pushData( 'test', 'bar' );
+    }
+
+
     /**
      * @group 10304
      * @throws InvalidArgumentException

--- a/tests/testcases/core/services/assets/RegistryTest.php
+++ b/tests/testcases/core/services/assets/RegistryTest.php
@@ -114,11 +114,16 @@ class RegistryTest extends EE_UnitTestCase
     }
 
 
-    public function pushDataWithArrayProvider() {
+    public function pushDataWithArrayProvider()
+    {
         return [
-            'initial creation of dataset when it does not exist' => [ 'test', 'foo', [ 'foo' ] ],
-            'adding a string to existing dataset' => [ 'test', 'bar', [ 'foo', 'bar' ] ],
-            'adding an array to existing dataset' => [ 'test', [ 'howdy', 'there' ], [ 'foo', 'bar', 'howdy', 'there' ] ]
+            'initial creation of dataset when it does not exist' => ['test', 'foo', ['foo']],
+            'adding a string to existing dataset'                => ['test', 'bar', ['foo', 'bar']],
+            'adding an array to existing dataset'                => [
+                'test',
+                ['howdy', 'there'],
+                ['foo', 'bar', 'howdy', 'there'],
+            ],
         ];
     }
 
@@ -143,6 +148,27 @@ class RegistryTest extends EE_UnitTestCase
     {
         $this->registry->addData( 'test', 'foo' );
         $this->registry->pushData( 'test', 'bar' );
+    }
+
+
+    public function pushDataWithAssociativeArrayProvider()
+    {
+        return [
+            'initial creation of dataset'           => ['test', ['a' => 'foo'], ['a' => 'foo']],
+            'adding new item with different key'    => ['test', ['b' => 'bar'], ['a' => 'foo', 'b' => 'bar']],
+            'adding new item with pre-existing key' => ['test', ['a' => 'bar'], ['a' => 'bar', 'b' => 'bar']],
+            'adding scalar array'                   => ['test', 'hello', ['a' => 'bar', 'b' => 'bar', 'hello']],
+        ];
+    }
+
+    
+    public function testPushDataWithAssociativeArray()
+    {
+        foreach ($this->pushDataWithAssociativeArrayProvider() as $test_description => $test_data) {
+            list($key, $value, $expected) = $test_data;
+            $this->registry->pushData($key, $value);
+            $this->assertEquals($expected, $this->registry->getData($key), $test_description);
+        }
     }
 
 


### PR DESCRIPTION
## Problem this Pull Request solves

See #855 for original issue.  While I agree the current behaviour of `pushData` is less than ideal, I think some of the suggestions for improvement are a bit overkill.  I don't think we should have variable merge strategies because it's an unknown on whether they will even be needed.  I'd prefer to have `pushData` have a specific known opinionated behaviour and there are alternatives if consumers don't want risk that behaviour.  If we discover that having different merge strategies are necessary, then we can add specific interfaces for each of them.  For now, this pull implements the following:

- `pushData` will always result in the provided value being added to an array on the given key.  So if you do `EE_Registry::pushData( 'test', 'foo' );` when `test` doesn't exist in the registry data, then `EE_Registry::getData( 'test' )` will return `[ 'foo' ]`.
- When an array is fed as the value using `pushData`, it will get _merged_ with the existing value on that key (if it exists).  The merge strategy is what `COLLISION_OVERWRITE` is described as in the issue.  `array_merge` is used, so that means arrays with numeric keys are appended to the existing array.
- If the consumer tries to submit a value for a key that already has a scalar value in the registry data, then an exception is thrown because `pushData` will not overwrite or convert existing key/value pairs cached that are not arrays.
- There are php unit tests added that describe and assert the above behaviour.

## How has this been tested

* [x] Verify new unit tests pass.

I also verified that `pushData` isn't used anywhere in our add-ons or EE core currently.  I'm fairly confident that it's usage in third party add-ons is close to nil as well.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
