### PR TITLE
Make sure EE_DEBUG is not defined before declaring it.

### DIFF
--- a/core/espresso_definitions.php
+++ b/core/espresso_definitions.php
@@ -86,7 +86,9 @@ define(
 // want to change its default value! or find when -1 means infinity
 define('EE_INF_IN_DB', -1);
 define('EE_INF', INF > (float) PHP_INT_MAX ? INF : PHP_INT_MAX);
-define('EE_DEBUG', false);
+if (! defined('EE_DEBUG')) {
+    define('EE_DEBUG', false);
+}
 // for older WP versions
 if (! defined('MONTH_IN_SECONDS')) {
     define('MONTH_IN_SECONDS', DAY_IN_SECONDS * 30);


### PR DESCRIPTION
`espresso_definitions.php` defined `EE_DEBUG` but this is a constant that typically is defined in `wp-config.php`.  So there should be a conditional check before setting the default to `false`.

This pull fixes that.

This will have 0 impact anywhere else so can be merged after review.