### PR TITLE
should be nvm install not npm install for npm installation!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
         - BUILD_TEST=1
       before_install:
         - nvm install && nvm use
-        - npm install npm --latest-npm
+        - nvm install npm --latest-npm
       before_script:
         - npm --version
         - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
         - node
       before_install:
         - nvm install && nvm use
-        - nvm install npm --latest-npm
+        - nvm install --latest-npm
       before_script:
         - npm --version
         - node --version
@@ -110,7 +110,7 @@ jobs:
         - BUILD_TEST=1
       before_install:
         - nvm install && nvm use
-        - nvm install npm --latest-npm
+        - nvm install --latest-npm
       before_script:
         - npm --version
         - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
         - node
       before_install:
         - nvm install && nvm use
-        - npm install npm --latest-npm
+        - nvm install npm --latest-npm
       before_script:
         - npm --version
         - node --version


### PR DESCRIPTION
Pretty self-explanatory little fix.

No review needed, if tests still work on travis then this can be merged.

This should also speed up travis builds because `npm install` won't be running twice!