### PR TITLE
Adds support for bin-2 mastercard card numbers

### DIFF
--- a/core/libraries/form_sections/strategies/validation/EE_Credit_Card_Validation_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/validation/EE_Credit_Card_Validation_Strategy.strategy.php
@@ -21,47 +21,11 @@ class EE_Credit_Card_Validation_Strategy extends EE_Text_Validation_Strategy
         if (! $validation_error_message) {
             $validation_error_message = __("Please enter a valid credit card number", "event_espresso");
         }
-        parent::__construct($validation_error_message);
-    }
-
-    /**
-     * just checks the field isn't blank
-     * @param $normalized_value
-     * @throws EE_Validation_Error
-     * @return void
-     */
-    public function validate($normalized_value)
-    {
-        if ($normalized_value && ! $this->verify_is_credit_card($normalized_value)) {
-            throw new EE_Validation_Error($this->get_validation_error_message(), 'required');
-        }
-    }
-
-
-
-    /**
-     * gets additional validation rules for use in the jQuery validation JS corresponding to this field when displaying.
-     *
-     * @return array
-     */
-    public function get_jquery_validation_rule_array()
-    {
-        return array('creditcard'=>true, 'messages' => array( 'creditcard' => $this->get_validation_error_message() ) );
-    }
-
-    /**
-     * Uses regular expressions to verify $card_number is actually a credit card number
-     * @param string $card_number
-     * @return boolean
-     */
-    private function verify_is_credit_card($card_number)
-    {
-        // Credit card: All major cards
-        $regex = '~^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6011[0-9]{12}|3(?:0[0-5]|[68][0-9])[0-9]{11}|3[47][0-9]{13})$~';
-        if (preg_match($regex, $card_number) || empty($card_number)) {
-            return true;
-        } else {
-            return false;
-        }
+        parent::__construct(
+            $validation_error_message,
+            // @codingStandardsIgnoreStart
+            '~^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|2[2-7][0-9]{14}|6011[0-9]{12}|3(?:0[0-5]|[68][0-9])[0-9]{11}|3[47][0-9]{13})$~'
+            // @codingStandardsIgnoreEnd
+        );
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Adds support for bin-2 mastercard card numbers.
Simplifies `EE_Credit_Card_Validation_Strategy` to just provide a regex to `EE_Text_Validation_Strategy`. That regex matches the old one, plus what was mentioned on  https://eventespresso.com/topic/2-series-mastercards-marked-as-invalid/.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Use any onsite payment method that has a credit card input (and not one with any fancy JS, like Stripe; I mean use one like PayPal Pro or AIM or the test onsite payment method). Use the credit card number "2212345678901234". That was considered invalid before, but now is valid.
* [x] Register again, but this time use "6011123456789012" (the next pattern in the regex). It worked before and should continue to work. Actually, any number that worked before should continue to work.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
