### PR TITLE
Added updateSnapshot option for unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
 		"lint-php:skip-warnings": "composer run-script lint:skip-warnings",
 		"lint-php:fix": "composer run-script lint-fix",
 		"test-unit": "wp-scripts test-unit-js --config tests/javascript-config/unit/jest.config.json",
-		"test-unit:coverage": "npm run test-unit -- --coverage",
-		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",
+		"test-unit:update": "npm run test-unit -- --updateSnapshot",
 		"test-unit:watch": "npm run test-unit -- --watch",
+		"test-unit:coverage": "npm run test-unit -- --coverage",
+		"test-unit:coverage-ci": "npm run test-unit -- --coverage --maxWorkers 1 && codecov",		
 		"lc": "jsgl --local ./",
 		"build:css": "node ./bin/css-builder/css-builder.js"
 	},


### PR DESCRIPTION
##  Problem this Pull Request solves
Have added the option to update unit tests snapshots via npm scripts as in GB: https://github.com/WordPress/gutenberg/blob/master/package.json#L195

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
