### PR TITLE
flush rewrite rules on shutdown

### DIFF
--- a/core/domain/services/custom_post_types/RewriteRules.php
+++ b/core/domain/services/custom_post_types/RewriteRules.php
@@ -37,7 +37,7 @@ class RewriteRules
         if (get_option(RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES, true)) {
             add_action(
                 'shutdown',
-                static function() {
+                static function () {
                     flush_rewrite_rules();
                     update_option(RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES, false);
                 }

--- a/core/domain/services/custom_post_types/RewriteRules.php
+++ b/core/domain/services/custom_post_types/RewriteRules.php
@@ -35,8 +35,13 @@ class RewriteRules
     public function flushRewriteRules()
     {
         if (get_option(RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES, true)) {
-            flush_rewrite_rules();
-            update_option(RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES, false);
+            add_action(
+                'shutdown',
+                static function() {
+                    flush_rewrite_rules();
+                    update_option(RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES, false);
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
See https://events.codebasehq.com/projects/event-espresso/tickets/8224 for backstory
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)

I'm going to set up a site to do some long term testing on this because it may or may not have any beneficial effect, but since WordPress documentation now says to flush permalinks on shutdown this may be a good idea.