### PR TITLE
Fix/fix datetime picker styles

### DIFF
--- a/assets/src/editor/editor.css
+++ b/assets/src/editor/editor.css
@@ -180,6 +180,11 @@
     position: relative;
 }
 
+.components-datetime select {
+    height: 38px;
+    padding: 3px 24px 3px 8px;
+}
+
 /* TIME PICKER
  * -------------------------------------------------------------------------*/
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves https://github.com/eventespresso/event-espresso-core/issues/1710 - applying proper style to date month picker. Issue happens at FF. 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Using Firefox and WP 5.3 beta...

Edit any ticket at new EDTR event editor - click in the date time picker and the month dropdown should be properly styled (height and padding ok).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
