### PR TITLE
Fet/credit card string changes

### DIFF
--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -53,8 +53,7 @@ class EE_PMT_Aim extends EE_PMT_Base
             'name'=>'AIM_Form',
             'subsections'=>array(
                 'credit_card'=>new EE_Credit_Card_Input(array(
-                    'required'=>true,
-                    'html_label_text' => __('Card Number', 'event_espresso')
+                    'required'=>true
                 )),
                 'exp_month'=>new EE_Credit_Card_Month_Input(true, array(
                     'required'=>true,

--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -65,7 +65,6 @@ class EE_PMT_Aim extends EE_PMT_Base
                 )),
                 'cvv'=>new EE_CVV_Input(array(
                     'required'=>true,
-                    'html_label_text' => __('CVV', 'event_espresso') )),
             )
         ));
         $billing_form->add_subsections(array(

--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -64,7 +64,8 @@ class EE_PMT_Aim extends EE_PMT_Base
                     'html_label_text' => __('Expiry Year', 'event_espresso')
                 )),
                 'cvv'=>new EE_CVV_Input(array(
-                    'required'=>true,
+                    'required'=>true
+                )),
             )
         ));
         $billing_form->add_subsections(array(

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -78,7 +78,7 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
                         array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Expiry Year', 'event_espresso')  )
                     ),
                     'cvv'=>new EE_CVV_Input(
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('CVV', 'event_espresso') )
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn' )
                     ),
                 )
             )

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -63,7 +63,7 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
             //              'html_id'=> 'ee-Paypal_Pro-billing-form',
                 'subsections'=>array(
                     'credit_card'=>new EE_Credit_Card_Input(
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Card Number', 'event_espresso'))
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn')
                     ),
                     'credit_card_type'=>new EE_Select_Input(
                         // the options are set dynamically

--- a/core/libraries/form_sections/inputs/EE_CVV_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_CVV_Input.input.php
@@ -39,11 +39,10 @@ class EE_CVV_Input extends EE_Text_Input
         ) {
             $this->_html_label_text = sprintf(
                 esc_html_x(
-                    '%1$s %2$s(What\'s this?)%3$s',
+                    'Card Security Code %1$s(What\'s this?)%2$s',
                     'CVV (What\'s this?)',
                     'event_espresso'
                 ),
-                $this->_html_label_text,
                 '<a href="https://www.cvvnumber.com/" target="_blank" rel="noopener noreferrer">',
                 '</a>'
             );

--- a/core/libraries/form_sections/inputs/EE_Credit_Card_Input.input.php
+++ b/core/libraries/form_sections/inputs/EE_Credit_Card_Input.input.php
@@ -21,5 +21,11 @@ class EE_Credit_Card_Input extends EE_Form_Input_Base
         $this->_add_validation_strategy(new EE_Credit_Card_Validation_Strategy(isset($input_settings['validation_error_message']) ? $input_settings['validation_error_message'] : null));
         $this->set_sensitive_data_removal_strategy(new EE_Credit_Card_Sensitive_Data_Removal());
         parent::__construct($input_settings);
+        // Don't allow the label text to be overridden. This is the text you want because it works for
+        // credit cards, debit cards, and bank cards.
+        $this->_html_label_text = esc_html__(
+            'Card Number',
+            'event_espresso'
+        );
     }
 }

--- a/core/libraries/form_sections/payment_methods/EE_Billing_Attendee_Info_Form.form.php
+++ b/core/libraries/form_sections/payment_methods/EE_Billing_Attendee_Info_Form.form.php
@@ -25,7 +25,7 @@ class EE_Billing_Attendee_Info_Form extends EE_Billing_Info_Form
             array(
                 'first_name'    => new EE_Text_Input(array( 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-fname', 'html_label_text' => __('First Name', 'event_espresso') )),
                 'last_name'     => new EE_Text_Input(array( 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-lname', 'html_label_text' => __('Last Name', 'event_espresso') )),
-                'email'             => new EE_Email_Input(array( 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-email', 'html_label_text' => __('Email', 'event_espresso') )),
+                'email'             => new EE_Email_Input(array( 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-email', 'html_label_text' => __('Email Address', 'event_espresso') )),
                 'address'           => new EE_Text_Input(array( 'html_label_text'=>  __('Address', 'event_espresso'), 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-address' )),
                 'address2'      => new EE_Text_Input(array( 'html_label_text'=> __('Address 2', 'event_espresso'), 'html_class' => 'ee-billing-qstn ee-billing-qstn-address2' )),
                 'city'                  => new EE_Text_Input(array( 'required'=>true, 'html_class' => 'ee-billing-qstn ee-billing-qstn-city', 'html_label_text' => __('City', 'event_espresso') )),

--- a/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EE_PMT_New_Payment_Method_Onsite.pm.php
+++ b/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EE_PMT_New_Payment_Method_Onsite.pm.php
@@ -74,7 +74,6 @@ class EE_PMT_New_Payment_Method_Onsite extends EE_PMT_Base{
 				) ),
 				'cvv'         => new EE_CVV_Input( array(
 					'required'        => false,
-					'html_label_text' => __( 'CVV', 'event_espresso' )
 				) ),
 			)
 		) );

--- a/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EE_PMT_New_Payment_Method_Onsite.pm.php
+++ b/tests/mocks/addons/new-payment-method/payment_methods/New_Payment_Method_Onsite/EE_PMT_New_Payment_Method_Onsite.pm.php
@@ -63,7 +63,6 @@ class EE_PMT_New_Payment_Method_Onsite extends EE_PMT_Base{
 				),
 				'credit_card' => new EE_Credit_Card_Input( array(
 					'required'        => false,
-					'html_label_text' => __( 'Credit Card', 'event_espresso' ),
 				) ),
 				'exp_month'   => new EE_Credit_Card_Month_Input( true, array(
 					'required'        => false,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Changes a few strings for label texts for billing inputs as [Lorenzo suggested](https://github.com/eventespresso/eea-stripe-gateway/pull/14#issuecomment-515713345). 
Specifically, 
* onsite billing forms' "Email" becomes "Email Address" (to match the registration form; btw it shouldn't break translations because that exact string is already in EE)
* `EE_Credit_Card_Input`s label text will now be "Card Number", so client code doesn't need to set it (or accidentally set it to something different from this standard; btw this also shouldn't break translations as, again, that exact string is already in-use)
* "CVV" becomes "Card Security Code" (this DOES break translations; so I'm not 100% certain it's worth breaking the translation for this change, but [Lorenzo thought so](https://github.com/eventespresso/eea-stripe-gateway/pull/14#issuecomment-516124369))

## Why do you think these changes are needed in Event Espresso core instead of being put in an add-on?
<!--  Additions to EE core should benefit 80% of its users, otherwise the work is probably best put in an add-on -->
Consistency lends itself to credibility, and so I think its best to default to always using the same input names where possible.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Just use a variety of billing forms from different gateways. Card numbers, email addresses, and card security codes' labels should use the correct label.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
