### PR TITLE
Bug/dompdf hotfix

### DIFF
--- a/core/third_party_libs/dompdf/lib/Cpdf.php
+++ b/core/third_party_libs/dompdf/lib/Cpdf.php
@@ -463,28 +463,28 @@ class Cpdf
                         // Named with limited valid values
                         case 'NonFullScreenPageMode':
                             if (!in_array($v, array('UseNone', 'UseOutlines', 'UseThumbs', 'UseOC'))) {
-                                continue;
+                                break;
                             }
                             $o['info'][$k] = $v;
                             break;
 
                         case 'Direction':
                             if (!in_array($v, array('L2R', 'R2L'))) {
-                                continue;
+                                break;
                             }
                             $o['info'][$k] = $v;
                             break;
 
                         case 'PrintScaling':
                             if (!in_array($v, array('None', 'AppDefault'))) {
-                                continue;
+                                break;
                             }
                             $o['info'][$k] = $v;
                             break;
 
                         case 'Duplex':
                             if (!in_array($v, array('None', 'AppDefault'))) {
-                                continue;
+                                break;
                             }
                             $o['info'][$k] = $v;
                             break;

--- a/core/third_party_libs/dompdf/src/Css/Stylesheet.php
+++ b/core/third_party_libs/dompdf/src/Css/Stylesheet.php
@@ -1355,9 +1355,9 @@ class Stylesheet
                             /** @noinspection PhpMissingBreakStatementInspection */
                             case ":first":
                                 $key = $page_selector;
-
+                                break;
                             default:
-                                continue;
+                                break 2;
                         }
 
                         // Store the style for later...

--- a/core/third_party_libs/dompdf/src/Dompdf.php
+++ b/core/third_party_libs/dompdf/src/Dompdf.php
@@ -607,7 +607,7 @@ class Dompdf
                             if (!$accept) {
                                 //found at least one mediatype, but none of the accepted ones
                                 //Skip this css file.
-                                continue;
+                                break;
                             }
                         }
 
@@ -628,7 +628,7 @@ class Dompdf
                         ($media = $tag->getAttribute("media")) &&
                         !in_array($media, $acceptedmedia)
                     ) {
-                        continue;
+                        break;
                     }
 
                     $css = "";

--- a/core/third_party_libs/dompdf/src/Renderer/Text.php
+++ b/core/third_party_libs/dompdf/src/Renderer/Text.php
@@ -137,7 +137,7 @@ class Text extends AbstractRenderer
 
             switch ($text_deco) {
                 default:
-                    continue;
+                    continue 2;
 
                 case "underline":
                     $deco_y += $base - $descent + $underline_offset + $line_thickness / 2;


### PR DESCRIPTION
The DOMPDF library (version 0.8.3) includes some fixes for PHP 7.3. EE's bundled library is currently at version 0.8.2. We decided to roll out a hotfix for this now and we'll update DOMPDF to current version later. Perhaps when 0.8.4 is ready.

Related PR's from dompdf:

https://github.com/dompdf/dompdf/pull/1825
https://github.com/dompdf/dompdf/pull/1889

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
