### PR TITLE
Improve open registration notice

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -732,9 +732,13 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             return;
         }
         EE_Error::add_attention(
-            esc_html__(
-                'Please be advised that this event has been published and is open for registrations on your website. If you update any registration-related details (i.e. custom questions, messages, tickets, datetimes, etc.) while a registration is in process, the registration process could be interrupted and result in errors for the person registering and potentially incorrect registration or transaction data inside Event Espresso. We recommend editing events during a period of slow traffic, or even temporarily changing the status of an event to "Draft" until your edits are complete.',
-                'event_espresso'
+            sprintf(
+                esc_html__(
+                    'Registration for your event is open. Making changes may disrupt any registrations in progress. %sLearn more%s',
+                    'event_espresso'
+                ),
+                '<a class="espresso-help-tab-lnk">',
+                '</a>'
             )
         );
     }

--- a/admin_pages/events/help_tabs/event_editor.help_tab.php
+++ b/admin_pages/events/help_tabs/event_editor.help_tab.php
@@ -3,7 +3,7 @@
 <?php _e('This page allows you to create and edit events with Event Espresso.', 'event_espresso'); ?>
 </p>
 <p class="ee-attention">
-<?php _e('Notice: Allowing too many registrations to be processed with a single order can cause transactions to fail. The decision of how many tickets you allow to be purchased per order should be influenced by your web hosting, how much traffic you get to your website, and the complexity of your registration forms. A more powerful web server will reduce the likelihood of transactions failing.', 'event_espresso'); ?>
+<?php _e('Please be advised: If you update any registration-related details (i.e. custom questions, messages, tickets, datetimes, etc.) while a registration is in progress, the registration process could be interrupted and result in errors for the person registering and potentially incorrect registration or transaction data inside Event Espresso. We recommend editing events during a period of slow traffic, or even temporarily changing the status of an event to "Draft" until your edits are complete.', 'event_espresso'); ?>
 </p>
 <p>
 <strong><?php _e('Screen Options', 'event_espresso'); ?></strong><br /> 

--- a/admin_pages/events/help_tabs/event_editor.help_tab.php
+++ b/admin_pages/events/help_tabs/event_editor.help_tab.php
@@ -1,11 +1,11 @@
-<p><strong><?php _e('Event Editor', 'event_espresso'); ?></strong></p>
+<p><strong><?php esc_html_e('Event Editor', 'event_espresso'); ?></strong></p>
 <p>
-<?php _e('This page allows you to create and edit events with Event Espresso.', 'event_espresso'); ?>
+<?php esc_html_e('This page allows you to create and edit events with Event Espresso.', 'event_espresso'); ?>
 </p>
 <p class="ee-attention">
-<?php _e('Please be advised: If you update any registration-related details (i.e. custom questions, messages, tickets, datetimes, etc.) while a registration is in progress, the registration process could be interrupted and result in errors for the person registering and potentially incorrect registration or transaction data inside Event Espresso. We recommend editing events during a period of slow traffic, or even temporarily changing the status of an event to "Draft" until your edits are complete.', 'event_espresso'); ?>
+<?php esc_html_e('Please be advised: If you update any registration-related details (i.e. custom questions, messages, tickets, datetimes, etc.) while a registration is in progress, the registration process could be interrupted and result in errors for the person registering and potentially incorrect registration or transaction data inside Event Espresso. We recommend editing events during a period of slow traffic, or even temporarily changing the status of an event to "Draft" until your edits are complete.', 'event_espresso'); ?>
 </p>
 <p>
-<strong><?php _e('Screen Options', 'event_espresso'); ?></strong><br /> 
-<?php _e('You can customize the information that is shown on this page by toggling the Screen Options tab. Then you can add or remove checkmarks to hide or show certain content and even adjust the screen layout.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Screen Options', 'event_espresso'); ?></strong><br /> 
+<?php esc_html_e('You can customize the information that is shown on this page by toggling the Screen Options tab. Then you can add or remove checkmarks to hide or show certain content and even adjust the screen layout.', 'event_espresso'); ?>
 </p>

--- a/admin_pages/events/help_tabs/event_editor_event_registration_options.help_tab.php
+++ b/admin_pages/events/help_tabs/event_editor_event_registration_options.help_tab.php
@@ -40,6 +40,9 @@
 <li>
 <strong><?php _e('Maximum number of tickets allowed per order for this event', 'event_espresso'); ?></strong><br />
 <?php _e('Control how many tickets can be purchased in a single order.', 'event_espresso'); ?>
+<div class="ee-attention">
+<?php _e('Notice: Allowing too many registrations to be processed with a single order can cause transactions to fail. The decision of how many tickets you allow to be purchased per order should be influenced by your web hosting, how much traffic you get to your website, and the complexity of your registration forms. A more powerful web server will reduce the likelihood of transactions failing.', 'event_espresso'); ?>
+</div>
 </li>
 <li>
 <strong><?php _e('Alternative Registration Page', 'event_espresso'); ?></strong><br />

--- a/admin_pages/events/help_tabs/event_editor_event_registration_options.help_tab.php
+++ b/admin_pages/events/help_tabs/event_editor_event_registration_options.help_tab.php
@@ -1,60 +1,60 @@
-<p><strong><?php _e('Event Registration Options', 'event_espresso'); ?></strong></p>
+<p><strong><?php esc_html_e('Event Registration Options', 'event_espresso'); ?></strong></p>
 <p>
-<?php _e('Customize the registration for your event.', 'event_espresso'); ?>
+<?php esc_html_e('Customize the registration for your event.', 'event_espresso'); ?>
 </p>
 <p>
 <ul>
 <li>
-<strong><?php _e('Active Status', 'event_espresso'); ?></strong><br />
-<?php _e('Shows the current status for an event. A status will appear as Active, Upcoming, Postponed, Inactive, Sold Out, Expired, or Cancelled.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Active Status', 'event_espresso'); ?></strong><br />
+<?php esc_html_e('Shows the current status for an event. A status will appear as Active, Upcoming, Postponed, Inactive, Sold Out, Expired, or Cancelled.', 'event_espresso'); ?>
 <ul>
 <li style="list-style-type: none;">
-<strong><?php _e('Active', 'event_espresso'); ?></strong><br>
-<?php _e('A status of active means that an event has started and is currently taking place.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Active', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of active means that an event has started and is currently taking place.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Upcoming', 'event_espresso'); ?></strong><br>
-<?php _e('A status of upcoming means that an event is scheduled to take place in the future.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Upcoming', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of upcoming means that an event is scheduled to take place in the future.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Postponed', 'event_espresso'); ?></strong><br>
-<?php _e('A status of postponed means that an event is not currently scheduled but may be in the future.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Postponed', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of postponed means that an event is not currently scheduled but may be in the future.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Inactive', 'event_espresso'); ?></strong><br>
-<?php _e('A status of inactive occurs when an event is set to draft.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Inactive', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of inactive occurs when an event is set to draft.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Sold Out', 'event_espresso'); ?></strong><br>
-<?php _e('A status of sold out means that tickets are no longer available for an event.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Sold Out', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of sold out means that tickets are no longer available for an event.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Expired', 'event_espresso'); ?></strong><br>
-<?php _e('A status of expired means that the event has already taken place.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Expired', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of expired means that the event has already taken place.', 'event_espresso'); ?>
 </li>
 <li style="list-style-type: none;">
-<strong><?php _e('Cancelled', 'event_espresso'); ?></strong><br>
-<?php _e('A status of cancelled means that the event will no longer take place.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Cancelled', 'event_espresso'); ?></strong><br>
+<?php esc_html_e('A status of cancelled means that the event will no longer take place.', 'event_espresso'); ?>
 </li>
 </ul>
 <li>
-<strong><?php _e('Maximum number of tickets allowed per order for this event', 'event_espresso'); ?></strong><br />
-<?php _e('Control how many tickets can be purchased in a single order.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Maximum number of tickets allowed per order for this event', 'event_espresso'); ?></strong><br />
+<?php esc_html_e('Control how many tickets can be purchased in a single order.', 'event_espresso'); ?>
 <div class="ee-attention">
-<?php _e('Notice: Allowing too many registrations to be processed with a single order can cause transactions to fail. The decision of how many tickets you allow to be purchased per order should be influenced by your web hosting, how much traffic you get to your website, and the complexity of your registration forms. A more powerful web server will reduce the likelihood of transactions failing.', 'event_espresso'); ?>
+<?php esc_html_e('Notice: Allowing too many registrations to be processed with a single order can cause transactions to fail. The decision of how many tickets you allow to be purchased per order should be influenced by your web hosting, how much traffic you get to your website, and the complexity of your registration forms. A more powerful web server will reduce the likelihood of transactions failing.', 'event_espresso'); ?>
 </div>
 </li>
 <li>
-<strong><?php _e('Alternative Registration Page', 'event_espresso'); ?></strong><br />
-<?php _e('Enter another registration URL (website address). This field is optional.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Alternative Registration Page', 'event_espresso'); ?></strong><br />
+<?php esc_html_e('Enter another registration URL (website address). This field is optional.', 'event_espresso'); ?>
 </li>
 <li>
-<strong><?php _e('Event Phone Number', 'event_espresso'); ?></strong><br />
-<?php _e('Enter a phone number for this event. This field is optional.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Event Phone Number', 'event_espresso'); ?></strong><br />
+<?php esc_html_e('Enter a phone number for this event. This field is optional.', 'event_espresso'); ?>
 </li>
 <li>
-<strong><?php _e('Default Registration Status', 'event_espresso'); ?></strong><br />
-<?php _e('Select the default registration status for this event. The options are Approved, Not Approved, and Pending Payment.', 'event_espresso'); ?>
+<strong><?php esc_html_e('Default Registration Status', 'event_espresso'); ?></strong><br />
+<?php esc_html_e('Select the default registration status for this event. The options are Approved, Not Approved, and Pending Payment.', 'event_espresso'); ?>
 </li>
 </ul>
 </p>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #918 


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Go to edit an event that's open for registration. Click the learn more link, View main help tab. Also view the help tab for the Event Registrations Options to confirm the text displays as expected.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)

We'll also need either Garth or Seth to do a final approval of the text changes.
