### PR TITLE
Add helper method for exposing filtered EE brand name and also expose to js (fixes #1183)

### DIFF
--- a/core/domain/Domain.php
+++ b/core/domain/Domain.php
@@ -66,4 +66,16 @@ class Domain extends DomainBase implements CaffeinatedInterface
         $this->caffeinated = (! defined('EE_DECAF') || EE_DECAF !== true)
             && is_readable($this->pluginPath() . 'caffeinated/brewing_regular.php');
     }
+
+
+    /**
+     * This should be used everywhere the Event Espresso brand name is referenced in public facing interfaces
+     * to allow for filtering the brand.
+     *
+     * @return string
+     */
+    public static function brandName()
+    {
+        return (string) apply_filters('FHEE__EventEspresso_core_domain_Domain__brandName', 'Event Espresso');
+    }
 }

--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -9,6 +9,7 @@ use EE_Template_Config;
 use EED_Core_Rest_Api;
 use EEH_DTT_Helper;
 use EEH_Qtip_Loader;
+use EventEspresso\core\domain\Domain;
 use EventEspresso\core\domain\DomainInterface;
 use EventEspresso\core\domain\values\assets\JavascriptAsset;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
@@ -312,6 +313,8 @@ class CoreAssetManager extends AssetManager
                 'admin_url' => admin_url('/'),
             )
         );
+        // Event Espresso brand name
+        $this->registry->addData('brandName', Domain::brandName());
         /** site formatting values **/
         $this->registry->addData(
             'site_formats',


### PR DESCRIPTION
## Problem this Pull Request solves

See #1183 for background.  In this pull:

* `EventEspresso\core\domain\Domain::brandName()` static method is introduced that returns a filtered `Event Espresso` brand name.
* This new value is exposed to javascript via the `eejsdata` object on `eejs.data.brandName`.  So modules can import it via doing something like this:

```js
import { data } from '@eventespresso/eejs';
import { __, sprintf } from '@wordpress/i18n';

const { brandName } = data;
const someLabel = sprintf( __( 'Provided by %s', 'event_espresso' ), brandName );
```

For php usage:

```php
use EventEspresso\core\domain\Domain;

$some_label = sprintf( __( 'Provided by %s', 'event_espresso' ), Domain::brandName() );
```

### Next Steps

* Once this pull is merged the new static method can be implemented in places referencing the Event Espresso brand in either add-ons or core.
* While I support this change myself (I think the benefits are significant), I do think this is something that needs to run by EE owners (cc @garthkoyle and @sethshoultes) because implementing this everywhere will make it much easier for third parties to white-label Event Espresso.
* I didn't add any documentation for this yet because I'm not sure where it should live.  As far as I can tell we don't have any documentation on proper usage of i18n in EE (that I could remember or find in a brief search) so I wonder if documentation can be done in a separate pull (and really anyone can do it - I'm kind of burned out from doing this kind of documentation).

## How has this been tested

* [x] Load up any ui view that enqueues `eejsdata` in the page output (the plugins page is a good one).  In the browser dev tools console, type `eejs.data.brandName` and you should see `Event Espresso` returned.  This verifies both the php output and the js output (because `eejsdata` gets the string from the new php method).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
