### PR TITLE
Jest Tests: Alias @wordpress/element to react

### DIFF
--- a/tests/javascript-config/unit/jest.config.json
+++ b/tests/javascript-config/unit/jest.config.json
@@ -18,6 +18,7 @@
 		"tinymce": "<rootDir>/tests/javascript-config/unit/mocks/tinymce",
 		"@wordpress/i18n": "<rootDir>/tests/javascript-config/unit/mocks/i18n",
 		"@eventespresso/i18n": "<rootDir>/tests/javascript-config/unit/mocks/i18n",
+		"@wordpress/element": "react",
 		"@wordpress/is-shallow-equal/objects": "<rootDir>/node_modules/@wordpress/is-shallow-equal/build/objects",
 		"@test/fixtures": "<rootDir>/tests/javascript-config/unit/fixtures"
 	},


### PR DESCRIPTION
## Problem this Pull Request solves

While working in a different branch where I'm implementing a react hook I was getting Invariant errors reported for the tests I was writing because of that hook.  Took me a while to troubleshoot the cause but essentially its produced because we import from `@wordpress/element` in our modules but also have `React` installed as a dependency in our package.  We have it installed because of our support for older versions of WordPress (WP < 5) where react via @wordpress/element is not bundled with WP.

The solution I found for now was to alias all imports from `@wordpress/element` to import from 'react' instead (in jest tests only).

This change impacts our tests only and since @wordpress/element is a thin wrapper over 'react' anyways I'm not too worried about their being inconsistencies with what we test against.

This problem will go away when we can drop the need for bundling react and react-dom etc in our own vendor file for back-compat on earlier versions of WP.

## How has this been tested

* [x] verified this fixed the issue prompting this pull
* [x] verify existing tests pass.

**Note** As mentioned already, this has 0 impact on released user facing features because it affects jest tests only.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
