### PR TITLE
Add filter hooks to allow for changing the way prices are displayed on the attendee information step

### DIFF
--- a/core/libraries/line_item_display/EE_Default_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_Default_Line_Item_Display_Strategy.strategy.php
@@ -155,8 +155,8 @@ class EE_Default_Line_Item_Display_Strategy implements EEI_Line_Item_Display
         );
         if ($line_item->is_taxable()) {
             $ticket_price_includes_taxes = EE_Registry::instance()->CFG->tax_settings->prices_displayed_including_taxes
-                ? __('* price includes taxes', 'event_espresso')
-                : __('* price does not include taxes', 'event_espresso');
+                ? esc_html__('* price includes taxes', 'event_espresso')
+                : esc_html__('* price does not include taxes', 'event_espresso');
             $name_and_desc .= '<span class="smaller-text lt-grey-text" style="margin:0 0 0 2em;">'
                   . $ticket_price_includes_taxes
                   . '</span>';

--- a/core/libraries/line_item_display/EE_Default_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_Default_Line_Item_Display_Strategy.strategy.php
@@ -171,10 +171,20 @@ class EE_Default_Line_Item_Display_Strategy implements EEI_Line_Item_Display
             ? 1 + ( $this->_tax_rate / 100 )
             : 1;
         // price td
-        $unit_price = EEH_Template::format_currency($line_item->unit_price() * $tax_rate, false, false);
+        $unit_price = apply_filters(
+            'FHEE__EE_Default_Line_Item_Display_Strategy___item_row__unit_price',
+            EEH_Template::format_currency($line_item->unit_price() * $tax_rate, false, false),
+            $line_item,
+            $tax_rate
+        );
         $html .= EEH_HTML::td($unit_price, '', 'item_c jst-rght');
         // total td
-        $total = EEH_Template::format_currency($line_item->unit_price() * $line_item->quantity() * $tax_rate, false, false);
+        $total = apply_filters(
+            'FHEE__EE_Default_Line_Item_Display_Strategy___item_row__total',
+            EEH_Template::format_currency($line_item->unit_price() * $line_item->quantity() * $tax_rate, false, false),
+            $line_item,
+            $tax_rate
+        );
         $html .= EEH_HTML::td($total, '', 'item_r jst-rght');
         // end of row
         $html .= EEH_HTML::trx();


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Sometimes people do not want to include the surcharge in the attendee information's ticket table. These filter hooks allow for changing this.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Verify no change to the appearance of the attendee information step's ticket information table
- [ ] test one of the filter hooks with a code snippet like this
```
add_filter(
    'FHEE__EE_Default_Line_Item_Display_Strategy___item_row__unit_price',
    'my_change_ticket_row_price',
    10,
    3
);
function my_change_ticket_row_price($unit_price, $line_item, $tax_rate) {
    $unit_price = EEH_Template::format_currency(
        $line_item->ticket()->base_price()->amount(),
        false,
        false
    );
    return $unit_price;
}
```

- [ ] with the above code snippet activated, a ticket with a price modifier will display the unmodified (or base) price

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
