### PR TITLE
Ticket Price Calculator modal:  replaced disabled base price with a label.

### DIFF
--- a/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
+++ b/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
@@ -483,10 +483,6 @@
     margin-top: 3px;
 }
 
-.ee-two-column-admin .ee-visible-label {
-    padding-left: .4rem;
-}
-
 .ee-two-column-admin .ee-hidden-label {
     display: none !important;
 }

--- a/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
+++ b/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
@@ -483,6 +483,10 @@
     margin-top: 3px;
 }
 
+.ee-two-column-admin .ee-visible-label {
+    padding-left: .4rem;
+}
+
 .ee-two-column-admin .ee-hidden-label {
     display: none !important;
 }

--- a/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
+++ b/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
@@ -487,6 +487,11 @@
     display: none !important;
 }
 
+.ee-two-column-admin .ee-base-price-type {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
 
 .ee-two-column-admin .ee-after-input-wrapper {
     display: flex;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/hooks/use-base-price.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/hooks/use-base-price.js
@@ -14,7 +14,7 @@ const { BASE_PRICE_TYPES } = priceTypeModel;
  * @return {Array} price modifiers
  */
 const useBasePrice = useMemo( ( prices ) => prices.find(
-	( price ) => price.prtId === BASE_PRICE_TYPES.BASE_PRICE
+	( price ) => price.PRT_ID === BASE_PRICE_TYPES.BASE_PRICE
 ) );
 
 export default useBasePrice;

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/hooks/use-ticket-price-calculator-form-rows.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/hooks/use-ticket-price-calculator-form-rows.js
@@ -49,7 +49,7 @@ const useTicketPriceCalculatorFormRows = (
 			if ( isModelEntityOfModel( price, 'price' ) ) {
 				// we don't want "Base Price" to be an option for
 				// price modifiers because THERE CAN ONLY BE ONE!!!
-				const options = price.prtId === BASE_PRICE_TYPES.BASE_PRICE ?
+				const options = price.PRT_ID === BASE_PRICE_TYPES.BASE_PRICE ?
 					priceTypeOptions :
 					filteredPriceTypeOptions;
 				const lastRow = i === ( priceCount - 1 );

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/delete-price-modifier-action-button.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/delete-price-modifier-action-button.js
@@ -17,7 +17,7 @@ const DeletePriceModifierActionButton = ( {
 } ) => {
 	const trashPriceModifier = useTrashPriceModifier();
 	return useMemo( () => (
-		priceType.prtId !== BASE_PRICE_TYPES.BASE_PRICE ? (
+		priceType.PRT_ID !== BASE_PRICE_TYPES.BASE_PRICE ? (
 			<Tooltip
 				position={ 'top left' }
 				text={ __( 'click to delete price modifier', 'event_espresso' ) }
@@ -34,7 +34,7 @@ const DeletePriceModifierActionButton = ( {
 				/>
 			</Tooltip>
 		) : null
-	), [ ticket.id, price.id, priceType.prtId ] );
+	), [ ticket.id, price.id, priceType.PRT_ID ] );
 };
 
 DeletePriceModifierActionButton.propTypes = {

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-amount-input.js
@@ -63,7 +63,7 @@ const PriceAmountInput = ( {
 					}
 				}
 				disabled={
-					price.prtId === BASE_PRICE_TYPES.BASE_PRICE &&
+					price.PRT_ID === BASE_PRICE_TYPES.BASE_PRICE &&
 					reverseCalculate === true
 				}
 				format={ ( value ) => {
@@ -77,7 +77,7 @@ const PriceAmountInput = ( {
 	), [
 		prefix,
 		values[ key ],
-		price.prtId,
+		price.PRT_ID,
 		price.amount.toNumber(),
 		priceType.isPercent,
 		reverseCalculate,

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
@@ -30,8 +30,17 @@ const PriceTypeInput = ( {
 } ) => {
 	const key = `${ prefix }-type`;
 	const defaultPriceType = useDefaultPriceType();
+	const isBasePriceType = basePriceType === BASE_PRICE_TYPES.BASE_PRICE;
+
 	return useMemo(
-		() => (
+		() => isBasePriceType ? (
+			<InputLabel
+				label={ __( 'Base price', 'event_espresso' ) }
+				htmlFor={ key }
+				strong={ false }
+				htmlClass="ee-visible-label"
+			/>
+		) : (
 			<Fragment>
 				<InputLabel
 					label={ __( 'Price Type', 'event_espresso' ) }
@@ -56,7 +65,6 @@ const PriceTypeInput = ( {
 							}
 						}
 					}
-					disabled={ basePriceType === BASE_PRICE_TYPES.BASE_PRICE }
 				/>
 			</Fragment>
 		),

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
@@ -30,6 +30,8 @@ const PriceTypeInput = ( {
 } ) => {
 	const key = `${ prefix }-type`;
 	const defaultPriceType = useDefaultPriceType();
+	const isBasePriceType = basePriceType === BASE_PRICE_TYPES.BASE_PRICE;	
+
 	return useMemo(
 		() => (
 			<Fragment>
@@ -41,6 +43,7 @@ const PriceTypeInput = ( {
 				<FormInput
 					key="type"
 					type="select"
+					htmlClass={ isBasePriceType && 'ee-base-price-type' }
 					name={ key }
 					value={
 						normalizeEntityId( values[ key ] ) || 0
@@ -56,7 +59,7 @@ const PriceTypeInput = ( {
 							}
 						}
 					}
-					disabled={ basePriceType === BASE_PRICE_TYPES.BASE_PRICE }
+					disabled={ isBasePriceType }
 				/>
 			</Fragment>
 		),

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/price-modifier-row/price-type-input.js
@@ -30,17 +30,8 @@ const PriceTypeInput = ( {
 } ) => {
 	const key = `${ prefix }-type`;
 	const defaultPriceType = useDefaultPriceType();
-	const isBasePriceType = basePriceType === BASE_PRICE_TYPES.BASE_PRICE;
-
 	return useMemo(
-		() => isBasePriceType ? (
-			<InputLabel
-				label={ __( 'Base price', 'event_espresso' ) }
-				htmlFor={ key }
-				strong={ false }
-				htmlClass="ee-visible-label"
-			/>
-		) : (
+		() => (
 			<Fragment>
 				<InputLabel
 					label={ __( 'Price Type', 'event_espresso' ) }
@@ -65,6 +56,7 @@ const PriceTypeInput = ( {
 							}
 						}
 					}
+					disabled={ basePriceType === BASE_PRICE_TYPES.BASE_PRICE }
 				/>
 			</Fragment>
 		),

--- a/assets/src/editor/events/tickets/editor-ticket/price-calculator/utils/get-base-price.js
+++ b/assets/src/editor/events/tickets/editor-ticket/price-calculator/utils/get-base-price.js
@@ -16,7 +16,7 @@ const { BASE_PRICE_TYPES } = priceTypeModel;
  */
 const getBasePrice = memoize(
 	( prices ) => prices.find( ( price ) => {
-		return price.prtId === BASE_PRICE_TYPES.BASE_PRICE;
+		return price.PRT_ID === BASE_PRICE_TYPES.BASE_PRICE;
 	} )
 );
 


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes this issue: https://github.com/eventespresso/event-espresso-core/issues/1743

## How has this been tested
Locally:
![image](https://user-images.githubusercontent.com/1477453/67849000-6559ab00-fb0e-11e9-8fc2-a8b79070ac8d.png)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
