### PR TITLE
export editor hocs

### DIFF
--- a/assets/src/components/ui/entity-list/index.js
+++ b/assets/src/components/ui/entity-list/index.js
@@ -17,8 +17,6 @@ import withFormContainerAndPlaceholder from '../../form/base/with-form-container
  * as either a list table or grid of entity blocks
  *
  * @function
- * @param {boolean} loading
- * @param {string} loadingNotice
  * @param {Array} entities
  * @param {mixed} otherProps
  * @param {Component} EntityGridView
@@ -29,8 +27,6 @@ import withFormContainerAndPlaceholder from '../../form/base/with-form-container
  * @return {Component} list of rendered entities
  */
 const EntityList = ( {
-	loading,
-	loadingNotice,
 	entities,
 	EntityGridView,
 	EntityListView,

--- a/assets/src/editor/events/hocs/with-editor-ticket-entities.js
+++ b/assets/src/editor/events/hocs/with-editor-ticket-entities.js
@@ -4,8 +4,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 export default createHigherOrderComponent(
 	withSelect( ( select ) => {
 		return {
-			ticketEntities: select( 'eventespresso/core' )
-				.getTickets(),
+			ticketEntities: select( 'eventespresso/core' ).getTickets(),
 		};
 	} ),
 	'withEditorTicketEntities'

--- a/assets/src/editor/events/index.js
+++ b/assets/src/editor/events/index.js
@@ -1,5 +1,6 @@
 export * from './dates-and-tickets-metabox';
 export * from './dates-and-times';
+export * from './hocs';
 export * from './ticket-assignments-manager';
 export * from './tickets';
 


### PR DESCRIPTION
## Problem this Pull Request solves
the HOCs in `/assets/src/editor/events/hocs` were not being exported as part of the `@eventespresso/editor` bundle and were therefore inaccessible to external addons like REM. Also fixed a couple of other minor issues that were missed in #1340

