### PR TITLE
Bug/bigger pay gateway column

### DIFF
--- a/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
@@ -265,7 +265,7 @@ class EE_DMS_Core_4_1_0 extends EE_Data_Migration_Script_Base
 					PAY_timestamp datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 					PAY_method varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_amount decimal(10,3) DEFAULT NULL,
-					PAY_gateway varchar(32) COLLATE utf8_bin DEFAULT NULL,
+					PAY_gateway varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_gateway_response text COLLATE utf8_bin,
 					PAY_txn_id_chq_nmbr varchar(32) COLLATE utf8_bin DEFAULT NULL,
 					PAY_po_number varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_1_0.dms.php
@@ -346,7 +346,7 @@ class EE_DMS_Core_4_1_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
@@ -302,7 +302,7 @@ class EE_DMS_Core_4_2_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_2_0.dms.php
@@ -221,7 +221,7 @@ class EE_DMS_Core_4_2_0 extends EE_Data_Migration_Script_Base
 					PAY_timestamp datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 					PAY_method varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_amount decimal(10,3) DEFAULT NULL,
-					PAY_gateway varchar(32) COLLATE utf8_bin DEFAULT NULL,
+					PAY_gateway varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_gateway_response text COLLATE utf8_bin,
 					PAY_txn_id_chq_nmbr varchar(32) COLLATE utf8_bin DEFAULT NULL,
 					PAY_po_number varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
@@ -310,7 +310,7 @@ class EE_DMS_Core_4_3_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_3_0.dms.php
@@ -228,7 +228,7 @@ class EE_DMS_Core_4_3_0 extends EE_Data_Migration_Script_Base
 					PAY_timestamp datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 					PAY_method varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_amount decimal(10,3) DEFAULT NULL,
-					PAY_gateway varchar(32) COLLATE utf8_bin DEFAULT NULL,
+					PAY_gateway varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_gateway_response text COLLATE utf8_bin,
 					PAY_txn_id_chq_nmbr varchar(32) COLLATE utf8_bin DEFAULT NULL,
 					PAY_po_number varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
@@ -231,7 +231,7 @@ class EE_DMS_Core_4_5_0 extends EE_Data_Migration_Script_Base
 					PAY_timestamp datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 					PAY_method varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_amount decimal(10,3) DEFAULT NULL,
-					PAY_gateway varchar(32) COLLATE utf8_bin DEFAULT NULL,
+					PAY_gateway varchar(45) COLLATE utf8_bin DEFAULT NULL,
 					PAY_gateway_response text COLLATE utf8_bin,
 					PAY_txn_id_chq_nmbr varchar(32) COLLATE utf8_bin DEFAULT NULL,
 					PAY_po_number varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_5_0.dms.php
@@ -268,7 +268,7 @@ class EE_DMS_Core_4_5_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_6_0.dms.php
@@ -325,7 +325,7 @@ class EE_DMS_Core_4_6_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_7_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_7_0.dms.php
@@ -347,7 +347,7 @@ class EE_DMS_Core_4_7_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) DEFAULT NULL,
 					QST_type varchar(25) NOT NULL DEFAULT "text",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_wp_user bigint(20) unsigned NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_8_0.dms.php
@@ -355,7 +355,7 @@ class EE_DMS_Core_4_8_0 extends EE_Data_Migration_Script_Base
 					QST_system varchar(25) NOT NULL DEFAULT "",
 					QST_type varchar(25) NOT NULL DEFAULT "TEXT",
 					QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-					QST_required_text varchar(100) NULL,
+					QST_required_text text NULL,
 					QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 					QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 					QST_max smallint(5) NOT NULL DEFAULT -1,

--- a/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_9_0.dms.php
@@ -404,7 +404,7 @@ class EE_DMS_Core_4_9_0 extends EE_Data_Migration_Script_Base
 				QST_system varchar(25) DEFAULT NULL,
 				QST_type varchar(25) NOT NULL DEFAULT "TEXT",
 				QST_required tinyint(1) unsigned NOT NULL DEFAULT 0,
-				QST_required_text varchar(100) NULL,
+				QST_required_text text NULL,
 				QST_order tinyint(2) unsigned NOT NULL DEFAULT 0,
 				QST_admin_only tinyint(1) NOT NULL DEFAULT 0,
 				QST_max smallint(5) NOT NULL DEFAULT -1,
@@ -412,7 +412,7 @@ class EE_DMS_Core_4_9_0 extends EE_Data_Migration_Script_Base
 				QST_deleted tinyint(2) unsigned NOT NULL DEFAULT 0,
 				PRIMARY KEY  (QST_ID),
 				KEY QST_order (QST_order)';
-        $this->_table_has_not_changed_since_previous($table_name, $sql, 'ENGINE=InnoDB');
+        $this->_table_is_changed_in_this_version($table_name, $sql, 'ENGINE=InnoDB');
         $table_name = 'esp_question_group_question';
         $sql = "QGQ_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 				QSG_ID int(10) unsigned NOT NULL,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->
# Note: this PR is NOT off master!
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes migrations from EE3 where old payments "txn_type" had a value between 32 and 45 characters. The column used to store that data in EE4 only allowed 32 characters, (whereas in EE3 it allowed up to 45), so there would be a database error during migration under those conditions.
This avoids the problem by allowing the column to have 45 characters. (It's removed later anyway, so it's not actually permanently taking up more space anyway!)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Nuke EE4 and activate EE3. Create a paid event, register for it, and add a payment from the admin. set the "Transaction Type" field to be "123456789a1234567890b123467890c1234567890". 
* Deactivate EE3 and migrate to EE4. Only do the first migration script though. You should see NO errors from it. You can continue the migration. Notice the payment still exists in EE4 (whereas on master, it would have failed to migrate).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
