### PR TITLE
Fix "events require pre-approval" message fixes #1304

### DIFF
--- a/modules/single_page_checkout/reg_steps/payment_options/EE_SPCO_Reg_Step_Payment_Options.class.php
+++ b/modules/single_page_checkout/reg_steps/payment_options/EE_SPCO_Reg_Step_Payment_Options.class.php
@@ -713,7 +713,7 @@ class EE_SPCO_Reg_Step_Payment_Options extends EE_SPCO_Reg_Step
      */
     private function _registrations_requiring_pre_approval($registrations_requiring_pre_approval = array())
     {
-        $events_requiring_pre_approval = '';
+        $events_requiring_pre_approval = array();
         foreach ($registrations_requiring_pre_approval as $registration) {
             if ($registration instanceof EE_Registration && $registration->event() instanceof EE_Event) {
                 $events_requiring_pre_approval[ $registration->event()->ID() ] = EEH_HTML::li(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #1304. Also, no list of events requiring pre-approval were displayed if the server has PHP 7 or greater.

## How has this been tested
Set up an event with a paid ticket, with DRS set to "Not Approved".
Test a registration and take note of the message starting with "The following events do not require payment at this time"...
With master branch, no events listed. With this branch, the event(s) are listed.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
