### PR TITLE
Ensure eejs.i18n locale data for a handle is only set once per handle (fixes #969)

### DIFF
--- a/core/services/assets/I18nRegistry.php
+++ b/core/services/assets/I18nRegistry.php
@@ -105,6 +105,7 @@ class I18nRegistry
                     $translations_for_domain['translations'],
                     $translations_for_domain['domain']
                 );
+                unset($this->queued_handle_translations[$handle]);
             }
         }
         return $handles;


### PR DESCRIPTION
## Problem this Pull Request solves

See #969 for original report.  It **is** expected that you'd see a `eejs.i18n.setLocaleData` call for each enqueued EE script (that has registered translation strings).  The contents of the locale data will be empty if there's no different active locale for the site.  It is **not** expected that you would see two calls to `eejs.i18n.setLocaleData` for each handle.  So the bug in this case is the latter point and this pull fixes that.

For more background, the reason why `eejs.i18n.setLocaleData` is invoked for each handle is because the strings that get set on `tannin` (the underlying js localization library via `setLocaleData`) are specific to the script they are being set for.  `setLocaleData` merges strings with the already registered strings (for a given domain).

## How has this been tested

* [x] Load a view that has `eejs.i18n` data enqueued (I use the post GB editor).  Open up developer tools and you should see something like this in the elements tab:

![screenshot showing expectation](https://www.evernote.com/l/AAMw1mYUQepAnrXKUG-836fvAmds83YXrnkB/image.png)

Namely, there should be at most one call to `eejs.i18n.setLocaleData` for each ee script.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
