### PR TITLE
make sure validation defaults are initialized when loading billing forms

### DIFF
--- a/modules/single_page_checkout/js/single_page_checkout.js
+++ b/modules/single_page_checkout/js/single_page_checkout.js
@@ -225,8 +225,6 @@ jQuery(document).ready( function($) {
 					if ( ! $(element ).hasClass('spco-next-step-btn') ) {
 						if ( $( element ).attr( 'value' ) ) {
 							$( element ).removeClass( 'ee-needs-value' ).addClass( 'ee-has-value' );
-						} else if ( $( element ).hasClass( 'ee-required' ) ) {
-							$( element ).removeClass( 'ee-needs-value' ).addClass( 'ee-needs-value' );
 						}
 					}
 				},

--- a/modules/single_page_checkout/js/single_page_checkout.js
+++ b/modules/single_page_checkout/js/single_page_checkout.js
@@ -223,7 +223,11 @@ jQuery(document).ready( function($) {
 
 				unhighlight: function( element ) {
 					if ( ! $(element ).hasClass('spco-next-step-btn') ) {
-						$(element).removeClass('ee-needs-value').addClass('ee-has-value');
+						if ( $( element ).attr( 'value' ) ) {
+							$( element ).removeClass( 'ee-needs-value' ).addClass( 'ee-has-value' );
+						} else if ( $( element ).hasClass( 'ee-required' ) ) {
+							$( element ).removeClass( 'ee-needs-value' ).addClass( 'ee-needs-value' );
+						}
 					}
 				},
 


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->


Discovered this while testing the new Stripe add-on. What was happening was all required fields on the billing form were highlighted with green, which shouldn't happen when the field is empty.
![Screen Shot 2019-08-15 at 3 58 03 PM](https://user-images.githubusercontent.com/891156/63123882-00af9b00-bf78-11e9-8cb3-bd86d6e4278c.png)

After a quick chat about this in Slack, @tn3rb came up with the solution in this PR.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Test SPCO reg form, there should be no change to the validation behavior.
then test a few onsite payment method forms, switching to and from other PMs. Blank required fields shouldn't initially be highlighted with green. They should be highlighted with green only when complete & pass validation.

![Screen Shot 2019-08-15 at 5 49 40 PM](https://user-images.githubusercontent.com/891156/63129684-33f92680-bf86-11e9-9728-2a11c4e48530.png)



## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
