### PR TITLE
Improve skipped date related test and make non-skipped (fixed #940)

### DIFF
--- a/tests/testcases/core/db_classes/EE_Datetime_Test.php
+++ b/tests/testcases/core/db_classes/EE_Datetime_Test.php
@@ -153,9 +153,12 @@ class EE_Datetime_Test extends EE_UnitTestCase{
         $now_for_test = new DateTime( 'now', $timezone );
         // set time explicitly
         $now_for_test->setTime(14, 00);
-        $upcoming_start_date = (clone $now_for_test)->add(new DateInterval('P1D'));
-		$past_start_date = (clone $now_for_test)->sub(new DateInterval('P2D'));
-		$upcoming_end_date = (clone $now_for_test)->add(new DateInterval('P2D'));
+        $upcoming_start_date = clone $now_for_test;
+        $past_start_date = clone $now_for_test;
+        $upcoming_end_date = clone $now_for_test;
+        $upcoming_start_date->add(new DateInterval('P1D'));
+		$past_start_date->sub(new DateInterval('P2D'));
+		$upcoming_end_date->add(new DateInterval('P2D'));
 		$current = clone $now_for_test;
 		$formats = array( 'Y-d-m',  'h:i a' );
 		$full_format = implode( ' ', $formats );

--- a/tests/testcases/core/db_classes/EE_Datetime_Test.php
+++ b/tests/testcases/core/db_classes/EE_Datetime_Test.php
@@ -145,18 +145,18 @@ class EE_Datetime_Test extends EE_UnitTestCase{
 	/**
 	 * This tests the ticket_types_available_for_purchase method.
 	 * @since 4.6.0
+     * @group testDate
 	 */
 	public function test_ticket_types_available_for_purchase() {
-		//@todo remove once test fixed.
-		$this->markTestSkipped(
-			'See https://events.codebasehq.com/projects/event-espresso/tickets/9635'
-		);/**/
 		//setup some dates we'll use for testing with.
 		$timezone = new DateTimeZone( 'America/Toronto' );
-		$upcoming_start_date = new DateTime( "now +1day", $timezone );
-		$past_start_date = new DateTime( "now -2days", $timezone );
-		$upcoming_end_date = new DateTime( "now +2days", $timezone );
-		$current = new DateTime( "now", $timezone );
+        $now_for_test = new DateTime( 'now', $timezone );
+        // set time explicitly
+        $now_for_test->setTime(14, 00);
+        $upcoming_start_date = (clone $now_for_test)->add(new DateInterval('P1D'));
+		$past_start_date = (clone $now_for_test)->sub(new DateInterval('P2D'));
+		$upcoming_end_date = (clone $now_for_test)->add(new DateInterval('P2D'));
+		$current = clone $now_for_test;
 		$formats = array( 'Y-d-m',  'h:i a' );
 		$full_format = implode( ' ', $formats );
 


### PR DESCRIPTION
## Problem this Pull Request solves

See #940 for details.  This improves the test so its less sensitive to time of day issues and removes the skipped flag so it runs.

## How has this been tested

This is strictly a unit test so if unit tests pass then its okay.

* [x] Verify unit tests pass.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
