### PR TITLE
Doc/eejs dependency implied gutenberg dependency

### DIFF
--- a/docs/AA--Javascript-in-EE/eejs-core-dependency.md
+++ b/docs/AA--Javascript-in-EE/eejs-core-dependency.md
@@ -1,5 +1,14 @@
 ## The `eejs-core` dependency.
 
+> Update from Mike, September 11 2019:
+>
+> The information in this doc seems to be incorrect or out-of-date. 
+> 
+> I've used the build process successfully (on PayPal Smart Buttons and Stripe Elements) without depending on `eejs-core`. 
+> In fact, adding that dependency may be a bad idea because it doesn't work on WP 4.9 or lower unless the Gutenberg plugin is active.
+>
+> So if your code requires WP 5.0 or Gutenberg anyway, it's fine. Otherwise, avoid adding `eejs-core` as a dependency!   
+
 Every js bundle built using the event-espresso core [build process](build-process.md) _must_ declare as a dependency the `eejs-core` registered script (or indirectly through another dependency).  For example: say we have a built file that ends up as something like `ee-blocks-07a088b9a2f510393f8f.dist.js` after building.  It would need to be registered like so (see [Asset Caching by Filename](asset-caching-by-filename.md) for information about the `$assets_registry->getAssetUrl()` call made in this example):
 
 ```js

--- a/docs/AA--Javascript-in-EE/eejs-data-api.md
+++ b/docs/AA--Javascript-in-EE/eejs-data-api.md
@@ -1,5 +1,7 @@
 # The `eejs.data` Api.
 
+> Note: the eejs.data API [does not work with WP 4.9 and lower](eejs-core-dependency.md)
+
 One common problem encountered with WordPress development is transferring arbitrary data from php (the server) to javascript (client).  WordPress natively has [`wp_localize_script`](https://developer.wordpress.org/reference/functions/wp_localize_script/) to assist with that and it usually is sufficient.  However, one caveat with `wp_localize_script` is you need to define a reference to the js object that will hold that arbitrary data and attach it to the script needing it.  This creates some potential issues such as:
 
 - Greater chance of collisions between other scripts that register a data object named the same.


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Updates documentation to warn against depending on some stellar EE JS dependencies if the code needs to work with WP 4.9. I'm not 100% certain what I'm saying is correct so passing for review

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
no testing needed, it's just a change to docs.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
