### PR TITLE
make QST_required_text a text column instead of varchar. let the peop…

### DIFF
--- a/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
@@ -346,7 +346,7 @@ class EE_DMS_Core_4_1_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
@@ -302,7 +302,7 @@ class EE_DMS_Core_4_2_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
@@ -310,7 +310,7 @@ class EE_DMS_Core_4_3_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
@@ -268,7 +268,7 @@ class EE_DMS_Core_4_5_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
@@ -325,7 +325,7 @@ class EE_DMS_Core_4_6_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_7_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_7_0.dms.php
@@ -347,7 +347,7 @@ class EE_DMS_Core_4_7_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
@@ -355,7 +355,7 @@ class EE_DMS_Core_4_8_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) NOT NULL DEFAULT "",
 					QST_type varchar(25) NOT NULL DEFAULT "TEXT",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_max smallint(5) NOT NULL DEFAULT -1,

--- a/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
@@ -412,7 +412,7 @@ class EE_DMS_Core_4_9_0 extends EE_Data_Migration_Script_Base
 				QST_deleted tinyint(2) unsigned NOT NULL DEFAULT 0,
 				PRIMARY KEY  (QST_ID),
 				KEY QST_order (QST_order)';
-        $this->_table_is_changed_in_this_version($table_name, $sql, 'ENGINE=InnoDB');
+        $this->_table_has_not_changed_since_previous($table_name, $sql, 'ENGINE=InnoDB');
         $table_name = 'esp_question_group_question';
         $sql = "QGQ_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 				QSG_ID int(10) unsigned NOT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
@@ -404,7 +404,7 @@ class EE_DMS_Core_4_9_0 extends EE_Data_Migration_Script_Base
 				QST_system varchar(25) DEFAULT NULL,
 				QST_type varchar(25) NOT NULL DEFAULT "TEXT",
 				QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-				QST_required_text varchar(100) NULL,
+				QST_required_text text NULL,
 				QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 				QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 				QST_max smallint(5) NOT NULL DEFAULT -1,
@@ -412,7 +412,7 @@ class EE_DMS_Core_4_9_0 extends EE_Data_Migration_Script_Base
 				QST_deleted tinyint(2) unsigned NOT NULL DEFAULT 0,
 				PRIMARY KEY  (QST_ID),
 				KEY QST_order (QST_order)';
-        $this->_table_has_not_changed_since_previous($table_name, $sql, 'ENGINE=InnoDB');
+        $this->_table_is_changed_in_this_version($table_name, $sql, 'ENGINE=InnoDB');
         $table_name = 'esp_question_group_question';
         $sql = "QGQ_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 				QSG_ID int(10) unsigned NOT NULL,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->
# Note: this is a PR into another bug branch (to clarify what's being changed here) NOT master

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes migrations from EE3 when the question's required text was larger than 100 characters. (In EE3 there was no limit to its size, so this restores that behaviour).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Nuke EE4 or create a new site.
* Install EE3 and set a question's required text to something bigger than 100 characters.
* Deactivate EE3 and activate EE4 and run the migrations. The question's required text should remain the same.
* In EE4, try to set a new question's require text to something larger than 100 characters. It should work fine now.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
