### PR TITLE
Add filter hook to allow filtering output of [ANSWER] shortcode

### DIFF
--- a/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
+++ b/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
@@ -85,7 +85,12 @@ class EE_Question_Shortcodes extends EE_Shortcodes
                         break;
 
                     default:
-                        $answer = $this->_data->get_pretty('ANS_value', 'no_wpautop');
+                        $answer = apply_filters(
+                            'FHEE__EE_Question_Shortcodes___parser__answer',
+                            $this->_data->get_pretty('ANS_value', 'no_wpautop'),
+                            $question,
+                            $this->_data
+                        );
                         break;
                 }
 

--- a/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
+++ b/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
@@ -27,11 +27,11 @@ class EE_Question_Shortcodes extends EE_Shortcodes
      */
     protected function _init_props()
     {
-        $this->label = __('Attendee Shortcodes', 'event_espresso');
-        $this->description = __('All shortcodes specific to attendee related data', 'event_espresso');
+        $this->label = esc_html__('Attendee Shortcodes', 'event_espresso');
+        $this->description = esc_html__('All shortcodes specific to attendee related data', 'event_espresso');
         $this->_shortcodes = array(
-            '[QUESTION]' => __('Will parse to a question.', 'event_espresso'),
-            '[ANSWER]'   => __('Will parse to the answer for a question', 'event_espresso'),
+            '[QUESTION]' => esc_html__('Will parse to a question.', 'event_espresso'),
+            '[ANSWER]'   => esc_html__('Will parse to the answer for a question', 'event_espresso'),
         );
     }
 

--- a/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
+++ b/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
@@ -85,12 +85,7 @@ class EE_Question_Shortcodes extends EE_Shortcodes
                         break;
 
                     default:
-                        $answer = apply_filters(
-                            'FHEE__EE_Question_Shortcodes___parser__answer',
-                            $this->_data->get_pretty('ANS_value', 'no_wpautop'),
-                            $question,
-                            $this->_data
-                        );
+                        $answer = $this->_data->get_pretty('ANS_value', 'no_wpautop');
                         break;
                 }
 

--- a/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
+++ b/caffeinated/core/libraries/shortcodes/EE_Question_Shortcodes.lib.php
@@ -89,7 +89,12 @@ class EE_Question_Shortcodes extends EE_Shortcodes
                         break;
                 }
 
-                return $answer;
+                return apply_filters(
+                    'FHEE__EE_Question_Shortcodes___parser__answer',
+                    $answer,
+                    $question,
+                    $this->_data
+                );
                 break;
         }
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

See forum topic:
https://eventespresso.com/topic/checkboxes-in-email-display-inline-instead-of-block/

## How has this been tested

- [ ] Set up a checkbox or multi select question type
- [ ] Register for the event and select multiple answers
- [ ] With the default Registration Approved message template active, check the email 
The answer output should be the same (comma separated & inline)

- [ ] Now add this filter function:
```
add_filter(
    'FHEE__EE_Question_Shortcodes___parser__answer',
    'the_example_function_for_testing',
    10, 
    3
);
function the_example_function_for_testing($answer, $question, $data) {
    if($question->get('QST_type') == 'CHECKBOX' || $question->get('QST_type') == 'MULTI_SELECT' ) {
            $answer = implode('<br>', $data->get('ANS_value'));
    }
    return $answer;
}
```
And resend the message, the answer output should have each selected answer on its own line.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
