### PR TITLE
Tweak Filter Bar Styles

### DIFF
--- a/assets/src/components/ui/entity-list-filter-bar/collapsible.js
+++ b/assets/src/components/ui/entity-list-filter-bar/collapsible.js
@@ -33,7 +33,7 @@ const Collapsible = ( {
 	perPage,
 	searchText,
 	setPerPage,
-	setSearchText,	
+	setSearchText,
 	showEntityFilters = false
 } ) => {
 	const ref = useRef();
@@ -41,7 +41,7 @@ const Collapsible = ( {
 	const props = useSpring({
 		height: showEntityFilters ? height : 0,
 		opacity: showEntityFilters ? 1 : 0
-	})
+	} );
 
 	const perPageControl = useMemo( () => (
 		<SelectControl
@@ -81,7 +81,7 @@ const Collapsible = ( {
 			</div>
 		</animated.div>
 	);
-}
+};
 
 Collapsible.propTypes = {
 	entityFilters: PropTypes.object,

--- a/assets/src/components/ui/entity-list-filter-bar/entity-list-filter-bar.js
+++ b/assets/src/components/ui/entity-list-filter-bar/entity-list-filter-bar.js
@@ -55,7 +55,11 @@ const EntityListFilterBar = ( {
 			</label>
 			<IconButton
 				id={ `ee-list-view-btn-${ listId }` }
-				className={ view === 'list' ? 'active-list' : '' }
+				className={
+					view === 'list' ?
+						'ee-filter-bar-filter ee-active-filters' :
+						'ee-filter-bar-filter'
+				}
 				icon="list-view"
 				tooltip={ __( 'list view', 'event_espresso' ) }
 				onClick={ setListView }
@@ -72,7 +76,11 @@ const EntityListFilterBar = ( {
 			</label>
 			<IconButton
 				id={ `ee-grid-view-btn-${ listId }` }
-				className={ view === 'grid' ? 'active-list' : '' }
+				className={
+					view === 'grid' ?
+						'ee-filter-bar-filter ee-active-filters' :
+						'ee-filter-bar-filter'
+				}
 				icon="grid-view"
 				tooltip={ __( 'grid view', 'event_espresso' ) }
 				onClick={ setGridView }
@@ -85,20 +93,25 @@ const EntityListFilterBar = ( {
 			<label
 				className="screen-reader-text"
 				htmlFor={ `ee-grid-filter-btn-${ listId }` }>
-				{ __( 'filter', 'event_espresso' ) }
+				{ __( 'show filters', 'event_espresso' ) }
 			</label>
 			<IconButton
 				id={ `ee-grid-filter-btn-${ listId }` }
 				icon="filter"
 				tooltip={ __( 'filter', 'event_espresso' ) }
 				onClick={ toggleEntityFilters }
+				className={
+					showEntityFilters ?
+						'ee-filter-bar-filter ee-active-filters' :
+						'ee-filter-bar-filter'
+				}
 			/>
 		</Fragment>
 	), [ listId, toggleEntityFilters ] );
 
 	return (
 		<div className="ee-entity-list-filter-bar-wrapper">
-			<div className="ee-filter-bar-filter-main ee-filter-bar-filter">
+			<div className="ee-filter-bar-filter-main">
 				{ listViewButton }
 				{ gridViewButton }
 				{ showFiltersButton }

--- a/assets/src/components/ui/entity-list-filter-bar/style.css
+++ b/assets/src/components/ui/entity-list-filter-bar/style.css
@@ -19,6 +19,7 @@
 .ee-filter-bar-filter-main {
     display: flex;
     flex-flow: row wrap;
+    align-items: flex-start;
 }
 
 .ee-filter-bar-filter-collapsible {
@@ -30,24 +31,6 @@
     margin-right: 1rem;
 }
 
-.ee-entity-list-filter-bar,
-.ee-entity-list-view-bar {
-    display: flex;
-    flex-flow: row wrap;
-    /*align-items: flex-end;*/
-    align-items: flex-start;
-}
-
-.ee-entity-list-filter-bar {
-    justify-content: flex-start;
-    margin-right: var(--ee-margin-small);
-}
-
-.ee-entity-list-view-bar {
-    /*max-height: var(--ee-icon-button-size);*/
-    justify-content: flex-end;
-    /*margin: -1px calc(var(--ee-margin-micro) * -1) var(--ee-margin-smaller) 0;*/
-}
 .ee-entity-list-filter-bar-perPage-select {
     min-width: 60px;
 }
@@ -58,30 +41,29 @@
     white-space: pre;
 }
 
-.ee-entity-list-view-bar .ee-filter-bar-filter {
+.ee-entity-list-ee-active-filters .ee-filter-bar-filter {
     display: flex;
     flex-flow: row nowrap;
-    /*height: var(--ee-icon-button-size);*/
     justify-content: flex-end;
     align-items: flex-start;
     margin: 0 0 0 var(--ee-margin-small);
     max-width: 100%;
 }
-.ee-entity-list-view-bar .ee-search-filter {
+.ee-entity-list-ee-active-filters .ee-search-filter {
     margin: 0;
 }
 
-.ee-entity-list-view-bar .ee-per-page-filter {
+.ee-entity-list-ee-active-filters .ee-per-page-filter {
     margin: 0 var(--ee-margin-micro) 0 0;
     /*max-height: var(--ee-icon-button-size);*/
 }
 
-.ee-entity-list-view-bar .ee-grid-view-filter {
+.ee-entity-list-ee-active-filters .ee-grid-view-filter {
     margin: 0 calc(var(--ee-margin-micro) * -1) 0 0;
 }
 
-.ee-entity-list-view-bar .ee-grid-view-filter,
-.ee-entity-list-view-bar .ee-list-view-filter {
+.ee-entity-list-ee-active-filters .ee-grid-view-filter,
+.ee-entity-list-ee-active-filters .ee-list-view-filter {
     height: var(--ee-icon-button-size);
     width: var(--ee-icon-button-size);
 }
@@ -94,14 +76,11 @@
 }
 
 .ee-entity-list-filter-bar-wrapper .components-icon-button {
-    margin-top: calc(var(--ee-margin-micro) + 19px);
-}
-
-.ee-entity-list-view-bar .components-icon-button {
     color: var(--ee-default-text-color);
+    margin-top: var(--ee-margin-micro);
 }
 
-.ee-entity-list-view-bar .components-icon-button.active-list {
+.ee-entity-list-filter-bar-wrapper .components-icon-button.ee-active-filters {
     color: var(--ee-color-primary);
 }
 
@@ -157,6 +136,10 @@
     padding: calc(var(--ee-padding-small) * 10) var(--ee-padding-tiny) !important;
 }
 
+.ee-entity-list-filter-bar-wrapper .components-base-control + .components-base-control {
+    margin-bottom: var(--ee-margin-micro);
+}
+
 
 /* Media Queries for specific screen sizes
  * -------------------------------------------------------------------------*/
@@ -179,10 +162,6 @@
 
     .ee-entity-list-filter-bar {
         margin: 0 0 var(--ee-margin-default);
-    }
-
-    .ee-entity-list-view-bar {
-        max-height: 118px;
     }
 }
 
@@ -209,23 +188,18 @@
         padding-bottom: var(--ee-padding-small);
     }
 
-    .ee-entity-list-filter-bar,
-    .ee-entity-list-view-bar {
-        width: 100%;
-    }
+    /*.ee-entity-list-view-bar {*/
+    /*    flex-flow: row nowrap;*/
+    /*    justify-content: flex-start;*/
+    /*    height: calc(var(--ee-icon-button-size) * 1.5);*/
+    /*    margin: 0;*/
+    /*    text-align: left;*/
+    /*}*/
 
-    .ee-entity-list-view-bar {
-        flex-flow: row nowrap;
-        justify-content: flex-start;
-        height: calc(var(--ee-icon-button-size) * 1.5);
-        margin: 0;
-        text-align: left;
-    }
-
-    .ee-entity-list-view-bar .ee-filter-bar-filter {
-        height: auto;
-        margin: 0 var(--ee-margin-small) 0 0;
-    }
+    /*.ee-entity-list-view-bar .ee-filter-bar-filter {*/
+    /*    height: auto;*/
+    /*    margin: 0 var(--ee-margin-small) 0 0;*/
+    /*}*/
 }
 
 @media only screen and (max-width: 480px) {
@@ -234,18 +208,18 @@
         margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;
     }
 
-    .ee-entity-list-view-bar {
-        flex-flow: row wrap;
-        height: auto;
-        max-height: unset;
-    }
+    /*.ee-entity-list-view-bar {*/
+    /*    flex-flow: row wrap;*/
+    /*    height: auto;*/
+    /*    max-height: unset;*/
+    /*}*/
 
-    .ee-entity-list-view-bar .ee-filter-bar-filter {
-        height: auto;
-        justify-content: flex-start;
-        margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;
-        max-height: unset;
-    }
+    /*.ee-entity-list-view-bar .ee-filter-bar-filter {*/
+    /*    height: auto;*/
+    /*    justify-content: flex-start;*/
+    /*    margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;*/
+    /*    max-height: unset;*/
+    /*}*/
 }
 
 @media only screen and (max-width: 360px) {


### PR DESCRIPTION
In #1774 the layout and structure of the entity filter bar filters changed which resulted in some of the CSS styles no longer getting applied. 

The fixes in this branch include changing the colour for the main filter icon buttons when they are active, as well as fixing some margins that were out of whack.

before:
![filter bar styles - before](https://user-images.githubusercontent.com/1751030/68361423-adfa0100-00d8-11ea-9f05-8ef78b23a857.png)

after:
![filter bar styles - after](https://user-images.githubusercontent.com/1751030/68361373-87d46100-00d8-11ea-971a-e1188838ac22.png)
