### PR TITLE
add date input calendar button

### DIFF
--- a/assets/src/components/form/inputs/date-time-input.css
+++ b/assets/src/components/form/inputs/date-time-input.css
@@ -1,3 +1,12 @@
+.ee-date-time-input-text-field-wrapper {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-items: flex-start;
+}
+
+.ee-date-time-input-text-field-wrapper .ee-date-time-input-text-field {
+    margin-right: var(--ee-margin-smaller);
+}
 
 .ee-date-time-input-dialog {
     margin-left: -25% !important;

--- a/assets/src/components/form/inputs/date-time-input.js
+++ b/assets/src/components/form/inputs/date-time-input.js
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Field } from 'react-final-form';
 import {
 	Button,

--- a/assets/src/components/form/inputs/date-time-input.js
+++ b/assets/src/components/form/inputs/date-time-input.js
@@ -3,10 +3,16 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { Field } from 'react-final-form';
-import { Button, DateTimePicker, Dropdown } from '@wordpress/components';
+import {
+	Button,
+	DateTimePicker,
+	Dropdown,
+	IconButton,
+} from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { EspressoIcon, ESPRESSO_ICON_CALENDAR } from '../../ui/image/espresso-icon';
 import { SERVER_LOCALE } from '@eventespresso/eejs';
 import { DATE_TIME_FORMAT_SITE, TIME_FORMAT_SITE } from '@eventespresso/helpers';
 import { __ } from '@eventespresso/i18n';
@@ -152,6 +158,7 @@ class DateTimeDropdown extends Component {
 		delete attributes.initialValue;
 		const inputClass = classNames( {
 			[ htmlClass ]: true,
+			'ee-date-time-input-text-field': true,
 			'form-control': true,
 			[ `ee-input-width-${ inputWidth }` ]: inputWidth,
 		} );
@@ -161,26 +168,40 @@ class DateTimeDropdown extends Component {
 				position="bottom center"
 				contentClassName="ee-date-time-input-dialog"
 				renderToggle={ ( { onToggle } ) => (
-					<input
-						type="text"
-						id={ htmlId }
-						className={ inputClass }
-						value={ inputValue.toFormat( DATE_TIME_FORMAT_SITE ) }
-						onChange={ input.onChange }
-						onClick={ onToggle }
-						onKeyDown={ ( event ) => {
-							if (
-								event.keyCode === ENTER ||
-								event.keyCode === SPACE
-							) {
-								onToggle( event );
+					<div className={ 'ee-date-time-input-text-field-wrapper' }>
+						<input
+							type="text"
+							id={ htmlId }
+							className={ inputClass }
+							value={ inputValue.toFormat( DATE_TIME_FORMAT_SITE ) }
+							onClick={ onToggle }
+							onChange={ input.onChange }
+							onKeyDown={ ( event ) => {
+								if (
+									event.keyCode === ENTER ||
+									event.keyCode === SPACE
+								) {
+									onToggle( event );
+								}
+							} }
+							aria-describedby={ helpTextID }
+							aria-live="polite"
+							{ ...dataSet }
+							{ ...attributes }
+						/>
+						<IconButton
+							icon={
+								<EspressoIcon
+									icon={ ESPRESSO_ICON_CALENDAR }
+									onClick={ onToggle }
+								/>
 							}
-						} }
-						aria-describedby={ helpTextID }
-						aria-live="polite"
-						{ ...dataSet }
-						{ ...attributes }
-					/>
+							label={ __(
+								'Click to choose date and time',
+								'event_espresso'
+							) }
+						/>
+					</div>
 				) }
 				renderContent={ ( { onToggle } ) => (
 					<div className={ 'ee-date-time-input-picker-wrapper' } >

--- a/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
+++ b/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
@@ -443,6 +443,11 @@
     box-sizing: border-box;
 }
 
+.ee-two-column-admin .ee-toggle-input .components-toggle-control__label {
+    font-size: var(--ee-font-size-default);
+    width: calc( 100% - 40px );
+}
+
 .ee-two-column-admin .ee-checkbox-toggle input[type="checkbox"] {
     border: 1px solid var(--ee-border-color);
     border-radius: var(--ee-border-radius-small);

--- a/assets/src/components/ui/entity-details-panel/style.css
+++ b/assets/src/components/ui/entity-details-panel/style.css
@@ -47,7 +47,7 @@
 }
 
 .ee-infinity-sign {
-    font-size: var(--ee-font-size-big);
+    font-size: var(--ee-font-size-bigger);
     line-height: var(--ee-font-size-big);
     vertical-align: middle;
 }


### PR DESCRIPTION
## Problem this Pull Request solves
This pull adds a calendar icon button after the date time input text field to help indicate that there is a modal window that is launched for displaying a datepicker.
Also fixes a couple of other super tiny css issues that I didn't want to create a separate pull for, so they got stuck in here :)

