### PR TITLE
Remove is_int check for numeric IDs from global unique IDs

### DIFF
--- a/core/domain/services/graphql/mutators/DatetimeDelete.php
+++ b/core/domain/services/graphql/mutators/DatetimeDelete.php
@@ -55,7 +55,7 @@ class DatetimeDelete
             }
             $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
 
-            $id = ! empty($id_parts['id']) && is_int($id_parts['id']) ? $id_parts['id'] : 0;
+            $id = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
             $entity = null;
 
             if ($id) {

--- a/core/domain/services/graphql/mutators/DatetimeUpdate.php
+++ b/core/domain/services/graphql/mutators/DatetimeUpdate.php
@@ -56,7 +56,7 @@ class DatetimeUpdate
             }
             $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
 
-            $id = ! empty($id_parts['id']) && is_int($id_parts['id']) ? $id_parts['id'] : 0;
+            $id = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
             $entity = null;
 
             if ($id) {

--- a/core/domain/services/graphql/mutators/TicketDelete.php
+++ b/core/domain/services/graphql/mutators/TicketDelete.php
@@ -58,7 +58,7 @@ class TicketDelete
             }
             $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
 
-            $id = ! empty($id_parts['id']) && is_int($id_parts['id']) ? $id_parts['id'] : 0;
+            $id = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
             $entity = null;
 
             if ($id) {

--- a/core/domain/services/graphql/mutators/TicketUpdate.php
+++ b/core/domain/services/graphql/mutators/TicketUpdate.php
@@ -56,7 +56,7 @@ class TicketUpdate
             }
             $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
 
-            $id = ! empty($id_parts['id']) && is_int($id_parts['id']) ? $id_parts['id'] : 0;
+            $id = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
             $entity = null;
 
             if ($id) {


### PR DESCRIPTION
This PR fixes the issue caused by `is_int` check for the numeric IDs from `Relay::fromGlobalId` which return the ID as string.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
