### PR TITLE
Add links to docs on plugin page entry

### DIFF
--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -1053,16 +1053,16 @@ final class EE_Admin implements InterminableInterface
         if (EE_PLUGIN_BASENAME === $file) {
             $row_meta = array(
                 'docs' => '<a href="https://eventespresso.com/support/documentation/versioned-docs/?doc_ver=ee4"'
-                          . ' aria-label="' 
-                          . esc_attr__('View Event Espresso documentation', 'espresso_events') 
-                          . '">' 
-                          . esc_html__('Docs', 'espresso_events') 
+                          . ' aria-label="'
+                          . esc_attr__('View Event Espresso documentation', 'event_espresso')
+                          . '">'
+                          . esc_html__('Docs', 'event_espresso')
                           . '</a>',
                 'api'  => '<a href="https://github.com/eventespresso/event-espresso-core/tree/master/docs/C--REST-API"'
                           . ' aria-label="'
-                          . esc_attr__('View Event Espresso API docs', 'espresso_events')
+                          . esc_attr__('View Event Espresso API docs', 'event_espresso')
                           . '">'
-                          . esc_html__('API docs', 'espresso_events')
+                          . esc_html__('API docs', 'event_espresso')
                           . '</a>',
             );
             return array_merge($meta, $row_meta);

--- a/core/admin/EE_Admin.core.php
+++ b/core/admin/EE_Admin.core.php
@@ -90,6 +90,7 @@ final class EE_Admin implements InterminableInterface
         add_filter('admin_footer_text', array($this, 'espresso_admin_footer'));
         add_action('load-plugins.php', array($this, 'hookIntoWpPluginsPage'));
         add_action('display_post_states', array($this, 'displayStateForCriticalPages'), 10, 2);
+        add_filter('plugin_row_meta', array($this, 'addLinksToPluginRowMeta'), 10, 2);
         // reset Environment config (we only do this on admin page loads);
         EE_Registry::instance()->CFG->environment->recheck_values();
         do_action('AHEE__EE_Admin__loaded');
@@ -1037,5 +1038,35 @@ final class EE_Admin implements InterminableInterface
             );
         }
         return $post_states;
+    }
+
+
+    /**
+     * Show documentation links on the plugins page
+     *
+     * @param mixed $meta Plugin Row Meta
+     * @param mixed $file Plugin Base file
+     * @return array
+     */
+    public function addLinksToPluginRowMeta($meta, $file)
+    {
+        if (EE_PLUGIN_BASENAME === $file) {
+            $row_meta = array(
+                'docs' => '<a href="https://eventespresso.com/support/documentation/versioned-docs/?doc_ver=ee4"'
+                          . ' aria-label="' 
+                          . esc_attr__('View Event Espresso documentation', 'espresso_events') 
+                          . '">' 
+                          . esc_html__('Docs', 'espresso_events') 
+                          . '</a>',
+                'api'  => '<a href="https://github.com/eventespresso/event-espresso-core/tree/master/docs/C--REST-API"'
+                          . ' aria-label="'
+                          . esc_attr__('View Event Espresso API docs', 'espresso_events')
+                          . '">'
+                          . esc_html__('API docs', 'espresso_events')
+                          . '</a>',
+            );
+            return array_merge($meta, $row_meta);
+        }
+        return (array) $meta;
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
see https://events.codebasehq.com/projects/event-espresso/tickets/6618

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
test clicking the new links on the WP > Plugins page. Links go to Event Espresso 4 documentation page and REST API docs for EE4.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
