### PR TITLE
Remove memoization for getEntitiesForModel

### DIFF
--- a/assets/src/data/eventespresso/core/selectors/entities.js
+++ b/assets/src/data/eventespresso/core/selectors/entities.js
@@ -37,15 +37,15 @@ const getEntityRecordsForModel = createSelector(
  * @return {Array<BaseEntity>|null} An array of entities for the given model or
  * null if none have been set in the state.
  */
-const getEntitiesForModel = createSelector(
+const getEntitiesForModel = /* createSelector( */
 	( state, modelName ) => {
 		modelName = singularModelName( modelName );
 		return state.entities.has( modelName ) ?
 			state.entities.get( modelName ).valueSeq().toArray() :
 			[];
-	},
+	}/* ,
 	( state, modelName ) => [ state.entities.get( modelName ) ],
-);
+) */;
 
 /**
  * Returns the model entity for the given model and id.

--- a/assets/src/data/eventespresso/core/selectors/test/entities.js
+++ b/assets/src/data/eventespresso/core/selectors/test/entities.js
@@ -48,7 +48,7 @@ describe( 'getEntityRecordsForModel()', () => {
 	} );
 } );
 describe( 'getEntitiesForModel', () => {
-	beforeEach( () => getEntitiesForModel.clear() );
+	// beforeEach( () => getEntitiesForModel.clear() );
 	it( 'returns an empty array when the model does not exist in the ' +
 		'state', () => {
 		expect(
@@ -66,13 +66,13 @@ describe( 'getEntitiesForModel', () => {
 			);
 		expect( records[ 0 ] ).toEqual( EventEntities.a );
 	} );
-	it( 'returns cached copy when selector executed multiple times', () => {
+	/* it( 'returns cached copy when selector executed multiple times', () => {
 		const records = getEntitiesForModel( mockStateForTests, 'event' );
 		const records2 = getEntitiesForModel( mockStateForTests, 'event' );
 		const records3 = getEntitiesForModel( mockStateForTests, 'datetime' );
 		expect( records ).toBe( records2 );
 		expect( records ).not.toBe( records3 );
-	} );
+	} ); */
 } );
 describe( 'getEntityById()', () => {
 	it( 'returns null if the model does not exist in the state', () => {


### PR DESCRIPTION
This is to temporarily disable performance optimization to fix a few issues. We can work on optimization at a later stage.

## Problem this Pull Request solves
Fixes #1612 , #1615 

## How has this been tested
unit tests

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
