### PR TITLE
default to having select2s using the REST API to use descending order

### DIFF
--- a/core/libraries/form_sections/inputs/EE_Select_Ajax_Model_Rest_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Select_Ajax_Model_Rest_Input.input.php
@@ -72,11 +72,22 @@ class EE_Select_Ajax_Model_Rest_Input extends EE_Form_Input_With_Options_Base
             'query_params',
             array()
         );
-        // make sure limit and caps are always set
+        // Make sure limit and caps are always set.
         $query_params = array_merge(
-            array( 'limit' => 10, 'caps' => EEM_Base::caps_read_admin ),
+            [
+                'limit' => 10,
+                'caps' => EEM_Base::caps_read_admin
+            ],
             $query_params
         );
+
+        // And default to showing the most recently created items first.
+        if ($model->has_primary_key_field()) {
+            $query_params['order_by'] = [
+                $model->primary_key_name() => 'DESC'
+            ];
+        }
+        
         $this->_value_field_name = EEH_Array::is_set(
             $input_settings,
             'value_field_name',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Makes `EE_Select2_Ajax_Model_Rest_Input`s default to showing items in descending order, so most recently created items appear first by default. (As Josh suggested on https://github.com/eventespresso/eea-attendee-importer/issues/16, under "Step 3")

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
Valid question here. I just thought this would be a better default (it's what our admin list tables all do). I could be wrong though.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Fire up the attendee mover. When you start typing in the name of an event, the MOST RECENTLY CREATED events should appear first, instead of the oldest first.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
