### PR TITLE
add use-editor-date-entities hook and tests

### DIFF
--- a/assets/src/editor/events/hooks/test/use-editor-date-entities.js
+++ b/assets/src/editor/events/hooks/test/use-editor-date-entities.js
@@ -1,0 +1,64 @@
+import TestRenderer, { act } from 'react-test-renderer';
+import {
+	createRegistry,
+	RegistryProvider,
+} from '@wordpress/data';
+import { AuthedDateTimeEntity } from '@test/fixtures';
+
+import useEditorDateEntities from '../use-editor-date-entities';
+
+describe( 'useEditorDateEntities', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+	} );
+
+	const getTestComponent = () =>
+		( ( WrappedComponent ) => ( props ) => {
+			return <RegistryProvider value={ registry }>
+				<WrappedComponent { ...props } />
+			</RegistryProvider>;
+		} )(
+			() => {
+				const dateEntities = useEditorDateEntities();
+				return <div dateEntities={ dateEntities } />;
+			}
+		);
+
+	it( 'returns empty array if there are no date entities in the state', () => {
+		registry.registerStore( 'eventespresso/core', {
+			reducer: () => null,
+			selectors: {
+				getDatetimes: () => [],
+			},
+		} );
+		const TestComponent = getTestComponent();
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create( <TestComponent /> );
+		} );
+		const testInstance = renderer.root;
+		expect( testInstance.findByType( 'div' ).props.dateEntities )
+			.toEqual( [] );
+	} );
+	it( 'returns date entities available in the state', () => {
+		registry.registerStore( 'eventespresso/core', {
+			reducer: () => null,
+			selectors: {
+				getDatetimes: () => [ AuthedDateTimeEntity ],
+			},
+		} );
+		const TestComponent = getTestComponent();
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create(
+				<TestComponent eventEntity={ 'event' } />
+			);
+		} );
+		const testInstance = renderer.root;
+		const props = testInstance.findByType( 'div' ).props;
+		expect( props.dateEntities ).toEqual(
+			[ AuthedDateTimeEntity ]
+		);
+	} );
+} );

--- a/assets/src/editor/events/hooks/use-editor-date-entities.js
+++ b/assets/src/editor/events/hooks/use-editor-date-entities.js
@@ -1,3 +1,6 @@
+/**
+ * External imports
+ */
 import { useSelect } from '@wordpress/data';
 
 /**

--- a/assets/src/editor/events/hooks/use-editor-date-entities.js
+++ b/assets/src/editor/events/hooks/use-editor-date-entities.js
@@ -1,0 +1,9 @@
+import { useSelect } from '@wordpress/data';
+
+const useEditorDateEntities = () => {
+	return useSelect( ( select ) => {
+		return select( 'eventespresso/core' ).getDatetimes();
+	} );
+};
+
+export default useEditorDateEntities;

--- a/assets/src/editor/events/hooks/use-editor-date-entities.js
+++ b/assets/src/editor/events/hooks/use-editor-date-entities.js
@@ -1,5 +1,11 @@
 import { useSelect } from '@wordpress/data';
 
+/**
+ * A hook for retrieving all the date entities currently in the
+ * eventespresso/core data store.
+ *
+ * @return { BaseEntity[] } An array of Datetime entities.
+ */
 const useEditorDateEntities = () => {
 	return useSelect( ( select ) => {
 		return select( 'eventespresso/core' ).getDatetimes();


### PR DESCRIPTION
This pull adds a `useEditorDateEntities` hook as a relative of the `withEditorDateEntities` HOC.  Implementation is something like this:

```js
const MyComponentUsingDatetimes = () => {
    const datetimes = useEditorDateEntities();
    return <DateList dateEntities={ datetimes } />;
}
```

Unit tests have been added for the hook to verify behaviour.