### PR TITLE
BUG: Fix Fatal error on file edit screen when uxip notice present. (fixes #1298)

### DIFF
--- a/core/domain/services/pue/Stats.php
+++ b/core/domain/services/pue/Stats.php
@@ -5,6 +5,7 @@ namespace EventEspresso\core\domain\services\pue;
 use Closure;
 use EE_Admin_Page;
 use EE_Error;
+use EEH_URL;
 use EE_Maintenance_Mode;
 use EEH_Template;
 use EEM_Payment_Method;
@@ -145,7 +146,7 @@ class Stats
                 '</a>'
             );
         } else {
-            $settings_url = EE_Admin_Page::add_query_args_and_nonce(
+            $settings_url = EEH_URL::add_query_args_and_nonce(
                 array('action' => 'default'),
                 admin_url('admin.php?page=espresso_general_settings')
             );

--- a/core/domain/services/pue/Stats.php
+++ b/core/domain/services/pue/Stats.php
@@ -3,13 +3,9 @@
 namespace EventEspresso\core\domain\services\pue;
 
 use Closure;
-use EE_Admin_Page;
-use EE_Error;
 use EEH_URL;
 use EE_Maintenance_Mode;
 use EEH_Template;
-use EEM_Payment_Method;
-use Exception;
 
 /**
  * Stats


### PR DESCRIPTION
## Problem this Pull Request solves

See #1298 for details.  `EE_Admin_Page` is fragile to rely on it appears for the use-case here.  Since we also have a `EEH_URL` helper for generating urls and that is available more widely, I've switched to using it in this pull.

## How has this been tested

* [x] Using the steps Tony outlined in #1298, try reproducing the fatal,  you should not be able to reproduce.

**Note:**  I was unable to test this locally because loopback requests aren't working on my vvv instance and I haven't been able to resolve that yet.  So apologies for not verifying this fix works - it _will_ need tested by someone else.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
