### PR TITLE
Improve BaseEntity.forClone method to allow for cloning primary key too.

### DIFF
--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -137,7 +137,7 @@ class BaseEntity {
 			const newEntity = factory.createNew( this.forClone );
 			if ( keepId ) {
 				newEntity.id = this.id;
-				setSaveState( this, SAVE_STATE.CLEAN );
+				setSaveState( this, newEntity.saveState );
 			}
 			return newEntity;
 		};

--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -129,12 +129,12 @@ class BaseEntity {
 	 */
 	get clone() {
 		return ( keepId = false ) => {
-			// @todo memoize this
-			const factory = memoize( createEntityFactory(
+			const createFactory = memoize( () => createEntityFactory(
 				this.modelName,
 				{ $schema: {}, properties: this.schema },
 				this.fieldPrefixes
 			) );
+			const factory = createFactory();
 			const newEntity = factory.createNew( this.forClone );
 			if ( keepId ) {
 				newEntity.id = this.id;

--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import { isArray, upperFirst, camelCase } from 'lodash';
+import memoize from 'memize';
 
 /**
  * Internal imports
@@ -129,11 +130,11 @@ class BaseEntity {
 	get clone() {
 		return ( keepId = false ) => {
 			// @todo memoize this
-			const factory = createEntityFactory(
+			const factory = memoize( createEntityFactory(
 				this.modelName,
 				{ $schema: {}, properties: this.schema },
 				this.fieldPrefixes
-			);
+			) );
 			const newEntity = factory.createNew( this.forClone );
 			if ( keepId ) {
 				newEntity.id = this.id;

--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -137,7 +137,7 @@ class BaseEntity {
 			const newEntity = factory.createNew( this.forClone );
 			if ( keepId ) {
 				newEntity.id = this.id;
-				setSaveState( this, newEntity.saveState );
+				setSaveState( newEntity, this.saveState, true );
 			}
 			return newEntity;
 		};

--- a/assets/src/data/model/entity-factory/base-entity.js
+++ b/assets/src/data/model/entity-factory/base-entity.js
@@ -127,13 +127,20 @@ class BaseEntity {
 	 * @return {BaseEntity} A new instance of BaseEntity
 	 */
 	get clone() {
-		return new BaseEntity(
-			this.modelName,
-			this.forClone,
-			{ $schema: {}, properties: this.schema },
-			this.fieldPrefixes,
-			true
-		);
+		return ( keepId = false ) => {
+			// @todo memoize this
+			const factory = createEntityFactory(
+				this.modelName,
+				{ $schema: {}, properties: this.schema },
+				this.fieldPrefixes
+			);
+			const newEntity = factory.createNew( this.forClone );
+			if ( keepId ) {
+				newEntity.id = this.id;
+				setSaveState( this, SAVE_STATE.CLEAN );
+			}
+			return newEntity;
+		};
 	}
 
 	static name = 'BaseEntity'

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -100,13 +100,19 @@ export const createGetterAndSetter = (
 			return propertyValue;
 		},
 		set( receivedValue ) {
+			const isPrimaryField = isPrimaryKeyField( fieldName, instance.schema );
+			if ( ! instance.isNew && isPrimaryField ) {
+				return;
+			}
 			assertValidValueForPreparedField(
 				fieldName,
 				receivedValue,
 				instance
 			);
-			setSaveState( instance, SAVE_STATE.DIRTY );
-			setFieldToPersist( instance, fieldName );
+			if ( ! isPrimaryField ) {
+				setSaveState( instance, SAVE_STATE.DIRTY );
+				setFieldToPersist( instance, fieldName );
+			}
 			propertyValue = receivedValue;
 		},
 		...opts,
@@ -286,13 +292,13 @@ const populatePrimaryKeys = ( instance ) => {
 		if ( instance[ schemaField ] ) {
 			delete instance[ schemaField ];
 		}
-		createGetter(
+		createGetterAndSetter(
 			instance,
 			schemaField,
 			cuid(),
 			{ configurable: true, enumerable: true }
 		);
-		createAliasGetterForField( instance, schemaField );
+		createAliasGetterAndSetterForField( instance, schemaField );
 	} );
 	createPrimaryKeyFieldGetters(
 		instance,

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -741,13 +741,20 @@ export const setRelationsResource = (
  *
  * @param {Object} instance
  * @param {string} saveState Expected to be one of SAVE_STATE constant values.
+ * @param {boolean} override Set to true when overriding the default logic for
+ * setting state.  When true, the saveState is set to whatever the incoming
+ * saveState value is.
  */
-export const setSaveState = ( instance, saveState ) => {
+export const setSaveState = ( instance, saveState, override = false ) => {
 	const currentState = instance[ PRIVATE_PROPERTIES.SAVE_STATE ];
 	switch ( saveState ) {
 		case SAVE_STATE.DIRTY:
 		case SAVE_STATE.NEW:
 		case SAVE_STATE.CLEAN:
+			if ( override ) {
+				instance[ PRIVATE_PROPERTIES.SAVE_STATE ] = saveState;
+				break;
+			}
 			instance[ PRIVATE_PROPERTIES.SAVE_STATE ] =
 				currentState === SAVE_STATE.CLEAN ?
 					saveState :

--- a/assets/src/data/model/entity-factory/test/base-entity.js
+++ b/assets/src/data/model/entity-factory/test/base-entity.js
@@ -649,17 +649,56 @@ describe( 'createEntityFactory()', () => {
 		const factory = createEntityFactory(
 			'event',
 			EventSchema.schema,
-			[ 'EVT_ID' ]
+			[ 'EVT' ]
 		);
-		it( 'returns a new instance of BaseEntity', () => {
-			const entity = factory.fromExisting( EventResponse );
-			const newEntity = entity.clone;
-			expect( newEntity ).not.toBe( entity );
+		let entity;
+		beforeEach( () => {
+			entity = factory.fromExisting( EventResponse );
 		} );
-		it( 'returns a new instance that differs only in id', () => {
-			const entity = factory.fromExisting( EventResponse );
-			const newEntity = entity.clone;
-			expect( newEntity.forUpdate ).toEqual( entity.forUpdate );
+		afterEach( () => {
+			entity = null;
+		} );
+		describe( 'not keeping id of original', () => {
+			it( 'returns a new instance of BaseEntity', () => {
+				const newEntity = entity.clone();
+				expect( newEntity ).not.toBe( entity );
+			} );
+			it( 'returns a new instance that differs only in id', () => {
+				const newEntity = entity.clone();
+				expect( newEntity.forUpdate ).toEqual( entity.forUpdate );
+			} );
+			it( 'has state of new', () => {
+				const newEntity = entity.clone();
+				expect( newEntity.isNew ).toBe( true );
+			} );
+			it( 'primary key can be modified', () => {
+				const newEntity = entity.clone();
+				newEntity.id = 999;
+				expect( newEntity.id ).toEqual( 999 );
+				expect( newEntity.isNew ).toBe( true );
+			} );
+		} );
+		describe( 'keeping id of original', () => {
+			it( 'returns a new instance of BaseEntity', () => {
+				const newEntity = entity.clone( true );
+				expect( newEntity ).not.toBe( entity );
+			} );
+			it( 'returns a new instance that shares the same id as ' +
+				'original', () => {
+				const newEntity = entity.clone( true );
+				expect( newEntity.id ).toEqual( entity.id );
+			} );
+			it( 'has same state as original', () => {
+				const newEntity = entity.clone( true );
+				expect( newEntity.saveState ).toEqual( entity.saveState );
+				expect( newEntity.isClean ).toBe( true );
+			} );
+			it( 'primary key can not be modified (when save state is not ' +
+				'new)', () => {
+				const newEntity = entity.clone( true );
+				newEntity.id = 999;
+				expect( newEntity.id ).toEqual( entity.id );
+			} );
 		} );
 	} );
 } );

--- a/assets/src/data/model/entity-factory/test/base-entity.js
+++ b/assets/src/data/model/entity-factory/test/base-entity.js
@@ -700,5 +700,24 @@ describe( 'createEntityFactory()', () => {
 				expect( newEntity.id ).toEqual( entity.id );
 			} );
 		} );
+		describe( 'memized factory behaviour on clone', () => {
+			const dttFactory = createEntityFactory(
+				'datetime',
+				DateTimeSchema.schema,
+				[ 'DTT_EVT', 'DTT' ]
+			);
+			const dttEntity = dttFactory.fromExisting( AuthedDateTimeResponse );
+			it( 'keeps different entity factories separate', () => {
+				// first clone event entity to set the memized factory value.
+				entity.clone();
+				// next clone datetime entity
+				const dateClone = dttEntity.clone( true );
+				expect( dateClone.id ).toEqual( dttEntity.id );
+
+				//clone event again
+				const eventClone = entity.clone( true );
+				expect( eventClone.id ).toEqual( entity.id );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Problem this Pull Request solves

While working on #961 I encountered a use-case where a clone of a `BaseEntity` instance is needed _including_ the id of the entity and with a state other than `SAVE_STATE.NEW`.   This use-case was:

- A form is loaded, clone the entity so that changes are specific to the clone.
- Form provides option to discard changes and if changes are discarded the clone is discarded and original entity is untouched.
- If changes are accepted, dispatch cloned entity to replace existing entity in the state.

For the above, the cloned entity needed to have the same ID and inherit the same save state as the clone.

So in this pull:

- Entities with `SAVE_STATE.NEW` have a setter for the primary key id (but ONLY if the state is new).
- the `BaseEntity.clone` getter is now a function that accepts a `keepId` boolean argument. When this is true, the entity is cloned completely including the save state and the primary key value.

## How has this been tested

* [ ] Automated tests for behaviour

Currently the clone functionality is not used in any released user-facing features so should be safe to break back-compat, also can be merged after passing tests.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
