### PR TITLE
Disable eslint rule for ResizeObserver.

### DIFF
--- a/assets/src/hooks/useRect.js
+++ b/assets/src/hooks/useRect.js
@@ -20,8 +20,9 @@ const useRect = ( ref ) => {
 		}
 
 		handleResize();
-
+		// eslint-disable-next-line
 		if ( ResizeObserver && typeof ResizeObserver === 'function' ) {
+			// eslint-disable-next-line
 			let resizeObserver = new ResizeObserver( () => handleResize() );
 			resizeObserver.observe( element );
 


### PR DESCRIPTION
##  Problem this Pull Request solves
Eslint is showing error for `no-undef` in case of `ResizeObserver`, but it that function body is wrapped with this check, in case browser do not support this resizing API:
```
if ( ResizeObserver && typeof ResizeObserver === 'function' ) {
```
more info on ResizeObserver here: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
## How has this been tested
In IDE

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
