### PR TITLE
place execution of modify_current_screen() into the do_action() in `EE_Admin_Page_CPT`

### DIFF
--- a/core/admin/EE_Admin_Page_CPT.core.php
+++ b/core/admin/EE_Admin_Page_CPT.core.php
@@ -397,8 +397,8 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
         // This is for any plugins that are doing things properly
         // and hooking into the load page hook for core wp cpt routes.
         global $pagenow;
+        add_action('load-' . $pagenow, array($this, 'modify_current_screen'), 20);
         do_action('load-' . $pagenow);
-        $this->modify_current_screen();
         add_action('admin_enqueue_scripts', array($this, 'setup_autosave_hooks'), 30);
         // we route REALLY early.
         try {


### PR DESCRIPTION



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
The OceanWP theme has a companion plugin, [Ocean Extra](https://wordpress.org/plugins/ocean-extra/), that adds extra controls for customizing the display of individual posts/pages. Other post types can also make use of this if you add to their filter hook [documentation](https://docs.oceanwp.org/article/368-add-the-oceanwp-settings-metabox-in-your-custom-post-type)

However, even with the filter hook function in place the Event Espresso events post type did not load the OceanWP settings metabox. I tracked this down to where framework checks for the post type,
https://github.com/justintadlock/butterbean/blob/master/class-butterbean.php#L228
and found that at that point, the post_type property wasn't set for the current screen. It was getting set a bit later in the request. 

@tn3rb suggested in chat to attach the modify_current_screen() callback to the hook, which fixes the issue. 

### Testing notes

load up an event editor page in the admin, both for a new event and edit an existing event
- [x] event editor page should load as usual

also try the OceanWP + Ocean Extras plugin settings

- [x] add this to a functions file:
```
function oceanwp_metabox( $types ) {

    // Your custom post type
    $types[] = 'espresso_events';

    // Return
    return $types;

}
add_filter( 'ocean_main_metaboxes_post_types', 'oceanwp_metabox', 20 );
```
then load up the event editor and you'll be able to use the settings box that looks like this screenshot:
<img width="1038" alt="Screen Shot 2019-08-02 at 6 36 26 PM" src="https://user-images.githubusercontent.com/891156/62485705-74d58c00-b78b-11e9-9308-c6031eb4529a.png">




## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
