### PR TITLE
Clean up a few things in the skeleton add-ons

### DIFF
--- a/tests/mocks/addons/eea-new-addon/tests/testcases/espresso_addon_skeleton.php
+++ b/tests/mocks/addons/eea-new-addon/tests/testcases/espresso_addon_skeleton.php
@@ -15,7 +15,7 @@
  * @package 		EE4 Addon Skeleton
  * @subpackage 	tests
  */
-class espresso_promotions_tests extends EE_UnitTestCase {
+class EE_New_Addon_Tests extends EE_UnitTestCase {
 
 	/**
 	 * Tests the loading of the main file

--- a/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EEG_New_Payment_Method_Onsite.gateway.php
+++ b/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EEG_New_Payment_Method_Onsite.gateway.php
@@ -47,15 +47,15 @@ class EEG_New_Payment_Method_Onsite extends EE_Onsite_Gateway{
 				break;
 			case 'Pending':
 				$payment->set_status( $this->_pay_model->pending_status() );
-				$payment->set_gateway_response( "WE are on vacation, we will process your payment when we get back.");
+				$payment->set_gateway_response("The payment is in progress. Another message will be sent when payment is approved.");
 				break;
 			case 'Declined':
 				$payment->set_status( $this->_pay_model->declined_status() );
-				$payment->set_gateway_response( "You don't have enough spunk, payment was declined");
+				$payment->set_gateway_response("The payment has been declined.");
 				break;
 			case 'Failed':
 				$payment->set_status( $this->_pay_model->failed_status() );
-				$payment->set_gateway_response( "Mice got into our servers. The exterminator will be over after he finishes his day job. Sorry");
+				$payment->set_gateway_response("The payment failed for technical reasons or expired.");
 		}
 		return $payment;
 	}

--- a/tests/mocks/addons/new-payment-method/tests/testcases/espresso_addon_skeleton.php
+++ b/tests/mocks/addons/new-payment-method/tests/testcases/espresso_addon_skeleton.php
@@ -15,7 +15,7 @@
  * @package 		EE4 Addon Skeleton
  * @subpackage 	tests
  */
-class espresso_promotions_tests extends EE_UnitTestCase {
+class EE_New_Payment_Method_Tests extends EE_UnitTestCase {
 
 	/**
 	 * Tests the loading of the main file


### PR DESCRIPTION
Originally reported in https://events.codebasehq.com/projects/event-espresso/tickets/8223. The part about the main add-on class autoloading itself was fixed somewhere along the way. 

This PR cleans up the unit test class names & makes the example responses for the Onsite gateway sound slightly more professional. 
