### PR TITLE
Don't include a thousands separator in ld+json ticket prices

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -59,7 +59,7 @@ class EEH_Schema
                 $ticket->price(),
                 EE_Registry::instance()->CFG->currency->dec_plc,
                 EE_Registry::instance()->CFG->currency->dec_mrk,
-                EE_Registry::instance()->CFG->currency->thsnds
+                ''
             );
             switch ($ticket->ticket_status()) {
                 case 'TKO':


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
When a ticket price is $1000.00 or more the format includes a thousands separator. This isn't recommended in the schema.org specification, and Google's validator says it's not a valid price.

<img width="543" alt="Screen Shot 2019-06-26 at 8 50 03 AM" src="https://user-images.githubusercontent.com/891156/60184359-e9fd8b00-97f5-11e9-9a6f-b2452b9d30c6.png">



## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Add a ticket with a price of $1000.00 or more, then view the event
Test the ld+json output with the validator https://search.google.com/structured-data/testing-tool


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
