### PR TITLE
Remove dependency on Moment lib from DateTimeDropdown

### DIFF
--- a/assets/src/components/form/inputs/date-time-input.css
+++ b/assets/src/components/form/inputs/date-time-input.css
@@ -3,6 +3,15 @@
     margin-left: -25% !important;
 }
 
+.ee-date-time-input-picker-wrapper {
+    padding: 1rem 2rem 2rem;
+}
+
+.ee-date-time-input-buttons-wrapper {
+    padding: 2rem 0 0;
+    text-align: right;
+}
+
 
 /* Media Queries for specific screen sizes
  * -------------------------------------------------------------------------*/

--- a/assets/src/components/form/inputs/date-time-input.js
+++ b/assets/src/components/form/inputs/date-time-input.js
@@ -1,17 +1,18 @@
 /**
  * External imports
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import moment from 'moment-timezone';
 import { Component } from '@wordpress/element';
 import { Field } from 'react-final-form';
-import { __experimentalGetSettings as getSettings } from '@wordpress/date';
 import { Button, DateTimePicker, Dropdown } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { SERVER_LOCALE } from '@eventespresso/eejs';
+import { DATE_TIME_FORMAT_SITE, TIME_FORMAT_SITE } from '@eventespresso/helpers';
 import { __ } from '@eventespresso/i18n';
+import { ServerDateTime } from '@eventespresso/value-objects';
 
 import './date-time-input.css';
-
 /**
  * generates an HTML5 text input that opens a WP Dropdown + DateTimePicker
  * for populating the input with a date and time
@@ -45,16 +46,49 @@ class DateTimeDropdown extends Component {
 
 	constructor( props ) {
 		super( props );
+		const initialValue = new Date();
 		this.state = {
+			is12HourTime: true,
 			editorOpen: false,
-			inputValue: props.initialValue ? props.initialValue : '',
-			newValue: props.initialValue ? props.initialValue : '',
-			prevValue: props.initialValue ? props.initialValue : '',
-			onChange: props.input && props.input.onChange ?
-				props.input.onChange :
-				null,
+			inputValue: initialValue,
+			newValue: initialValue,
+			prevValue: initialValue,
+			onChange: null,
 		};
 	}
+
+	/**
+	 * opens and closes DateTimePicker Modal
+	 *
+	 * @function
+	 */
+	componentDidMount = () => {
+		const initialValue = this.props.initialValue ?
+			new Date( this.props.initialValue ) :
+			new Date();
+		// To know if the current timezone is a 12 hour time
+		// we look for "a" in the time format
+		// We also make sure this a is not escaped by a "/"
+		const is12HourTime = /a(?!\\)/i.test(
+			TIME_FORMAT_SITE
+			// Test only the lower case a
+				.toLowerCase()
+				// Replace "//" with empty strings
+				.replace( /\\\\/g, '' )
+				// Reverse the string and test for "a" not followed by a slash
+				.split( '' ).reverse().join( '' )
+		);
+		this.setState( {
+			is12HourTime,
+			editorOpen: false,
+			inputValue: initialValue,
+			newValue: initialValue,
+			prevValue: initialValue,
+			onChange: this.props.input && this.props.input.onChange ?
+				this.props.input.onChange :
+				null,
+		} );
+	};
 
 	/**
 	 * opens and closes DateTimePicker Modal
@@ -74,14 +108,13 @@ class DateTimeDropdown extends Component {
 	 * @param {string} newDate
 	 */
 	onChange = ( newDate ) => {
-		this.setState( { newValue: newDate } );
+		this.setState( { newValue: new Date( newDate ) } );
 	};
 
 	/**
 	 * opens and closes DateTimePicker Modal
 	 *
 	 * @function
-	 * @param {string} newDate
 	 */
 	cancel = () => {
 		this.setState( ( prevState ) => (
@@ -90,14 +123,15 @@ class DateTimeDropdown extends Component {
 	};
 
 	/**
-	 * opens and closes DateTimePicker Modal
+	 * submits the value from the Datepicker
 	 *
 	 * @function
-	 * @param {string} newDate
 	 */
 	update = () => {
 		this.setState( ( prevState ) => {
-			prevState.onChange( prevState.newValue );
+			if ( typeof prevState.onChange === 'function' ) {
+				prevState.onChange( prevState.newValue.toISOString() );
+			}
 			return {
 				inputValue: prevState.newValue,
 				prevValue: prevState.newValue,
@@ -109,34 +143,19 @@ class DateTimeDropdown extends Component {
 		const {
 			input,
 			htmlId,
+			htmlClass,
 			helpTextID,
 			dataSet,
 			inputWidth = '',
 			...attributes
 		} = this.props;
-		delete attributes.htmlClass;
 		delete attributes.initialValue;
-		let {
-			htmlClass,
-		} = this.props;
-		htmlClass = inputWidth ?
-			`${ htmlClass } ee-input-width-${ inputWidth }` :
-			htmlClass;
-		const settings = getSettings();
-		// To know if the current timezone is a 12 hour time
-		// we look for "a" in the time format
-		// We also make sure this a is not escaped by a "/"
-		const is12HourTime = /a(?!\\)/i.test(
-			settings.formats.time
-			// Test only the lower case a
-				.toLowerCase()
-				// Replace "//" with empty strings
-				.replace( /\\\\/g, '' )
-				// Reverse the string and test for "a" not followed by a slash
-				.split( '' ).reverse().join( '' )
-		);
-		let inputValue = moment( this.state.inputValue );
-		inputValue = inputValue.format( 'YYYY-MM-DD HH:mm A' );
+		const inputClass = classNames( {
+			[ htmlClass ]: true,
+			'form-control': true,
+			[ `ee-input-width-${ inputWidth }` ]: inputWidth,
+		} );
+		const inputValue = ServerDateTime.fromJSDate( this.state.inputValue );
 		return (
 			<Dropdown
 				position="bottom center"
@@ -145,8 +164,8 @@ class DateTimeDropdown extends Component {
 					<input
 						type="text"
 						id={ htmlId }
-						className={ `${ htmlClass } form-control` }
-						value={ inputValue }
+						className={ inputClass }
+						value={ inputValue.toFormat( DATE_TIME_FORMAT_SITE ) }
 						onChange={ input.onChange }
 						onClick={ onToggle }
 						onKeyDown={ ( event ) => {
@@ -164,20 +183,15 @@ class DateTimeDropdown extends Component {
 					/>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<div style={ { padding: '1rem 2rem 2rem' } }>
+					<div className={ 'ee-date-time-input-picker-wrapper' } >
 						<DateTimePicker
 							key="ee-date-time-picker"
 							currentDate={ this.state.newValue }
 							onChange={ this.onChange }
-							locale={ settings.l10n.locale }
-							is12Hour={ is12HourTime }
+							locale={ SERVER_LOCALE }
+							is12Hour={ this.state.is12HourTime }
 						/>
-						<div
-							style={ {
-								padding: '2rem 0 0',
-								textAlign: 'right',
-							} }
-						>
+						<div className={ 'ee-date-time-input-buttons-wrapper' } >
 							<Button isPrimary
 								onClick={ () => {
 									this.update();

--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/edit-event-date-form-modal.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/edit-event-date-form-modal.js
@@ -7,7 +7,7 @@ import { __ } from '@eventespresso/i18n';
 import { withEditorModal } from '@eventespresso/editor-hocs';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { dateTimeModel } from '@eventespresso/model';
+import { isModelEntityOfModel } from '@eventespresso/validators';
 
 /**
  * Internal dependencies
@@ -18,8 +18,6 @@ import {
 	eventDateEntityFormSubmitHandler,
 } from './event-date-entity-form-submit-handler';
 import withUpdateEventDateRelation from '../action-handlers/with-update-event-date-relation';
-
-const { MODEL_NAME: DATETIME } = dateTimeModel;
 
 /**
  * @function
@@ -38,7 +36,9 @@ class EditEventDateFormModal extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			eventDate: props.eventDate ? props.eventDate.clone( true ) : {},
+			eventDate: isModelEntityOfModel( props.eventDate, 'datetime' ) ?
+				props.eventDate.clone( true ) :
+				{},
 			originalEventDate: props.eventDate ? props.eventDate : {},
 		};
 	}
@@ -100,7 +100,7 @@ export default compose( [
 	withDispatch( ( dispatch, { updateEventDateRelation } ) => {
 		const { receiveAndReplaceEntityRecords } = dispatch( 'eventespresso/core' );
 		const replaceDateInStore = ( replaceDate, originalDate, eventEntity ) => {
-			receiveAndReplaceEntityRecords( DATETIME, [ replaceDate ] );
+			receiveAndReplaceEntityRecords( 'datetime', [ replaceDate ] );
 			updateEventDateRelation( eventEntity, replaceDate );
 		};
 		return { replaceDateInStore };

--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/event-date-entity-form-submit-handler.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/event-date-entity-form-submit-handler.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@eventespresso/i18n';
 import { dateTimeModel } from '@eventespresso/model';
-import { DateTime } from '@eventespresso/value-objects';
+import { ServerDateTime } from '@eventespresso/value-objects';
 import { isModelEntityOfModel } from '@eventespresso/validators';
 
 const { MODEL_NAME: DATETIME } = dateTimeModel;
@@ -29,22 +29,16 @@ export const eventDateEntityFormSubmitHandler = (
 		);
 	}
 	const prefix = `ee-event-date-${ dateEntity.id }`;
-	dateEntity.name = formData[ `${ prefix }-name` ] || '';
-	dateEntity.description = formData[ `${ prefix }-description` ] || '';
-	dateEntity.start = new DateTime( formData[ `${ prefix }-start` ] || '' );
-	dateEntity.end = new DateTime( formData[ `${ prefix }-end` ] || '' );
-	dateEntity.regLimit = parseInt(
-		formData[ `${ prefix }-reg-limit` ] || -1,
-		10
-	);
-	dateEntity.isPrimary = !! formData[ `${ prefix }-is-primary` ] || false;
-	dateEntity.order = parseInt(
-		formData[ `${ prefix }-order` ] || 0,
-		10
-	);
-	dateEntity.parent = parseInt(
-		formData[ `${ prefix }-parent` ] || 0,
-		10
-	);
-	dateEntity.deleted = !! formData[ `${ prefix }-deleted` ] || false;
+	const getValue = ( field, defaultValue = '' ) => {
+		return formData[ `${ prefix }-${ field }` ] || defaultValue;
+	};
+	dateEntity.name = getValue( 'name' );
+	dateEntity.description = getValue( 'description' );
+	dateEntity.start = new ServerDateTime( getValue( 'start' ) );
+	dateEntity.end = new ServerDateTime( getValue( 'end' ) );
+	dateEntity.regLimit = parseInt( getValue( 'reg-limit', -1 ), 10 );
+	dateEntity.isPrimary = !! getValue( 'is-primary', false );
+	dateEntity.order = parseInt( getValue( 'order', 0 ), 10 );
+	dateEntity.parent = parseInt( getValue( 'parent', 0 ), 10 );
+	dateEntity.deleted = !! getValue( 'deleted', false );
 };


### PR DESCRIPTION
## Problem this Pull Request solves
The `DateTimeDropdown` input at `/assets/src/components/form/inputs/date-time-input.js` was using `Moment` internally for parsing and formatting dates but we want to minimize dependencies on external libraries as much as possible.

There were also a few other things that needed improvement such as initial data capture and handling of css classes.

## How has this been tested
monkey based browser testing only
