### PR TITLE
Fix Required Fields Notice Display - closes #1703

### DIFF
--- a/assets/src/components/form/base/form-info-base.css
+++ b/assets/src/components/form/base/form-info-base.css
@@ -15,8 +15,6 @@
 }
 
 .ee-form-info {
-    color: var(--ee-default-text-color-low-contrast);
-    font-size: var(--ee-font-size-default);
     font-style: italic;
     height: auto;
     line-height: 1.25rem;
@@ -42,6 +40,7 @@
 
 .ee-form-info.ee-form-info-type-warning .ee-form-info-type {
     color: var(--ee-color-hot-pink);
+    font-size: var(--ee-font-size-default);
 }
 
 .ee-form-info .ee-form-info-text .dashicon {

--- a/assets/src/components/form/base/form-info-base.js
+++ b/assets/src/components/form/base/form-info-base.js
@@ -1,6 +1,7 @@
 /**
  * External imports
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { __ } from '@eventespresso/i18n';
 import { Dashicon, IconButton } from '@wordpress/components';
@@ -38,12 +39,14 @@ const FormInfoBase = ( {
 	onDismiss,
 	formInfoVars,
 } ) => {
-	let classes = htmlClass ?
-		`${ htmlClass } ee-form-info` :
-		'ee-form-info';
-	classes = dashicon ?
-		`${ classes } ee-form-info-type-${ dashicon } has-info-type` :
-		classes;
+	const classes = classNames(
+		htmlClass,
+		'ee-form-info',
+		{
+			[ `ee-form-info-type-${ dashicon }` ]: dashicon,
+			'has-info-type': dashicon,
+		}
+	);
 	const typeIcon = dashicon ? (
 		<Dashicon
 			className="ee-form-info-type"

--- a/assets/src/components/form/inputs/base/input-help-text.js
+++ b/assets/src/components/form/inputs/base/input-help-text.js
@@ -8,7 +8,10 @@ import PropTypes from 'prop-types';
  */
 const InputHelpText = ( { helpTextID, helpText } ) => {
 	return helpText ? (
-		<p id={ helpTextID } className="espresso-input-help-text" >
+		<p
+			id={ helpTextID }
+			className={ 'espresso-input-help-text ee-focus-priority-6' }
+		>
 			{ helpText }
 		</p>
 	) : null;

--- a/assets/src/components/form/layouts/two-column-admin/form-info.js
+++ b/assets/src/components/form/layouts/two-column-admin/form-info.js
@@ -36,7 +36,7 @@ const FormInfo = ( {
 	formInfoVars,
 } ) => {
 	const [ dismiss, setDismiss ] = useState( false );
-	const onDismiss = () => dismissable ? setDismiss( true ) : null;
+	const onDismiss = dismissable ? () => setDismiss( true ) : null;
 	const classes = classNames(
 		htmlClass,
 		'ee-form-info-row',

--- a/assets/src/components/form/layouts/two-column-admin/form-section.js
+++ b/assets/src/components/form/layouts/two-column-admin/form-section.js
@@ -42,6 +42,7 @@ const FormSection = ( {
 	...extraProps
 } ) => {
 	const {
+		formInfoNotice,
 		requiredNotice,
 		errorsNotice,
 		hasValidationErrors,
@@ -51,20 +52,37 @@ const FormSection = ( {
 	const classes = htmlClass ?
 		`${ htmlClass } ee-form-section px-0 pt-3 border rounded` :
 		'ee-form-section px-0 pt-3 border rounded';
-	const formInfo = useMemo( () => showRequiredNotice && (
-		<FormInfo
-			key="formInfo"
-			formInfo={ requiredNotice }
-			dismissable={ false }
-		/>
-	), [ showRequiredNotice ] );
-	const formErrors = hasValidationErrors ? (
-		<FormInfo
-			formInfo={ errorsNotice }
-			dashicon={ 'warning' }
-			dismissable={ false }
-		/>
-	) : null;
+	const formInfo = useMemo(
+		() => formInfoNotice ? (
+			<FormInfo
+				key="formInfo"
+				formInfo={ formInfoNotice }
+				dismissable={ true }
+			/>
+		) : null,
+		[ showRequiredNotice, requiredNotice ]
+	);
+	const formErrors = useMemo(
+		() => errorsNotice && hasValidationErrors ? (
+			<FormInfo
+				formInfo={ errorsNotice }
+				dashicon={ 'warning' }
+				dismissable={ false }
+			/>
+		) : null,
+		[ hasValidationErrors, errorsNotice ]
+	);
+	const requiredFields = useMemo(
+		() => requiredNotice && showRequiredNotice ? (
+			<FormInfo
+				key="requiredFields"
+				formInfo={ requiredNotice }
+				dismissable={ false }
+				htmlClass={ 'ee-focus-priority-8' }
+			/>
+		) : null,
+		[ showRequiredNotice, requiredNotice ]
+	);
 	return (
 		<div id={ htmlId } className={ classes }>
 			<div className="px-3">
@@ -81,6 +99,7 @@ const FormSection = ( {
 						);
 					} )
 				}
+				{ requiredFields }
 			</div>
 		</div>
 	);

--- a/assets/src/components/form/layouts/two-column-admin/form-section.js
+++ b/assets/src/components/form/layouts/two-column-admin/form-section.js
@@ -53,34 +53,34 @@ const FormSection = ( {
 		`${ htmlClass } ee-form-section px-0 pt-3 border rounded` :
 		'ee-form-section px-0 pt-3 border rounded';
 	const formInfo = useMemo(
-		() => formInfoNotice ? (
+		() => !! formInfoNotice && (
 			<FormInfo
 				key="formInfo"
 				formInfo={ formInfoNotice }
 				dismissable={ true }
 			/>
-		) : null,
+		),
 		[ formInfoNotice ]
 	);
 	const formErrors = useMemo(
-		() => errorsNotice && hasValidationErrors ? (
+		() => errorsNotice && !! hasValidationErrors && (
 			<FormInfo
 				formInfo={ errorsNotice }
 				dashicon={ 'warning' }
 				dismissable={ false }
 			/>
-		) : null,
+		),
 		[ hasValidationErrors, errorsNotice ]
 	);
 	const requiredFields = useMemo(
-		() => requiredNotice && showRequiredNotice ? (
+		() => requiredNotice && !! showRequiredNotice && (
 			<FormInfo
 				key="requiredFields"
 				formInfo={ requiredNotice }
 				dismissable={ false }
 				htmlClass={ 'ee-focus-priority-8' }
 			/>
-		) : null,
+		),
 		[ showRequiredNotice, requiredNotice ]
 	);
 	return (

--- a/assets/src/components/form/layouts/two-column-admin/form-section.js
+++ b/assets/src/components/form/layouts/two-column-admin/form-section.js
@@ -60,7 +60,7 @@ const FormSection = ( {
 				dismissable={ true }
 			/>
 		) : null,
-		[ showRequiredNotice, requiredNotice ]
+		[ formInfoNotice ]
 	);
 	const formErrors = useMemo(
 		() => errorsNotice && hasValidationErrors ? (

--- a/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
+++ b/assets/src/components/form/layouts/two-column-admin/two-column-admin.css
@@ -355,7 +355,6 @@
 }
 
 .ee-two-column-admin .espresso-input-help-text {
-    color: var(--ee-default-text-color-low-contrast);
     display: inline-block;
     font-style: italic;
     line-height: inherit;
@@ -368,7 +367,6 @@
 }
 
 .ee-two-column-admin .espresso-input-help-text > p {
-    font-size: inherit;
     line-height: inherit;
     margin: 0;
 }


### PR DESCRIPTION
plz see #1703

this branch does the following:

- separates required fields notices from other form info notices
- moves the required fields notice to the bottom of forms
- fixes dismiss buttons so they don't display when form info isn't dismissable
- tweaks the text "focus priority" (size and colour) for form info notices and help text
- uses classNames library for setting css classes