### PR TITLE
Add venue filter to events

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1836,6 +1836,10 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 'EVT_short_desc' => array('LIKE', $search_string),
             );
         }
+        // filter events by venue.
+        if (isset($this->_req_data['venue']) && ! empty($this->_req_data['venue'])) {
+            $where['Venue.VNU_ID'] = absint($this->_req_data['venue']);
+        }
         $where = apply_filters('FHEE__Events_Admin_Page__get_events__where', $where, $this->_req_data);
         $query_params = apply_filters(
             'FHEE__Events_Admin_Page__get_events__query_params',
@@ -1865,6 +1869,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                     break;
             }
         }
+
         $events = $count ? $EEME->count(array($where), 'EVT_ID', true) : $EEME->get_all($query_params);
         return $events;
     }

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -967,6 +967,9 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
             $filters[] = $this->active_status_dropdown(
                 isset($this->_req_data['active_status']) ? $this->_req_data['active_status'] : ''
             );
+            $filters[] = $this->venuesDropdown(
+                isset($this->_req_data['venue']) ? $this->_req_data['venue'] : ''
+            );
         }
         // category filter
         $filters[] = $this->category_dropdown();
@@ -1013,6 +1016,31 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
             'inactive' => esc_html__('Inactive', 'event_espresso'),
         );
         $id = 'id="espresso-active-status-dropdown-filter"';
+        $class = 'wide';
+        return EEH_Form_Fields::select_input($select_name, $values, $current_value, $id, $class);
+    }
+
+    /**
+     * returns a list of "venues"
+     *
+     * @param  string $current_value whatever the current active status is
+     * @return string
+     */
+    protected function venuesDropdown($current_value = '')
+    {
+        $select_name = 'venue';
+        $values = array(
+            '' => esc_html__('All Venues', 'event_espresso'),
+        );
+        // populate the list of venues.
+        $vnumdl = EE_Registry::instance()->load_model('Venue');
+        $venues = $vnumdl->get_all(array('order_by' => array('VNU_name' => 'ASC')));
+
+        foreach ($venues as $venue) {
+            $values[ $venue->ID() ] = $venue->name();
+        }
+
+        $id = 'id="espresso-venues-dropdown-filter"';
         $class = 'wide';
         return EEH_Form_Fields::select_input($select_name, $values, $current_value, $id, $class);
     }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves https://github.com/eventespresso/event-espresso-core/issues/981 - adding a new Venue filter to Events archive.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Go to Events page at admin and now you might filter the events using the new Venues dropdown.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
