### PR TITLE
Auto update ticket quantity when the datetime capacity is changed

### DIFF
--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/use-date-entity-input-config.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/use-date-entity-input-config.js
@@ -19,6 +19,11 @@ import {
 } from '@eventespresso/value-objects';
 
 /**
+ * Internal dependencies
+ */
+import { updateTicketQtyAfterCapacityChange } from '../../../mutations/ticket-mutations';
+
+/**
  * input configuration for event date entity edit form
  *
  * @function
@@ -133,13 +138,14 @@ const useDateEntityInputConfig = ( {
 			label: __( 'Capacity', 'event_espresso' ),
 			default: -1,
 			changeListener: ( value ) => {
-				const regLimit = parseInfinity(
+				const capacity = parseInfinity(
 					value || -1,
 					true,
 					true
 				);
-				dateEntity.regLimit = regLimit;
-				updateRelatedTickets( { capacity: regLimit } );
+				dateEntity.regLimit = capacity;
+				const updateTicketQty = updateTicketQtyAfterCapacityChange( capacity );
+				updateRelatedTickets( [ updateTicketQty ] );
 			},
 			min: -1,
 			inputWidth: 3,

--- a/assets/src/editor/events/dates-and-times/editor-date/edit-form/use-date-entity-input-config.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/edit-form/use-date-entity-input-config.js
@@ -9,6 +9,7 @@ import {
 	useEndDateAfterStartDateValidator,
 	useEntityDateChangeListeners,
 	useEntityDateChangeValidators,
+	useEventDateUpdateRelatedTickets,
 } from '@eventespresso/hooks';
 import { parseInfinity } from '@eventespresso/utils';
 import { isModelEntityOfModel } from '@eventespresso/validators';
@@ -60,6 +61,7 @@ const useDateEntityInputConfig = ( {
 	const endDateIsAfterStartDate = useEndDateAfterStartDateValidator(
 		dateInputFormProps
 	);
+	const updateRelatedTickets = useEventDateUpdateRelatedTickets( dateEntity );
 	// useEntityDateChangeValidators use-entity-date-change-validators
 	return useMemo( () => [
 		{
@@ -131,11 +133,13 @@ const useDateEntityInputConfig = ( {
 			label: __( 'Capacity', 'event_espresso' ),
 			default: -1,
 			changeListener: ( value ) => {
-				dateEntity.regLimit = parseInfinity(
+				const regLimit = parseInfinity(
 					value || -1,
 					true,
 					true
 				);
+				dateEntity.regLimit = regLimit;
+				updateRelatedTickets( { capacity: regLimit } );
 			},
 			min: -1,
 			inputWidth: 3,

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
@@ -13,6 +13,7 @@ import { useEventDateUpdateRelatedTickets } from '@eventespresso/hooks';
  * Internal dependencies
  */
 import EventDateRegistrationsLink from '../event-date-registrations-link';
+import { updateTicketQtyAfterCapacityChange } from '../../../mutations/ticket-mutations';
 
 const EventDateDetailsPanel = ( { eventDate } ) => {
 	const updateRelatedTickets = useEventDateUpdateRelatedTickets( eventDate );
@@ -39,7 +40,8 @@ const EventDateDetailsPanel = ( { eventDate } ) => {
 						onChange: ( cap ) => {
 							const capacity = parseInfinity( cap, true, true );
 							eventDate.regLimit = capacity;
-							updateRelatedTickets( { capacity } );
+							const updateTicketQty = updateTicketQtyAfterCapacityChange( capacity );
+							updateRelatedTickets( [ updateTicketQty ] );
 							return <InfinitySymbol value={ capacity } asInt />;
 						},
 					},

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
@@ -37,10 +37,10 @@ const EventDateDetailsPanel = ( { eventDate } ) => {
 						type: 'text',
 						valueType: 'infinite',
 						onChange: ( cap ) => {
-							cap = parseInfinity( cap, true, true );
-							eventDate.regLimit = cap;
-							updateRelatedTickets( { capacity: cap } );
-							return <InfinitySymbol value={ cap } asInt />;
+							const capacity = parseInfinity( cap, true, true );
+							eventDate.regLimit = capacity;
+							updateRelatedTickets( { capacity } );
+							return <InfinitySymbol value={ capacity } asInt />;
 						},
 					},
 				},

--- a/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
+++ b/assets/src/editor/events/dates-and-times/editor-date/grid-view/event-date-details-panel.js
@@ -7,61 +7,66 @@ import { parseInfinity } from '@eventespresso/utils';
 import { __ } from '@eventespresso/i18n';
 import { InfinitySymbol } from '@eventespresso/value-objects';
 import PropTypes from 'prop-types';
+import { useEventDateUpdateRelatedTickets } from '@eventespresso/hooks';
 
 /**
  * Internal dependencies
  */
 import EventDateRegistrationsLink from '../event-date-registrations-link';
 
-const EventDateDetailsPanel = ( { eventDate } ) => useMemo(
-	() => {
-		const details = [
-			{
-				id: 'ee-event-date-sold',
-				label: __( 'sold', 'event_espresso' ),
-				value: eventDate.sold || 0,
-			},
-			{
-				id: 'ee-event-date-reserved',
-				label: __( 'reserved', 'event_espresso' ),
-				value: eventDate.reserved || 0,
-			},
-			{
-				id: 'ee-event-date-capacity',
-				label: __( 'capacity', 'event_espresso' ),
-				value: <InfinitySymbol value={ eventDate.regLimit } asInt />,
-				editable: {
-					type: 'text',
-					valueType: 'infinite',
-					onChange: ( cap ) => {
-						cap = parseInfinity( cap, true, true );
-						eventDate.regLimit = cap;
-						return <InfinitySymbol value={ cap } asInt />;
+const EventDateDetailsPanel = ( { eventDate } ) => {
+	const updateRelatedTickets = useEventDateUpdateRelatedTickets( eventDate );
+	return useMemo(
+		() => {
+			const details = [
+				{
+					id: 'ee-event-date-sold',
+					label: __( 'sold', 'event_espresso' ),
+					value: eventDate.sold || 0,
+				},
+				{
+					id: 'ee-event-date-reserved',
+					label: __( 'reserved', 'event_espresso' ),
+					value: eventDate.reserved || 0,
+				},
+				{
+					id: 'ee-event-date-capacity',
+					label: __( 'capacity', 'event_espresso' ),
+					value: <InfinitySymbol value={ eventDate.regLimit } asInt />,
+					editable: {
+						type: 'text',
+						valueType: 'infinite',
+						onChange: ( cap ) => {
+							cap = parseInfinity( cap, true, true );
+							eventDate.regLimit = cap;
+							updateRelatedTickets( { capacity: cap } );
+							return <InfinitySymbol value={ cap } asInt />;
+						},
 					},
 				},
-			},
-			{
-				id: 'ee-event-date-registrants',
-				htmlClass: 'ee-has-tooltip',
-				label: __( 'registrants', 'event_espresso' ),
-				value: (
-					<EventDateRegistrationsLink dateEntity={ eventDate } />
-				),
-			},
-		];
-		return <EntityDetailsPanel
-			details={ details }
-			htmlClass="ee-editor-date-details-sold-rsrvd-cap-div"
-		/>;
-	},
-	[
-		eventDate.evtId,
-		eventDate.id,
-		eventDate.sold,
-		eventDate.reserved,
-		eventDate.regLimit,
-	]
-);
+				{
+					id: 'ee-event-date-registrants',
+					htmlClass: 'ee-has-tooltip',
+					label: __( 'registrants', 'event_espresso' ),
+					value: (
+						<EventDateRegistrationsLink dateEntity={ eventDate } />
+					),
+				},
+			];
+			return <EntityDetailsPanel
+				details={ details }
+				htmlClass="ee-editor-date-details-sold-rsrvd-cap-div"
+			/>;
+		},
+		[
+			eventDate.evtId,
+			eventDate.id,
+			eventDate.sold,
+			eventDate.reserved,
+			eventDate.regLimit,
+		]
+	);
+};
 
 EventDateDetailsPanel.propTypes = {
 	eventDate: PropTypes.object.isRequired,

--- a/assets/src/editor/events/mutations/ticket-mutations.js
+++ b/assets/src/editor/events/mutations/ticket-mutations.js
@@ -1,0 +1,19 @@
+/**
+ * External imports
+ */
+import { parseInfinity } from '@eventespresso/utils';
+
+/**
+ * A mutation function to update the ticket quantity
+ * based on the related datetime capacity change.
+ *
+ * @param {number} capacity  The datetime capacity.
+ */
+export const updateTicketQtyAfterCapacityChange = ( capacity ) => ( ticket ) => {
+	// Make sure that the non negative ticket qty value is compared with
+	// a non negative datetime capacity value in Math.min()
+	const nonNegativeDTTCapacity = parseInfinity( capacity, false, false );
+	const nonNegativeTKTQty = parseInfinity( ticket.qty, false, false );
+	const qty = Math.min( nonNegativeDTTCapacity, nonNegativeTKTQty );
+	ticket.qty = parseInfinity( qty, true, true );
+};

--- a/assets/src/hooks/index.js
+++ b/assets/src/hooks/index.js
@@ -46,3 +46,4 @@ export { default as useTrashDateEntity } from './use-trash-date-entity';
 export { default as useTrashPriceModifier } from './use-trash-price-modifier';
 export { default as useTrashTicket } from './use-trash-ticket';
 export { default as usePrevious } from './use-previous';
+export { default as useTriggerTicketUIUpdate } from './use-trigger-ticket-ui-update';

--- a/assets/src/hooks/index.js
+++ b/assets/src/hooks/index.js
@@ -25,6 +25,7 @@ export { default as useEntityDateChangeValidators }
 	from './use-entity-date-change-validators';
 export { default as useEventDateEvent } from './use-event-date-event';
 export { default as useEventDateTickets } from './use-event-date-tickets';
+export { default as useEventDateUpdateRelatedTickets } from './use-event-date-update-related-tickets';
 export { default as useEventDatesForEvent } from './use-event-dates-for-event';
 export { default as useEventEditorEvent } from './use-event-editor-event';
 export { default as useEventEditorEventDates }

--- a/assets/src/hooks/index.js
+++ b/assets/src/hooks/index.js
@@ -46,4 +46,4 @@ export { default as useTrashDateEntity } from './use-trash-date-entity';
 export { default as useTrashPriceModifier } from './use-trash-price-modifier';
 export { default as useTrashTicket } from './use-trash-ticket';
 export { default as usePrevious } from './use-previous';
-export { default as useTriggerTicketUIUpdate } from './use-trigger-ticket-ui-update';
+export { default as useTriggerTicketUiUpdate } from './use-trigger-ticket-ui-update';

--- a/assets/src/hooks/use-event-date-update-related-tickets.js
+++ b/assets/src/hooks/use-event-date-update-related-tickets.js
@@ -1,0 +1,35 @@
+/**
+ * External imports.
+ */
+import { useCallback } from '@wordpress/element';
+import { parseInfinity } from '@eventespresso/utils';
+/**
+ * Internal imports
+ */
+import useEventDateTickets from './use-event-date-tickets';
+
+/**
+ * A custom react hook to update the related ticket entities for the given
+ * datetime entity from the eventespresso/core store state.
+ *
+ * @param {BaseEntity} eventDate  A datetime BaseEntity instance.
+ */
+const useEventDateUpdateRelatedTickets = ( eventDate ) => {
+	const { tickets: relatedTickets, ticketsLoaded } = useEventDateTickets( eventDate );
+	return useCallback( ( { capacity = null } ) => {
+		if ( ticketsLoaded ) {
+			// Make sure that the ticket qty value is compared with
+			// a non negative datetime capacity value in Math.min()
+			const nonNegativeDTTCapacity = parseInfinity( capacity, false, false );
+			relatedTickets.forEach( ( ticket ) => {
+				if ( capacity !== null ) {
+					const nonNegativeTKTQty = parseInfinity( ticket.qty, false, false );
+					const qty = Math.min( nonNegativeDTTCapacity, nonNegativeTKTQty );
+					ticket.qty = parseInfinity( qty, true, true );
+				}
+			} );
+		}
+	}, [ eventDate ] );
+};
+
+export default useEventDateUpdateRelatedTickets;

--- a/assets/src/hooks/use-event-date-update-related-tickets.js
+++ b/assets/src/hooks/use-event-date-update-related-tickets.js
@@ -2,7 +2,6 @@
  * External imports.
  */
 import { useCallback } from '@wordpress/element';
-import { parseInfinity } from '@eventespresso/utils';
 /**
  * Internal imports
  */
@@ -16,16 +15,13 @@ import useEventDateTickets from './use-event-date-tickets';
  */
 const useEventDateUpdateRelatedTickets = ( eventDate ) => {
 	const { tickets: relatedTickets, ticketsLoaded } = useEventDateTickets( eventDate );
-	return useCallback( ( { capacity = null } ) => {
+	return useCallback( ( mutations = [] ) => {
 		if ( ticketsLoaded ) {
-			// Make sure that the ticket qty value is compared with
-			// a non negative datetime capacity value in Math.min()
-			const nonNegativeDTTCapacity = parseInfinity( capacity, false, false );
 			relatedTickets.forEach( ( ticket ) => {
-				if ( capacity !== null ) {
-					const nonNegativeTKTQty = parseInfinity( ticket.qty, false, false );
-					const qty = Math.min( nonNegativeDTTCapacity, nonNegativeTKTQty );
-					ticket.qty = parseInfinity( qty, true, true );
+				for ( const mutation of mutations ) {
+					if ( typeof mutation === 'function' ) {
+						mutation( ticket );
+					}
 				}
 			} );
 		}

--- a/assets/src/hooks/use-event-date-update-related-tickets.js
+++ b/assets/src/hooks/use-event-date-update-related-tickets.js
@@ -7,7 +7,7 @@ import { useCallback } from '@wordpress/element';
  * Internal imports
  */
 import useEventDateTickets from './use-event-date-tickets';
-import useTriggerTicketUIUpdate from './use-trigger-ticket-ui-update';
+import useTriggerTicketUiUpdate from './use-trigger-ticket-ui-update';
 
 /**
  * A custom react hook to update the related ticket entities for the given
@@ -17,7 +17,7 @@ import useTriggerTicketUIUpdate from './use-trigger-ticket-ui-update';
  */
 const useEventDateUpdateRelatedTickets = ( eventDate ) => {
 	const { tickets: relatedTickets, ticketsLoaded } = useEventDateTickets( eventDate );
-	const triggerUIUpdate = useTriggerTicketUIUpdate();
+	const triggerUiUpdate = useTriggerTicketUiUpdate();
 
 	return useCallback( ( mutations = [] ) => {
 		if ( ticketsLoaded ) {
@@ -28,7 +28,7 @@ const useEventDateUpdateRelatedTickets = ( eventDate ) => {
 					}
 				}
 			} );
-			triggerUIUpdate();
+			triggerUiUpdate();
 		}
 	}, [ eventDate ] );
 };

--- a/assets/src/hooks/use-event-date-update-related-tickets.js
+++ b/assets/src/hooks/use-event-date-update-related-tickets.js
@@ -2,6 +2,7 @@
  * External imports.
  */
 import { useCallback } from '@wordpress/element';
+
 /**
  * Internal imports
  */

--- a/assets/src/hooks/use-event-date-update-related-tickets.js
+++ b/assets/src/hooks/use-event-date-update-related-tickets.js
@@ -7,6 +7,7 @@ import { useCallback } from '@wordpress/element';
  * Internal imports
  */
 import useEventDateTickets from './use-event-date-tickets';
+import useTriggerTicketUIUpdate from './use-trigger-ticket-ui-update';
 
 /**
  * A custom react hook to update the related ticket entities for the given
@@ -16,6 +17,8 @@ import useEventDateTickets from './use-event-date-tickets';
  */
 const useEventDateUpdateRelatedTickets = ( eventDate ) => {
 	const { tickets: relatedTickets, ticketsLoaded } = useEventDateTickets( eventDate );
+	const triggerUIUpdate = useTriggerTicketUIUpdate();
+
 	return useCallback( ( mutations = [] ) => {
 		if ( ticketsLoaded ) {
 			relatedTickets.forEach( ( ticket ) => {
@@ -25,6 +28,7 @@ const useEventDateUpdateRelatedTickets = ( eventDate ) => {
 					}
 				}
 			} );
+			triggerUIUpdate();
 		}
 	}, [ eventDate ] );
 };

--- a/assets/src/hooks/use-trigger-ticket-ui-update.js
+++ b/assets/src/hooks/use-trigger-ticket-ui-update.js
@@ -1,0 +1,39 @@
+/**
+ * External imports.
+ */
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * To show the changes in ticket details
+ * trigger the ticket UI update wihout any side effect.
+ */
+const useTriggerTicketUIUpdate = () => {
+	const listId = 'event-editor-ticket-list';
+	const defaultDisplayDate = 'start';
+	const storeKey = 'eventespresso/filter-state';
+
+	return () => {
+		const { getFilter } = select( storeKey );
+		const { setFilter } = dispatch( storeKey );
+		const displayDate = getFilter(
+			listId,
+			'displayTicketDate',
+			defaultDisplayDate
+		);
+		const intermediateValue = displayDate === 'start' ? 'end' : 'start';
+		// Set the display date to the intermediate value.
+		setFilter(
+			listId,
+			'displayTicketDate',
+			intermediateValue
+		);
+		// Restore the actual value.
+		setFilter(
+			listId,
+			'displayTicketDate',
+			displayDate
+		);
+	};
+};
+
+export default useTriggerTicketUIUpdate;

--- a/assets/src/hooks/use-trigger-ticket-ui-update.js
+++ b/assets/src/hooks/use-trigger-ticket-ui-update.js
@@ -11,10 +11,10 @@ const useTriggerTicketUIUpdate = () => {
 	const listId = 'event-editor-ticket-list';
 	const defaultDisplayDate = 'start';
 	const storeKey = 'eventespresso/filter-state';
+	const { getFilter } = select( storeKey );
+	const { setFilter } = dispatch( storeKey );
 
 	return () => {
-		const { getFilter } = select( storeKey );
-		const { setFilter } = dispatch( storeKey );
 		const displayDate = getFilter(
 			listId,
 			'displayTicketDate',

--- a/assets/src/hooks/use-trigger-ticket-ui-update.js
+++ b/assets/src/hooks/use-trigger-ticket-ui-update.js
@@ -7,7 +7,7 @@ import { select, dispatch } from '@wordpress/data';
  * To show the changes in ticket details
  * trigger the ticket UI update wihout any side effect.
  */
-const useTriggerTicketUIUpdate = () => {
+const useTriggerTicketUiUpdate = () => {
 	const listId = 'event-editor-ticket-list';
 	const defaultDisplayDate = 'start';
 	const storeKey = 'eventespresso/filter-state';
@@ -36,4 +36,4 @@ const useTriggerTicketUIUpdate = () => {
 	};
 };
 
-export default useTriggerTicketUIUpdate;
+export default useTriggerTicketUiUpdate;


### PR DESCRIPTION
Fixes #1747 

## How has this been tested
monkey testing

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
