### PR TITLE
FET/deprecate log functionality

### DIFF
--- a/admin_pages/general_settings/help_tabs/general_settings_admin_options.help_tab.php
+++ b/admin_pages/general_settings/help_tabs/general_settings_admin_options.help_tab.php
@@ -8,16 +8,6 @@
 </p>
 <ul>
 <li>
-<strong><?php esc_html_e('Enable Full Logging', 'event_espresso'); ?></strong><br />
-<?php esc_html_e('This option will save all Event Espresso registration form data, and debugging information to a file in the /wp-content/uploads/espresso/logs directory on your server. This will occur each time a page is accessed on your site until this option is turned off.', 'event_espresso'); ?>
-<br/>
-<?php printf(
-    esc_html__('Note that if you are accessing your filesystem over FTP or SSH, and logging writes to the filesystem on every request, you should put your credentials in your wp-config.php file, as described %1$shere.%2$s', 'event_espresso'),
-    '<a href="https://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants" target="_blank" rel="noopener noreferrer">',
-    '</a>'
-); ?>
-</li>
-<li>
 <strong><?php esc_html_e('Enable Remote Logging', 'event_espresso'); ?></strong><br />
 <?php esc_html_e('Every time a page is accessed on your site, this option will send all Event Espresso registration form data, your server details, and debugging information to a remote server.', 'event_espresso'); ?>
 </li>

--- a/admin_pages/general_settings/help_tours/Admin_Options_Help_Tour.class.php
+++ b/admin_pages/general_settings/help_tours/Admin_Options_Help_Tour.class.php
@@ -27,15 +27,6 @@ class Admin_Options_Help_Tour extends EE_Help_Tour
             10 => array(
                 'content' => $this->_start(),
             ),
-            20 => array(
-                'id'      => 'use_full_logging',
-                'content' => $this->_use_full_logging_stop(),
-                'options' => array(
-                    'tipLocation'    => 'right',
-                    'tipAdjustmentY' => -50,
-                    'tipAdjustmentX' => 15,
-                ),
-            ),
             30 => array(
                 'id'      => 'use_remote_logging',
                 'content' => $this->_use_remote_logging_stop(),
@@ -77,15 +68,6 @@ class Admin_Options_Help_Tour extends EE_Help_Tour
                         'event_espresso'
                     ) . '</p>';
         return $content;
-    }
-
-    protected function _use_full_logging_stop()
-    {
-        return '<p>'
-               . __(
-                   'When enabled, a log file is created which can be useful for debugging. Please disable this option when you are finished debugging.',
-                   'event_espresso'
-               ) . '</p>';
     }
 
     protected function _use_remote_logging_stop()

--- a/caffeinated/admin/extend/general_settings/Extend_General_Settings_Admin_Page.core.php
+++ b/caffeinated/admin/extend/general_settings/Extend_General_Settings_Admin_Page.core.php
@@ -53,7 +53,6 @@ class Extend_General_Settings_Admin_Page extends General_Settings_Admin_Page
      */
     public function debug_logging_options($template_args = array())
     {
-        $template_args['use_full_logging'] = EE_Registry::instance()->CFG->admin->use_full_logging;
         $template_args['use_remote_logging'] = isset(EE_Registry::instance()->CFG->admin->use_remote_logging) ? absint(
             EE_Registry::instance()->CFG->admin->use_remote_logging
         ) : false;
@@ -74,10 +73,6 @@ class Extend_General_Settings_Admin_Page extends General_Settings_Admin_Page
      */
     public function update_debug_logging_options($admin_options = array())
     {
-        $use_full_logging = isset($this->_req_data['use_full_logging']) ? (bool) absint(
-            $this->_req_data['use_full_logging']
-        ) : $admin_options->use_full_logging;
-        $admin_options->use_full_logging = $use_full_logging;
         $admin_options->use_remote_logging = isset($this->_req_data['use_remote_logging']) ? absint(
             $this->_req_data['use_remote_logging']
         ) : $admin_options->use_remote_logging;

--- a/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
+++ b/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
@@ -34,7 +34,7 @@
             <input name="remote_logging_url" id="remote_logging_url" size="20" class="regular-text" type="text"
                    value="<?php echo $remote_logging_url; ?>"/>
             <p class="description">
-                <?php _e('Example: http://requestb.in/MY_UNIQUE_ID', 'event_espresso'); ?>
+                <?php _e('Example: https://requestbin.com/MY_UNIQUE_ID', 'event_espresso'); ?>
 
             </p>
         </td>

--- a/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
+++ b/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
@@ -1,5 +1,4 @@
 <?php
-/** @var string $use_full_logging */
 /** @var string $use_remote_logging */
 /** @var string $remote_logging_url */
 ?>
@@ -9,33 +8,6 @@
 
 <table class="form-table">
     <tbody>
-
-    <tr>
-        <th>
-            <label for="use_full_logging">
-                <?php _e('Enable Full Logging', 'event_espresso'); ?>
-                <?php echo EEH_Template::get_help_tab_link('full_logging_info'); ?>
-            </label>
-        </th>
-        <td>
-            <?php echo EEH_Form_Fields::select_input('use_full_logging', $values, $use_full_logging); ?>
-            <p class="description">
-                    <span class="reminder-spn">
-                        <?php _e(
-                            'Please use caution when using this feature. These files may be publicly available.',
-                            'event_espresso'
-                        ); ?>
-                    </span><br/>
-                <?php echo sprintf(
-                    __('Once saved, this file will be available at: %s', 'event_espresso'),
-                    '<br /><b>/wp-content/uploads/espresso/logs/' . EE_Registry::instance()->CFG->admin->log_file_name(
-                    ) . '</b>'
-                ); ?>
-            </p>
-
-        </td>
-    </tr>
-
     <tr>
         <th>
             <label for="use_remote_logging">

--- a/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
+++ b/caffeinated/admin/extend/general_settings/templates/debug_log_settings.template.php
@@ -34,8 +34,7 @@
             <input name="remote_logging_url" id="remote_logging_url" size="20" class="regular-text" type="text"
                    value="<?php echo $remote_logging_url; ?>"/>
             <p class="description">
-                <?php _e('Example: https://requestbin.com/MY_UNIQUE_ID', 'event_espresso'); ?>
-
+                <?php _e('Example: https://your-webhook-url.com/', 'event_espresso'); ?>
             </p>
         </td>
     </tr>

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -2546,11 +2546,6 @@ class EE_Admin_Config extends EE_Config_Base
     public $use_event_timezones;
 
     /**
-     * @var boolean $use_full_logging
-     */
-    public $use_full_logging;
-
-    /**
      * @var string $log_file_name
      */
     public $log_file_name;
@@ -2610,7 +2605,6 @@ class EE_Admin_Config extends EE_Config_Base
         $this->use_dashboard_widget = true;
         $this->events_in_dashboard = 30;
         $this->use_event_timezones = false;
-        $this->use_full_logging = false;
         $this->use_remote_logging = false;
         $this->remote_logging_url = null;
         $this->show_reg_footer = apply_filters(

--- a/core/EE_Log.core.php
+++ b/core/EE_Log.core.php
@@ -79,7 +79,7 @@ class EE_Log
     public function verify_filesystem()
     {
         $msg = esc_html__(
-            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'The Local File Logging functionality was removed permanently. Remote Logging is recommended instead.',
             'event_espresso'
         );
         EE_Error::doing_it_wrong(
@@ -137,7 +137,7 @@ class EE_Log
     public function write_log()
     {
         $msg = esc_html__(
-            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'The Local File Logging functionality was removed permanently. Remote Logging is recommended instead.',
             'event_espresso'
         );
         EE_Error::doing_it_wrong(
@@ -191,7 +191,7 @@ class EE_Log
     public function write_debug()
     {
         $msg = esc_html__(
-            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'The Local File Logging functionality was removed permanently. Remote Logging is recommended instead.',
             'event_espresso'
         );
         EE_Error::doing_it_wrong(

--- a/core/EE_Log.core.php
+++ b/core/EE_Log.core.php
@@ -20,27 +20,7 @@ class EE_Log
     /**
      * @var string
      */
-    private $_logs_folder = '';
-
-    /**
-     * @var string
-     */
-    private $_log_file = '';
-
-    /**
-     * @var string
-     */
     private $_log = '';
-
-    /**
-     * @var string
-     */
-    private $_debug_file = '';
-
-    /**
-     * @var string
-     */
-    private $_debug_log = '';
 
     /**
      * Used for remote logging
@@ -78,26 +58,13 @@ class EE_Log
     private function __construct()
     {
 
-        if (! EE_Registry::instance()->CFG->admin->use_full_logging
-            && ! EE_Registry::instance()->CFG->admin->use_remote_logging) {
+        if (! EE_Registry::instance()->CFG->admin->use_remote_logging) {
             return;
         }
 
-        $this->_logs_folder = EVENT_ESPRESSO_UPLOAD_DIR . 'logs/';
-        $this->_log_file = EE_Registry::instance()->CFG->admin->log_file_name();
-        $this->_log = '';
-        $this->_debug_file = EE_Registry::instance()->CFG->admin->debug_file_name();
-        $this->_debug_log = '';
         $this->_remote_logging_url = EE_Registry::instance()->CFG->admin->remote_logging_url;
         $this->_remote_log = '';
 
-        add_action('admin_init', array($this, 'verify_filesystem'), -10);
-        add_action('AHEE_log', array($this, 'log'), 10, 4);
-        if (EE_Registry::instance()->CFG->admin->use_full_logging) {
-            add_action('shutdown', array($this, 'write_log'), 9999);
-            // if WP_DEBUG
-            add_action('shutdown', array($this, 'write_debug'), 9999);
-        }
         if (EE_Registry::instance()->CFG->admin->use_remote_logging) {
             add_action('shutdown', array($this, 'send_log'), 9999);
         }
@@ -111,22 +78,15 @@ class EE_Log
      */
     public function verify_filesystem()
     {
-        try {
-            EEH_File::ensure_file_exists_and_is_writable($this->_logs_folder . $this->_log_file);
-            EEH_File::ensure_file_exists_and_is_writable($this->_logs_folder . $this->_debug_file);
-            EEH_File::add_htaccess_deny_from_all($this->_logs_folder);
-        } catch (EE_Error $e) {
-            EE_Error::add_error(
-                sprintf(
-                    __('Event Espresso logging could not be setup because: %s', 'event_espresso'),
-                    ' &nbsp; &nbsp; ' . $e->getMessage()
-                ),
-                __FILE__,
-                __FUNCTION__,
-                __LINE__
-            );
-            return;
-        }
+        $msg = esc_html__(
+            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'event_espresso'
+        );
+        EE_Error::doing_it_wrong(
+            __METHOD__,
+            $msg,
+            '$VID:$'
+        );
     }
 
 
@@ -176,22 +136,15 @@ class EE_Log
      */
     public function write_log()
     {
-        try {
-            // get existing log file and append new log info
-            $this->_log = EEH_File::get_file_contents($this->_logs_folder . $this->_log_file) . $this->_log;
-            EEH_File::write_to_file($this->_logs_folder . $this->_log_file, $this->_log, 'Event Espresso Log');
-        } catch (EE_Error $e) {
-            EE_Error::add_error(
-                sprintf(
-                    __('Could not write to the Event Espresso log file because: %s', 'event_espresso'),
-                    ' &nbsp; &nbsp; ' . $e->getMessage()
-                ),
-                __FILE__,
-                __FUNCTION__,
-                __LINE__
-            );
-            return;
-        }
+        $msg = esc_html__(
+            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'event_espresso'
+        );
+        EE_Error::doing_it_wrong(
+            __METHOD__,
+            $msg,
+            '$VID:$'
+        );
     }
 
 
@@ -237,33 +190,15 @@ class EE_Log
      */
     public function write_debug()
     {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            $this->_debug_log = '';
-            foreach ($_GET as $key => $value) {
-                $this->_debug_log .= '$_GET["' . $key . '"] = "' . serialize($value) . '"' . PHP_EOL;
-            }
-            foreach ($_POST as $key => $value) {
-                $this->_debug_log .= '$_POST["' . $key . '"] = "' . serialize($value) . '"' . PHP_EOL;
-            }
-            try {
-                EEH_File::write_to_file(
-                    $this->_logs_folder . $this->_debug_file,
-                    $this->_debug_log,
-                    'Event Espresso Debug Log'
-                );
-            } catch (EE_Error $e) {
-                EE_Error::add_error(
-                    sprintf(
-                        __('Could not write to the Event Espresso debug log file because: %s', 'event_espresso'),
-                        ' &nbsp; &nbsp; ' . $e->getMessage()
-                    ),
-                    __FILE__,
-                    __FUNCTION__,
-                    __LINE__
-                );
-                return;
-            }
-        }
+        $msg = esc_html__(
+            'The Local File Logging functionality was removed permanentely. Remote Logging is recommended instead.',
+            'event_espresso'
+        );
+        EE_Error::doing_it_wrong(
+            __METHOD__,
+            $msg,
+            '$VID:$'
+        );
     }
 
 

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -854,6 +854,11 @@ final class EE_System implements ResettableInterface
         // load and setup EE_Config and EE_Network_Config
         $config = $this->loader->getShared('EE_Config');
         $this->loader->getShared('EE_Network_Config');
+        // setup autoloaders
+        // enable logging?
+        if ($config->admin->use_remote_logging) {
+            $this->loader->getShared('EE_Log');
+        }
         // check for activation errors
         $activation_errors = get_option('ee_plugin_activation_errors', false);
         if ($activation_errors) {

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -854,11 +854,6 @@ final class EE_System implements ResettableInterface
         // load and setup EE_Config and EE_Network_Config
         $config = $this->loader->getShared('EE_Config');
         $this->loader->getShared('EE_Network_Config');
-        // setup autoloaders
-        // enable logging?
-        if ($config->admin->use_full_logging) {
-            $this->loader->getShared('EE_Log');
-        }
         // check for activation errors
         $activation_errors = get_option('ee_plugin_activation_errors', false);
         if ($activation_errors) {

--- a/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_org_options.dmsstage.php
+++ b/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_org_options.dmsstage.php
@@ -256,9 +256,6 @@ class EE_DMS_4_1_0_org_options extends EE_Data_Migration_Script_Stage
             case 'use_event_timezones':
                 $c->admin->use_event_timezones = ($value == 'Y');
                 break;
-            case 'full_logging':
-                $c->admin->use_full_logging = ($value == 'Y');
-                break;
             case 'affiliate_id':
                 $c->admin->affiliate_id = $value;
                 break;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves

It removes local logging functionality to avoid issues with file size and others. Solves: https://github.com/eventespresso/event-espresso-core/issues/848

## How to Test
The option and related functionality was deleted, there's nothing left to test related to this. Only Remote Logging is enabled.

Public facing functions were deprecated with proper alerts.

To ensure this is working, when going to In Event Espresso > General Settings > Admin Options there's **NOT** a setting called "Enable Full Logging" anymore.

* [x] There was some potential for these changes to have introduced warnings during the 4.1 DMS. So it would be good to do a migration from EE3 to EE 4.1 (no need to go further) and verify no warnings or errors are produced

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
