### PR TITLE
Remove unnecessary WP_DEBUG conditional (fixes #1127)

### DIFF
--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_attached_tickets_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_attached_tickets_row.template.php
@@ -1,9 +1,5 @@
 <tr id="advanced-dtt-edit-row-<?php echo $dtt_row; ?>" class="advanced-dtt-edit-row">
-    <?php if (WP_DEBUG) {  // for now we are only showing reserved counts if WP_DEBUG is on ?>
     <td colspan="7">
-    <?php } else { ?>
-    <td colspan="6">
-    <?php } ?>
         <section id="edit-event-datetime-tickets-<?php echo $dtt_row; ?>"
                  class="datetime-tickets-edit"<?php echo $show_tickets_row; ?>>
             <div class="datetime-description-container">


### PR DESCRIPTION
## Problem this Pull Request solves

See #1127 for context.  This pull removes a `WP_DEBUG` conditional block that led to styling issues for the advanced datetime editor (on the event editor page) when `WP_DEBUG` is false (see issue for details).

## How has this been tested

* [x] Ensure `WP_DEBUG` is set to false and then view the advanced datetime editor.  The style should look like this:

![verification screenshot](https://www.evernote.com/l/AANdGyIA2P9KMZaQESxflOCo9lhj_60UJ2oB/image.png)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
