### PR TITLE
Pass the current $response var to paymentDetails()

### DIFF
--- a/core/domain/services/admin/ajax/ThankYouPageIpnMonitor.php
+++ b/core/domain/services/admin/ajax/ThankYouPageIpnMonitor.php
@@ -94,7 +94,7 @@ class ThankYouPageIpnMonitor
         $since = isset($data['espresso_thank_you_page']['get_payments_since'])
             ? $data['espresso_thank_you_page']['get_payments_since']
             : 0;
-        return $this->paymentDetails($since);
+        return $this->paymentDetails($since, $response);
     }
 
 
@@ -181,7 +181,7 @@ class ThankYouPageIpnMonitor
      * @return array
      * @throws EE_Error
      */
-    private function paymentDetails($since)
+    private function paymentDetails($since, $response)
     {
         // then check for payments
         $payments = $this->thank_you_page->get_txn_payments($since);


### PR DESCRIPTION
I'm not sure this is the right fix for this one, seems odd passing the response like this but as I had it open and it's a 2 line change I created this.

For details see: #1231 

## How has this been tested
Register onto a ticket and pay.

With master, you won't see a 'transaction details' table on the thank you page, with this branch you should.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
