### PR TITLE
Update "max_input_vars" exceeded message for clarity & make sure limit isn't stale

### DIFF
--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -3185,7 +3185,7 @@ class EE_Environment_Config extends EE_Config_Base
             if ($input_count >= $max_input_vars) {
                 return sprintf(
                     esc_html__(
-                        'The maximum number of inputs on this page has been exceeded. You cannot make edits to this page because of your server\'s PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.%4$sYou can contact your web host and ask them to raise the "max_input_vars" limit.',
+                        'The maximum number of inputs on this page has been exceeded. You cannot make edits to this page because of your server\'s PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.%4$sPlease contact your web host and ask them to raise the "max_input_vars" limit.',
                         'event_espresso'
                     ),
                     '<br>',

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -3185,13 +3185,12 @@ class EE_Environment_Config extends EE_Config_Base
             if ($input_count >= $max_input_vars) {
                 return sprintf(
                     esc_html__(
-                        'The maximum number of inputs on this page has been exceeded. You cannot make edits to this page because of your server\'s PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.%4$sPlease contact your web host and ask them to raise the "max_input_vars" limit.',
+                        'The maximum number of inputs on this page has been exceeded. You cannot make edits to this page because of your server\'s PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.%1$sPlease contact your web host and ask them to raise the "max_input_vars" limit.',
                         'event_espresso'
                     ),
                     '<br>',
                     $input_count,
-                    $max_input_vars,
-                    '<br>'
+                    $max_input_vars
                 );
             } else {
                 return '';

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -3180,15 +3180,22 @@ class EE_Environment_Config extends EE_Config_Base
         if (! empty($this->php->max_input_vars)
             && ($input_count >= $this->php->max_input_vars)
         ) {
-            return sprintf(
-                __(
-                    'The maximum number of inputs on this page has been exceeded.  You cannot add anymore items (i.e. tickets, datetimes, custom fields) on this page because of your servers PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.',
-                    'event_espresso'
-                ),
-                '<br>',
-                $input_count,
-                $this->php->max_input_vars
-            );
+            // check the server setting because the config value could be stale
+            $max_input_vars = ini_get('max_input_vars');
+            if ($input_count >= $max_input_vars) {
+                return sprintf(
+                    esc_html__(
+                        'The maximum number of inputs on this page has been exceeded. You cannot make edits to this page because of your server\'s PHP "max_input_vars" setting.%1$sThere are %2$d inputs and the maximum amount currently allowed by your server is %3$d.%4$sYou can contact your web host and ask them to raise the "max_input_vars" limit.',
+                        'event_espresso'
+                    ),
+                    '<br>',
+                    $input_count,
+                    $max_input_vars,
+                    '<br>'
+                );
+            } else {
+                return '';
+            }
         } else {
             return '';
         }


### PR DESCRIPTION
Fixes #908


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #908 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
1) Save the General settings page
2) Go into the db and artificially set the ee_config's max_input_vars limit to something like 200
3) Go to edit an event and duplicate the tickets a dozen or so times, then some more

Eventually you'll see the updated warning about the max_input_vars limit but only until the actual limit is reached (not the limit cached in ee_options)
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
