### PR TITLE
Add new check-in components 

### DIFF
--- a/assets/src/components/index.js
+++ b/assets/src/components/index.js
@@ -4,6 +4,8 @@ export { QueryLimit } from './query/limit';
 export * from './form/model';
 // general ui components
 export * from './ui';
+//model specific components
+export * from './model-specific';
 
 // other
 export { default as EventAttendeeList } from './event-attendees';

--- a/assets/src/components/model-specific/checkin/button.js
+++ b/assets/src/components/model-specific/checkin/button.js
@@ -1,0 +1,55 @@
+/**
+ * External imports.
+ */
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { checkInModel } from '@eventespresso/model';
+import { useCallback } from '@wordpress/element';
+
+const { getCheckInActionText, getCheckInActionClassName } = checkInModel;
+
+/**
+ * A component outputting a button for the given checkIn entity.
+ *
+ * The button will have its coloring and action text presented from the context
+ * of toggling the state of the given checkIn Entity.
+ *
+ * @param {BaseEntity|null} checkinEntity  A checkin entity or null (which
+ * means not checked in yet.
+ * @param {function} onClick  The callback to fire when the button is clicked.
+ * @param {boolean}  force	  If true, then when the checkin entity is null or
+ * has a status of checked out, this allows for an action that ignores checkin
+ * restrictions.
+ * @return {*}  The component rendered.
+ * @constructor
+ */
+const CheckInButton = ( { checkinEntity, onClick, force } ) => {
+	const clickHandler = useCallback(
+		() => onClick( force ),
+		[ checkinEntity, force ]
+	);
+	const buttonText = getCheckInActionText( checkinEntity, force );
+	const cssClass = classnames(
+		getCheckInActionClassName( checkinEntity, force ),
+		'ee-button',
+		'ee-roundish'
+	);
+	return <Button onClick={ clickHandler } className={ cssClass }>
+		{ buttonText }
+	</Button>;
+};
+
+CheckInButton.propTypes = {
+	checkinEntity: PropTypes.object,
+	onClick: PropTypes.func,
+	force: PropTypes.bool,
+};
+
+CheckInButton.defaultProps = {
+	checkinEntity: null,
+	onClick: () => null,
+	force: false,
+};
+
+export default CheckInButton;

--- a/assets/src/components/model-specific/checkin/index.js
+++ b/assets/src/components/model-specific/checkin/index.js
@@ -1,1 +1,2 @@
 export { default as CheckInButton } from './button';
+export { default as CheckInStatusIcon } from './status-icon';

--- a/assets/src/components/model-specific/checkin/index.js
+++ b/assets/src/components/model-specific/checkin/index.js
@@ -1,0 +1,1 @@
+export { default as CheckInButton } from './button';

--- a/assets/src/components/model-specific/checkin/status-icon.js
+++ b/assets/src/components/model-specific/checkin/status-icon.js
@@ -1,0 +1,28 @@
+/**
+ * External imports
+ */
+import { Dashicon } from '@wordpress/components';
+import PropTypes from 'prop-types';
+import { checkInModel } from '@eventespresso/model';
+
+const { getCheckInStatusIcon, getCheckInStatusClassName } = checkInModel;
+
+/**
+ * A component displaying a check-in status indicator for the given check-in
+ * entity.
+ *
+ * @param {BaseEntity|null} checkinEntity
+ * @return {*}  component
+ * @constructor
+ */
+const CheckInStatusIcon = ( { checkinEntity } ) => {
+	return <Dashicon
+		className={ getCheckInStatusClassName( checkinEntity ) }
+		icon={ getCheckInStatusIcon( checkinEntity ) }
+	/>;
+};
+
+CheckInStatusIcon.propTypes = { checkinEntity: PropTypes.object };
+CheckInStatusIcon.defaultProps = { checkinEntity: null };
+
+export default CheckInStatusIcon;

--- a/assets/src/components/model-specific/checkin/test/__snapshots__/button.js.snap
+++ b/assets/src/components/model-specific/checkin/test/__snapshots__/button.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckInButton renders as expected for default props 1`] = `
+<ForwardRef(Button)
+  className="ee-green ee-button ee-roundish"
+  onClick={[Function]}
+>
+  Check In
+</ForwardRef(Button)>
+`;

--- a/assets/src/components/model-specific/checkin/test/__snapshots__/status-icon.js.snap
+++ b/assets/src/components/model-specific/checkin/test/__snapshots__/status-icon.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckInStatusIcon renders as expected for default props 1`] = `
+<Dashicon
+  className="ee-red"
+  icon="no-alt"
+/>
+`;

--- a/assets/src/components/model-specific/checkin/test/button.js
+++ b/assets/src/components/model-specific/checkin/test/button.js
@@ -1,0 +1,55 @@
+/**
+ * External imports
+ */
+import { shallow } from 'enzyme';
+import { CheckinFactory, AuthedCheckinResponse } from '@test/fixtures';
+import { checkInModel } from '@eventespresso/model';
+
+/**
+ * Internal imports
+ */
+import CheckInButton from '../button';
+
+const {
+	STATUS_CHECKED_NEVER: neverChecked,
+	STATUS_CHECKED_IN: checkIn,
+	STATUS_CHECKED_OUT: checkOut,
+} = checkInModel.CHECKIN_STATUS_ID;
+
+describe( 'CheckInButton', () => {
+	const getCheckin = ( status ) => {
+		if ( status === neverChecked ) {
+			return null;
+		}
+		const entity = CheckinFactory.fromExisting( AuthedCheckinResponse );
+		entity.in = status;
+		return entity;
+	};
+	const rendered = ( props ) => shallow( <CheckInButton { ...props } /> );
+	it( 'renders as expected for default props', () => {
+		const wrapper = rendered();
+		expect( wrapper ).toMatchSnapshot();
+	} );
+	describe( 'renders expected classname for various checkin actions', () => {
+		const description = 'should return the css class "$expectedClass" and the ' +
+			'"$expectedText" for the given status of "$status" and with the ' +
+			'force argument value of "$force"';
+		it.each`
+			status | expectedClass | expectedText | force
+			${ neverChecked } | ${ 'ee-green' } | ${ 'Check In' } | ${ false }
+			${ neverChecked } | ${ 'ee-yellow' } | ${ 'Check In Anyways' } | ${ true }
+			${ checkIn } | ${ 'ee-red' } | ${ 'Check Out' } | ${ false }
+			${ checkOut } | ${ 'ee-green' } | ${ 'Check In' } | ${ false }
+		`( description,
+	( { status, expectedClass, expectedText, force } ) => {
+		const wrapper = rendered( {
+			checkinEntity: getCheckin( status ),
+			force,
+		} );
+		const button = wrapper.find( '.ee-button' );
+		expect( button.hasClass( 'ee-roundish', expectedClass ) ).toBe( true );
+		expect( button.text() )
+			.toEqual( expect.stringContaining( expectedText ) );
+	} );
+	} );
+} );

--- a/assets/src/components/model-specific/checkin/test/status-icon.js
+++ b/assets/src/components/model-specific/checkin/test/status-icon.js
@@ -1,0 +1,17 @@
+/**
+ * External imports
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal imports
+ */
+import CheckInStatusIcon from '../status-icon';
+
+describe( 'CheckInStatusIcon', () => {
+	const rendered = ( props ) => shallow( <CheckInStatusIcon { ...props } /> );
+	it( 'renders as expected for default props', () => {
+		const wrapper = rendered();
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/assets/src/components/model-specific/index.js
+++ b/assets/src/components/model-specific/index.js
@@ -1,0 +1,1 @@
+export * from './checkin';

--- a/assets/src/data/model/checkin/get-check-in-status-configuration.js
+++ b/assets/src/data/model/checkin/get-check-in-status-configuration.js
@@ -1,0 +1,168 @@
+/**
+ * External imports
+ */
+import { checkInModel } from '@eventespresso/model';
+import { isModelEntityOfModel } from '@eventespresso/validators';
+import { sprintf } from '@eventespresso/i18n';
+import memize from 'memize';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Helper for getting checkin status configuration strings.
+ *
+ * @param {BaseEntity|null} checkInEntity	A checkin entity or null.
+ * @param {boolean} 		force			If true and checkInEntity is null
+ * 											this returns strings related to
+ * 											forcing a checkin.
+ * @return {Object}  An configuration object.
+ */
+const getCheckInStatusConfiguration = ( checkInEntity, force = false ) => {
+	let status = isModelEntityOfModel( checkInEntity, 'checkin' ) ?
+		checkInEntity.in :
+		checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_NEVER;
+	status = [
+		checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_NEVER,
+		checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_OUT,
+	].includes( status ) && force ?
+		null :
+		status;
+	let checkInStatusText,
+		checkInActionText,
+		checkInActionClassName,
+		checkInStatusIcon,
+		checkInStatusClassName;
+	switch ( status ) {
+		case checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_NEVER:
+			checkInStatusText = __(
+				'Has not been checked in yet.',
+				'event_espresso'
+			);
+			checkInActionText = __( 'Check In', 'event_espresso' );
+			checkInActionClassName = 'ee-green';
+			checkInStatusClassName = 'ee-red';
+			checkInStatusIcon = 'no-alt';
+			break;
+		case checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_IN:
+			checkInStatusText = sprintf(
+				__( 'Last checked in on %s', 'event_espresso' ),
+				checkInEntity.timestamp
+			);
+			checkInActionText = __( 'Check Out', 'event_espresso ' );
+			checkInActionClassName = 'ee-red';
+			checkInStatusClassName = 'ee-green';
+			checkInStatusIcon = 'yes';
+			break;
+		case checkInModel.CHECKIN_STATUS_ID.STATUS_CHECKED_OUT:
+			checkInStatusText = sprintf(
+				__( 'Last checked out on %s', 'event_espresso' ),
+				checkInEntity.timestamp
+			);
+			checkInActionText = __( 'Check In', 'event_espresso ' );
+			checkInActionClassName = 'ee-green';
+			checkInStatusClassName = 'ee-red';
+			checkInStatusIcon = 'no-alt';
+			break;
+		default:
+			checkInStatusText = __(
+				'Has access to datetime, but not approved.',
+				'event_espresso'
+			);
+			checkInActionText = __( 'Check In Anyways', 'event_espresso ' );
+			checkInActionClassName = 'ee-yellow';
+			checkInStatusClassName = 'ee-red';
+			checkInStatusIcon = 'no-alt';
+			break;
+	}
+	return {
+		checkInStatusText,
+		checkInActionText,
+		checkInActionClassName,
+		checkInStatusIcon,
+		checkInStatusClassName,
+	};
+};
+
+/**
+ * Returns user friendly checkin status text for the current checkin status.
+ *
+ * @param {BaseEntity|null}	Checkin entity or null
+ * @param {boolean} force	If true and checkInEntity is null this returns
+ * 							strings related to forcing a checkin.
+ * @return {string} A user-friendly string describing the checkin status.
+ * @type {memoized}
+ */
+export const getCheckInStatusText = memize(
+	( checkInEntity, force = false ) => getCheckInStatusConfiguration(
+		checkInEntity,
+		force,
+	).checkInStatusText
+);
+
+/**
+ * Returns user friendly checkin action text for the current checkin status.
+ *
+ * "Action text" refers to describing toggling the checkin status for the given
+ * status.  So for example if the provided checkin status is never checked in or
+ * checked out, the action text would be "Check In"
+ *
+ * @param {BaseEntity|null}	Checkin entity or null
+ * @param {boolean} force	If true and checkInEntity is null this returns
+ * 							strings related to forcing a checkin.
+ * @return {string} A user friendly string describing a the action the user can
+ * 					take on this checkin record.
+ * @type {memoized}
+ */
+export const getCheckInActionText = memize(
+	( checkInEntity, force = false ) => getCheckInStatusConfiguration(
+		checkInEntity,
+		force
+	).checkInActionText
+);
+
+/**
+ * Returns a css class name for the checkin action.
+ *
+ * @param {BaseEntity|null}	Checkin entity or null
+ * @param {boolean} force	If true and checkInEntity is null this returns
+ * 							strings related to forcing a checkin.
+ * @return {string} The css class for the action on this checkin.
+ * @type {memoized}
+ */
+export const getCheckInActionClassName = memize(
+	( checkInEntity, force = false ) => getCheckInStatusConfiguration(
+		checkInEntity,
+		force
+	).checkInActionClassName
+);
+
+/**
+ * Returns a dashicon reference for the checkin status.
+ *
+ * @param {BaseEntity|null}	Checkin entity or null
+ * @param {boolean} force	If true and checkInEntity is null this returns
+ * 							strings related to forcing a checkin.
+ * @return {string} The dashicon reference for this checkin status.
+ * @type {memoized}
+ */
+export const getCheckInStatusIcon = memize(
+	( checkInEntity, force = false ) => getCheckInStatusConfiguration(
+		checkInEntity,
+		force
+	).checkInStatusIcon
+);
+
+/**
+ * Returns css class string for the current checkin status.
+ *
+ * @param {BaseEntity|null}	Checkin entity or null
+ * @param {boolean} force	If true and checkInEntity is null this returns
+ * 							strings related to forcing a checkin.
+ * @return {string} The css class name for the current checkin status.
+ * @type {memoized}
+ */
+export const getCheckInStatusClassName = memize(
+	( checkInEntity, force = false ) => getCheckInStatusConfiguration(
+		checkInEntity,
+		force
+	).checkInStatusClassName
+);

--- a/assets/src/data/model/checkin/index.js
+++ b/assets/src/data/model/checkin/index.js
@@ -1,2 +1,3 @@
 export * from './constants';
 export * from './query';
+export * from './get-check-in-status-configuration';

--- a/assets/src/data/model/checkin/test/get-check-in-status-configuration.js
+++ b/assets/src/data/model/checkin/test/get-check-in-status-configuration.js
@@ -1,0 +1,120 @@
+/**
+ * External imports
+ */
+import { CheckinFactory, AuthedCheckinResponse } from '@test/fixtures';
+
+/**
+ * Internal imports
+ */
+import {
+	getCheckInStatusText,
+	getCheckInActionText,
+	getCheckInActionClassName,
+	getCheckInStatusClassName,
+	getCheckInStatusIcon,
+} from '../get-check-in-status-configuration';
+import { CHECKIN_STATUS_ID } from '../index';
+
+const {
+	STATUS_CHECKED_NEVER: neverChecked,
+	STATUS_CHECKED_IN: checkIn,
+	STATUS_CHECKED_OUT: checkOut,
+} = CHECKIN_STATUS_ID;
+
+describe( 'checkin status helpers', () => {
+	const getCheckin = ( status ) => {
+		const chkEntity = CheckinFactory.fromExisting( AuthedCheckinResponse );
+		chkEntity.in = status;
+		return chkEntity;
+	};
+	describe( 'getCheckinStatusText', () => {
+		it.each`
+			status            | force       | expected
+			${ neverChecked } | ${ false }  | ${ 'Has not been checked in yet' }
+			${ neverChecked } | ${ true }   | ${ 'Has access to datetime, but not approved' }
+			${ checkIn }      | ${ false }  | ${ 'Last checked in on' }
+			${ checkOut }     | ${ false }  | ${ 'Last checked out on' }
+			${ checkOut }     | ${ true }   | ${ 'Has access to datetime, but not approved.' }
+		`(
+	'should return "$expected" for $status status and when force is $force',
+	( { status, force, expected } ) => {
+		const chkEntity = status !== neverChecked ?
+			getCheckin( status ) :
+			null;
+		expect( getCheckInStatusText( chkEntity, force ) )
+			.toEqual( expect.stringContaining( expected ) );
+	} );
+	} );
+	describe( 'getCheckInActionText', () => {
+		it.each`
+			status            | force       | expected
+			${ neverChecked } | ${ false }  | ${ 'Check In' }
+			${ neverChecked } | ${ true }   | ${ 'Check In Anyways' }
+			${ checkIn }      | ${ false }  | ${ 'Check Out' }
+			${ checkOut }     | ${ false }  | ${ 'Check In' }
+			${ checkOut }     | ${ true }   | ${ 'Check In Anyways' }
+		`(
+	'should return "$expected" for $status status and when force is $force',
+	( { status, force, expected } ) => {
+		const chkEntity = status !== neverChecked ?
+			getCheckin( status ) :
+			null;
+		expect( getCheckInActionText( chkEntity, force ) )
+			.toEqual( expect.stringContaining( expected ) );
+	} );
+	} );
+	describe( 'getCheckInActionClassName', () => {
+		it.each`
+			status            | force       | expected
+			${ neverChecked } | ${ false }  | ${ 'ee-green' }
+			${ neverChecked } | ${ true }   | ${ 'ee-yellow' }
+			${ checkIn }      | ${ false }  | ${ 'ee-red' }
+			${ checkOut }     | ${ false }  | ${ 'ee-green' }
+			${ checkOut }     | ${ true }   | ${ 'ee-yellow' }
+		`(
+	'should return "$expected" for $status status and when force is $force',
+	( { status, force, expected } ) => {
+		const chkEntity = status !== neverChecked ?
+			getCheckin( status ) :
+			null;
+		expect( getCheckInActionClassName( chkEntity, force ) )
+			.toEqual( expect.stringContaining( expected ) );
+	} );
+	} );
+	describe( 'getCheckInStatusIcon', () => {
+		it.each`
+			status            | force       | expected
+			${ neverChecked } | ${ false }  | ${ 'no-alt' }
+			${ neverChecked } | ${ true }   | ${ 'no-alt' }
+			${ checkIn }      | ${ false }  | ${ 'yes' }
+			${ checkOut }     | ${ false }  | ${ 'no-alt' }
+			${ checkOut }     | ${ true }   | ${ 'no-alt' }
+		`(
+	'should return "$expected" for $status status and when force is $force',
+	( { status, force, expected } ) => {
+		const chkEntity = status !== neverChecked ?
+			getCheckin( status ) :
+			null;
+		expect( getCheckInStatusIcon( chkEntity, force ) )
+			.toEqual( expect.stringContaining( expected ) );
+	} );
+	} );
+	describe( 'getCheckInStatusClassName', () => {
+		it.each`
+			status            | force       | expected
+			${ neverChecked } | ${ false }  | ${ 'ee-red' }
+			${ neverChecked } | ${ true }   | ${ 'ee-red' }
+			${ checkIn }      | ${ false }  | ${ 'ee-green' }
+			${ checkOut }     | ${ false }  | ${ 'ee-red' }
+			${ checkOut }     | ${ true }   | ${ 'ee-red' }
+		`(
+	'should return "$expected" for $status status and when force is $force',
+	( { status, force, expected } ) => {
+		const chkEntity = status !== neverChecked ?
+			getCheckin( status ) :
+			null;
+		expect( getCheckInStatusClassName( chkEntity, force ) )
+			.toEqual( expect.stringContaining( expected ) );
+	} );
+	} );
+} );


### PR DESCRIPTION
## Problem this Pull Request solves

This pull adds various ui components for the check-in model for interactions with that model:

* `<CheckInButton />`  Outputs a button with the action context (color/text) derived from the provided check-in entity via props.
* `<CheckInStatusIcon />`  A component exposing a ui indicator derived from the provided check-in entity via props.

The above components have dependency on some new functions were added to the check-in model exposed on `@eventespresso/model`:

| Function | Description |
| --------- | ----------- |
| `getCheckInStatusText` | Returns user friendly check-in status text for the current check-in status |
| `getCheckInActionText` | Returns user friendly check-in action text for the current check-in status |
| `getCheckInActionClassName` | Returns a css class name for the check-in action |
| `getCheckInStatusIcon` | Returns a dashicon reference for the check-in status |
| `getCheckInStatusClassName` | Returns a css class string for the current check-in status |

All of these functions receive two arguments:

* `checkInEntity`:  Either the check-in entity instance (instance of `BaseEntity`) or null (which is used when there is no check-in record yet.
* `force`: A boolean.  If true and the provided check-in instance is null or it's status is "checked-out" this returns strings related to forcing a check-in action.

> Note: This is a WIP, and has a dependency on some CSS work for core.

## How has this been tested

* [ ] New tests written for added code
* [ ] Existing tests pass
* [ ] Verified components work with Barcode Scanner App where they were first implemented embedded there.

There is no impact to current user-facing features in ee core.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
