### PR TITLE
stop build process if only doing a doc change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ before_install:
         phpenv config-rm xdebug.ini
         echo "xdebug removed";
       fi
+   - |
+     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+       TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+     fi
+     git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/' || {
+       echo "Only docs were updated, stopping build process."
+       exit
+     }
 before_script:
   - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

This pull implements a travis configuration change to stop travis builds when there are only `md` or docs changes in the pull.  This should save having unnecessary builds run.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [ ] verify normal builds are unaffected.
* [ ] Do a pull based off of this one as a test that only has a doc change.