### PR TITLE
Add static function for creating a Money VO from a number or string.

### DIFF
--- a/assets/src/vo/test/money.js
+++ b/assets/src/vo/test/money.js
@@ -497,4 +497,31 @@ describe( 'Money Value Object', () => {
 			) ).toThrow();
 		} );
 	} );
+	describe( 'Money.fromMoneyValue', () => {
+		it( 'throws a TypeError if provided currency is not a Currency ' +
+			'vo', () => {
+			expect( () => Money.fromMoneyValue( '10.10' ) )
+				.toThrow( TypeError );
+		} );
+		it( 'converts a number as expected', () => {
+			expect( Money.fromMoneyValue( 10, DefaultCurrency ).toNumber() )
+				.toBe( 10 );
+			expect( Money.fromMoneyValue( 10.10, DefaultCurrency ).toNumber() )
+				.toBe( 10.1 );
+		} );
+		it( 'converts a money value for the currency passed in as ' +
+			'expected', () => {
+			expect( Money.fromMoneyValue( '$10.10', DefaultCurrency ).toNumber() )
+				.toBe( 10.1 );
+		} );
+		it( 'throws an error with an invalid money value string', () => {
+			expect( () => Money.fromMoneyValue( 'fail fail', DefaultCurrency ) )
+				.toThrow();
+		} );
+		it( 'throws an error with a money value having a different currency ' +
+			'sign than the provided currency value object.', () => {
+			expect( () => Money.fromMoneyValue( '10,10€', DefaultCurrency ) )
+				.toThrow();
+		} );
+	} );
 } );

--- a/docs/AA--Javascript-in-EE/value-objects/money.md
+++ b/docs/AA--Javascript-in-EE/value-objects/money.md
@@ -57,6 +57,14 @@ Money.assertSameCurrency( currencyA, currencyB );
 ```
 This method throws a `TypeError` if either of the provided arguments is not an instance of `Currency` and throws an `eejs.Exception` if the provided currencies are not equal.  The equivalence test is done via a shallow comparison of the properties on each currency.
 
+#### `Money.fromMoneyValue`
+
+```js
+const money = Money.fromMoneyValue( moneyValue, currency );
+```
+
+This constructs an instance of Money value object from a given string or numeric value as the first argument and a Currency value object as the second argument.
+
 ### _Properties_
 #### `Money.ROUND_UP`
 This is used for indicating rounding that should round to away from zero.


### PR DESCRIPTION
## Problem this Pull Request solves

There will be cases in apps where the value for a money value object will come from a form input and will thus be in a string format (and might have the currency sign on it).  The helper added in this pull  assists with converting that value to the value object.

Usage:

```js
import { SiteCurrency as Currency, Money } from '@eventespresso/value-objects';

const value = '$10.10';
const moneyValue = Money.fromMoneyValue( value, Currency );

// outputs 10.1
console.log( moneyValue.toNumber() );
```
## How has this been tested
* [x] Changes are covered by unit tests and this has no impact on existing released user interfaces.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
