### PR TITLE
add logic to prevent closing div where not needed, fixes #1553

### DIFF
--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -3064,7 +3064,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 );
                 $template_args['content'] =
                     EED_Ticket_Selector::instance()->display_ticket_selector($this->_reg_event);
-                $template_args['content'] .= '</div>';
+                // the ticket selector html needs a closing div tag here
+                // and the closing div tag should be added only if there is a ticket selector present
+                if (! $this->_reg_event->is_expired()) {
+                    $template_args['content'] .= '</div>';
+                }
                 $template_args['step_button_text'] = esc_html__(
                     'Add Tickets and Continue to Registrant Details',
                     'event_espresso'


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #1553 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [ ] Go to the registration list of an expired event, click the button to add a new registration. The page should display as expected
- [ ] Repeat the above for an upcoming event, the page should also display as expected.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
