### PR TITLE
Remove github config from add-on boilerplate's info.json

### DIFF
--- a/tests/mocks/addons/eea-new-addon/info.json
+++ b/tests/mocks/addons/eea-new-addon/info.json
@@ -13,7 +13,6 @@
 		"src/circle.yml",
         "src/.travis.yml"
 	],
-	"github" : false,
 	"awsbucket" : "",
 	"awsregion" : ""
 }


### PR DESCRIPTION
If I recall correctly this is something that's no longer needed since migrating over to GitHub from Codebase. This was removed in add-ons e.g.
https://github.com/eventespresso/eea-mailchimp/commit/833977095f4147d783751824bdacc4ecf05353c4#diff-379da8ee275d0393f12cdff8542d368d
and
https://github.com/eventespresso/eea-attendee-mover/commit/d25093887f69bc7ceda3425d300b12385c7e53c2#diff-379da8ee275d0393f12cdff8542d368d

Removing from the boilerplate would also be good since as it stands now we need to remove this in every new add-on.
