### PR TITLE
Edtr/refactor remove alias getters and setters

### DIFF
--- a/assets/src/data/model/entity-factory/constants.js
+++ b/assets/src/data/model/entity-factory/constants.js
@@ -56,7 +56,7 @@ export const MODEL_PREFIXES = ( modelName ) => {
 			country: [ 'CNT' ],
 			currency: [ 'CUR' ],
 			currency_payment_method: [ 'CPM' ],
-			datetime: [ 'DTT', 'DTT_EVT' ],
+			datetime: [ 'DTT_EVT', 'DTT' ],
 			datetime_ticket: [ 'DTK' ],
 			event: [ 'EVT' ],
 			event_message_template: [ 'EMT' ],

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -3,7 +3,6 @@
  */
 import {
 	camelCase,
-	upperFirst,
 	forEach,
 	isUndefined,
 	isArray,

--- a/assets/src/data/model/entity-factory/create.js
+++ b/assets/src/data/model/entity-factory/create.js
@@ -21,7 +21,6 @@ import {
 	assertValidValueForPreparedField,
 } from './assertions';
 import {
-	deriveRenderedValue,
 	derivePreparedValueForField,
 	getRelationNameFromLink,
 	getBaseFieldsAndValuesForCloning,
@@ -171,27 +170,9 @@ export const createAliasGetter = (
 };
 
 /**
- * Creates a fluent setter on the provided instance for the given field name.
- *
- * @param {Object} instance
- * @param {string} fieldName
- * @param {Object} opts  Options for Object.defineProperty
- */
-export const createFluentSetter = ( instance, fieldName, opts = {} ) => {
-	Object.defineProperty( instance, 'set' + upperFirst( fieldName ), {
-		get() {
-			return ( receivedValue ) => {
-				instance[ fieldName ] = receivedValue;
-				return instance;
-			};
-		},
-		...opts,
-	} );
-};
-
-/**
  * Creates initial getters and setters for entities on the provided entity
  * instance using the given data.
+ *
  * @param {Object} instance
  * keys on instance.
  */
@@ -308,6 +289,7 @@ const populatePrimaryKeys = ( instance ) => {
 
 /**
  * Sets the validate type for a field property.
+ *
  * @param {Object} instance
  * @param {string} fieldName
  * @param {*} fieldValue
@@ -442,13 +424,6 @@ const setInitialEntityFieldsAndValues = (
 		derivePreparedValueForField( fieldName, fieldValue, instance ),
 		isPrimaryKey
 	);
-	if ( ! isPrimaryKey ) {
-		createRenderedGetters(
-			instance,
-			fieldName,
-			deriveRenderedValue( fieldValue )
-		);
-	}
 };
 
 /**
@@ -483,13 +458,13 @@ export const createRawEntityGettersSetters = (
 			fieldValue,
 			opts
 		);
-		createFluentSetter( instance, fieldName );
 		createAliasGetterAndSetterForField( instance, fieldName );
 	}
 };
 
 /**
  * Creates "alias" getter for the given field name on the entity instance.
+ *
  * @param {Object} instance
  * @param {string} fieldName
  */
@@ -517,36 +492,33 @@ export const createAliasGetterAndSetterForField = ( instance, fieldName ) => {
 
 /**
  * Creates Aliases using the provided method.
+ *
  * @param {Object} instance
  * @param {string} fieldName
- * @param {function} method
+ * @param {Function} method
  */
 const createAliasesForMethod = ( instance, fieldName, method ) => {
-	// camelCase getter (or setter) for full field name (eg. EVT_desc => evtDesc)
-	method( instance, fieldName, camelCase( fieldName ) );
 	// strip field prefixes and camelCase (if there are field prefixes for the
-	// entity. (eg. EVT_desc => desc);
+	// entity. (eg. EVT_desc => desc and DTT_EVT_start => start);
 	if ( instance.fieldPrefixes ) {
-		let newFieldName = '';
-		// Yes, its intended that if there are multiple prefixes, this could
-		// end up creating multiple aliased getters (or setters)
-		// (eg Datetime: DTT_EVT_start would end up with `evtStart` and `start`
-		// as getter accessors).
+		let newFieldName = fieldName;
+
 		instance.fieldPrefixes.forEach( ( fieldPrefix ) => {
-			newFieldName = fieldName.replace( fieldPrefix + '_', '' );
-			if ( newFieldName !== fieldName ) {
-				method(
-					instance,
-					fieldName,
-					camelCase( newFieldName )
-				);
-			}
+			newFieldName = newFieldName.replace( fieldPrefix + '_', '' );
 		} );
+		if ( newFieldName !== fieldName ) {
+			method(
+				instance,
+				fieldName,
+				camelCase( newFieldName )
+			);
+		}
 	}
 };
 
 /**
  * Returns a callback that is used in the `getRendered` field getter.
+ *
  * @param {Object} instance
  * @return {function(string): *}  A callback.
  */
@@ -647,6 +619,7 @@ const hasCalculatedFieldCallback = ( instance ) =>
 
 /**
  * Creates the getters for all the calculated fields and value on the entity.
+ *
  * @param {Object} instance
  * @param {Object.<string,*>}fieldsAndValues
  */

--- a/assets/src/data/model/entity-factory/test/base-entity.js
+++ b/assets/src/data/model/entity-factory/test/base-entity.js
@@ -78,98 +78,29 @@ describe( 'createEntityFactory()', () => {
 	];
 	const nonEnumerableEntityProperties = [
 		'id',
-		'evtId',
 		'name',
-		'evtName',
-		'setEVT_name',
-		'nameRendered',
 		'desc',
-		'evtDesc',
-		'setEVT_desc',
-		'descRendered',
 		'slug',
-		'evtSlug',
-		'setEVT_slug',
-		'slugRendered',
 		'created',
-		'evtCreated',
-		'setEVT_created',
-		'createdRendered',
 		'shortDesc',
-		'evtShortDesc',
-		'setEVT_short_desc',
-		'shortDescRendered',
 		'modified',
-		'evtModified',
-		'setEVT_modified',
-		'modifiedRendered',
 		'wpUser',
-		'evtWpUser',
-		'setEVT_wp_user',
-		'wpUserRendered',
-		'setParent',
-		'parentRendered',
 		'order',
-		'evtOrder',
-		'setEVT_order',
-		'orderRendered',
-		'setStatus',
-		'statusRendered',
-		'commentStatus',
-		'setComment_status',
-		'commentStatusRendered',
-		'pingStatus',
-		'setPing_status',
-		'pingStatusRendered',
 		'displayDesc',
-		'evtDisplayDesc',
-		'setEVT_display_desc',
-		'displayDescRendered',
 		'displayTicketSelector',
-		'evtDisplayTicketSelector',
-		'setEVT_display_ticket_selector',
-		'displayTicketSelectorRendered',
 		'visibleOn',
-		'evtVisibleOn',
-		'setEVT_visible_on',
-		'visibleOnRendered',
 		'additionalLimit',
-		'evtAdditionalLimit',
-		'setEVT_additional_limit',
-		'additionalLimitRendered',
 		'defaultRegistrationStatus',
-		'evtDefaultRegistrationStatus',
-		'defaultRegistrationStatusRendered',
-		'setEVT_default_registration_status',
 		'memberOnly',
-		'evtMemberOnly',
-		'setEVT_member_only',
-		'memberOnlyRendered',
 		'phone',
-		'evtPhone',
-		'setEVT_phone',
-		'phoneRendered',
 		'allowOverflow',
-		'evtAllowOverflow',
-		'setEVT_allow_overflow',
-		'allowOverflowRendered',
 		'timezoneString',
-		'evtTimezoneString',
-		'setEVT_timezone_string',
-		'timezoneStringRendered',
 		'externalUrl',
-		'evtExternalUrl',
-		'setEVT_external_URL',
-		'externalUrlRendered',
 		'donations',
-		'evtDonations',
-		'setEVT_donations',
-		'donationsRendered',
 		'forClone',
 		'forUpdate',
 		'forInsert',
 		'forPersist',
-		'getRendered',
 		'primaryKey',
 		'primaryKeys',
 		'hasMultiplePrimaryKeys',
@@ -218,23 +149,23 @@ describe( 'createEntityFactory()', () => {
 		describe( 'Test of expected values for props', () => {
 			const testConditions = [
 				[
-					[ 'EVT_name', 'evtName', 'name', 'nameRendered' ],
+					[ 'EVT_name', 'name' ],
 					'Some Event',
 				],
 				[
-					[ 'EVT_desc', 'desc', 'evtDesc', 'descRendered' ],
+					[ 'EVT_desc', 'desc' ],
 					'Some description',
 				],
 				[
-					[ 'EVT_slug', 'evtSlug', 'slug', 'slugRendered' ],
+					[ 'EVT_slug', 'slug' ],
 					'',
 				],
 				[
-					[ 'EVT_wp_user', 'wpUser', 'evtWpUser', 'wpUserRendered' ],
+					[ 'EVT_wp_user', 'wpUser' ],
 					1,
 				],
 				[
-					[ 'parent', 'parentRendered' ],
+					[ 'parent' ],
 					0,
 				],
 				[
@@ -242,29 +173,18 @@ describe( 'createEntityFactory()', () => {
 					'draft',
 				],
 				[
-					[ 'statusRendered' ],
-					'Draft',
-				],
-				[
 					[
 						'EVT_display_ticket_selector',
-						'evtDisplayTicketSelector',
 						'displayTicketSelector',
-						'displayTicketSelectorRendered',
 					],
 					true,
 				],
 				[
 					[
 						'EVT_default_registration_status',
-						'evtDefaultRegistrationStatus',
 						'defaultRegistrationStatus',
 					],
 					'RPP',
-				],
-				[
-					[ 'defaultRegistrationStatusRendered' ],
-					'PENDING_PAYMENT',
 				],
 			];
 			testConditions.forEach( ( [
@@ -282,7 +202,6 @@ describe( 'createEntityFactory()', () => {
 				() => {
 					const testProperties = [
 						'EVT_visible_on',
-						'evtVisibleOn',
 						'visibleOn',
 					];
 					testProperties.forEach( ( testProperty ) => {
@@ -292,15 +211,10 @@ describe( 'createEntityFactory()', () => {
 								.toBeInstanceOf( ServerDateTime );
 						} );
 					} );
-					it( 'event.visibleOnRendered is a string and has ' +
-						'expected value', () => {
-						expect( event.visibleOnRendered )
-							.toBe( '2018-09-17T14:36:59' );
-					} );
 				} );
 			describe( 'primary key property values are a cuid (and the same ' +
 				'cuid)', () => {
-				const idProps = [ 'EVT_ID', 'id', 'evtId' ];
+				const idProps = [ 'EVT_ID', 'id' ];
 				const canonicalCuid = event.EVT_ID;
 				idProps.forEach( ( idProp ) => {
 					it( 'event.' + idProp + ' is a cuid', () => {
@@ -397,35 +311,32 @@ describe( 'createEntityFactory()', () => {
 					const testConditions = [
 						[
 							'EVT_name',
-							[ 'EVT_name', 'evtName', 'name', 'nameRendered' ],
+							[ 'EVT_name', 'name' ],
 						],
 						[
 							[ 'EVT_desc', 'rendered' ],
-							[ 'EVT_desc', 'desc', 'evtDesc', 'descRendered' ],
+							[ 'EVT_desc', 'desc' ],
 						],
 						[
 							'EVT_slug',
-							[ 'EVT_slug', 'evtSlug', 'slug', 'slugRendered' ],
+							[ 'EVT_slug', 'slug' ],
 						],
 						[
 							[ 'EVT_created', 'date' ],
 							[
 								'EVT_created',
-								'evtCreated',
 								'created',
 							],
 						],
 						[
 							'EVT_created',
-							[ 'createdRendered' ],
+							[],
 						],
 						[
 							'EVT_wp_user',
 							[
 								'EVT_wp_user',
 								'wpUser',
-								'evtWpUser',
-								'wpUserRendered',
 							],
 						],
 						[
@@ -434,32 +345,29 @@ describe( 'createEntityFactory()', () => {
 						],
 						[
 							[ 'status', 'pretty' ],
-							[ 'statusRendered' ],
+							[],
 						],
 						[
 							'parent',
-							[ 'parent', 'parentRendered' ],
+							[ 'parent' ],
 						],
 						[
 							'EVT_display_ticket_selector',
 							[
 								'EVT_display_ticket_selector',
-								'evtDisplayTicketSelector',
 								'displayTicketSelector',
-								'displayTicketSelectorRendered',
 							],
 						],
 						[
 							[ 'EVT_default_registration_status', 'raw' ],
 							[
 								'EVT_default_registration_status',
-								'evtDefaultRegistrationStatus',
 								'defaultRegistrationStatus',
 							],
 						],
 						[
 							[ 'EVT_default_registration_status', 'pretty' ],
-							[ 'defaultRegistrationStatusRendered' ],
+							[],
 						],
 					];
 					testRuns( event, testConditions, EventResponse );
@@ -477,39 +385,36 @@ describe( 'createEntityFactory()', () => {
 						const testConditions = [
 							[
 								'EVT_name',
-								[ 'EVT_name', 'evtName', 'name', 'nameRendered' ],
+								[ 'EVT_name', 'name' ],
 							],
 							[
 								[ 'EVT_desc', 'raw' ],
-								[ 'EVT_desc', 'desc', 'evtDesc' ],
+								[ 'EVT_desc', 'desc' ],
 							],
 							[
 								[ 'EVT_desc', 'rendered' ],
-								[ 'descRendered' ],
+								[],
 							],
 							[
 								'EVT_slug',
-								[ 'EVT_slug', 'evtSlug', 'slug', 'slugRendered' ],
+								[ 'EVT_slug', 'slug' ],
 							],
 							[
 								[ 'EVT_created', 'date' ],
 								[
 									'EVT_created',
-									'evtCreated',
 									'created',
 								],
 							],
 							[
 								'EVT_created',
-								[ 'createdRendered' ],
+								[],
 							],
 							[
 								'EVT_wp_user',
 								[
 									'EVT_wp_user',
 									'wpUser',
-									'evtWpUser',
-									'wpUserRendered',
 								],
 							],
 							[
@@ -518,32 +423,29 @@ describe( 'createEntityFactory()', () => {
 							],
 							[
 								[ 'status', 'pretty' ],
-								[ 'statusRendered' ],
+								[],
 							],
 							[
 								'parent',
-								[ 'parent', 'parentRendered' ],
+								[ 'parent' ],
 							],
 							[
 								'EVT_display_ticket_selector',
 								[
 									'EVT_display_ticket_selector',
-									'evtDisplayTicketSelector',
 									'displayTicketSelector',
-									'displayTicketSelectorRendered',
 								],
 							],
 							[
 								[ 'EVT_default_registration_status', 'raw' ],
 								[
 									'EVT_default_registration_status',
-									'evtDefaultRegistrationStatus',
 									'defaultRegistrationStatus',
 								],
 							],
 							[
 								[ 'EVT_default_registration_status', 'pretty' ],
-								[ 'defaultRegistrationStatusRendered' ],
+								[],
 							],
 						];
 						testRuns( event, testConditions, AuthedEventResponse );
@@ -603,16 +505,10 @@ describe( 'createEntityFactory()', () => {
 		);
 		const testConditions = [
 			'DTT_ID',
-			'dttId',
 			'id',
 			'EVT_ID',
-			'evtId',
 			'DTT_EVT_start',
-			'dttEvtStart',
-			'evtStart',
 			'start',
-			'startRendered',
-			'soldRendered',
 		];
 		testConditions.forEach( ( fieldName ) => {
 			test( 'The ' + fieldName + ' field exists', () => {

--- a/assets/src/data/model/entity-factory/test/create.js
+++ b/assets/src/data/model/entity-factory/test/create.js
@@ -11,7 +11,6 @@ import {
 	createCallbackGetter,
 	createGetterAndSetter,
 	createAliasGetterAndSetter,
-	createFluentSetter,
 	createRenderedGetters,
 	createPrimaryKeyFieldGetters,
 	setCalculatedFieldAndValues,
@@ -113,30 +112,6 @@ describe( 'testing create functions for model-entity factory', () => {
 			} );
 			it( 'sets new value on alias prop', () => {
 				expect( testInstance.aliasField ).toEqual( 20 );
-			} );
-		} );
-	} );
-	describe( 'createFluentSetter()', () => {
-		const testInstance = getMockInstance();
-		testInstance.schema = { someProp: { type: 'number' } };
-		createGetterAndSetter( testInstance, 'someProp', 42 );
-		createFluentSetter( testInstance, 'someProp' );
-		it( 'has expected getter', () => {
-			expect( testInstance.setSomeProp ).toBeDefined();
-		} );
-		describe( 'testing setting new value', () => {
-			const returnedInstance = testInstance.setSomeProp( 20 );
-			it( 'throws TypeError for value that doesn\'t match type in ' +
-				'schem', () => {
-				const setInvalidValue = () =>
-					testInstance.setSomeProp( 'invalid' );
-				expect( setInvalidValue ).toThrow( TypeError );
-			} );
-			it( 'sets new value on prop', () => {
-				expect( testInstance.someProp ).toEqual( 20 );
-			} );
-			it( 'returns expected instance', () => {
-				expect( returnedInstance ).toBe( testInstance );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR removes the unnecessary getters and setters created for every field/property of an entity in the model system. After this PR there will be only two getters and setters for a field.

For example, if a field in the schema is defined as `PFX_field_name`, it can be accessed or set using `entity.PFX_field_name` and/or `entity.fieldName` (camelCase).

Removed:
- `entity.PfxFieldName`
- `entity.setPfxFieldName`
- `entity.setFieldName`

Likewise if a field in the schema is defined as `PFX_SFX_field_name`, it can be accessed or set using `entity.PFX_SFX_field_name` and/or `entity.fieldName` (camelCase).

Removed:
- `entity.PfxSfxFieldName`
- `entity.SfxFieldName`
- `entity.setPfxSfxFieldName`
- `entity.setSfxFieldName`
- `entity.setFieldName`,

`js_only`

## Problem this Pull Request solves
Fixes #1594 

## How has this been tested
unit tests

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
*x [ ] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
