### PR TITLE
Remove duplicate of Ticket's description from list of prices fixes #672

### DIFF
--- a/caffeinated/modules/ticket_selector_caff/templates/ticket_selector_price_details.template.php
+++ b/caffeinated/modules/ticket_selector_caff/templates/ticket_selector_price_details.template.php
@@ -41,10 +41,8 @@ if ($display_ticket_price) { ?>
                 <?php
                 if ($ticket->base_price() instanceof EE_Price) { ?>
                     <tr>
-                        <td data-th="<?php esc_html_e('Name', 'event_espresso'); ?>" class="small-text">
+                        <td data-th="<?php esc_html_e('Name', 'event_espresso'); ?>" class="small-text" colspan="2">
                             <b><?php echo $ticket->base_price()->name(); ?></b></td>
-                        <td data-th="<?php esc_html_e('Description', 'event_espresso'); ?>"
-                            class="small-text"><?php echo $ticket->base_price()->desc(); ?></td>
                         <td data-th="<?php esc_html_e('Amount', 'event_espresso'); ?>"
                             class="jst-rght small-text"><?php echo $ticket->base_price()->pretty_price(); ?></td>
                     </tr>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #672 


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Create an event and set the fields for the ticket's name and description, and add at least one price modifer. Set a name & description for the price modifier too. Then view the event and open the "show details" for the ticket. 

Here are a few screenshots that show the expected changes:
Master:

<img width="487" alt="Screen Shot 2019-06-06 at 1 26 21 PM" src="https://user-images.githubusercontent.com/891156/59053138-b666bb00-885e-11e9-972a-f4da7bb28086.png">


This branch:
<img width="487" alt="Screen Shot 2019-06-06 at 1 22 07 PM" src="https://user-images.githubusercontent.com/891156/59053052-7b648780-885e-11e9-81f8-7c1bc811bc10.png">




Master, small screens:
<img width="355" alt="Screen Shot 2019-06-06 at 1 25 29 PM" src="https://user-images.githubusercontent.com/891156/59053110-a18a2780-885e-11e9-87f4-5243ef47467f.png">

this branch, small screens:
<img width="359" alt="Screen Shot 2019-06-06 at 1 23 48 PM" src="https://user-images.githubusercontent.com/891156/59053027-6ee02f00-885e-11e9-9a05-0ad152d1cc52.png">





## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)