### PR TITLE
EDTR: add useEditorDateTicketEntities custom react hook

### DIFF
--- a/assets/src/editor/events/hooks/test/use-editor-date-ticket-entities.js
+++ b/assets/src/editor/events/hooks/test/use-editor-date-ticket-entities.js
@@ -1,0 +1,67 @@
+import TestRenderer, { act } from 'react-test-renderer';
+import {
+	createRegistry,
+	RegistryProvider,
+} from '@wordpress/data';
+import { AuthedTicketEntity, AuthedDateTimeEntity } from '@test/fixtures';
+
+import useEditorDateTicketEntities from '../use-editor-date-ticket-entities';
+
+describe( 'useEditorDateTicketEntities', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+	} );
+
+	const getTestComponent = () =>
+		( ( WrappedComponent ) => ( props ) => {
+			return <RegistryProvider value={ registry }>
+				<WrappedComponent { ...props } />
+			</RegistryProvider>;
+		} )(
+			( props ) => {
+				const ticketEntities = useEditorDateTicketEntities( props.dateEntity );
+				return <div ticketEntities={ ticketEntities } />;
+			}
+		);
+
+	it( 'returns empty array if there is no date entity in the state and ' +
+		'throws a console error (warning)', () => {
+		registry.registerStore( 'eventespresso/core', {
+			reducer: () => null,
+			selectors: {
+				getRelatedEntities: () => [ AuthedTicketEntity ],
+			},
+		} );
+		const TestComponent = getTestComponent();
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create( <TestComponent /> );
+		} );
+		const testInstance = renderer.root;
+		expect( testInstance.findByType( 'div' ).props.ticketEntities )
+			.toEqual( [] );
+		expect( console ).toHaveErroredWith(
+			'Warning: The provided value is not a valid datetime entity.'
+		);
+	} );
+	it( 'returns the expected array of ticket entities for the given date ' +
+		'entity', () => {
+		registry.registerStore( 'eventespresso/core', {
+			reducer: () => null,
+			selectors: {
+				getRelatedEntities: () => [ AuthedTicketEntity ],
+			},
+		} );
+		const TestComponent = getTestComponent();
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create(
+				<TestComponent dateEntity={ AuthedDateTimeEntity } />
+			);
+		} );
+		const testInstance = renderer.root;
+		const props = testInstance.findByType( 'div' ).props;
+		expect( props.ticketEntities ).toEqual( [ AuthedTicketEntity ] );
+	} );
+} );

--- a/assets/src/editor/events/hooks/use-editor-date-ticket-entities.js
+++ b/assets/src/editor/events/hooks/use-editor-date-ticket-entities.js
@@ -1,0 +1,32 @@
+/**
+ * External imports.
+ */
+import { useSelect } from '@wordpress/data';
+import { isModelEntityOfModel } from '@eventespresso/validators';
+import warning from 'warning';
+
+const DEFAULT_ARRAY = [];
+
+/**
+ * A custom react hook for retrieving the related ticket entities for the given
+ * date entity from the eventespresso/core store state.
+ *
+ * @param {BaseEntity} dateEntity  A datetime BaseEntity instance.
+ *
+ * @return {BaseEntity[]} An array of tickets belonging to the given datetime.
+ */
+const useEditorDateTicketEntities = ( dateEntity ) => {
+	return useSelect( ( select ) => {
+		if ( ! isModelEntityOfModel( dateEntity, 'datetime' ) ) {
+			warning(
+				false,
+				'The provided value is not a valid datetime entity.'
+			);
+			return DEFAULT_ARRAY;
+		}
+		const { getRelatedEntities } = select( 'eventespresso/core' );
+		return getRelatedEntities( dateEntity, 'ticket' );
+	}, [ dateEntity ] );
+};
+
+export default useEditorDateTicketEntities;


### PR DESCRIPTION
## Problem this Pull Request solves

This adds the `useEditorDateTicketEntities` hook which is a sibling to the `withEditorDateTicketEntities` HOC.

### Usage:

```jsx
const MyCustomComponent = ( { dateEntity } ) => {
    const ticketEntities = useEditorDateTicketEntities( dateEntity );
    return <TicketEntityList ticketEntities={ ticketEntities } />;
}
```

## How has this been tested

Testing is covered by new unit tests added for the custom react hook.
