### PR TITLE
Add Utility for Parsing Placeholders in Strings closes #1498

### DIFF
--- a/assets/src/components/form/base/form-info-base.js
+++ b/assets/src/components/form/base/form-info-base.js
@@ -1,10 +1,10 @@
 /**
  * External imports
  */
-import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { __ } from '@eventespresso/i18n';
 import { Dashicon, IconButton } from '@wordpress/components';
+import { parseHtmlPlaceholders } from '@eventespresso/utils';
 
 /**
  * Internal dependencies
@@ -58,26 +58,7 @@ const FormInfoBase = ( {
 			onClick={ onDismiss }
 		/>
 	) : null;
-	// parseHtmlPlaceholders parse-html-placeholders
-	if ( ! isEmpty( formInfoVars ) ) {
-		const formInfoText = [];
-		const chunks = formInfo.split( '%%var%%' );
-		if ( chunks.length !== formInfoVars.length ) {
-			throw new RangeError(
-				'The number of notice placeholders does not match' +
-				' the number of form info variables supplied.'
-			);
-		}
-		for ( let x = 0; x < chunks.length; x++ ) {
-			if ( chunks[ x ] ) {
-				formInfoText.push( chunks[ x ] );
-			}
-			if ( formInfoVars[ x ] ) {
-				formInfoText.push( formInfoVars[ x ] );
-			}
-		}
-		formInfo = formInfoText;
-	}
+	formInfo = parseHtmlPlaceholders( formInfo, formInfoVars );
 	return formInfo ? (
 		<div
 			aria-label={ __( 'important information', 'event_espresso' ) }

--- a/assets/src/components/ui/responsive-table/table.js
+++ b/assets/src/components/ui/responsive-table/table.js
@@ -19,7 +19,7 @@ const Table = ( {
 	tableClass,
 	captionID,
 	captionText,
-	...extraProps,
+	...extraProps
 } ) => {
 	tableClass = tableClass ?
 		`${ tableClass } ee-rspnsv-table` :

--- a/assets/src/utils/index.js
+++ b/assets/src/utils/index.js
@@ -1,6 +1,7 @@
 export { default as amountsMatch } from './amounts-match';
 export { default as cancelClickEvent } from './cancel-click-event';
 export { default as getServerDateTime } from './get-server-date-time';
+export { default as parseHtmlPlaceholders } from './parse-html-placeholders';
 export { default as parseInfinity } from './parse-infinity';
 export { default as parseMoneyValue } from './parse-money-value';
 export { default as shortenCuid } from './shorten-cuid';

--- a/assets/src/utils/parse-html-placeholders.js
+++ b/assets/src/utils/parse-html-placeholders.js
@@ -14,16 +14,14 @@ const PLACEHOLDER = '%%var%%';
  * @return {string} text with placeholders replaced by variables
  */
 const parseHtmlPlaceholders = ( placeholderText, replacements ) => {
-	if ( isEmpty( replacements ) ) {
+	if (
+		isEmpty( replacements ) ||
+		! placeholderText.includes( PLACEHOLDER )
+	) {
 		return placeholderText;
 	}
 	if ( ! Array.isArray( replacements ) ) {
 		replacements = [ replacements ];
-	}
-	if ( ! placeholderText.includes( PLACEHOLDER ) ) {
-		throw new RangeError(
-			'The provided string does not have any placeholders.'
-		);
 	}
 	const finalText = [];
 	const chunks = placeholderText.split( PLACEHOLDER );
@@ -33,14 +31,12 @@ const parseHtmlPlaceholders = ( placeholderText, replacements ) => {
 			' the number of replacement strings supplied.'
 		);
 	}
-	for ( let x = 0; x < chunks.length; x++ ) {
-		if ( chunks[ x ] ) {
-			finalText.push( chunks[ x ] );
+	chunks.forEach( ( chunk, index ) => {
+		finalText.push( chunk );
+		if ( replacements[ index ] ) {
+			finalText.push( replacements[ index ] );
 		}
-		if ( replacements[ x ] ) {
-			finalText.push( replacements[ x ] );
-		}
-	}
+	} );
 	return finalText.join( '' );
 };
 

--- a/assets/src/utils/parse-html-placeholders.js
+++ b/assets/src/utils/parse-html-placeholders.js
@@ -1,0 +1,47 @@
+/**
+ * External imports
+ */
+import { isEmpty } from 'lodash';
+
+const PLACEHOLDER = '%%var%%';
+
+/**
+ * kinda like a weaker version of sprintf that won't choke on HTML elements
+ *
+ * @function
+ * @param {string} placeholderText
+ * @param {Array} replacements
+ * @return {string} text with placeholders replaced by variables
+ */
+const parseHtmlPlaceholders = ( placeholderText, replacements ) => {
+	if ( isEmpty( replacements ) ) {
+		return placeholderText;
+	}
+	if ( ! Array.isArray( replacements ) ) {
+		replacements = [ replacements ];
+	}
+	if ( ! placeholderText.includes( PLACEHOLDER ) ) {
+		throw new RangeError(
+			'The provided string does not have any placeholders.'
+		);
+	}
+	const finalText = [];
+	const chunks = placeholderText.split( PLACEHOLDER );
+	if ( chunks.length - replacements.length !== 1 ) {
+		throw new RangeError(
+			'The number of text placeholders does not match' +
+			' the number of replacement strings supplied.'
+		);
+	}
+	for ( let x = 0; x < chunks.length; x++ ) {
+		if ( chunks[ x ] ) {
+			finalText.push( chunks[ x ] );
+		}
+		if ( replacements[ x ] ) {
+			finalText.push( replacements[ x ] );
+		}
+	}
+	return finalText.join( '' );
+};
+
+export default parseHtmlPlaceholders;

--- a/assets/src/utils/test/parse-html-placeholders.js
+++ b/assets/src/utils/test/parse-html-placeholders.js
@@ -1,0 +1,123 @@
+
+/**
+ * Internal dependencies
+ */
+import parseHtmlPlaceholders from '../parse-html-placeholders';
+
+const PLACEHOLDER = '%%var%%';
+const stringA = '%%var%% the preceding text should be replaced';
+const stringB = 'ths text %%var%% should be replaced';
+const stringC = 'the following text should be replaced: %%var%%';
+const stringD = '%%var%%this text should be between two placeholders%%var%%';
+const noPlaceholders = 'this string is missing placeholders';
+
+const testData = [
+	{
+		testName: 'returns original text if "replacements" is empty array',
+		testString: stringA,
+		replacements: [],
+		expectedResult: stringA,
+		throwsError: false,
+	},
+	{
+		testName: 'returns original text if "replacements" is empty string',
+		testString: stringA,
+		replacements: '',
+		expectedResult: stringA,
+		throwsError: false,
+	},
+	{
+		testName: 'returns original text if "replacements" is null',
+		testString: stringA,
+		replacements: null,
+		expectedResult: stringA,
+		throwsError: false,
+	},
+	{
+		testName: 'throws RangeError if string is missing placeholders',
+		testString: noPlaceholders,
+		replacements: [ 'turtle' ],
+		expectedResult: null,
+		throwsError: true,
+	},
+	{
+		testName: 'throws RangeError if string has too many placeholders',
+		testString: stringD,
+		replacements: [ 'turtle' ],
+		expectedResult: null,
+		throwsError: true,
+	},
+	{
+		testName: 'throws RangeError if too many replacements',
+		testString: stringA,
+		replacements: [ 'turtle', 'tortoise', 'terrapin' ],
+		expectedResult: null,
+		throwsError: true,
+	},
+	{
+		testName: 'correctly substitutes placeholder at start of string',
+		testString: stringA,
+		replacements: [ 'turtle' ],
+		expectedResult: stringA.replace( PLACEHOLDER, 'turtle' ),
+		throwsError: false,
+	},
+	{
+		testName: 'correctly substitutes placeholder in middle of string',
+		testString: stringB,
+		replacements: [ 'turtle' ],
+		expectedResult: stringB.replace( PLACEHOLDER, 'turtle' ),
+		throwsError: false,
+	},
+	{
+		testName: 'correctly substitutes placeholder at end of string',
+		testString: stringC,
+		replacements: [ 'turtle' ],
+		expectedResult: stringC.replace( PLACEHOLDER, 'turtle' ),
+		throwsError: false,
+	},
+	{
+		testName: 'correctly substitutes placeholders at both ends of string',
+		testString: stringD,
+		replacements: [ 'before', 'after' ],
+		expectedResult: 'before' +
+			stringD.replace( new RegExp( PLACEHOLDER, 'g' ), '' ) +
+			'after',
+		throwsError: false,
+	},
+	{
+		testName: 'correctly substitutes linebreak for placeholder',
+		testString: stringB,
+		replacements: [ '<br />' ],
+		expectedResult: stringB.replace( PLACEHOLDER, '<br />' ),
+		throwsError: false,
+	},
+	{
+		testName: 'correctly substitutes linebreak for HTML header tags',
+		testString: stringD,
+		replacements: [ '<h1>', '</h1>' ],
+		expectedResult: '<h1>' +
+			stringD.replace( new RegExp( PLACEHOLDER, 'g' ), '' ) +
+			'</h1>',
+		throwsError: false,
+	},
+];
+
+describe( 'parseHtmlPlaceholders', () => {
+	testData.forEach( ( test ) => {
+		const {
+			testName,
+			testString,
+			replacements,
+			expectedResult,
+			throwsError,
+		} = test;
+		it( testName, () => {
+			const result = () => parseHtmlPlaceholders( testString, replacements );
+			if ( throwsError ) {
+				expect( result ).toThrow( RangeError );
+			} else {
+				expect( result() ).toEqual( expectedResult );
+			}
+		} );
+	} );
+} );

--- a/assets/src/utils/test/parse-html-placeholders.js
+++ b/assets/src/utils/test/parse-html-placeholders.js
@@ -34,11 +34,11 @@ const testData = [
 		throwsError: false,
 	},
 	{
-		testName: 'throws RangeError if string is missing placeholders',
+		testName: 'returns original text if string is missing placeholders',
 		testString: noPlaceholders,
 		replacements: [ 'turtle' ],
-		expectedResult: null,
-		throwsError: true,
+		expectedResult: noPlaceholders,
+		throwsError: false,
 	},
 	{
 		testName: 'throws RangeError if string has too many placeholders',


### PR DESCRIPTION
## Problem this Pull Request solves
plz see #1498
Adds a new parseHtmlPlaceholders() function to the `@eventespresso/utils` module for substituting placeholders in string with HTML tags because the existing translation functions in WordPress do not work with `sprintf()`.
Not an extensively thorough solution but enough to get us by for the time being.

## How has this been tested
has accompanying unit tests to verify functionality

