### PR TITLE
Fix Stale Date - Ticket Relations

### DIFF
--- a/assets/src/editor/events/ticket-assignments-manager/hooks/use-ticket-assignments.js
+++ b/assets/src/editor/events/ticket-assignments-manager/hooks/use-ticket-assignments.js
@@ -23,8 +23,8 @@ const useTicketAssignments = ( {
 	allDateEntities: dateEntities,
 	allTicketEntities: ticketEntities,
 } ) => {
-	const assignmentCounts = useRef( INITIAL_COUNTS );
 	const ticketDateMap = useRef( EMPTY_OBJECT );
+	const assignmentCounts = useRef( INITIAL_COUNTS );
 	return useSelect( ( select ) => {
 		const { getRelatedEntities } = select( 'eventespresso/core' );
 		let entities;
@@ -39,25 +39,23 @@ const useTicketAssignments = ( {
 			entities = sortDateEntitiesList( dateEntities );
 			ticketEntities = sortTicketEntitiesList( ticketEntities );
 		}
-
 		// setup the assignmentCounts for all the tickets and all the dates!
 		entities.forEach( ( date ) => {
-			if ( typeof ticketDateMap.current[ date.id ] === 'undefined' ) {
-				const relatedTickets = getRelatedEntities( date, 'ticket' );
-				ticketDateMap.current[ date.id ] = relatedTickets;
-				assignmentCounts.current.dates[ date.id ] =
-					relatedTickets.length || 0;
-			}
+			const relatedTickets = getRelatedEntities( date, 'ticket' );
+			ticketDateMap.current[ date.id ] = relatedTickets;
+			assignmentCounts.current.dates[ date.id ] =
+				relatedTickets.length || 0;
 		} );
 		ticketEntities.forEach( ( ticket ) => {
-			if ( typeof assignmentCounts.current.tickets[ ticket.id ] === 'undefined' ) {
-				assignmentCounts.current.tickets[ ticket.id ] =
-					getRelatedEntities( ticket, 'datetime' ).length || 0;
-				// no need to set ticketDateMap here as
-				// those will already have been setup for all dates.
-			}
+			const relatedDates = getRelatedEntities(
+				ticket,
+				'datetime'
+			);
+			assignmentCounts.current.tickets[ ticket.id ] =
+				relatedDates.length || 0;
+			// no need to set ticketDateMap here as
+			// those will already have been setup for all dates.
 		} );
-
 		return {
 			entities,
 			dateEntities,

--- a/assets/src/editor/events/ticket-assignments-manager/submit-ticket-assignments-button.js
+++ b/assets/src/editor/events/ticket-assignments-manager/submit-ticket-assignments-button.js
@@ -39,9 +39,7 @@ const SubmitTicketAssignmentsButton = ( {
 	} );
 	return useMemo( () => (
 		<FormSubmitButton
-			onClick={ ( click ) => {
-				processChanges( click );
-			} }
+			onClick={ () => processChanges() }
 			buttonText={ __(
 				'Update Ticket Assignments',
 				'event_espresso'
@@ -53,7 +51,13 @@ const SubmitTicketAssignmentsButton = ( {
 			) }
 			disabled={ disabled }
 		/>
-	), [ assignedState, processChanges, submitting, disabled ] );
+	), [
+		assignedState,
+		hasNoAssignments,
+		processChanges,
+		submitting,
+		disabled,
+	] );
 };
 
 SubmitTicketAssignmentsButton.propTypes = {

--- a/assets/src/hooks/use-create-relations-for-event-date-id-to-ticket-ids.js
+++ b/assets/src/hooks/use-create-relations-for-event-date-id-to-ticket-ids.js
@@ -23,25 +23,27 @@ const useCreateRelationsForEventDateIdToTicketIds = () => {
 		[]
 	);
 	return useCallback( async ( eventDateId, ticketIds ) => {
-		let tickets = await getEntitiesByIds( 'ticket', ticketIds );
-		tickets = Array.isArray( tickets ) ? tickets : [ tickets ];
-		tickets.forEach( ( ticket ) => {
-			if ( ! isModelEntityOfModel( ticket, 'ticket' ) ) {
-				throw new Error(
-					__(
-						'Unable to create relation because an invalid Ticket Entity was supplied.',
-						'event_espresso'
-					)
-				);
-			}
+		return new Promise( async ( resolve ) => {
+			let tickets = await getEntitiesByIds( 'ticket', ticketIds );
+			tickets = Array.isArray( tickets ) ? tickets : [ tickets ];
+			tickets.forEach( ( ticket ) => {
+				if ( ! isModelEntityOfModel( ticket, 'ticket' ) ) {
+					throw new Error(
+						__(
+							'Unable to create relation because an invalid Ticket Entity was supplied.',
+							'event_espresso'
+						)
+					);
+				}
+			} );
+			await createRelations(
+				'datetime',
+				eventDateId,
+				'ticket',
+				tickets,
+			);
+			resolve( true );
 		} );
-		await createRelations(
-			'datetime',
-			eventDateId,
-			'ticket',
-			tickets,
-		);
-		return new Promise( ( resolve ) => resolve( true ) );
 	} );
 };
 

--- a/assets/src/hooks/use-remove-relations-for-event-date-id-to-ticket-ids.js
+++ b/assets/src/hooks/use-remove-relations-for-event-date-id-to-ticket-ids.js
@@ -12,24 +12,22 @@ import { useCallback } from '@wordpress/element';
  *  -  eventDateId ID for event date entity
  *  -  ticketIds array of ticket entity IDs
  *
- * @return {function}  A function for updating the ticket relation.
+ * @return {Function}  A function for updating the ticket relation.
  */
 const useRemoveRelationsForEventDateIdToTicketIds = () => {
 	const { removeRelationForEntity } = useDispatch( 'eventespresso/core' );
 	return useCallback( ( eventDateId, ticketIds ) => {
-		const relationsRemoved = [];
-		ticketIds = Array.isArray( ticketIds ) ? ticketIds : [ ticketIds ];
-		ticketIds.forEach( ( ticketId ) => {
-			relationsRemoved.push(
-				removeRelationForEntity(
+		return new Promise( ( resolve ) => {
+			ticketIds.forEach( async ( ticketId ) => {
+				await removeRelationForEntity(
 					'datetime',
 					eventDateId,
 					'ticket',
 					ticketId,
-				)
-			);
+				);
+			} );
+			resolve( true );
 		} );
-		return Promise.all( relationsRemoved );
 	} );
 };
 


### PR DESCRIPTION
## Problem this Pull Request solves
while demonstrating the new EDTR to Manzoor, I noticed that the relations between tickets and dates were not updating when re-opening the Ticket Assignments Manager after having been previously changed.

This PR simply fixes that issue so that the current relations are always utilized when opening the Ticket Assignments Manager

## How has this been tested
monkey based browser testing only

