### PR TITLE
Bug/fix to persist not returning expected values

### DIFF
--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -52,6 +52,11 @@ class BaseEntity {
 		);
 		createGetter( this, 'modelName', modelName );
 		createGetter( this, 'originalFieldsAndValues', entityFieldsAndValues );
+		createGetter(
+			this,
+			'fieldsToPersistOnInsert',
+			new Set( Object.keys( entityFieldsAndValues ) )
+		);
 		createEntityGettersAndSetters( this );
 		createPersistingGettersAndSetters( this );
 	}

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -91,7 +91,7 @@ export const createGetterAndSetter = (
 	instance,
 	fieldName,
 	initialFieldValue,
-	opts = {}
+	opts = {},
 ) => {
 	let propertyValue = initialFieldValue;
 	Object.defineProperty( instance, fieldName, {
@@ -105,6 +105,7 @@ export const createGetterAndSetter = (
 				instance
 			);
 			setSaveState( instance, SAVE_STATE.DIRTY );
+			setFieldToPersist( instance, fieldName );
 			propertyValue = receivedValue;
 		},
 		...opts,
@@ -734,5 +735,18 @@ export const setSaveState = ( instance, saveState ) => {
 				'Save state for entity can only be set to either ' +
 				'SAVE_STATE.DIRTY, SAVE_STATE.NEW or SAVE_STATE.CLEAN'
 			);
+	}
+};
+
+/**
+ * Add the field name to the fieldToPersistOnInsert property on the instance
+ * if it exists.
+ *
+ * @param {Object} instance
+ * @param {string} fieldName
+ */
+export const setFieldToPersist = ( instance, fieldName ) => {
+	if ( instance.fieldsToPersistOnInsert ) {
+		instance.fieldsToPersistOnInsert.add( fieldName );
 	}
 };

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -360,7 +360,10 @@ const forUpdate = ( instance ) => {
  * @return {Object} Plain object of field:value pairs.
  */
 const forInsert = ( instance ) => {
-	const entityValues = getBaseFieldsAndValuesForPersisting( instance );
+	const entityValues = getBaseFieldsAndValuesForPersisting(
+		instance,
+		true
+	);
 	instance.primaryKeys.forEach( ( primaryKey ) => {
 		entityValues[ primaryKey ] = instance[ primaryKey ];
 	} );

--- a/assets/src/data/model/entity-factory/extractors.js
+++ b/assets/src/data/model/entity-factory/extractors.js
@@ -178,12 +178,20 @@ export const getRelationNameFromLink = ( resourceLink ) => {
  * Returns a plain object containing the entity field name and values from the
  * provided entity instance
  * @param {Object} entityInstance
+ * @param {boolean} forInsert  Whether to return the fields and values for
+ * insert or for update.
  * @return {Object} A plain object
  */
-export const getBaseFieldsAndValuesForPersisting = ( entityInstance ) => {
-	return reduce( entityInstance.originalFieldsAndValues, (
+export const getBaseFieldsAndValuesForPersisting = (
+	entityInstance,
+	forInsert = false
+) => {
+	const iterator = forInsert ?
+		Array.from( entityInstance.fieldsToPersistOnInsert.values() ) :
+		Object.keys( entityInstance );
+
+	return iterator.reduce( (
 		fieldsAndValues,
-		originalFieldValue,
 		fieldName
 	) => {
 		if (

--- a/assets/src/data/model/entity-factory/extractors.js
+++ b/assets/src/data/model/entity-factory/extractors.js
@@ -5,7 +5,6 @@ import {
 	isPlainObject,
 	camelCase,
 	last,
-	reduce,
 	pick,
 	pickBy,
 	isArray,

--- a/assets/src/data/model/entity-factory/test/base-entity.js
+++ b/assets/src/data/model/entity-factory/test/base-entity.js
@@ -173,6 +173,7 @@ describe( 'createEntityFactory()', () => {
 		'primaryKeys',
 		'hasMultiplePrimaryKeys',
 		'fieldPrefixes',
+		'fieldsToPersistOnInsert',
 		'schema',
 		'modelName',
 		'originalFieldsAndValues',
@@ -616,6 +617,31 @@ describe( 'createEntityFactory()', () => {
 			test( 'The ' + fieldName + ' field exists', () => {
 				expect( DateTimeEntity[ fieldName ] ).toBeDefined();
 			} );
+		} );
+	} );
+	describe( 'forPersist returns expected values', () => {
+		const factory = createEntityFactory(
+			'datetime',
+			DateTimeSchema.schema,
+			[ 'DTT_EVT', 'DTT' ]
+		);
+		it( 'returns expected values with nothing provided on new entity' +
+			'instantiation', () => {
+			const entity = factory.createNew( {} );
+			expect( entity.forPersist ).toEqual( {
+				DTT_ID: entity.id,
+			} );
+		} );
+		it( 'returns expected values with nothing provided on new entity ' +
+			'instantiation and setters used to set values', () => {
+			const entity = factory.createNew( {} );
+			entity.name = 'Test Datetime';
+			expect( entity.forPersist ).toEqual(
+				{
+					DTT_ID: entity.id,
+					DTT_name: 'Test Datetime',
+				}
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

While working on REM, @tn3rb discovered a bug with the the store persisting entity changes to the db.  In troubleshooting, we discovered that `toPersist` was working as expected for the `BaseEntity` instances, but remained complicated to use for the use-case it was in use for.  In the original implementation, the design was that `forPersist` would only return fields and values from the entity for fields the entity was instantiated with.  The intent being, that when the entity is persisted, any _defaults_ would be set by the database vs client side (non included fields in an insert request would get have default values determined by the server on saving to the db).  The problem with this approach is that it's reasonable to expect consuming code to create a "blank" entity and then use the setters to set the values at a later point.  When `forPersist` is called later however, those new set values would not get persisted.

The solution in this pull involved:

- Creating a new property for `BaseEntity` labelled `fieldsToPersistOnInsert`.  This property automatically captures the initial fieldNames passed in on instantiating the `BaseInstance` as well as any additional fieldNames that have a value set to their property through the life of the instance.  The value of `fieldsToPersistOnInsert` is a javascript [Set](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Set) object which ensures there's only ever unique field names in the iterator.
- When `forInsert` is called (either directly or via `forPersist`), it will iterate through `fieldsToPersistOnInsert` for determining what fields and values are exported from the instance.
- When `forUpdate` is called (either directly or via `forPersist`), it will use `Object.keys` on the `BaseEntity` instance as the iterator thus included all enumerable properties (and their values) on the export (which currently are just field names for the model).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

* [x] Ensure existing unit-tests pass.
* [x] I wrote new tests covering the flaw that was exposed.  Ensure these tests pass.

While `BaseEntity` instances _are_ used in released code (EventAttendees block), I'm confident the existing tests cover usage there because:

a. `EventAttendees` block is read only, so the affected functions are not used.
b. Any impact due to instantiation of `BaseEntity` instances would surface immediately in the existing unit test coverage.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
