### PR TITLE
change default format settings for zero values to match positive values

### DIFF
--- a/assets/src/vo/currency.js
+++ b/assets/src/vo/currency.js
@@ -105,7 +105,7 @@ export class Currency {
 				format: {
 					pos: this.signB4 ? '%s%v' : '%v%s',
 					neg: this.signB4 ? '- $s%v' : '- %v%s',
-					zero: this.signB4 ? '%s--' : '--%s',
+					zero: this.signB4 ? '%s%v' : '%v%s',
 				},
 				...decimalInfo,
 			},


### PR DESCRIPTION
## Problem this Pull Request solves
Zero money values are currently formatted by the Money VO to appear as `$--` (assuming USD/CAD).
This pull simply changes the default Accounting JS settings in the Currency VO to match those for non-zero positive values for consistency.

## How has this been tested
browser based monkey testing only
