### PR TITLE
Add propTypes and defaultProps to components

### DIFF
--- a/assets/src/components/ui/entity-list/index.js
+++ b/assets/src/components/ui/entity-list/index.js
@@ -4,6 +4,7 @@
 import { without } from 'lodash';
 import { __ } from '@eventespresso/i18n';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -64,6 +65,22 @@ const EntityList = ( {
 			{ ...otherProps }
 		/>
 	);
+};
+
+EntityList.propTypes = {
+	entities: PropTypes.array,
+	EntityGridView: PropTypes.elementType.isRequired,
+	EntityListView: PropTypes.elementType.isRequired,
+	htmlClass: PropTypes.string,
+	view: PropTypes.string,
+	noResultsText: PropTypes.string,
+};
+
+EntityList.defaultProps = {
+	entities: [],
+	htmlClass: '',
+	view: 'grid',
+	noResultsText: '',
 };
 
 export default withFormContainerAndPlaceholder( EntityList );

--- a/assets/src/components/ui/entity-list/index.js
+++ b/assets/src/components/ui/entity-list/index.js
@@ -33,8 +33,8 @@ const EntityList = ( {
 	EntityGridView,
 	EntityListView,
 	htmlClass,
-	view = 'grid',
-	noResultsText = '',
+	view,
+	noResultsText,
 	...otherProps
 } ) => {
 	// verify array and remove undefined

--- a/assets/src/components/ui/image/espresso-icon.js
+++ b/assets/src/components/ui/image/espresso-icon.js
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { Dashicon, Path, SVG } from '@wordpress/components';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 export const ESPRESSO_ICON_CALCULATOR = 'calculator';
 export const ESPRESSO_ICON_CALENDAR = 'calendar';
@@ -34,9 +35,9 @@ export const isEspressoIcon = ( icon ) => {
  * @param {number} size
  * @param {string} className
  */
-export class EspressoIcon extends Component {
+class EspressoIcon extends Component {
 	render() {
-		const { icon, size = 20, className, ...otherProps } = this.props;
+		const { icon, size, className, ...otherProps } = this.props;
 		let path;
 
 		switch ( icon ) {
@@ -161,3 +162,16 @@ export class EspressoIcon extends Component {
 		);
 	}
 }
+
+EspressoIcon.propTypes = {
+	icon: PropTypes.string.isRequired,
+	size: PropTypes.number,
+	className: PropTypes.string,
+};
+
+EspressoIcon.defaultProps = {
+	size: 20,
+	className: '',
+};
+
+export { EspressoIcon }; 

--- a/assets/src/components/ui/image/espresso-icon.js
+++ b/assets/src/components/ui/image/espresso-icon.js
@@ -174,4 +174,4 @@ EspressoIcon.defaultProps = {
 	className: '',
 };
 
-export { EspressoIcon }; 
+export default EspressoIcon; 

--- a/assets/src/components/ui/price-type-sign/price-type-sign.js
+++ b/assets/src/components/ui/price-type-sign/price-type-sign.js
@@ -1,5 +1,6 @@
 import { useMemo } from '@wordpress/element';
 import { isModelEntityOfModel } from '@eventespresso/validators';
+import PropTypes from 'prop-types';
 
 import CurrencySign from './currency-sign';
 import PercentSign from './percent-sign';
@@ -16,6 +17,10 @@ const PriceTypeSign = ( { priceType } ) => {
 		() => isPercent ? <PercentSign /> : <CurrencySign />,
 		[ isPercent ]
 	);
+};
+
+PriceTypeSign.propTypes = {
+	priceType: PropTypes.object.isRequired,
 };
 
 export default PriceTypeSign;

--- a/assets/src/components/ui/responsive-table/responsive-cell.js
+++ b/assets/src/components/ui/responsive-table/responsive-cell.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import { Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
 
 /**
  * @function
@@ -9,7 +10,7 @@ import { Fragment } from '@wordpress/element';
  * @param {string} value
  * @return {Object} rendered headings row
  */
-const ResponsiveCell = ( { heading = '', value = '' } ) => {
+const ResponsiveCell = ( { heading, value } ) => {
 	return (
 		<Fragment>
 			<div aria-hidden
@@ -22,6 +23,16 @@ const ResponsiveCell = ( { heading = '', value = '' } ) => {
 			</div>
 		</Fragment>
 	);
+};
+
+ResponsiveCell.propTypes = {
+	heading: PropTypes.string,
+	value: PropTypes.string,
+};
+
+ResponsiveCell.defaultProps = {
+	heading: '',
+	value: '',
 };
 
 export default ResponsiveCell;

--- a/assets/src/components/ui/responsive-table/table-body.js
+++ b/assets/src/components/ui/responsive-table/table-body.js
@@ -23,7 +23,7 @@ const TableBody = ( { children, htmlClass, ...extraProps } ) => {
 };
 
 TableBody.propTypes = {
-	children: PropTypes.element.isRequired,
+	children: PropTypes.node,
 	htmlClass: PropTypes.string,
 };
 

--- a/assets/src/components/ui/responsive-table/table-body.js
+++ b/assets/src/components/ui/responsive-table/table-body.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * @param {Array} children
@@ -19,6 +20,15 @@ const TableBody = ( { children, htmlClass, ...extraProps } ) => {
 			{ children }
 		</tbody>
 	);
+};
+
+TableBody.propTypes = {
+	children: PropTypes.element.isRequired,
+	htmlClass: PropTypes.string,
+};
+
+TableBody.defaultProps = {
+	htmlClass: '',
 };
 
 export default TableBody;

--- a/assets/src/components/ui/responsive-table/table-data-cell.js
+++ b/assets/src/components/ui/responsive-table/table-data-cell.js
@@ -41,7 +41,7 @@ const TableDataCell = ( {
 };
 
 TableDataCell.propTypes = {
-	children: PropTypes.element.isRequired,
+	children: PropTypes.node,
 	rowNumber: PropTypes.number.isRequired,
 	colNumber: PropTypes.number.isRequired,
 	htmlId: PropTypes.string,

--- a/assets/src/components/ui/responsive-table/table-data-cell.js
+++ b/assets/src/components/ui/responsive-table/table-data-cell.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * @param {mixed} children
@@ -18,9 +19,9 @@ const TableDataCell = ( {
 	children,
 	rowNumber,
 	colNumber,
-	htmlId = '',
-	htmlClass = '',
-	classes = {},
+	htmlId,
+	htmlClass,
+	classes,
 	...extraProps
 } ) => {
 	htmlId = htmlId ?
@@ -37,6 +38,21 @@ const TableDataCell = ( {
 			{ children }
 		</td>
 	);
+};
+
+TableDataCell.propTypes = {
+	children: PropTypes.element.isRequired,
+	rowNumber: PropTypes.number.isRequired,
+	colNumber: PropTypes.number.isRequired,
+	htmlId: PropTypes.string,
+	htmlClass: PropTypes.string,
+	classes: PropTypes.object,
+};
+
+TableDataCell.defaultProps = {
+	htmlId: '',
+	htmlClass: '',
+	classes: {},
 };
 
 export default TableDataCell;

--- a/assets/src/components/ui/responsive-table/table-footer.js
+++ b/assets/src/components/ui/responsive-table/table-footer.js
@@ -25,7 +25,7 @@ const TableFooter = ( { showFooter, children, htmlClass, ...extraProps } ) => {
 
 TableFooter.propTypes = {
 	showFooter: PropTypes.bool.isRequired,
-	children: PropTypes.element,
+	children: PropTypes.node,
 	htmlClass: PropTypes.string,
 };
 

--- a/assets/src/components/ui/responsive-table/table-footer.js
+++ b/assets/src/components/ui/responsive-table/table-footer.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * @param {boolean} showFooter
@@ -20,6 +21,16 @@ const TableFooter = ( { showFooter, children, htmlClass, ...extraProps } ) => {
 			{ children }
 		</tfoot>
 	) : null;
+};
+
+TableFooter.propTypes = {
+	showFooter: PropTypes.bool.isRequired,
+	children: PropTypes.element,
+	htmlClass: PropTypes.string,
+};
+
+TableFooter.defaultProps = {
+	htmlClass: '',
 };
 
 export default TableFooter;

--- a/assets/src/components/ui/responsive-table/table-header.js
+++ b/assets/src/components/ui/responsive-table/table-header.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * @param {Array} children
@@ -20,5 +21,15 @@ const TableHeader = ( { children, htmlClass, ...extraProps } ) => {
 		</thead>
 	);
 };
+
+TableHeader.propTypes = {
+	children: PropTypes.element,
+	htmlClass: PropTypes.string,
+};
+
+TableHeader.defaultProps = {
+	htmlClass: '',
+};
+
 
 export default TableHeader;

--- a/assets/src/components/ui/responsive-table/table-header.js
+++ b/assets/src/components/ui/responsive-table/table-header.js
@@ -23,7 +23,7 @@ const TableHeader = ( { children, htmlClass, ...extraProps } ) => {
 };
 
 TableHeader.propTypes = {
-	children: PropTypes.element,
+	children: PropTypes.node,
 	htmlClass: PropTypes.string,
 };
 

--- a/assets/src/components/ui/responsive-table/table-heading-cell.js
+++ b/assets/src/components/ui/responsive-table/table-heading-cell.js
@@ -48,7 +48,7 @@ const TableHeadingCell = ( {
 };
 
 TableHeadingCell.propTypes = {
-	children: PropTypes.element.isRequired,
+	children: PropTypes.node,
 	rowNumber: PropTypes.number.isRequired,
 	colNumber: PropTypes.number.isRequired,
 	rowType: PropTypes.string,

--- a/assets/src/components/ui/responsive-table/table-heading-cell.js
+++ b/assets/src/components/ui/responsive-table/table-heading-cell.js
@@ -1,4 +1,9 @@
 /**
+ * External imports
+ */
+import PropTypes from 'prop-types';
+
+/**
  * @param {mixed} children
  * @param {number} rowNumber
  * @param {number} colNumber
@@ -14,9 +19,9 @@ const TableHeadingCell = ( {
 	rowNumber,
 	colNumber,
 	rowType,
-	htmlId = '',
-	htmlClass = '',
-	classes = {},
+	htmlId,
+	htmlClass,
+	classes,
 	...extraProps
 } ) => {
 	htmlId = htmlId ?
@@ -40,6 +45,23 @@ const TableHeadingCell = ( {
 			{ children }
 		</th>
 	);
+};
+
+TableHeadingCell.propTypes = {
+	children: PropTypes.element.isRequired,
+	rowNumber: PropTypes.number.isRequired,
+	colNumber: PropTypes.number.isRequired,
+	rowType: PropTypes.string,
+	htmlId: PropTypes.string,
+	htmlClass: PropTypes.string,
+	classes: PropTypes.object,
+};
+
+TableHeadingCell.defaultProps = {
+	rowType: 'body',
+	htmlId: '',
+	htmlClass: '',
+	classes: {},
 };
 
 export default TableHeadingCell;

--- a/assets/src/components/ui/responsive-table/table-row.js
+++ b/assets/src/components/ui/responsive-table/table-row.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * @param {Array} children
@@ -17,10 +18,10 @@ import classNames from 'classnames';
 const TableRow = ( {
 	children,
 	rowNumber,
-	htmlId = '',
-	htmlClass = '',
-	classes = {},
-	rowType = 'body',
+	htmlId,
+	htmlClass,
+	classes,
+	rowType,
 	...extraProps
 } ) => {
 	htmlId = htmlId ?
@@ -37,6 +38,22 @@ const TableRow = ( {
 			{ children }
 		</tr>
 	);
+};
+
+TableRow.propTypes = {
+	children: PropTypes.element.isRequired,
+	rowNumber: PropTypes.number.isRequired,
+	rowType: PropTypes.string,
+	htmlId: PropTypes.string,
+	htmlClass: PropTypes.string,
+	classes: PropTypes.object,
+};
+
+TableRow.defaultProps = {
+	rowType: 'body',
+	htmlId: '',
+	htmlClass: '',
+	classes: {},
 };
 
 export default TableRow;

--- a/assets/src/components/ui/responsive-table/table-row.js
+++ b/assets/src/components/ui/responsive-table/table-row.js
@@ -41,7 +41,7 @@ const TableRow = ( {
 };
 
 TableRow.propTypes = {
-	children: PropTypes.element.isRequired,
+	children: PropTypes.node,
 	rowNumber: PropTypes.number.isRequired,
 	rowType: PropTypes.string,
 	htmlId: PropTypes.string,

--- a/assets/src/components/ui/responsive-table/table.js
+++ b/assets/src/components/ui/responsive-table/table.js
@@ -1,4 +1,9 @@
 /**
+ * External imports
+ */
+import PropTypes from 'prop-types';
+
+/**
  * @param {Array} children
  * @param {string} tableId
  * @param {string} tableClass
@@ -37,6 +42,21 @@ const Table = ( {
 			</table>
 		</div>
 	);
+};
+
+Table.propTypes = {
+	children: PropTypes.element.isRequired,
+	tableId: PropTypes.string,
+	tableClass: PropTypes.string,
+	captionID: PropTypes.string,
+	captionText: PropTypes.string,
+};
+
+Table.defaultProps = {
+	tableId: '',
+	tableClass: '',
+	captionID: '',
+	captionText: '',
 };
 
 export default Table;

--- a/assets/src/components/ui/responsive-table/table.js
+++ b/assets/src/components/ui/responsive-table/table.js
@@ -45,7 +45,7 @@ const Table = ( {
 };
 
 Table.propTypes = {
-	children: PropTypes.element.isRequired,
+	children: PropTypes.node,
 	tableId: PropTypes.string,
 	tableClass: PropTypes.string,
 	captionID: PropTypes.string,

--- a/assets/src/editor/events/dates-and-times/editor-date/actions-menu/editor-date-entity-actions-menu.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/actions-menu/editor-date-entity-actions-menu.js
@@ -4,6 +4,7 @@
 import { useEffect } from '@wordpress/element';
 import { useEntityActionMenuItems } from '@eventespresso/components';
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -69,6 +70,10 @@ const EditorDateEntityActionsMenu = ( { dateEntity } ) => {
 			/>
 		</>
 	);
+};
+
+EditorDateEntityActionsMenu.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidDateEntity( EditorDateEntityActionsMenu );

--- a/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/assign-tickets-menu-item.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/assign-tickets-menu-item.js
@@ -8,6 +8,7 @@ import {
 	useEventEditorTickets,
 } from '@eventespresso/hooks';
 import { __, _x, sprintf } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal imports
@@ -70,6 +71,10 @@ const AssignTicketsMenuItem = ( { dateEntity } ) => {
 			/>
 		</>
 	);
+};
+
+AssignTicketsMenuItem.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidDateEntity( AssignTicketsMenuItem );

--- a/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/date-entity-main-menu-item.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/date-entity-main-menu-item.js
@@ -8,6 +8,7 @@ import {
 	useTrashDateEntity,
 } from '@eventespresso/hooks';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 import useEventDateEditorId from '../../edit-form/use-event-date-editor-id';
 
@@ -35,6 +36,10 @@ const DateEntityMainMenuItem = ( { dateEntity } ) => {
 			] }
 		/>
 	);
+};
+
+DateEntityMainMenuItem.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidDateEntity( DateEntityMainMenuItem );

--- a/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/edit-date-details-menu-item.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/actions-menu/menu-items/edit-date-details-menu-item.js
@@ -4,6 +4,7 @@
 import { IconMenuItem } from '@eventespresso/components';
 import { ifValidDateEntity, useOpenEditor } from '@eventespresso/editor-hocs';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -22,6 +23,10 @@ const EditDateDetailsMenuItem = ( { dateEntity } ) => {
 			onClick={ useOpenEditor( editorId ) }
 		/>
 	);
+};
+
+EditDateDetailsMenuItem.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidDateEntity( EditDateDetailsMenuItem );

--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/date-entity-form-modal.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/date-entity-form-modal.js
@@ -4,6 +4,7 @@
 import { FormHandler } from '@eventespresso/components';
 import { EditorModal, ifValidDateEntity } from '@eventespresso/editor-hocs';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -48,6 +49,12 @@ const DateEntityFormModal = ( {
 			/>
 		</EditorModal>
 	);
+};
+
+DateEntityFormModal.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
+	onEditorOpen: PropTypes.func.isRequired,
+	onEditorClose: PropTypes.func.isRequired,
 };
 
 export default ifValidDateEntity( DateEntityFormModal );

--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/date-entity-form.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/date-entity-form.js
@@ -4,6 +4,7 @@
 import { isEmpty } from 'lodash';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -27,8 +28,8 @@ const {
  */
 const DateEntityForm = ( {
 	dateEntity,
-	currentValues = {},
-	initialValues = {},
+	currentValues,
+	initialValues,
 } ) => {
 	const prefix = useDateEntityFormInputPrefix( dateEntity );
 	const inputConfig = useDateEntityInputConfig( dateEntity );
@@ -59,6 +60,17 @@ const DateEntityForm = ( {
 			/>
 		</FormWrapper>
 	) : null;
+};
+
+DateEntityForm.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
+	currentValues: PropTypes.object,
+	initialValues: PropTypes.object,
+};
+
+DateEntityForm.defaultProps = {
+	currentValues: {},
+	initialValues: {},
 };
 
 export default ifValidDateEntity( DateEntityForm );

--- a/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
@@ -55,7 +55,7 @@ const EventDateRegistrationsLink = ( { dateEntity } ) => {
 };
 
 EventDateRegistrationsLink.propTypes = {
-	dateEntity: PropTypes.string.isRequired,
+	dateEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidDateEntity( EventDateRegistrationsLink );

--- a/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
 import { routes } from '@eventespresso/eejs';
 import { __ } from '@eventespresso/i18n';
+InlineEditEventDateName
 
 const { ADMIN_ROUTES, ADMIN_ROUTE_ACTION_DEFAULT, getAdminUrl } = routes;
 
@@ -51,6 +52,10 @@ const EventDateRegistrationsLink = ( { dateEntity } ) => {
 		},
 		[ dateEntity.evtId, dateEntity.id ]
 	);
+};
+
+EventDateRegistrationsLink.propTypes = {
+	dateEntity: PropTypes.string.isRequired,
 };
 
 export default ifValidDateEntity( EventDateRegistrationsLink );

--- a/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/event-date-registrations-link.js
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
 import { routes } from '@eventespresso/eejs';
 import { __ } from '@eventespresso/i18n';
-InlineEditEventDateName
+import PropTypes from 'prop-types';
 
 const { ADMIN_ROUTES, ADMIN_ROUTE_ACTION_DEFAULT, getAdminUrl } = routes;
 

--- a/assets/src/editor/events/dates-and-times/editor-date/event-date-venue-edit-link.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/event-date-venue-edit-link.js
@@ -8,6 +8,7 @@ import { routes } from '@eventespresso/eejs';
 import { __ } from '@eventespresso/i18n';
 import { useEventForEventDate, useEventVenue } from '@eventespresso/hooks';
 import { isModelEntityOfModel } from '@eventespresso/validators';
+import PropTypes from 'prop-types';
 
 const { ADMIN_ROUTES, ADMIN_ROUTE_ACTIONS, getAdminUrl } = routes;
 
@@ -71,6 +72,16 @@ const EventDateVenueEditLink = ( { eventDate, showVenue, wrapperElement } ) => {
 		},
 		[ venueId, venueName, showVenue, wrapperElement ]
 	);
+};
+
+EventDateVenueEditLink.propTypes = {
+	eventDate: PropTypes.string.isRequired,
+	showVenue: PropTypes.bool,
+	wrapperElement: PropTypes.string,
+};
+
+EventDateVenueEditLink.propTypes = {
+	showVenue: false,
 };
 
 export default EventDateVenueEditLink;

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entities-grid-view.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entities-grid-view.js
@@ -3,6 +3,7 @@
  */
 import { isModelEntityOfModel } from '@eventespresso/validators';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -46,6 +47,16 @@ const EditorDateEntitiesGridView = ( {
 			}
 		</div>
 	);
+};
+
+EditorDateEntitiesGridView.propTypes = {
+	entities: PropTypes.array.isRequired,
+	htmlClass: PropTypes.string,
+};
+
+EditorDateEntitiesGridView.defaultProps = {
+	entities: [],
+	htmlClass: '',
 };
 
 export default EditorDateEntitiesGridView;

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entity-details.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entity-details.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -13,8 +14,8 @@ import EventDateVenueEditLink from '../event-date-venue-edit-link';
 
 const EditorDateEntityDetails = ( {
 	dateEntity,
-	showDesc = 'excerpt',
-	showVenue = true,
+	showDesc,
+	showVenue,
 } ) => {
 	return (
 		<div className={ 'ee-editor-date-details-wrapper-div' }>
@@ -30,6 +31,17 @@ const EditorDateEntityDetails = ( {
 			<EventDateDetailsPanel eventDate={ dateEntity } />
 		</div>
 	);
+};
+
+EditorDateEntityDetails.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
+	showDesc: PropTypes.string,
+	showVenue: PropTypes.bool,
+};
+
+EditorDateEntityDetails.defaultProps = {
+	showDesc: 'excerpt',
+	showVenue: true,
 };
 
 export default ifValidDateEntity( EditorDateEntityDetails );

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entity-grid-item.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/editor-date-entity-grid-item.js
@@ -4,6 +4,7 @@
 import classNames from 'classnames';
 import { EntityPaperFrame } from '@eventespresso/components';
 import { ifValidDateEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -28,9 +29,9 @@ import EditorDateEntityActionsMenu
 const EditorDateEntityGridItem = ( {
 	dateEntity,
 	eventEntity,
-	showDate = 'start',
-	showDesc = 'excerpt',
-	showVenue = true,
+	showDate,
+	showDesc,
+	showVenue,
 } ) => {
 	const dateStyleClass = classNames(
 		'ee-editor-date-main',
@@ -59,6 +60,20 @@ const EditorDateEntityGridItem = ( {
 			/>
 		</EntityPaperFrame>
 	);
+};
+
+EditorDateEntityGridItem.propTypes = {
+	dateEntity: PropTypes.object.isRequired,
+	eventEntity: PropTypes.object.isRequired,
+	showDate: PropTypes.string,
+	showDesc: PropTypes.string,
+	showVenue: PropTypes.bool,
+};
+
+EditorDateEntityGridItem.defaultProps = {
+	showDate: 'start',
+	showDesc: 'excerpt',
+	showVenue: true,
 };
 
 export default ifValidDateEntity( EditorDateEntityGridItem );

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-calendar-date.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-calendar-date.js
@@ -8,6 +8,7 @@ import {
 	CalendarDateRange,
 } from '@eventespresso/components';
 import { dateTimeModel } from '@eventespresso/model';
+import PropTypes from 'prop-types';
 
 const { getBackgroundColorClass, getDateTimeStatusTextLabel } = dateTimeModel;
 
@@ -61,5 +62,14 @@ const EventDateCalendarDate = ( { eventDate, showDate } ) => useMemo( () => {
 	eventDate.sold,
 	eventDate.deleted,
 ] );
+
+EventDateCalendarDate.propTypes = {
+	eventDate: PropTypes.object.isRequired,
+	showDate: PropTypes.string,
+};
+
+EventDateCalendarDate.defaultProps = {
+	showDate: '',
+};
 
 export default EventDateCalendarDate;

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
@@ -6,6 +6,7 @@ import { EntityDetailsPanel } from '@eventespresso/components';
 import { parseInfinity } from '@eventespresso/utils';
 import { __ } from '@eventespresso/i18n';
 import { InfinitySymbol } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -61,5 +62,9 @@ const EventDateDetailsPanel = ( { eventDate } ) => useMemo(
 		eventDate.regLimit,
 	]
 );
+
+EventDateDetailsPanel.propTypes = {
+	eventDate: PropTypes.object.isRequired,
+};
 
 export default EventDateDetailsPanel;

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/inline-edit-event-date-description.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/inline-edit-event-date-description.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { useMemo } from '@wordpress/element';
 import { InlineEditInput } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 const InlineEditEventDateDescription = ( {
 	eventDate,
@@ -34,5 +35,15 @@ const InlineEditEventDateDescription = ( {
 	},
 	[ eventDate.id, eventDate.description, showDesc, wrapperElement ]
 );
+
+InlineEditEventDateDescription.propTypes = {
+	eventDate: PropTypes.object.isRequired,
+	showDesc: PropTypes.string,
+	wrapperElement: PropTypes.string,
+};
+
+InlineEditEventDateDescription.defaultProps = {
+	showDesc: 'excerpt',
+};
 
 export default InlineEditEventDateDescription;

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/inline-edit-event-date-name.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/inline-edit-event-date-name.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { useMemo } from '@wordpress/element';
 import { InlineEditInput } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 const InlineEditEventDateName = ( { eventDate, wrapperElement } ) => useMemo(
 	() => {
@@ -35,5 +36,10 @@ const InlineEditEventDateName = ( { eventDate, wrapperElement } ) => useMemo(
 	},
 	[ eventDate.id, eventDate.name ]
 );
+
+InlineEditEventDateName.propTypes = {
+	eventDate: PropTypes.object.isRequired,
+	wrapperElement: PropTypes.string,
+};
 
 export default InlineEditEventDateName;

--- a/assets/src/editor/events/dates-and-times/editor-date/list-view/editor-date-entities-list-view.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/list-view/editor-date-entities-list-view.js
@@ -12,6 +12,7 @@ import {
 import { dateTimeModel } from '@eventespresso/model';
 import { isModelEntityOfModel } from '@eventespresso/validators';
 import { InfinitySymbol } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -105,6 +106,19 @@ const EditorDateEntitiesListView = ( {
 			classes={ { tableClass: htmlClass } }
 		/>
 	);
+};
+
+EditorDateEntitiesListView.propTypes = {
+	entities: PropTypes.array.isRequired,
+	showDate: PropTypes.string,
+	htmlClass: PropTypes.string,
+	doRefresh: PropTypes.func,
+};
+
+EditorDateEntitiesListView.defaultProps = {
+	entities: [],
+	showDate: '',
+	htmlClass: '',
 };
 
 export default EditorDateEntitiesListView;

--- a/assets/src/editor/events/ticket-assignments-manager/ticket-assignments-form-error-info.js
+++ b/assets/src/editor/events/ticket-assignments-manager/ticket-assignments-form-error-info.js
@@ -3,6 +3,7 @@
  */
 import { useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 const { FormInfo } = twoColumnAdminFormLayout;
 
@@ -17,9 +18,9 @@ const { FormInfo } = twoColumnAdminFormLayout;
  */
 const TicketAssignmentsFormErrorInfo = ( {
 	errorMessage,
-	dismissable = true,
-	colSize = 10,
-	offset = 1,
+	dismissable,
+	colSize,
+	offset,
 } ) => {
 	return useMemo( () => {
 		return errorMessage ?
@@ -31,6 +32,19 @@ const TicketAssignmentsFormErrorInfo = ( {
 				offset={ offset }
 			/> : null;
 	}, [ errorMessage, dismissable, colSize, offset ] );
+};
+
+TicketAssignmentsFormErrorInfo.propTypes = {
+	errorMessage: PropTypes.string,
+	dismissable: PropTypes.bool,
+	colSize: PropTypes.number,
+	offset: PropTypes.number,
+};
+
+TicketAssignmentsFormErrorInfo.defaultProps = {
+	dismissable: true,
+	colSize: 10,
+	offset: 1,
 };
 
 export default TicketAssignmentsFormErrorInfo;

--- a/assets/src/editor/events/tickets/editor-ticket/actions-menu/editor-ticket-actions-menu.js
+++ b/assets/src/editor/events/tickets/editor-ticket/actions-menu/editor-ticket-actions-menu.js
@@ -4,6 +4,7 @@
 import { useEffect } from '@wordpress/element';
 import { useEntityActionMenuItems } from '@eventespresso/components';
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -20,7 +21,6 @@ import TicketPriceCalculatorMenuItem
 
 const EditorTicketActionsMenu = ( {
 	ticketEntity,
-	toggleTicketAssignments,
 } ) => {
 	const {
 		getActionsMenuForEntity,
@@ -57,7 +57,6 @@ const EditorTicketActionsMenu = ( {
 					<AssignDatesMenuItem
 						key={ `assign-dates-${ ticketEntity.id }` }
 						ticketEntity={ ticketEntity }
-						toggleTicketAssignments={ toggleTicketAssignments }
 					/>
 				),
 			);
@@ -81,6 +80,10 @@ const EditorTicketActionsMenu = ( {
 			<EditTicketFormModal ticketEntity={ ticketEntity } />
 		</>
 	);
+};
+
+EditorTicketActionsMenu.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( EditorTicketActionsMenu );

--- a/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/assign-dates-menu-item.js
+++ b/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/assign-dates-menu-item.js
@@ -9,6 +9,7 @@ import {
 } from '@eventespresso/hooks';
 
 import { __, _x, sprintf } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -64,6 +65,10 @@ const AssignDatesMenuItem = ( { ticketEntity } ) => {
 			/>
 		</>
 	);
+};
+
+AssignDatesMenuItem.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( AssignDatesMenuItem );

--- a/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/edit-ticket-details-menu-item.js
+++ b/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/edit-ticket-details-menu-item.js
@@ -4,6 +4,7 @@
 import { IconMenuItem } from '@eventespresso/components';
 import { ifValidTicketEntity, useOpenEditor } from '@eventespresso/editor-hocs';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -22,6 +23,10 @@ const EditTicketDetailsMenuItem = ( { ticketEntity } ) => {
 			onClick={ useOpenEditor( useTicketEditorId( ticketEntity ) ) }
 		/>
 	);
+};
+
+EditTicketDetailsMenuItem.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( EditTicketDetailsMenuItem );

--- a/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/ticket-entity-main-menu-item.js
+++ b/assets/src/editor/events/tickets/editor-ticket/actions-menu/menu-items/ticket-entity-main-menu-item.js
@@ -10,6 +10,7 @@ import {
 } from '@eventespresso/hooks';
 
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -43,6 +44,10 @@ const TicketEntityMainMenuItem = ( { ticketEntity } ) => {
 			] }
 		/>
 	);
+};
+
+TicketEntityMainMenuItem.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( TicketEntityMainMenuItem );

--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form-modal.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form-modal.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { FormHandler } from '@eventespresso/components';
 import { EditorModal, ifValidTicketEntity } from '@eventespresso/editor-hocs';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -50,6 +51,10 @@ const EditTicketFormModal = ( {
 		formData,
 		otherProps,
 	] );
+};
+
+EditTicketFormModal.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( EditTicketFormModal );

--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash';
 import { useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -25,9 +26,9 @@ const EditTicketForm = ( {
 	ticketEntity,
 	submitButton,
 	cancelButton,
-	currentValues = {},
-	initialValues = {},
-	newObject = false,
+	currentValues,
+	initialValues,
+	newObject,
 } ) => {
 	const formDataKeyPrefix = useTicketFormInputPrefix( ticketEntity );
 	const inputConfig = useTicketFormInputConfig( ticketEntity );
@@ -76,6 +77,21 @@ const EditTicketForm = ( {
 			cancelButton,
 		]
 	);
+};
+
+EditTicketForm.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
+	submitButton: PropTypes.element.isRequired,
+	cancelButton: PropTypes.element.isRequired,
+	currentValues: PropTypes.object,
+	initialValues: PropTypes.object,
+	newObject: PropTypes.bool,
+};
+
+EditTicketForm.defaultProps = {
+	currentValues: {},
+	initialValues: {},
+	newObject: false,
 };
 
 /**

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entities-grid-view.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entities-grid-view.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import { isModelEntityOfModel } from '@eventespresso/validators';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -45,6 +46,16 @@ const EditorTicketEntitiesGridView = ( {
 			}
 		</div>
 	);
+};
+
+EditorTicketEntitiesGridView.propTypes = {
+	entities: PropTypes.array.isRequired,
+	htmlClass: PropTypes.string,
+};
+
+EditorTicketEntitiesGridView.defaultProps = {
+	entities: [],
+	htmlClass: '',
 };
 
 export default EditorTicketEntitiesGridView;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entity-details.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entity-details.js
@@ -2,6 +2,7 @@
  * External imports
  */
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -20,8 +21,8 @@ import TicketDetailsPanel from './ticket-details-panel';
  */
 const EditorTicketEntityDetails = ( {
 	ticketEntity,
-	showDesc = 'excerpt',
-	showPrice = true,
+	showDesc,
+	showPrice,
 } ) => (
 	<div className={ 'ee-editor-ticket-details-wrapper-div' }>
 		<InlineEditTicketName ticket={ ticketEntity } />
@@ -36,5 +37,16 @@ const EditorTicketEntityDetails = ( {
 		<TicketDetailsPanel ticket={ ticketEntity } />
 	</div>
 );
+
+EditorTicketEntityDetails.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
+	showDesc: PropTypes.string,
+	showPrice: PropTypes.bool,
+};
+
+EditorTicketEntityDetails.defaultProps = {
+	showDesc: 'excerpt',
+	showPrice: true,
+};
 
 export default ifValidTicketEntity( EditorTicketEntityDetails );

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entity-grid-item.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/editor-ticket-entity-grid-item.js
@@ -10,6 +10,7 @@ import {
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
 import { __ } from '@eventespresso/i18n';
 import { ticketModel } from '@eventespresso/model';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ const {
  */
 const EditorTicketEntityGridItem = ( {
 	ticketEntity,
-	displayTicketDate = 'start',
+	displayTicketDate,
 } ) => {
 	const ticketStart = ticketEntity.startDate.toISO();
 	const ticketEnd = ticketEntity.endDate.toISO();
@@ -149,6 +150,15 @@ const EditorTicketEntityGridItem = ( {
 			<EditorTicketActionsMenu ticketEntity={ ticketEntity } />
 		</EntityPaperFrame>
 	);
+};
+
+EditorTicketEntityGridItem.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
+	displayTicketDate: PropTypes.string,
+};
+
+EditorTicketEntityGridItem.defaultProps = {
+	displayTicketDate: 'start',
 };
 
 export default ifValidTicketEntity( EditorTicketEntityGridItem );

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-description.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-description.js
@@ -39,7 +39,7 @@ const InlineEditTicketDescription = ( {
 InlineEditTicketDescription.propTypes = {
 	ticket: PropTypes.object.isRequired,
 	showDesc: PropTypes.string,
-	wrapperElement: PropTypes.element,
+	wrapperElement: PropTypes.string,
 };
 
 InlineEditTicketDescription.defaultProps = {

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-description.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-description.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { useMemo } from '@wordpress/element';
 import { InlineEditInput } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 const InlineEditTicketDescription = ( {
 	ticket,
@@ -34,5 +35,15 @@ const InlineEditTicketDescription = ( {
 	},
 	[ ticket.id, ticket.description, showDesc, wrapperElement ]
 );
+
+InlineEditTicketDescription.propTypes = {
+	ticket: PropTypes.object.isRequired,
+	showDesc: PropTypes.string,
+	wrapperElement: PropTypes.element,
+};
+
+InlineEditTicketDescription.defaultProps = {
+	showDesc: '',
+};
 
 export default InlineEditTicketDescription;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-name.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-name.js
@@ -34,7 +34,7 @@ const InlineEditTicketName = ( { ticket, wrapperElement } ) => useMemo(
 
 InlineEditTicketName.propTypes = {
 	ticket: PropTypes.object.isRequired,
-	wrapperElement: PropTypes.element,
+	wrapperElement: PropTypes.string,
 };
 
 export default InlineEditTicketName;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-name.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-name.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { useMemo } from '@wordpress/element';
 import { InlineEditInput } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 const InlineEditTicketName = ( { ticket, wrapperElement } ) => useMemo(
 	() => {
@@ -30,5 +31,10 @@ const InlineEditTicketName = ( { ticket, wrapperElement } ) => useMemo(
 	},
 	[ ticket.id, ticket.name ]
 );
+
+InlineEditTicketName.propTypes = {
+	ticket: PropTypes.object.isRequired,
+	wrapperElement: PropTypes.element,
+};
 
 export default InlineEditTicketName;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-price.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-price.js
@@ -77,12 +77,12 @@ const InlineEditTicketPrice = ( {
 
 InlineEditTicketPrice.propTypes = {
 	ticket: PropTypes.object.isRequired,
-	showDesc: PropTypes.bool,
-	wrapperElement: PropTypes.element,
+	showPrice: PropTypes.bool,
+	wrapperElement: PropTypes.string,
 };
 
 InlineEditTicketPrice.defaultProps = {
-	showDesc: false,
+	showPrice: false,
 };
 
 export default InlineEditTicketPrice;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-price.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/inline-edit-ticket-price.js
@@ -6,6 +6,7 @@ import { InlineEditInput } from '@eventespresso/components';
 import { usePriceTypes, useTicketPrices } from '@eventespresso/hooks';
 import { __ } from '@eventespresso/i18n';
 import { Money, SiteCurrency } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -72,6 +73,16 @@ const InlineEditTicketPrice = ( {
 		showPrice,
 		WrapperElement,
 	] );
+};
+
+InlineEditTicketPrice.propTypes = {
+	ticket: PropTypes.object.isRequired,
+	showDesc: PropTypes.bool,
+	wrapperElement: PropTypes.element,
+};
+
+InlineEditTicketPrice.defaultProps = {
+	showDesc: false,
 };
 
 export default InlineEditTicketPrice;

--- a/assets/src/editor/events/tickets/editor-ticket/grid-view/ticket-details-panel.js
+++ b/assets/src/editor/events/tickets/editor-ticket/grid-view/ticket-details-panel.js
@@ -6,6 +6,7 @@ import { EntityDetailsPanel } from '@eventespresso/components';
 import { parseInfinity } from '@eventespresso/utils';
 import { __ } from '@eventespresso/i18n';
 import { InfinitySymbol } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -61,5 +62,9 @@ const TicketDetailsPanel = ( { ticket } ) => useMemo( () => {
 	ticket.reserved,
 	ticket.sold,
 ] );
+
+TicketDetailsPanel.propTypes = {
+	ticket: PropTypes.object.isRequired,
+};
 
 export default TicketDetailsPanel;

--- a/assets/src/editor/events/tickets/editor-ticket/list-view/editor-ticket-entities-list-view.js
+++ b/assets/src/editor/events/tickets/editor-ticket/list-view/editor-ticket-entities-list-view.js
@@ -11,6 +11,7 @@ import {
 import { __ } from '@eventespresso/i18n';
 import { ticketModel } from '@eventespresso/model';
 import { isModelEntityOfModel } from '@eventespresso/validators';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -103,6 +104,17 @@ const EditorTicketEntitiesListView = ( {
 			classes={ { tableClass: htmlClass } }
 		/>
 	);
+};
+
+EditorTicketEntitiesListView.propTypes = {
+	entities: PropTypes.array.isRequired,
+	displayTicketDate: PropTypes.string,
+	htmlClass: PropTypes.string,
+	doRefresh: PropTypes.func,
+};
+
+EditorTicketEntitiesListView.defaultProps = {
+	showDesc: false,
 };
 
 export default EditorTicketEntitiesListView;

--- a/assets/src/editor/events/tickets/editor-ticket/list-view/editor-ticket-entities-list-view.js
+++ b/assets/src/editor/events/tickets/editor-ticket/list-view/editor-ticket-entities-list-view.js
@@ -31,7 +31,6 @@ const noZebraStripe = [ 'row', 'stripe', 'name', 'actions' ];
  * @param {Array} entities 	array of JSON objects defining the Tickets
  * @param {string} displayTicketDate
  * @param {string} htmlClass
- * @param {Function} doRefresh
  * @param {Object} otherProps
  * @return {Component} 			list of rendered Tickets
  */
@@ -39,7 +38,6 @@ const EditorTicketEntitiesListView = ( {
 	entities,
 	displayTicketDate,
 	htmlClass,
-	doRefresh,
 	...otherProps
 } ) => {
 	htmlClass = classNames( htmlClass, 'ee-tickets-list-list-view' );
@@ -87,7 +85,6 @@ const EditorTicketEntitiesListView = ( {
 					getQuantity( ticketEntity.regLimit ),
 					status( ticketEntity ),
 					getBackgroundColorClass( ticketEntity ),
-					doRefresh,
 					otherProps
 				) : null;
 			return filterColumns( columns );
@@ -110,11 +107,10 @@ EditorTicketEntitiesListView.propTypes = {
 	entities: PropTypes.array.isRequired,
 	displayTicketDate: PropTypes.string,
 	htmlClass: PropTypes.string,
-	doRefresh: PropTypes.func,
 };
 
 EditorTicketEntitiesListView.defaultProps = {
-	showDesc: false,
+	htmlClass: '',
 };
 
 export default EditorTicketEntitiesListView;

--- a/assets/src/editor/events/tickets/editor-ticket/list-view/tickets-list-table-row.js
+++ b/assets/src/editor/events/tickets/editor-ticket/list-view/tickets-list-table-row.js
@@ -20,7 +20,6 @@ const DATE_TIME_FORMAT = 'ddd MMM YY h:mm a';
  * @param {string} quantity
  * @param {string} statusClass
  * @param {string} bgClass
- * @param {Function} doRefresh
  * @param {Object} otherProps
  * @return {Array} row data for the provided ticket entity
  */
@@ -29,7 +28,6 @@ const ticketsListTableRow = (
 	quantity,
 	statusClass,
 	bgClass,
-	doRefresh,
 	otherProps
 ) => {
 	return [
@@ -114,7 +112,6 @@ const ticketsListTableRow = (
 			value: (
 				<EditorTicketActionsMenu
 					ticketEntity={ ticketEntity }
-					doRefresh={ doRefresh }
 					{ ...otherProps }
 				/>
 			),

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/form-info-ticket-price-reverse-calculation.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/form-info-ticket-price-reverse-calculation.js
@@ -4,6 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { __ } from '@eventespresso/i18n';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 const { FormInfo } = twoColumnAdminFormLayout;
 
@@ -37,5 +38,13 @@ const FormInfoTicketPriceReverseCalculation = ( {
 		offset={ 1 }
 	/>
 ), [ reverseCalculate ] );
+
+FormInfoTicketPriceReverseCalculation.propTypes = {
+	reverseCalculate: PropTypes.bool,
+};
+
+FormInfoTicketPriceReverseCalculation.defaultProps = {
+	reverseCalculate: true,
+};
 
 export default FormInfoTicketPriceReverseCalculation;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/form-info-warning-no-ticket-prices.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/form-info-warning-no-ticket-prices.js
@@ -8,12 +8,13 @@ import {
 	LoadingNotice,
 	twoColumnAdminFormLayout,
 } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 const { FormInfo } = twoColumnAdminFormLayout;
 
 const FormInfoWarningNoTicketPrices = ( {
 	priceCount,
-	inProgress = false,
+	inProgress,
 } ) => useMemo( () => priceCount < 1 ? (
 	<>
 		<FormInfo
@@ -34,5 +35,14 @@ const FormInfoWarningNoTicketPrices = ( {
 		<LoadingNotice loading={ inProgress } />
 	</>
 ) : null, [ priceCount, inProgress ] );
+
+FormInfoWarningNoTicketPrices.propTypes = {
+	priceCount: PropTypes.number.isRequired,
+	inProgress: PropTypes.bool,
+};
+
+FormInfoWarningNoTicketPrices.defaultProps = {
+	inProgress: false,
+};
 
 export default FormInfoWarningNoTicketPrices;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/add-price-modifier-action-button.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/add-price-modifier-action-button.js
@@ -71,6 +71,8 @@ const AddPriceModifierActionButton = ( {
 AddPriceModifierActionButton.propTypes = {
 	ticket: PropTypes.object.isRequired,
 	lastRow: PropTypes.bool,
+	lastPrice: PropTypes.object.isRequired,
+	priceTypes: PropTypes.arrayOf( PropTypes.object ).isRequired,
 };
 
 AddPriceModifierActionButton.defaultProps = {

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/add-price-modifier-action-button.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/add-price-modifier-action-button.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@eventespresso/i18n';
 import { useAddPriceModifier } from '@eventespresso/hooks';
 import { Money, SiteCurrency } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 import { getPriceType } from '../utils/';
 
@@ -65,6 +66,15 @@ const AddPriceModifierActionButton = ( {
 	) : null,
 	[ ticket.id, lastRow ]
 	);
+};
+
+AddPriceModifierActionButton.propTypes = {
+	ticket: PropTypes.object.isRequired,
+	lastRow: PropTypes.bool,
+};
+
+AddPriceModifierActionButton.defaultProps = {
+	lastRow: false,
 };
 
 export default AddPriceModifierActionButton;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/delete-price-modifier-action-button.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/delete-price-modifier-action-button.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { useTrashPriceModifier } from '@eventespresso/hooks';
 import { __ } from '@eventespresso/i18n';
 import { priceTypeModel } from '@eventespresso/model';
+import PropTypes from 'prop-types';
 
 const { BASE_PRICE_TYPES } = priceTypeModel;
 
@@ -34,6 +35,12 @@ const DeletePriceModifierActionButton = ( {
 			</Tooltip>
 		) : null
 	), [ ticket.id, price.id, priceType.prtId ] );
+};
+
+DeletePriceModifierActionButton.propTypes = {
+	price: PropTypes.object.isRequired,
+	priceType: PropTypes.object.isRequired,
+	ticket: PropTypes.object.isRequired,
 };
 
 export default DeletePriceModifierActionButton;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
@@ -87,9 +87,10 @@ const PriceAmountInput = ( {
 PriceAmountInput.propTypes = {
 	prefix: PropTypes.string.isRequired,
 	values: PropTypes.object.isRequired,
-	priceEntity: PropTypes.object.isRequired,
-	priceTypeEntity: PropTypes.object.isRequired,
-	ticketEntity: PropTypes.object.isRequired,
+	price: PropTypes.object.isRequired,
+	priceType: PropTypes.object.isRequired,
+	ticket: PropTypes.object.isRequired,
+	reverseCalculate: PropTypes.bool,
 };
 
 export default PriceAmountInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
@@ -11,6 +11,7 @@ import { amountsMatch, parseMoneyValue } from '@eventespresso/utils';
 import { __ } from '@eventespresso/i18n';
 import { priceTypeModel } from '@eventespresso/model';
 import { Money, SiteCurrency } from '@eventespresso/value-objects';
+import PropTypes from 'prop-types';
 
 const { BASE_PRICE_TYPES } = priceTypeModel;
 const { FormInput, InputLabel } = twoColumnAdminFormLayout;
@@ -81,6 +82,14 @@ const PriceAmountInput = ( {
 		priceType.isPercent,
 		reverseCalculate,
 	] );
+};
+
+PriceAmountInput.propTypes = {
+	prefix: PropTypes.string.isRequired,
+	values: PropTypes.object.isRequired,
+	priceEntity: PropTypes.object.isRequired,
+	priceTypeEntity: PropTypes.object.isRequired,
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default PriceAmountInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
@@ -89,7 +89,6 @@ PriceAmountInput.propTypes = {
 	values: PropTypes.object.isRequired,
 	price: PropTypes.object.isRequired,
 	priceType: PropTypes.object.isRequired,
-	ticket: PropTypes.object.isRequired,
 	reverseCalculate: PropTypes.bool,
 };
 

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-description-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-description-input.js
@@ -5,6 +5,7 @@ import { Fragment, useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
 const { FormInput, InputLabel } = twoColumnAdminFormLayout;
+import PropTypes from 'prop-types';
 
 const PriceDescriptionInput = ( {
 	prefix,
@@ -27,5 +28,11 @@ const PriceDescriptionInput = ( {
 		/>
 	</Fragment>
 ), [ prefix, values[ `${ prefix }-desc` ], priceEntity.desc ] );
+
+PriceDescriptionInput.propTypes = {
+	prefix: PropTypes.string.isRequired,
+	values: PropTypes.object.isRequired,
+	priceEntity: PropTypes.object.isRequired,
+};
 
 export default PriceDescriptionInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-id-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-id-input.js
@@ -4,6 +4,7 @@
 import { Fragment, useMemo } from '@wordpress/element';
 import { __ } from '@eventespresso/i18n';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 const { FormInput, InputLabel } = twoColumnAdminFormLayout;
 
@@ -29,5 +30,10 @@ const PriceIdInput = ( { prefix, values } ) => useMemo( () => (
 		/>
 	</Fragment>
 ), [ prefix, values[ `${ prefix }-id` ] ] );
+
+PriceIdInput.propTypes = {
+	prefix: PropTypes.string.isRequired,
+	values: PropTypes.object.isRequired,
+};
 
 export default PriceIdInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-name-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-name-input.js
@@ -5,6 +5,7 @@ import { Fragment, useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { __ } from '@eventespresso/i18n';
 const { FormInput, InputLabel } = twoColumnAdminFormLayout;
+import PropTypes from 'prop-types';
 
 /**
  * @param {string} prefix
@@ -33,5 +34,11 @@ const PriceNameInput = ( {
 		/>
 	</Fragment>
 ), [ prefix, values[ `${ prefix }-name` ], priceEntity.name ] );
+
+PriceNameInput.propTypes = {
+	prefix: PropTypes.string.isRequired,
+	values: PropTypes.object.isRequired,
+	priceEntity: PropTypes.object.isRequired,
+};
 
 export default PriceNameInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
@@ -6,6 +6,7 @@ import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { normalizeEntityId } from '@eventespresso/helpers';
 import { __ } from '@eventespresso/i18n';
 import { priceTypeModel } from '@eventespresso/model';
+import PropTypes from 'prop-types';
 
 import useDefaultPriceType from '../hooks/use-default-price-type';
 
@@ -69,6 +70,18 @@ const PriceTypeInput = ( {
 			values[ key ],
 		]
 	);
+};
+
+PriceTypeInput.propTypes = {
+	prefix: PropTypes.string.isRequired,
+	values: PropTypes.object.isRequired,
+	priceTypeId: PropTypes.number.isRequired,
+	priceTypeOptions: PropTypes.array.isRequired,
+	basePriceType: PropTypes.number.isRequired,
+};
+
+PriceTypeInput.defaultProps = {
+	priceTypeOptions: [],
 };
 
 export default PriceTypeInput;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
@@ -73,9 +73,9 @@ const PriceTypeInput = ( {
 };
 
 PriceTypeInput.propTypes = {
+	price: PropTypes.object.isRequired,
 	prefix: PropTypes.string.isRequired,
 	values: PropTypes.object.isRequired,
-	priceTypeId: PropTypes.number.isRequired,
 	priceTypeOptions: PropTypes.array.isRequired,
 	basePriceType: PropTypes.number.isRequired,
 };

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-hidden-inputs.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-hidden-inputs.js
@@ -3,6 +3,7 @@
  */
 import { useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 const { FormInput } = twoColumnAdminFormLayout;
 
@@ -38,5 +39,9 @@ const TicketPriceCalculatorFormHiddenInputs = ( { values } ) => useMemo( () => {
 		</>
 	);
 }, [ values.ticketID, values.priceIDs, values.priceTypes ] );
+
+TicketPriceCalculatorFormHiddenInputs.propTypes = {
+	values: PropTypes.object.isRequired,
+};
 
 export default TicketPriceCalculatorFormHiddenInputs;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-modal.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-modal.js
@@ -5,6 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { EditorModal, ifValidTicketEntity } from '@eventespresso/editor-hocs';
 import { __, _x, sprintf } from '@eventespresso/i18n';
 import { FormHandler } from '@eventespresso/components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -77,6 +78,12 @@ const TicketPriceCalculatorFormModal = ( {
 			/>
 		</EditorModal>
 	) : null;
+};
+
+TicketPriceCalculatorFormModal.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
+	prices: PropTypes.array.isRequired,
+	pricesLoaded: PropTypes.bool.isRequired
 };
 
 export default ifValidTicketEntity( TicketPriceCalculatorFormModal );

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-modal.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form-modal.js
@@ -83,7 +83,7 @@ const TicketPriceCalculatorFormModal = ( {
 TicketPriceCalculatorFormModal.propTypes = {
 	ticketEntity: PropTypes.object.isRequired,
 	prices: PropTypes.array.isRequired,
-	pricesLoaded: PropTypes.bool.isRequired
+	pricesLoaded: PropTypes.bool.isRequired,
 };
 
 export default ifValidTicketEntity( TicketPriceCalculatorFormModal );

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-form.js
@@ -9,6 +9,7 @@ import {
 	twoColumnAdminFormLayout,
 } from '@eventespresso/components';
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -44,8 +45,8 @@ const TicketPriceCalculatorForm = ( {
 	ticketEntity,
 	priceEntities,
 	updateField,
-	initialValues = {},
-	currentValues = {},
+	initialValues,
+	currentValues,
 } ) => {
 	const {
 		addTicketBasePrice,
@@ -104,6 +105,19 @@ const TicketPriceCalculatorForm = ( {
 			</FormSection>
 		</FormWrapper>
 	);
+};
+
+TicketPriceCalculatorForm.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
+	priceEntities: PropTypes.array.isRequired,
+	updateField: PropTypes.func.isRequired,
+	initialValues: PropTypes.object,
+	currentValues: PropTypes.object,
+};
+
+TicketPriceCalculatorForm.defaultProps = {
+	initialValues: {},
+	currentValues: {},
 };
 
 export default ifValidTicketEntity( TicketPriceCalculatorForm );

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-menu-item.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/ticket-price-calculator-menu-item.js
@@ -5,6 +5,7 @@ import { EspressoIcon, IconMenuItem } from '@eventespresso/components';
 import { ifValidTicketEntity, useOpenEditor } from '@eventespresso/editor-hocs';
 import { useTicketPrices } from '@eventespresso/hooks';
 import { __ } from '@eventespresso/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal imports
@@ -41,6 +42,10 @@ const TicketPriceCalculatorMenuItem = ( { ticketEntity } ) => {
 			{ calculator }
 		</>
 	);
+};
+
+TicketPriceCalculatorMenuItem.propTypes = {
+	ticketEntity: PropTypes.object.isRequired,
 };
 
 export default ifValidTicketEntity( TicketPriceCalculatorMenuItem );


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves https://github.com/eventespresso/event-espresso-core/issues/1521

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

No real effect at FE - adds propTypes and defaultProps useful to development only.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
