### PR TITLE
PayPal Pro not working because of field name change

### DIFF
--- a/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
@@ -14,17 +14,17 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
     /**
      * @var $_paypal_api_username string
      */
-    protected $_username = null;
+    protected $_api_username = null;
 
     /**
-     * @var $_password string
+     * @var $_api_password string
      */
-    protected $_password = null;
+    protected $_api_password = null;
 
     /**
-     * @var $_signature string
+     * @var $_api_signature string
      */
-    protected $_signature = null;
+    protected $_api_signature = null;
 
     /**
      * @var $_credit_card_types array with the keys for credit card types accepted on this account
@@ -460,12 +460,12 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
         }
         // Now that we have each chunk we need to go ahead and append them all together for our entire NVP string
         $NVPRequest = 'USER='
-                      . $this->_username
+                      . $this->_api_username
                       . '&PWD='
-                      . $this->_password
+                      . $this->_api_password
                       . '&VERSION=64.0'
                       . '&SIGNATURE='
-                      . $this->_signature
+                      . $this->_api_signature
                       . $DPFieldsNVP
                       . $CCDetailsNVP
                       . $PayerInfoNVP

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -160,4 +160,26 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
         $billing_values['credit_card_type'] = $billing_form->get_input_value('credit_card_type');
         return $billing_values;
     }
+
+    public function set_instance($payment_method_instance)
+    {
+        // Check for the old extra meta inputs
+        $old_extra_metas = EEM_Extra_Meta::instance()->get_all(
+            [
+                [
+                    'EXM_type' => 'Payment_Method',
+                    'OBJ_ID' => $payment_method_instance->ID(),
+                    'EXM_key' => ['IN', ['username', 'password', 'signature']],
+                ]
+            ]
+        );
+        // If they existed, set the new ones instead
+        if( ! empty($old_extra_metas)){
+            foreach($old_extra_metas as $old_extra_meta){
+                $old_extra_meta->set('EXM_key','api_' . $old_extra_meta->get('EXM_key'));
+                $old_extra_meta->save();
+            }
+        }
+        return parent::set_instance($payment_method_instance);
+    }
 }

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -161,6 +161,16 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
         return $billing_values;
     }
 
+    /**
+     * Override parent to account for a change in extra meta inputs in 4.9.75.p
+     * @since $VID:$
+     * @param EE_Payment_Method $payment_method_instance
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     */
     public function set_instance($payment_method_instance)
     {
         // Check for the old extra meta inputs

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -184,9 +184,9 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
             ]
         );
         // If they existed, set the new ones instead
-        if( ! empty($old_extra_metas)){
-            foreach($old_extra_metas as $old_extra_meta){
-                $old_extra_meta->set('EXM_key','api_' . $old_extra_meta->get('EXM_key'));
+        if (!empty($old_extra_metas)) {
+            foreach ($old_extra_metas as $old_extra_meta) {
+                $old_extra_meta->set('EXM_key', 'api_' . $old_extra_meta->get('EXM_key'));
                 $old_extra_meta->save();
             }
         }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes paypal pro for new users. Automatically converts old settings to new settings. See https://github.com/eventespresso/event-espresso-core/issues/996#event-2175160230

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Start with PayPal 4.9.75.p. setup Paypal Pro and pay. Then switch to this branch. Pay with Paypal Pro again it should again work. Now re-save your PayPal pro settings, but don't actually change anything. They should be saved fine, and you should be able to pay just fine
* [x] Start with a new install of EE on this branch and setup PayPal Pro and pay with it. It should work again as usual

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
