### PR TITLE
add filter hook to allow for changing/adding to the heading displayed…

### DIFF
--- a/modules/single_page_checkout/reg_steps/payment_options/EE_SPCO_Reg_Step_Payment_Options.class.php
+++ b/modules/single_page_checkout/reg_steps/payment_options/EE_SPCO_Reg_Step_Payment_Options.class.php
@@ -999,7 +999,11 @@ class EE_SPCO_Reg_Step_Payment_Options extends EE_SPCO_Reg_Step
         $available_payment_methods = array(
             // display the "Payment Method" header
             'payment_method_header' => new EE_Form_Section_HTML(
-                EEH_HTML::h4($payment_method_header, 'method-of-payment-hdr')
+                apply_filters(
+                    'FHEE__EE_SPCO_Reg_Step_Payment_Options___setup_payment_options__payment_method_header',
+                    EEH_HTML::h4($payment_method_header, 'method-of-payment-hdr'),
+                    $payment_method_header
+                )
             ),
         );
         // the list of actual payment methods ( invoice, paypal, etc ) in a  ( slug => HTML )  format


### PR DESCRIPTION
… just before the payment options; fixes #888


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #888 as well as https://events.codebasehq.com/redirect?http://eventespresso.com/topic/custom-text-under-please-select-your-method-of-payment/#post-154436

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Tested a registration that requires payment, check the heading "Please Select your method of payment", no changes or errors should happen.

Then to test the filter, add to a custom functions file:

```
add_filter(
'FHEE__EE_SPCO_Reg_Step_Payment_Options___setup_payment_options__payment_method_header',

'my_custom_payment_instructions', 
10, 
3
);
function my_custom_payment_instructions($section, $payment_method_header) {
    $section .= '<p>A paragraph of text after the heading.</p>';
    return $section;
}
```


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)