### PR TITLE
Improve error message for preview/test-sends with no events available (fixes #1310)

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -2172,12 +2172,49 @@ class Messages_Admin_Page extends EE_Admin_Page
             $active_messenger_label,
             ucwords($message_types[ $this->_req_data['message_type'] ]->label['singular'])
         );
+        if ( empty( $preview ) ) {
+            $this->noEventsErrorMessage();
+        }
         // setup display of preview.
         $this->_admin_page_title = $preview_title;
+        $this->_template_args['admin_page_title'] = $preview_title;
         $this->_template_args['admin_page_content'] = $preview_button . '<br />' . $preview;
         $this->_template_args['data']['force_json'] = true;
 
         return '';
+    }
+
+
+    /**
+     * Used to set an error if there are no events available for generating a preview/test send.
+     *
+     * @param bool $test_send  Whether the error should be generated for the context of a test send.
+     */
+    protected function noEventsErrorMessage($test_send = false) {
+        $events_url = parent::add_query_args_and_nonce(
+            array(
+                'action' => 'default',
+                'page' => 'espresso_events',
+            ),
+            admin_url( 'admin.php' )
+        );
+        $message = $test_send
+            ? __(
+                'A test message could not be sent for this message template because there are no events created yet. The preview system uses actual events for generating the test message. %1$sGo see your events%2$s!',
+                'event_espresso'
+            )
+            : __(
+                'There is no preview for this message template available because there are no events created yet. The preview system uses actual events for generating the preview. %1$sGo see your events%2$s!',
+                'event_espresso'
+            );
+
+        EE_Error::add_attention(
+            sprintf(
+                $message,
+                "<a href='{$events_url}'>",
+                '</a>'
+            )
+        );
     }
 
 
@@ -2995,16 +3032,20 @@ class Messages_Admin_Page extends EE_Admin_Page
             $messenger,
             $message_type
         )) {
-            $success = $this->_preview_message(true);
-            if ($success) {
-                EE_Error::add_success(__('Test message sent', 'event_espresso'));
+            if ( EEM_Event::instance()->count() > 0 ) {
+                $success = $this->_preview_message(true);
+                if ($success) {
+                    EE_Error::add_success(__('Test message sent', 'event_espresso'));
+                } else {
+                    EE_Error::add_error(
+                        esc_html__('The test message was not sent', 'event_espresso'),
+                        __FILE__,
+                        __FUNCTION__,
+                        __LINE__
+                    );
+                }
             } else {
-                EE_Error::add_error(
-                    esc_html__('The test message was not sent', 'event_espresso'),
-                    __FILE__,
-                    __FUNCTION__,
-                    __LINE__
-                );
+                $this->noEventsErrorMessage(true);
             }
         }
     }

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -2172,7 +2172,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             $active_messenger_label,
             ucwords($message_types[ $this->_req_data['message_type'] ]->label['singular'])
         );
-        if ( empty( $preview ) ) {
+        if (empty($preview)) {
             $this->noEventsErrorMessage();
         }
         // setup display of preview.
@@ -2190,13 +2190,14 @@ class Messages_Admin_Page extends EE_Admin_Page
      *
      * @param bool $test_send  Whether the error should be generated for the context of a test send.
      */
-    protected function noEventsErrorMessage($test_send = false) {
+    protected function noEventsErrorMessage($test_send = false)
+    {
         $events_url = parent::add_query_args_and_nonce(
             array(
                 'action' => 'default',
-                'page' => 'espresso_events',
+                'page'   => 'espresso_events',
             ),
-            admin_url( 'admin.php' )
+            admin_url('admin.php')
         );
         $message = $test_send
             ? __(
@@ -3032,7 +3033,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             $messenger,
             $message_type
         )) {
-            if ( EEM_Event::instance()->count() > 0 ) {
+            if (EEM_Event::instance()->count() > 0) {
                 $success = $this->_preview_message(true);
                 if ($success) {
                     EE_Error::add_success(__('Test message sent', 'event_espresso'));


### PR DESCRIPTION
## Problem this Pull Request solves

See #1310 for details.  The changes in the pull result in this for the preview view:

![preview-screenshot](https://cl.ly/313ac7bc7560/Image%2525202019-07-18%252520at%25252011.04.06%252520AM.png)

And this for the test send (with no available events):

![test-send-screenshot](https://cl.ly/df8a5ff1d766/Image%2525202019-07-18%252520at%25252011.16.31%252520AM.png)

## How has this been tested

Create a fresh Event Espresso site and don't add any events.  Try previewing any message template or doing a test send.

* [x] Verify the error message displays.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
