### PR TITLE
Fix Ticket Editor Form Modal

### DIFF
--- a/assets/src/editor-hocs/editor-modal/editor-modal.js
+++ b/assets/src/editor-hocs/editor-modal/editor-modal.js
@@ -12,7 +12,6 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { cancelClickEvent } from '@eventespresso/utils';
 import { __, sprintf } from '@eventespresso/i18n';
 
 /**
@@ -100,13 +99,12 @@ const EditorModal = ( {
 	);
 
 	const onRequestClose = useCallback( ( click ) => {
-		cancelClickEvent( click, 'EditorModal.onRequestClose()' );
 		if ( ! changesSaved && closeEditorNotice !== '' ) {
 			if ( confirm( closeEditorNotice ) ) {
-				closeEditor();
+				closeEditor( click, 'EditorModal.onRequestClose()' );
 			}
 		} else {
-			closeEditor();
+			closeEditor( click, 'EditorModal.onRequestClose()' );
 		}
 	}, [
 		changesSaved,

--- a/assets/src/editor-hocs/editor-modal/use-close-editor.js
+++ b/assets/src/editor-hocs/editor-modal/use-close-editor.js
@@ -12,8 +12,9 @@ import { cancelClickEvent } from '@eventespresso/utils';
  */
 const useCloseEditor = ( editorId ) => {
 	const { closeEditor } = useDispatch( 'eventespresso/open-editor-state' );
-	return useCallback( ( click ) => {
-		cancelClickEvent( click, 'useCloseEditor' );
+	return useCallback( ( click, src ) => {
+		src = src ? src : editorId;
+		cancelClickEvent( click, src );
 		if ( editorId ) {
 			closeEditor( editorId );
 		}

--- a/assets/src/editor/events/tickets/editor-ticket/actions-menu/editor-ticket-actions-menu.js
+++ b/assets/src/editor/events/tickets/editor-ticket/actions-menu/editor-ticket-actions-menu.js
@@ -18,15 +18,16 @@ import TicketEntityMainMenuItem
 import EditTicketFormModal from '../edit-form/edit-ticket-form-modal';
 import TicketPriceCalculatorMenuItem
 	from '../price-calculator/ticket-price-calculator-menu-item';
+import useTicketEditorId from '../edit-form/use-ticket-editor-id';
 
 const EditorTicketActionsMenu = ( {
 	ticketEntity,
 } ) => {
+	const editorId = useTicketEditorId( ticketEntity );
 	const {
 		getActionsMenuForEntity,
 		registerEntityActionsMenuItem,
 	} = useEntityActionMenuItems();
-
 	const menuItems = getActionsMenuForEntity( ticketEntity );
 	useEffect( () => {
 		if ( Array.isArray( menuItems ) && menuItems.length < 1 ) {
@@ -77,7 +78,10 @@ const EditorTicketActionsMenu = ( {
 			<div className={ 'ee-editor-ticket-actions-menu' }>
 				{ menuItems }
 			</div>
-			<EditTicketFormModal ticketEntity={ ticketEntity } />
+			<EditTicketFormModal
+				editorId={ editorId }
+				ticketEntity={ ticketEntity }
+			/>
 		</>
 	);
 };

--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form-modal.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form-modal.js
@@ -12,20 +12,24 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import EditTicketForm from './edit-ticket-form';
-import useTicketEditorId from './use-ticket-editor-id';
 import useTicketFormSchema from './use-ticket-form-schema';
 
 /**
  * @function
+ * @param {string} editorId
  * @param {Object} ticketEntity model object defining the Ticket
+ * @param {Function} onEditorOpen
+ * @param {Function} onEditorClose
  * @param {Object} otherProps
  * @return {Object} rendered form with editor modal and form handler
  */
 const EditTicketFormModal = ( {
+	editorId,
 	ticketEntity,
+	onEditorOpen,
+	onEditorClose,
 	...otherProps
 } ) => {
-	const editorId = useTicketEditorId( ticketEntity );
 	const formData = useTicketFormSchema( ticketEntity );
 	return useMemo( () => (
 		<EditorModal
@@ -36,6 +40,8 @@ const EditTicketFormModal = ( {
 				'close ticket editor',
 				'event_espresso'
 			) }
+			onEditorOpen={ onEditorOpen }
+			onEditorClose={ onEditorClose }
 		>
 			<FormHandler
 				FormComponent={ EditTicketForm }
@@ -54,7 +60,10 @@ const EditTicketFormModal = ( {
 };
 
 EditTicketFormModal.propTypes = {
+	editorId: PropTypes.string.isRequired,
 	ticketEntity: PropTypes.object.isRequired,
+	onEditorOpen: PropTypes.func,
+	onEditorClose: PropTypes.func,
 };
 
 export default ifValidTicketEntity( EditTicketFormModal );

--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
@@ -19,13 +19,10 @@ import useEditEntityFormInputs
 const {
 	FormSection,
 	FormWrapper,
-	FormSaveCancelButtons,
 } = twoColumnAdminFormLayout;
 
 const EditTicketForm = ( {
 	ticketEntity,
-	submitButton,
-	cancelButton,
 	currentValues,
 	initialValues,
 	newObject,
@@ -60,11 +57,6 @@ const EditTicketForm = ( {
 							children={ formRows }
 							showRequiredNotice={ true }
 						/>
-						<FormSaveCancelButtons
-							htmlClass={ `ee-ticket-editor-${ ticketEntity.id }` }
-							submitButton={ submitButton }
-							cancelButton={ cancelButton }
-						/>
 					</FormWrapper>
 				) : null;
 		},
@@ -73,16 +65,12 @@ const EditTicketForm = ( {
 			initialValues,
 			ticketEntity,
 			formRows,
-			submitButton,
-			cancelButton,
 		]
 	);
 };
 
 EditTicketForm.propTypes = {
 	ticketEntity: PropTypes.object.isRequired,
-	submitButton: PropTypes.element.isRequired,
-	cancelButton: PropTypes.element.isRequired,
 	currentValues: PropTypes.object,
 	initialValues: PropTypes.object,
 	newObject: PropTypes.bool,

--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/use-ticket-editor-id.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/use-ticket-editor-id.js
@@ -6,12 +6,16 @@ import { isModelEntityOfModel } from '@eventespresso/validators';
 /**
  * @function
  * @param {Object} ticket
+ * @param {string} prefix
  * @return {string} editor id for ticket
  */
-const useTicketEditorId = ( ticket ) => (
-	isModelEntityOfModel( ticket, 'ticket' ) ?
+const useTicketEditorId = ( ticket, prefix = '' ) => {
+	const editorId = isModelEntityOfModel( ticket, 'ticket' ) ?
 		`ticket-editor-${ ticket.id }` :
-		''
-);
+		'';
+	return prefix !== '' && editorId !== '' ?
+		`${ prefix }-${ editorId }` :
+		editorId;
+};
 
 export default useTicketEditorId;


### PR DESCRIPTION
## Problem this Pull Request solves
Due to some other recent changes a problem arose where the ticket editor modal would not close after creating a new ticket simply due to the logic that was being used for handling things. This branch adds logic that is similar to what AddNewDateButton component uses for managing its editor form modal.

## How has this been tested
monkey based browser testing only
