### PR TITLE
Fix PayPal Pro gateway to send correct value for the State/Province field, fixes #453

### DIFF
--- a/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
@@ -260,7 +260,7 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
                 ? $attendee->city()
                 : $billing_info['city'], 0, 40),
             'shiptostate'          => substr($use_registration_address_info
-                ? $attendee->state_abbrev()
+                ? $attendee->state_name()
                 : $billing_info['state'], 0, 40),
             'shiptocountry'  => $use_registration_address_info
                 ? $attendee->country_ID()

--- a/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
@@ -260,7 +260,7 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
                 ? $attendee->city()
                 : $billing_info['city'], 0, 40),
             'state'          => substr($use_registration_address_info
-                ? $attendee->state_name()
+                ? $attendee->state_abbrev()
                 : $billing_info['state'], 0, 40),
             'shiptocountry'  => $use_registration_address_info
                 ? $attendee->country_ID()

--- a/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
@@ -259,7 +259,7 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
             'shiptocity'     => substr($use_registration_address_info
                 ? $attendee->city()
                 : $billing_info['city'], 0, 40),
-            'state'          => substr($use_registration_address_info
+            'shiptostate'          => substr($use_registration_address_info
                 ? $attendee->state_abbrev()
                 : $billing_info['state'], 0, 40),
             'shiptocountry'  => $use_registration_address_info

--- a/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EEG_Paypal_Pro.gateway.php
@@ -322,7 +322,7 @@ class EEG_Paypal_Pro extends EE_Onsite_Gateway
             }
             if (empty($PayPalResult['RAWRESPONSE'])) {
                 $payment->set_status($this->_pay_model->failed_status());
-                $payment->set_gateway_response(__('No response received from Paypal Pro', 'event_espresso'));
+                $payment->set_gateway_response(esc_html__('No response received from Paypal Pro', 'event_espresso'));
                 $payment->set_details($PayPalResult);
             } else {
                 if ($this->_APICallSuccessful($PayPalResult)) {

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -22,8 +22,8 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
     {
         require_once($this->file_folder().'EEG_Paypal_Pro.gateway.php');
         $this->_gateway = new EEG_Paypal_Pro();
-        $this->_pretty_name = __("Paypal Pro", 'event_espresso');
-        $this->_default_description = __('Please provide the following billing information.', 'event_espresso');
+        $this->_pretty_name = esc_html__("Paypal Pro", 'event_espresso');
+        $this->_default_description = esc_html__('Please provide the following billing information.', 'event_espresso');
         $this->_requires_https = true;
         parent::__construct($pm_instance);
     }
@@ -64,22 +64,22 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
                 'subsections'=>array(
                     'state'=>new EE_State_Select_Input(null, ['value_field_name' => 'STA_abbrev']),
                     'credit_card'=>new EE_Credit_Card_Input(
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Card Number', 'event_espresso'))
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => esc_html__('Card Number', 'event_espresso'))
                     ),
                     'credit_card_type'=>new EE_Select_Input(
                         // the options are set dynamically
                         array_intersect_key(EE_PMT_Paypal_Pro::card_types_supported(), array_flip($allowed_types)),
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Card Type', 'event_espresso'))
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => esc_html__('Card Type', 'event_espresso'))
                     ),
                     'exp_month'=>new EE_Credit_Card_Month_Input(
                         true,
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' =>  __('Expiry Month', 'event_espresso')  )
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' =>  esc_html__('Expiry Month', 'event_espresso')  )
                     ),
                     'exp_year'=>new EE_Credit_Card_Year_Input(
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Expiry Year', 'event_espresso')  )
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => esc_html__('Expiry Year', 'event_espresso')  )
                     ),
                     'cvv'=>new EE_CVV_Input(
-                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('CVV', 'event_espresso') )
+                        array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => esc_html__('CVV', 'event_espresso') )
                     ),
                 )
             )
@@ -124,10 +124,10 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
     public static function card_types_supported()
     {
         return array(
-            'Visa'=>  __("Visa", 'event_espresso'),
-            'MasterCard'=>  __("MasterCard", 'event_espresso'),
-            'Amex'=>  __("American Express", 'event_espresso'),
-            'Discover'=>  __("Discover", 'event_espresso')
+            'Visa'=>  esc_html__("Visa", 'event_espresso'),
+            'MasterCard'=>  esc_html__("MasterCard", 'event_espresso'),
+            'Amex'=>  esc_html__("American Express", 'event_espresso'),
+            'Discover'=>  esc_html__("Discover", 'event_espresso')
             );
     }
 
@@ -142,7 +142,7 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
     {
         return array(
             $this->get_help_tab_name() => array(
-                        'title' => __('PayPal Pro Settings', 'event_espresso'),
+                        'title' => esc_html__('PayPal Pro Settings', 'event_espresso'),
                         'filename' => 'payment_methods_overview_paypalpro'
                         ),
         );

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -62,6 +62,7 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
                 'name'=> 'Paypal_Pro_Billing_Form',
             //              'html_id'=> 'ee-Paypal_Pro-billing-form',
                 'subsections'=>array(
+                    'state'=>new EE_State_Select_Input(null, ['value_field_name' => 'STA_abbrev']),
                     'credit_card'=>new EE_Credit_Card_Input(
                         array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => __('Card Number', 'event_espresso'))
                     ),
@@ -156,6 +157,7 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
     protected function _get_billing_values_from_form($billing_form)
     {
         $billing_values = parent::_get_billing_values_from_form($billing_form);
+        $billing_values['state'] = $billing_form->get_input_value('state');
         $billing_values['country'] = $billing_form->get_input_value('country');
         $billing_values['credit_card_type'] = $billing_form->get_input_value('credit_card_type');
         return $billing_values;

--- a/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
+++ b/caffeinated/payment_methods/Paypal_Pro/EE_PMT_Paypal_Pro.pm.php
@@ -62,7 +62,6 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
                 'name'=> 'Paypal_Pro_Billing_Form',
             //              'html_id'=> 'ee-Paypal_Pro-billing-form',
                 'subsections'=>array(
-                    'state'=>new EE_State_Select_Input(null, ['value_field_name' => 'STA_abbrev']),
                     'credit_card'=>new EE_Credit_Card_Input(
                         array( 'required'=>true, 'html_class' => 'ee-billing-qstn', 'html_label_text' => esc_html__('Card Number', 'event_espresso'))
                     ),
@@ -157,7 +156,6 @@ class EE_PMT_Paypal_Pro extends EE_PMT_Base
     protected function _get_billing_values_from_form($billing_form)
     {
         $billing_values = parent::_get_billing_values_from_form($billing_form);
-        $billing_values['state'] = $billing_form->get_input_value('state');
         $billing_values['country'] = $billing_form->get_input_value('country');
         $billing_values['credit_card_type'] = $billing_form->get_input_value('credit_card_type');
         return $billing_values;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
See #453 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Test payments using PayPal Pro. Do one payment where the Registration form includes address fields (and complete those fields). Do another payment where the registration form does not include address fields.

- [x] After testing payments, check the Transaction records and verify billing info's State field looks correct (it should show the full state/province name).

- [x] Then check the PayPal transactions admin and verify the shipping address now includes something for the State field.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
