### PR TITLE
Add preact-context to the whitelist for license checks

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -27,6 +27,7 @@
 		"colors",
 		"underscore",
 		"detect-libc",
-		"gaxios"
+		"gaxios",
+		"preact-context"
 	]
 }


### PR DESCRIPTION
This is used by @typeform-embed but is not actually installed in our dependencies (it is a derivative of `preact-compat`.

`preact-context` is licensed Apache-2.0 which isn't compatible with GPLv2.  However, since it's not actually in use I think we can ignore it.