### PR TITLE
remove single quotes from line items and descriptions sent to AIM

### DIFF
--- a/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
+++ b/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
@@ -215,7 +215,7 @@ class EEG_Aim extends EE_Onsite_Gateway
                     $line_item->unit_price(),
                     'N'
                 );
-                $order_description .= $line_item->desc().', ';
+                $order_description .= str_replace('\'', '', $line_item->desc() . ', ');
             }
             foreach ($total_line_item->tax_descendants() as $tax_line_item) {
                 $this->addLineItem(
@@ -329,8 +329,8 @@ class EEG_Aim extends EE_Onsite_Gateway
     {
         $args = array(
             substr($item_id, 0, 31),
-            substr($item_name, 0, 31),
-            substr($item_description, 0, 255),
+            substr(str_replace('\'', '', $item_name), 0, 31),
+            substr(str_replace('\'', '', $item_description), 0, 255),
             number_format(abs($item_quantity), 2, '.', ''),
             number_format(abs($item_unit_price), 2, '.', ''),
             $item_taxable === 'N' ? 'N' : 'Y'

--- a/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
+++ b/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
@@ -1,5 +1,6 @@
 <?php
 
+use EventEspresso\core\services\formatters\AsciiOnly;
 use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
@@ -197,7 +198,7 @@ class EEG_Aim extends EE_Onsite_Gateway
         $item_num = 1;
         $transaction = $payment->transaction();
         $gateway_formatter = $this->_get_gateway_formatter();
-        $order_description = $gateway_formatter->formatOrderDescription($payment);
+        $order_description = $this->prepareStringForAuthnet($gateway_formatter->formatOrderDescription($payment));
         $primary_registrant = $transaction->primary_registration();
         // if we're are charging for the full amount, show the normal line items
         // and the itemized total adds up properly
@@ -215,7 +216,7 @@ class EEG_Aim extends EE_Onsite_Gateway
                     $line_item->unit_price(),
                     'N'
                 );
-                $order_description .= str_replace('\'', '', $line_item->desc() . ', ');
+                $order_description .= $this->prepareStringForAuthnet($line_item->desc()) . ', ';
             }
             foreach ($total_line_item->tax_descendants() as $tax_line_item) {
                 $this->addLineItem(
@@ -329,8 +330,8 @@ class EEG_Aim extends EE_Onsite_Gateway
     {
         $args = array(
             substr($item_id, 0, 31),
-            substr(str_replace('\'', '', $item_name), 0, 31),
-            substr(str_replace('\'', '', $item_description), 0, 255),
+            substr($this->prepareStringForAuthnet($item_name), 0, 31),
+            substr($this->prepareStringForAuthnet($item_description), 0, 255),
             number_format(abs($item_quantity), 2, '.', ''),
             number_format(abs($item_unit_price), 2, '.', ''),
             $item_taxable === 'N' ? 'N' : 'Y'
@@ -445,6 +446,21 @@ class EEG_Aim extends EE_Onsite_Gateway
         $response_obj->account_number = '';
         $this->log(array('AIM Response received:' => (array) $response_obj), $payment);
         return $response_obj;
+    }
+
+    /**
+     * Removes characters Authorize.net doesn't handle well.
+     * @since $VID:$
+     * @param $text
+     * @return string
+     */
+    private function prepareStringForAuthnet($text)
+    {
+        return str_replace(
+            ['\''],
+            [''],
+            $text
+        );
     }
 }
 

--- a/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
+++ b/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
@@ -457,8 +457,8 @@ class EEG_Aim extends EE_Onsite_Gateway
     private function prepareStringForAuthnet($text)
     {
         return str_replace(
-            ['\''],
-            [''],
+            '\'',
+            '',
             $text
         );
     }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
If you had a ticket name or description that had a single quote in it, it would cause an error making a payment with AIM. In order to resolve this, single quotes are removed when sending ticket names and descriptions to AIM.
FYI: double quotes, accented characters, and all the other special characters I could think to use did NOT cause problems.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Create an event and ticket and put all the crazy characters you can think of into their name and descriptions (eg  `J'ai été là déjà!@#$%^&*()"`). Activate AIM. Register for that event and pay with AIM. It should work fine.
## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
