### PR TITLE
add check for help tours setting to load scripts only if needed

### DIFF
--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1884,7 +1884,9 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
             EVENT_ESPRESSO_VERSION,
             true
         );
-        add_filter('FHEE_load_joyride', '__return_true');
+        if (EE_Registry::instance()->CFG->admin->help_tour_activation) {
+            add_filter('FHEE_load_joyride', '__return_true');
+        }
         // script for sorting tables
         wp_register_script(
             'espresso_ajax_table_sorting',


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The scripts/styles for the Joyride library load in the admin even if the help tours setting is deactivated. This change makes it so the assets are loaded only when help tours are activated.
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] View source when help tours are deactivated to verify no joyride scripts/styles

- [x] Activate the help tours, they should work as usual

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
