### PR TITLE
Use wp default link text color for better a11y

### DIFF
--- a/admin_pages/registrations/form_sections/EE_Registration_Custom_Questions_Form.form.php
+++ b/admin_pages/registrations/form_sections/EE_Registration_Custom_Questions_Form.form.php
@@ -123,8 +123,8 @@ class EE_Registration_Custom_Questions_Form extends EE_Form_Section_Proper
             $this->_registration->ID()
         )) {
             $parts_of_subsection['edit_link'] = new EE_Form_Section_HTML(
-                '<tr><th/><td class="reg-admin-edit-attendee-question-td"><a class="reg-admin-edit-attendee-question-lnk" href="#" title="' . esc_attr__('click to edit question', 'event_espresso') . '">
-		  			<span class="reg-admin-edit-question-group-spn lt-grey-txt">' . __('edit the above question group', 'event_espresso') . '</span>
+                '<tr><th/><td class="reg-admin-edit-attendee-question-td"><a class="reg-admin-edit-attendee-question-lnk" href="#" aria-label="' . esc_attr__('click to edit question', 'event_espresso') . '">
+		  			<span class="reg-admin-edit-question-group-spn">' . __('edit the above question group', 'event_espresso') . '</span>
 		  			<div class="dashicons dashicons-edit"></div>
 		  		</a></td></tr>'
             );


### PR DESCRIPTION



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The registration admin page has a link that says "edit the above question group" and its color contrast does not pass WCAG. Removing the class that hooks to gray text allows for WCAG compliant link text.

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
load up the registration admin page for a single registration that has custom questions. The link text should have easier to read text.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
