### PR TITLE
Shorter Table locking queries during 4.10 migration

### DIFF
--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -40,7 +40,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
             global $wpdb;
             // If the question group was also for primary attendees, we should just update that row.
             // And we delete this row.
-            // Updating all the rows could be slow on massive DBs, so do the slow selection first, then a quick delete
+            // Updating all the rows could be slow on massive DBs, so do the slow selection first, then a quick update
             // in order to avoid locking the table for too long.
             $ids_to_update = $wpdb->get_col(
                 $wpdb->prepare(

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -45,7 +45,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
             $ids_to_update = $wpdb->get_col(
                 $wpdb->prepare(
                     'SELECT EQG_ID FROM ' . $this->_old_table . ' WHERE EQG_primary=1 AND EVT_ID=%d AND QSG_ID=%d',
-                    $event_question_group['EQG_ID'],
+                    $event_question_group['EVT_ID'],
                     $event_question_group['QSG_ID']
                 )
             );

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -40,6 +40,8 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
             global $wpdb;
             // If the question group was also for primary attendees, we should just update that row.
             // And we delete this row.
+            // Updating all the rows could be slow on massive DBs, so do the slow selection first, then a quick delete
+            // in order to avoid locking the table for too long.
             $ids_to_update = $wpdb->get_col(
                 $wpdb->prepare(
                     'SELECT EQG_ID FROM ' . $this->_old_table . ' WHERE EQG_primary=1 AND EVT_ID=%d AND QSG_ID=%d',
@@ -52,7 +54,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                     'UPDATE '
                     . $this->_old_table
                     . ' SET EQG_additional=1 WHERE EQG_IN IN ('
-                    . implode(',', array_map('intval',$ids_to_update))
+                    . implode(',', array_map('intval', $ids_to_update))
                     . ') LIMIT ' . count($ids_to_update)
                 );
             }

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -57,46 +57,46 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                     . implode(',', array_map('intval', $ids_to_update))
                     . ') LIMIT ' . count($ids_to_update)
                 );
-            }
-            if ($success) {
-                // Ok it's confirmed: the question group WAS for the primary attendee group too. So
-                // now we just need to delete this row.
-                $successful_delete = $wpdb->delete(
-                    $this->_old_table,
-                    [
-                        'EQG_ID' => $event_question_group['EQG_ID']
-                    ],
-                    ['%d']
-                );
-                if (! $successful_delete) {
-                    $this->add_error(
-                        sprintf(
-                            __('Could not delete old event-question group relation row "%1$s" because "%2$s"', 'event_espresso'),
-                            wp_json_encode($event_question_group),
-                            $wpdb->last_error
+                if ($success) {
+                    // Ok it's confirmed: the question group WAS for the primary attendee group too. So
+                    // now we just need to delete this row.
+                    $successful_delete = $wpdb->delete(
+                        $this->_old_table,
+                        [
+                            'EQG_ID' => $event_question_group['EQG_ID']
+                        ],
+                        ['%d']
+                    );
+                    if (!$successful_delete) {
+                        $this->add_error(
+                            sprintf(
+                                __('Could not delete old event-question group relation row "%1$s" because "%2$s"', 'event_espresso'),
+                                wp_json_encode($event_question_group),
+                                $wpdb->last_error
+                            )
+                        );
+                    }
+                } else {
+                    // Oh, the question group actually was NOT for the primary attendee. So we just need to update this row
+                    // Let's do the selection separately from the deletion, this way we don't lock big tables for too long.
+                    $ids_to_update2 = $wpdb->get_col(
+                        $wpdb->prepare(
+                            'SELECT EQG_ID FROM '
+                            . $this->_old_table
+                            . ' WHERE EVT_ID=%d AND QSG_ID=%d',
+                            $event_question_group['EVT_ID'],
+                            $event_question_group['QSG_ID']
                         )
                     );
-                }
-            } else {
-                // Oh, the question group actually was NOT for the primary attendee. So we just need to update this row
-                // Let's do the selection separately from the deletion, this way we don't lock big tables for too long.
-                $ids_to_update2 = $wpdb->get_col(
-                    $wpdb->prepare(
-                        'SELECT EQG_ID FROM '
-                        . $this->_old_table
-                        . ' WHERE EVT_ID=%d AND QSG_ID=%d',
-                        $event_question_group['EVT_ID'],
-                        $event_question_group['QSG_ID']
-                    )
-                );
-                if ($ids_to_update2) {
-                    $wpdb->query(
-                        'UPDATE '
-                        . $this->_old_table
-                        . ' SET EQG_additional=1 WHERE EQG_ID IN ('
-                        . implode(',',array_map('intval',$ids_to_update2))
-                        . ') LIMIT ' . count($ids_to_update2)
-                    );
+                    if ($ids_to_update2) {
+                        $wpdb->query(
+                            'UPDATE '
+                            . $this->_old_table
+                            . ' SET EQG_additional=1 WHERE EQG_ID IN ('
+                            . implode(',', array_map('intval', $ids_to_update2))
+                            . ') LIMIT ' . count($ids_to_update2)
+                        );
+                    }
                 }
             }
         }

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -140,7 +140,9 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
             $this->_migrate_old_row($old_row);
             $items_actually_migrated++;
         }
-        if ($this->count_records_migrated() + $items_actually_migrated >= $this->count_records_to_migrate()) {
+        if (empty($rows)
+            || ($this->count_records_migrated() + $items_actually_migrated >= $this->count_records_to_migrate())
+        ) {
             $this->set_completed();
         }
         return $items_actually_migrated;

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -49,6 +49,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                     $event_question_group['QSG_ID']
                 )
             );
+            $success = false;
             if ($ids_to_update) {
                 $success = $wpdb->query(
                     'UPDATE '
@@ -57,46 +58,46 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                     . implode(',', array_map('intval', $ids_to_update))
                     . ') LIMIT ' . count($ids_to_update)
                 );
-                if ($success) {
-                    // Ok it's confirmed: the question group WAS for the primary attendee group too. So
-                    // now we just need to delete this row.
-                    $successful_delete = $wpdb->delete(
-                        $this->_old_table,
-                        [
-                            'EQG_ID' => $event_question_group['EQG_ID']
-                        ],
-                        ['%d']
-                    );
-                    if (!$successful_delete) {
-                        $this->add_error(
-                            sprintf(
-                                __('Could not delete old event-question group relation row "%1$s" because "%2$s"', 'event_espresso'),
-                                wp_json_encode($event_question_group),
-                                $wpdb->last_error
-                            )
-                        );
-                    }
-                } else {
-                    // Oh, the question group actually was NOT for the primary attendee. So we just need to update this row
-                    // Let's do the selection separately from the deletion, this way we don't lock big tables for too long.
-                    $ids_to_update2 = $wpdb->get_col(
-                        $wpdb->prepare(
-                            'SELECT EQG_ID FROM '
-                            . $this->_old_table
-                            . ' WHERE EVT_ID=%d AND QSG_ID=%d',
-                            $event_question_group['EVT_ID'],
-                            $event_question_group['QSG_ID']
+            }
+            if ($success) {
+                // Ok it's confirmed: the question group WAS for the primary attendee group too. So
+                // now we just need to delete this row.
+                $successful_delete = $wpdb->delete(
+                    $this->_old_table,
+                    [
+                        'EQG_ID' => $event_question_group['EQG_ID']
+                    ],
+                    ['%d']
+                );
+                if (!$successful_delete) {
+                    $this->add_error(
+                        sprintf(
+                            __('Could not delete old event-question group relation row "%1$s" because "%2$s"', 'event_espresso'),
+                            wp_json_encode($event_question_group),
+                            $wpdb->last_error
                         )
                     );
-                    if ($ids_to_update2) {
-                        $wpdb->query(
-                            'UPDATE '
-                            . $this->_old_table
-                            . ' SET EQG_additional=1 WHERE EQG_ID IN ('
-                            . implode(',', array_map('intval', $ids_to_update2))
-                            . ') LIMIT ' . count($ids_to_update2)
-                        );
-                    }
+                }
+            } else {
+                // Oh, the question group actually was NOT for the primary attendee. So we just need to update this row
+                // Let's do the selection separately from the deletion, this way we don't lock big tables for too long.
+                $ids_to_update2 = $wpdb->get_col(
+                    $wpdb->prepare(
+                        'SELECT EQG_ID FROM '
+                        . $this->_old_table
+                        . ' WHERE EVT_ID=%d AND QSG_ID=%d',
+                        $event_question_group['EVT_ID'],
+                        $event_question_group['QSG_ID']
+                    )
+                );
+                if ($ids_to_update2) {
+                    $wpdb->query(
+                        'UPDATE '
+                        . $this->_old_table
+                        . ' SET EQG_additional=1 WHERE EQG_ID IN ('
+                        . implode(',', array_map('intval', $ids_to_update2))
+                        . ') LIMIT ' . count($ids_to_update2)
+                    );
                 }
             }
         }

--- a/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
+++ b/core/data_migration_scripts/4_10_0_stages/EE_DMS_4_10_0_Event_Question_Group.dmsstage.php
@@ -53,7 +53,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                 $success = $wpdb->query(
                     'UPDATE '
                     . $this->_old_table
-                    . ' SET EQG_additional=1 WHERE EQG_IN IN ('
+                    . ' SET EQG_additional=1 WHERE EQG_ID IN ('
                     . implode(',', array_map('intval', $ids_to_update))
                     . ') LIMIT ' . count($ids_to_update)
                 );
@@ -85,7 +85,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                         'SELECT EQG_ID FROM '
                         . $this->_old_table
                         . ' WHERE EVT_ID=%d AND QSG_ID=%d',
-                        $event_question_group['EQG_ID'],
+                        $event_question_group['EVT_ID'],
                         $event_question_group['QSG_ID']
                     )
                 );
@@ -94,7 +94,7 @@ class EE_DMS_4_10_0_Event_Question_Group extends EE_Data_Migration_Script_Stage_
                         'UPDATE '
                         . $this->_old_table
                         . ' SET EQG_additional=1 WHERE EQG_ID IN ('
-                        . $ids_to_update2
+                        . implode(',',array_map('intval',$ids_to_update2))
                         . ') LIMIT ' . count($ids_to_update2)
                     );
                 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
An attempt to fix https://github.com/eventespresso/event-espresso-core/issues/1739 by having the 4.10 migration not doing UPDATE queries with lots of conditions (which can make the queries take a while, and locks the table the whole time) and instead do a SELECT query with all the conditions (which is about the same speed, but doesn't lock the table) to get all the IDs we want to update, then do a really quick UPDATE query (which locks the table for much less time).
Here's my benchmarking (time in milliseconds, my wp_esp_event_question_group table had 2000 records):

```
       | master run 1 | master run 2 | this branch run 1 | this branch run 2
update1| 03.001       | 02.000       | 01.000            | 01.000
update2| 10.000       | 04.000       | 04.000            | 04.001
```

So not only is the table locked for less time, it seems to consistently be about an order of magnitude faster (I'm suspicious of that- I don't have a controlled environment by any means, but certainly it's not significantly slower than before)

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Run the 4.10 DMS. There should be no errors

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
