### PR TITLE
Fix coffee cup icon location on front end admin bar (WP 5.3)

### DIFF
--- a/core/templates/global_assets/css/espresso_default.css
+++ b/core/templates/global_assets/css/espresso_default.css
@@ -50,8 +50,18 @@
 #wp-admin-bar-espresso-toolbar .ee-icon-ee-cup-thick:before {
     content: "\e60e";
     font-size: 24px !important;
-    left: 8px;
+    left: 4px;
     top: -2px;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+@media screen and (min-width: 783px) {
+	#wp-admin-bar-espresso-toolbar .ee-icon-ee-cup-thick:before {
+		vertical-align: middle;
+		position: relative;
+	}
 }
 
 @media screen and (max-width: 782px) {

--- a/core/templates/global_assets/css/espresso_default.css
+++ b/core/templates/global_assets/css/espresso_default.css
@@ -52,16 +52,16 @@
     font-size: 24px !important;
     left: 4px;
     top: -2px;
-	line-height: 1;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 @media screen and (min-width: 783px) {
-	#wp-admin-bar-espresso-toolbar .ee-icon-ee-cup-thick:before {
-		vertical-align: middle;
-		position: relative;
-	}
+    #wp-admin-bar-espresso-toolbar .ee-icon-ee-cup-thick:before {
+        vertical-align: middle;
+        position: relative;
+    }
 }
 
 @media screen and (max-width: 782px) {


### PR DESCRIPTION


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Some CSS changes in WP 5.3 override some of EE's styles for the front end admin bar. This PR is an attempt to fix that to make the EE admin bar menu item display as expected.

Before:
<img width="637" alt="Screen Shot 2019-09-25 at 1 34 46 PM" src="https://user-images.githubusercontent.com/891156/65625361-aa337480-df99-11e9-892c-11dc8f754a4d.png">

After:
<img width="691" alt="Screen Shot 2019-09-25 at 1 34 24 PM" src="https://user-images.githubusercontent.com/891156/65625376-b61f3680-df99-11e9-8dcb-3a67ccdfff96.png">


Smaller viewport before:
<img width="523" alt="Screen Shot 2019-09-25 at 1 34 59 PM" src="https://user-images.githubusercontent.com/891156/65625396-c0d9cb80-df99-11e9-923a-e9cc41b6d0b4.png">

Smaller viewport after:
<img width="493" alt="Screen Shot 2019-09-25 at 1 35 26 PM" src="https://user-images.githubusercontent.com/891156/65625419-ccc58d80-df99-11e9-8afe-d883b29fdb1a.png">


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Test on a variety of browsers on a site with WP 5.3(beta)
Should also test a site with WP 5.2 too.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
