### PR TITLE
EDTR: Show archive option only for existing tickets.

### DIFF
--- a/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
+++ b/assets/src/editor/events/tickets/editor-ticket/edit-form/edit-ticket-form.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { twoColumnAdminFormLayout } from '@eventespresso/components';
 import { ifValidTicketEntity } from '@eventespresso/editor-hocs';
 import PropTypes from 'prop-types';
+import cuid from 'cuid';
 
 /**
  * Internal dependencies
@@ -56,6 +57,13 @@ const EditTicketForm = ( {
 		'wpUser',
 		'status',
 	];
+
+	const isNewTicket = cuid.isCuid( ticketEntity.TKT_ID );
+
+	if ( isNewTicket ) {
+		exclude.push( 'deleted' );
+	}
+
 	const formRows = useEditEntityFormInputs(
 		ticketEntity,
 		inputConfig,
@@ -63,6 +71,7 @@ const EditTicketForm = ( {
 		currentValues,
 		exclude
 	);
+
 	return useMemo(
 		() => {
 			// edit forms for existing objects must have initial values


### PR DESCRIPTION
## Problem this Pull Request solves
Currently, the archive option is shown for both: new and existing tickets.
The fix is aimed to show that option only to existing tickets.
Fixes https://github.com/eventespresso/event-espresso-core/issues/1755

## How has this been tested
Locally/ manually.

![Peek 2019-11-01 18-21](https://user-images.githubusercontent.com/1477453/68039314-8c61d980-fcd4-11e9-91db-a9f2bfd560af.gif)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
