### PR TITLE
Run PHP 5.5 Travis builds on Ubuntu Trusty 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: required
 
 language: php
 
-matrix:
-  include:
-      - php: 5.5
-        dist: trusty
-
 services:
   - mysql
 
@@ -145,6 +140,7 @@ jobs:
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
     # wp 4.5 builds
     - php: 5.5
+      dist: trusty
       env: WP_VERSION=4.5
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: required
 
 language: php
 
+matrix:
+  include:
+      - php: 5.5
+        dist: trusty
+
 services:
   - mysql
 


### PR DESCRIPTION
## Problem this Pull Request solves

Unit tests for PHP 5.5 have been failing with the following error:

```
$ phpenv global 5.5 2>/dev/null
5.5 is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.5.tar.bz2
0.16s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
0.01s0.02s$ phpenv global 5.5
rbenv: version `5.5' not installed
The command "phpenv global 5.5" failed and exited with 1 during .

Your build has been stopped.
```

this pull updates our Travis.yml to run PHP 5.5 tests on the Ubuntu Trusty platform that comes with 5.5.9 installed.

No testing required other than a successful pass on Travis
