### PR TITLE
update travis to allow for triggering js_only test builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ jobs:
         - PHP_LINT_WITH_WARNINGS=yes
   include:
     - stage: test
+      if: NOT commit_message =~ js_only
       php: 7.3
       env:
         - PHP_LINT=1
@@ -75,6 +76,7 @@ jobs:
         - composer config-eventespressocs || exit 1
         - npm run lint-php:skip-warnings || exit 1
     - php: 7.3
+      if: NOT commit_message =~ js_only
       env:
         - PHP_LINT=1
         - PHP_LINT_WITH_WARNINGS=yes
@@ -98,18 +100,27 @@ jobs:
       script:
         - npm run lc || exit 1
     - php: 7.3
+      if: NOT commit_message =~ js_only
     - php: 7.2
+      if: NOT commit_message =~ js_only
     - php: 7.1
+      if: NOT commit_message =~ js_only
     - php: 7.0
+      if: NOT commit_message =~ js_only
     - php: 5.6
+      if: NOT commit_message =~ js_only
     - php: 5.5
+      if: NOT commit_message =~ js_only
     # multisite
     - php: 7.2
       env: WP_MULTISITE=1
+      if: NOT commit_message =~ js_only
     # wp 4.5 builds
     - php: 5.6
       env: WP_VERSION=4.5
+      if: NOT commit_message =~ js_only
     - php: nightly
+      if: NOT commit_message =~ js_only
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Latest Tag](https://img.shields.io/github/tag/eventespresso/event-espresso-core.svg?style=flat&label=Latest%20Tag)](https://github.com/eventespresso/event-espresso-core/releases)
 [![Travis](https://travis-ci.com/eventespresso/event-espresso-core.svg?branch=master)](https://travis-ci.com/eventespresso/event-espresso-core)
 [![PHP](https://img.shields.io/badge/PHP-7%20Ready-brightgreen.svg?style=flat)](https://eventespresso.com/)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=eventespresso/event-espresso-core)](https://dependabot.com)
 [![WordPress](https://img.shields.io/badge/WordPress-v4.7.x+%20Tested-brightgreen.svg?style=flat)](https://eventespresso.com/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue.svg?style=flat)](https://www.gnu.org/licenses/gpl-2.0.html)
 [![Join Chat](https://img.shields.io/badge/Slack-Join%20Chat-aa30ff.svg?style=flat)](https://eventespresso.com/contact/community-chat/)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ At Event Espresso we follow a set pattern for releases:
 
 
 ## Testing
+
 For all testers on GitHub, please take note of the following when reporting issues.
 
 1. There is a difference between a feature and a bug, we consider a bug is something that reveals brokenness in intended functionality.  A feature, is something beyond intended functionality.  To help determine the difference, think about your issue like this, "I know A does C, however I *wish* it did D."  If you find yourself saying that, its a feature.  For Event Espresso,  GitHub is not the place to suggest a new feature UNLESS you've already got a pull request to implement it (see pull requests section below).  Info on sponsoring new features can [be found here](https://eventespresso.com/rich-features/sponsor-new-features/).  If you aren't sure whether something is a feature or bug feel free to post the issue - however we give priority to bug issues here.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This is the Core for Event Espresso 4. This README.md file is targeted for displ
 
 
 ## Event Espresso Releases
+
 At Event Espresso we follow a set pattern for releases:
 
 1. Active development for new features happens on a **FET/{ticket-number}/{description}** branch.  We continually merge master into the feature branch while its in development.  Once its complete, then testing is done on it and its merged back to master ready for release.

--- a/docs/B--Automated-Testing/README.md
+++ b/docs/B--Automated-Testing/README.md
@@ -1,5 +1,9 @@
 The documents in this folder outline how we do automated testing in EE.
 
+**Note:** 
+
+Currently we have automated tests running in travis-ci.com.  The tests are configured so that if the last commit pushed to a pull has the string `js_only` anywhere in it, then only javascript test builds will run.  This is useful when you know the pull only has javascript changes and there's no need to run php tests.
+
 ## Table of Contents
 
 - [Automated Testing in Event Espresso](automated-testing-in-event-espresso.md)


### PR DESCRIPTION
## Problem this Pull Request solves

Frequently we have pull requests that only affect javascript.  This pull uses the [conditional jobs](https://docs.travis-ci.com/user/conditional-builds-stages-jobs/) configuration feature of travis to skip jobs when the last commit in a pulls push has the string `js_only` somewhere in the commit message.

Ideally we'd be able to automate this via detection of the changes but from what I've read and seen tried online that's flaky and not reliable.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Testing this feature in this pull first!

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
