### PR TITLE
Bug/missing columns in csv report

### DIFF
--- a/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_answers.dmsstage.php
+++ b/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_answers.dmsstage.php
@@ -62,7 +62,7 @@ class EE_DMS_4_1_0_answers extends EE_Data_Migration_Script_Stage_Table
         }
         // as inefficient as this sounds, we create an answer per REGISTRATION, (even if the registrations use the same attendee)
         foreach ($regs as $new_reg_id) {
-            $new_answer_id = $this->_insert_new_answer($old_row, $new_reg_id);
+            $this->_insert_new_answer($old_row, $new_reg_id);
         }
     }
     /**
@@ -78,8 +78,14 @@ class EE_DMS_4_1_0_answers extends EE_Data_Migration_Script_Stage_Table
         $old_question_table = $wpdb->prefix."events_question";
         $new_question_id = $this->get_migration_script()->get_mapping_new_pk($old_question_table, $old_answer['question_id'], $this->_new_question_table);
 
-        $question_type = $this->_get_question_type($new_question_id);
-        if (in_array($question_type, array('MULTIPLE'))) {
+        $question_row = $this->_get_question_type_and_system($new_question_id);
+        if ($question_row['QST_system']) {
+            // It's an answer to a system question? EE3 used to store that on both the attendee and the answers column,
+            // but not EE4! It's just stored in the attendee meta table. The answers table is ONLY for answers to custom
+            // questions.
+            return 0;
+        }
+        if (in_array($question_row['QST_type'], array('MULTIPLE'))) {
             $ans_value = serialize(explode(",", stripslashes($old_answer['answer'])));
         } else {
             $ans_value = stripslashes($old_answer['answer']);
@@ -107,12 +113,21 @@ class EE_DMS_4_1_0_answers extends EE_Data_Migration_Script_Stage_Table
      * Gets the question's type
      * @global type $wpdb
      * @param type $question_id
-     * @return string
+     * @return array {
+     *  @type string $QST_type
+     *  @type string $QST_system
+     * }
      */
-    private function _get_question_type($question_id)
+    private function _get_question_type_and_system($question_id)
     {
         global $wpdb;
-        $type = $wpdb->get_var($wpdb->prepare("SELECT QST_type FROM ".$this->_new_question_table." WHERE QST_ID=%d LIMIT 1", $question_id));
-        return $type;
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT QST_type, QST_system FROM ".$this->_new_question_table." WHERE QST_ID=%d LIMIT 1",
+                $question_id
+            ),
+            ARRAY_A
+        );
+        return $row;
     }
 }

--- a/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_questions.dmsstage.php
+++ b/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_questions.dmsstage.php
@@ -106,16 +106,16 @@ class EE_DMS_4_1_0_questions extends EE_Data_Migration_Script_Stage
         }
 
         $cols_n_values = array(
-            'QST_display_text'=>stripslashes($old_question['question']),
-            'QST_admin_label'=> $old_question['system_name'] ? $old_question['system_name'] : sanitize_title($old_question['question']),
-            'QST_system'=>$old_question['system_name'],
-            'QST_type'=>$old_question['question_type'],
-            'QST_required'=> 'Y' == $old_question['required'],
-            'QST_required_text'=>stripslashes($old_question['required_text']),
-            'QST_order'=>$old_question['sequence'],
-            'QST_admin_only'=> 'Y' == $old_question['admin_only'],
-            'QST_wp_user'=>$old_question['wp_user'],
-            'QST_deleted'=>false
+            'QST_display_text' => stripslashes($old_question['question']),
+            'QST_admin_label' => $old_question['system_name'] ? $old_question['system_name'] : sanitize_title($old_question['question']),
+            'QST_system' => (string) $old_question['system_name'],
+            'QST_type' => $old_question['question_type'],
+            'QST_required' => 'Y' == $old_question['required'],
+            'QST_required_text' => stripslashes($old_question['required_text']),
+            'QST_order' => $old_question['sequence'],
+            'QST_admin_only' => 'Y' == $old_question['admin_only'],
+            'QST_wp_user' => $old_question['wp_user'],
+            'QST_deleted' => false
         );
         $datatypes = array(
             '%s',// QST_display_text

--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -456,7 +456,7 @@ class RegistrationsReport extends JobHandlerFile
                 ));
                 // now fill out the questions THEY answered
                 foreach ($answers as $answer_row) {
-                    if($answer_row['Question.QST_system']){
+                    if ($answer_row['Question.QST_system']) {
                         // it's an answer to a system question. That was already displayed as part of the attendee
                         // fields, so don't write it out again thanks.
                         continue;

--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -145,10 +145,11 @@ class RegistrationsReport extends JobHandlerFile
                 $this->_change_registration_where_params_to_question_where_params($registration_query_params[0]),
             );
         }
-        $question_query_params[0]['QST_system'] = array(
-            'NOT_IN',
-            array_keys(EEM_Attendee::instance()->system_question_to_attendee_field_mapping()),
-        );
+        // Make sure it's not a system question
+        $question_query_params[0]['OR*not-system-questions'] = [
+            'QST_system' => '',
+            'QST_system*null' => ['IS_NULL']
+        ];
         if (apply_filters(
             'FHEE__EventEspressoBatchRequest__JobHandlers__RegistrationsReport___get_question_labels__only_include_answered_questions',
             false,
@@ -455,6 +456,11 @@ class RegistrationsReport extends JobHandlerFile
                 ));
                 // now fill out the questions THEY answered
                 foreach ($answers as $answer_row) {
+                    if($answer_row['Question.QST_system']){
+                        // it's an answer to a system question. That was already displayed as part of the attendee
+                        // fields, so don't write it out again thanks.
+                        continue;
+                    }
                     if ($answer_row['Question.QST_ID']) {
                         $question_label = EEH_Export::prepare_value_from_db_for_display(
                             EEM_Question::instance(),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Fixed how EE4 Registrations CSV reports could have more data columns than header columns when there were questions for additional attendees only imported from EE3. See https://github.com/eventespresso/event-espresso-core/issues/1087 for more info on the original issue.
Also fixed how system questions imported from EE3 would appear twice in the EE4 registrations CSV reports (once as an attendee column, and again with the custom questions).

The first issue was because custom questions imported from EE3 would have `QST_system=null`, whereas custom questions created in EE4 would have `QST_system=""`. We now always set `QST_system=""`, but the registrations-report-generating code is accommodating to both.
The second issue was because answers to custom questions imported from EE3 would have a row in esp_answer, whereas answers to custom questions in EE4 answers would not. We now don't add rows to esp_answer for answers to custom questions imported from EE3, but the registrations-report-generating code is, again, accommodating to both.



## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Follow josh's instructions from https://github.com/eventespresso/event-espresso-core/issues/1087#issuecomment-488355381 and verify there is a column header for custom questions asked for additional attendees only
* [x] also after that, verify there aren't two columns for system questions like the attendee first name, last name, and email (system questions should just be mentioned in the columns for attendee fields, NOT custom questions)
* [x] if you have direct DB access, check there are no rows in esp_question where `QST_system` is null
* [x] and no rows in esp_answer for system questions (eg questions with IDs 1-10)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
