### PR TITLE
Add support for relational data in GQL queries

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -936,6 +936,12 @@ class EE_Dependency_Map
             'EventEspresso\core\domain\services\graphql\types\Ticket' => [
                 'EEM_Ticket' => EE_Dependency_Map::load_from_cache,
             ],
+            'EventEspresso\core\domain\services\graphql\types\Price' => [
+                'EEM_Price' => EE_Dependency_Map::load_from_cache,
+            ],
+            'EventEspresso\core\domain\services\graphql\types\PriceType' => [
+                'EEM_Price_Type' => EE_Dependency_Map::load_from_cache,
+            ],
             'EventEspresso\core\domain\services\graphql\types\Venue' => [
                 'EEM_Venue' => EE_Dependency_Map::load_from_cache,
             ],

--- a/core/domain/services/graphql/resolvers/FieldResolver.php
+++ b/core/domain/services/graphql/resolvers/FieldResolver.php
@@ -93,6 +93,9 @@ class FieldResolver extends ResolverBase
             if ($field->hasInternalResolver()) {
                 return $field->resolve($source, $args, $context, $info);
             }
+            if (! ($source instanceof EE_Base_Class)) {
+                return null;
+            }
             // Check if the field has a key mapped to model.
             if (! empty($field->key())) {
                 $value = $source->{$field->key()}();

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -211,6 +211,12 @@ class Datetime extends TypeBase
                     esc_html__('Ignored if empty.', 'event_espresso')
                 )
             ),
+            new GraphQLOutputField(
+                'relatedTickets',
+                ['list_of' => 'ID'],
+                null,
+                esc_html__('Globally unique IDs of teh related tickets.', 'event_espresso')
+            ),
         ];
     }
 

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -140,13 +140,13 @@ class Datetime extends TypeBase
             ),
             new GraphQLOutputField(
                 'parent',
-                'Datetime',
+                $this->name(),
                 null,
                 esc_html__('The parent datetime of the current datetime', 'event_espresso')
             ),
             new GraphQLInputField(
                 'parent',
-                'Int',
+                'ID',
                 null,
                 esc_html__('The parent datetime ID', 'event_espresso')
             ),
@@ -210,12 +210,6 @@ class Datetime extends TypeBase
                     esc_html__('Globally uqinue IDs of the tickets related to the datetime.', 'event_espresso'),
                     esc_html__('Ignored if empty.', 'event_espresso')
                 )
-            ),
-            new GraphQLOutputField(
-                'relatedTickets',
-                ['list_of' => 'ID'],
-                null,
-                esc_html__('Globally unique IDs of teh related tickets.', 'event_espresso')
             ),
         ];
     }

--- a/core/domain/services/graphql/types/Price.php
+++ b/core/domain/services/graphql/types/Price.php
@@ -108,7 +108,7 @@ class Price extends TypeBase
                 'isDeleted',
                 'Boolean',
                 'deleted',
-                esc_html__('Flag indicating price type has been trashed.', 'event_espresso')
+                esc_html__('Flag indicating price has been trashed.', 'event_espresso')
             ),
             new GraphQLField(
                 'isDefault',

--- a/core/domain/services/graphql/types/Price.php
+++ b/core/domain/services/graphql/types/Price.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\types;
+
+use EEM_Price;
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\types\TypeBase;
+use EventEspresso\core\services\graphql\fields\GraphQLField;
+use EventEspresso\core\services\graphql\fields\GraphQLInputField;
+use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class Price
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\types
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class Price extends TypeBase
+{
+
+    /**
+     * Price constructor.
+     *
+     * @param EEM_Price $price_model
+     */
+    public function __construct(EEM_Price $price_model)
+    {
+        $this->model = $price_model;
+        $this->setName('Price');
+        $this->setDescription(__('A price.', 'event_espresso'));
+        $this->setIsCustomPostType(false);
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     * @since $VID:$
+     */
+    public function getFields()
+    {
+        return [
+            new GraphQLField(
+                'id',
+                ['non_null' => 'ID'],
+                null,
+                esc_html__('The globally unique ID for the object.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                lcfirst($this->name()) . 'Id',
+                ['non_null' => 'Int'],
+                'ID',
+                esc_html__('Price ID', 'event_espresso')
+            ),
+            new GraphQLField(
+                'name',
+                'String',
+                'name',
+                esc_html__('Price Name', 'event_espresso')
+            ),
+            new GraphQLField(
+                'amount',
+                'Float',
+                'amount',
+                esc_html__('Price Amount', 'event_espresso')
+            ),
+            new GraphQLField(
+                'desc',
+                'String',
+                'desc',
+                esc_html__('Price description', 'event_espresso')
+            ),
+            new GraphQLField(
+                'overrides',
+                'Int',
+                'overrides',
+                esc_html__('Price ID for a global Price that will be overridden by this Price.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'order',
+                'Int',
+                'order',
+                esc_html__('Order of Application of Price.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'parent',
+                $this->name(),
+                null,
+                esc_html__('The parent price of the current price', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'priceType',
+                'PriceType',
+                'type_obj',
+                esc_html__('The related price type object.', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'parent',
+                'ID',
+                null,
+                esc_html__('The parent price ID', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isDeleted',
+                'Boolean',
+                'deleted',
+                esc_html__('Flag indicating price type has been trashed.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isDefault',
+                'Boolean',
+                'is_default',
+                esc_html__('Flag indicating price is the default one.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isPercent',
+                'Boolean',
+                'is_percent',
+                esc_html__('Flag indicating price is a percentage.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isBasePrice',
+                'Boolean',
+                'is_base_price',
+                esc_html__('Flag indicating price is a base price type.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isDiscount',
+                'Boolean',
+                'is_discount',
+                esc_html__('Flag indicating price is a discount.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'wpUser',
+                'User',
+                null,
+                esc_html__('Price Creator', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'wpUser',
+                'Int',
+                null,
+                esc_html__('Price Creator ID', 'event_espresso')
+            ),
+        ];
+    }
+}

--- a/core/domain/services/graphql/types/PriceType.php
+++ b/core/domain/services/graphql/types/PriceType.php
@@ -78,13 +78,13 @@ class PriceType extends TypeBase
                 'isPercent',
                 'Boolean',
                 'is_percent',
-                esc_html__('Flag indicating price is a percentage.', 'event_espresso')
+                esc_html__('Flag indicating price type is a percentage.', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'isDiscount',
                 'Boolean',
                 'is_discount',
-                esc_html__('Flag indicating price is a discount.', 'event_espresso')
+                esc_html__('Flag indicating price type is a discount.', 'event_espresso')
             ),
             new GraphQLField(
                 'isDeleted',

--- a/core/domain/services/graphql/types/PriceType.php
+++ b/core/domain/services/graphql/types/PriceType.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\types;
+
+use EEM_Price_Type;
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\types\TypeBase;
+use EventEspresso\core\services\graphql\fields\GraphQLField;
+use EventEspresso\core\services\graphql\fields\GraphQLInputField;
+use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class PriceType
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\types
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class PriceType extends TypeBase
+{
+
+    /**
+     * PriceType constructor.
+     *
+     * @param EEM_Price_Type $price_type_model
+     */
+    public function __construct(EEM_Price_Type $price_type_model)
+    {
+        $this->model = $price_type_model;
+        $this->setName('PriceType');
+        $this->setDescription(__('A price type.', 'event_espresso'));
+        $this->setIsCustomPostType(false);
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     * @since $VID:$
+     */
+    public function getFields()
+    {
+        return [
+            new GraphQLField(
+                'id',
+                ['non_null' => 'ID'],
+                null,
+                esc_html__('The globally unique ID for the object.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                lcfirst($this->name()) . 'Id',
+                ['non_null' => 'Int'],
+                'ID',
+                esc_html__('Price type ID', 'event_espresso')
+            ),
+            new GraphQLField(
+                'name',
+                'String',
+                'name',
+                esc_html__('Price type Name', 'event_espresso')
+            ),
+            new GraphQLField(
+                'baseType',
+                'Int',
+                'base_type',
+                esc_html__('Price Base type ID, 1 = Price , 2 = Discount , 3 = Surcharge , 4 = Tax', 'event_espresso')
+            ),
+            new GraphQLField(
+                'order',
+                'Int',
+                'order',
+                esc_html__('Order in which price should be applied.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isPercent',
+                'Boolean',
+                'is_percent',
+                esc_html__('Flag indicating price is a percentage.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isDiscount',
+                'Boolean',
+                'is_discount',
+                esc_html__('Flag indicating price is a discount.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isDeleted',
+                'Boolean',
+                'deleted',
+                esc_html__('Flag indicating price type has been trashed.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'wpUser',
+                'User',
+                null,
+                esc_html__('Price Type Creator', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'wpUser',
+                'Int',
+                null,
+                esc_html__('Price Type Creator ID', 'event_espresso')
+            ),
+        ];
+    }
+}

--- a/core/domain/services/graphql/types/RootQuery.php
+++ b/core/domain/services/graphql/types/RootQuery.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\types;
+
+use EEM_Ticket;
+use EEM_Price;
+use EEM_Price_Type;
+use EEM_Datetime;
+use EE_Error;
+use Exception;
+use InvalidArgumentException;
+use ReflectionException;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
+
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\types\TypeBase;
+use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
+use GraphQL\Error\UserError;
+use WPGraphQL\AppContext;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
+
+/**
+ * Class RootQuery
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\types
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class RootQuery extends TypeBase
+{
+
+    /**
+     * RootQuery constructor.
+     */
+    public function __construct()
+    {
+        $this->setName('RootQuery');
+        $this->setIsCustomPostType(true);
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     * @since $VID:$
+     */
+    public function getFields()
+    {
+        return [
+            new GraphQLOutputField(
+                'eventRelations',
+                'String',
+                null,
+                esc_html__('JSON encoded relational data of the models', 'event_espresso'),
+                null,
+                [$this, 'getEventRelationalData'],
+                [
+                    'eventId' => [
+                        'type'        => ['non_null' => 'Int'],
+                        'description' => esc_html__('The event ID to get the relational data for.', 'event_espresso'),
+                    ],
+                ]
+            ),
+        ];
+    }
+
+
+    /**
+     * @param mixed       $source  The source that's passed down the GraphQL queries
+     * @param array       $args    The inputArgs on the field
+     * @param AppContext  $context The AppContext passed down the GraphQL tree
+     * @param ResolveInfo $info    The ResolveInfo passed down the GraphQL tree
+     * @return string
+     * @throws EE_Error
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     * @throws UserError
+     * @throws UnexpectedEntityException
+     * @since $VID:$
+     */
+    public function getEventRelationalData($source, array $args, AppContext $context, ResolveInfo $info)
+    {
+        /**
+         * Throw an exception if there's no event ID
+         */
+        if (empty($args['eventId']) || ! absint($args['eventId'])) {
+            throw new UserError(esc_html__(
+                'No event ID was provided to get the relational data for',
+                'event_espresso'
+            ));
+        }
+
+        $eventId = absint($args['eventId']);
+
+        $data = [
+            'datetimes'  => [],
+            'tickets'    => [],
+            'prices'     => [],
+        ];
+
+        $eem_datetime   = EEM_Datetime::instance();
+        $eem_ticket     = EEM_Ticket::instance();
+        $eem_price      = EEM_Price::instance();
+        $eem_price_type = EEM_Price_Type::instance();
+
+        // PROCESS DATETIMES
+        $related_models = [
+            'tickets' => $eem_ticket,
+        ];
+        // Get the IDs of event datetimes.
+        $datetimeIds = $eem_datetime->get_col([['EVT_ID' => $eventId]]);
+        foreach ($datetimeIds as $datetimeId) {
+            $GID = self::convertToGlobalId($eem_datetime->item_name(), $datetimeId);
+            foreach ($related_models as $key => $model) {
+                // Get the IDs of related entities for the datetime ID.
+                $Ids = $model->get_col([['Datetime.DTT_ID' => $datetimeId]]);
+                if (! empty($Ids)) {
+                    $data['datetimes'][ $GID ][ $key ] = self::convertToGlobalId($model->item_name(), $Ids);
+                }
+            }
+        }
+
+        // PROCESS TICKETS
+        $related_models = [
+            'datetimes' => $eem_datetime,
+            'prices'    => $eem_price,
+        ];
+        // Get the IDs of all datetime tickets.
+        $ticketIds = $eem_ticket->get_col([['Datetime.DTT_ID' => ['in', $datetimeIds]]]);
+        foreach ($ticketIds as $ticketId) {
+            $GID = self::convertToGlobalId($eem_ticket->item_name(), $ticketId);
+
+            foreach ($related_models as $key => $model) {
+                // Get the IDs of related entities for the ticket ID.
+                $Ids = $model->get_col([['Ticket.TKT_ID' => $ticketId]]);
+                if (! empty($Ids)) {
+                    $data['tickets'][ $GID ][ $key ] = self::convertToGlobalId($model->item_name(), $Ids);
+                }
+            }
+        }
+
+        // PROCESS PRICES
+        $related_models = [
+            'tickets'    => $eem_ticket,
+            'priceTypes' => $eem_price_type,
+        ];
+        // Get the IDs of all ticket prices.
+        $priceIds = $eem_price->get_col([['Ticket.TKT_ID' => ['in', $ticketIds]]]);
+        foreach ($priceIds as $priceId) {
+            $GID = self::convertToGlobalId($eem_price->item_name(), $priceId);
+
+            foreach ($related_models as $key => $model) {
+                // Get the IDs of related entities for the price ID.
+                $Ids = $model->get_col([['Price.PRC_ID' => $priceId]]);
+                if (! empty($Ids)) {
+                    $data['prices'][ $GID ][ $key ] = self::convertToGlobalId($model->item_name(), $Ids);
+                }
+            }
+        }
+
+        return json_encode($data);
+    }
+
+    /**
+     * Convert the DB ID into GID
+     *
+     * @param string    $type
+     * @param int|int[] $ID
+     * @return mixed
+     */
+    public static function convertToGlobalId($type, $ID)
+    {
+        if (is_array($ID)) {
+            return array_map(function ($id) use ($type) {
+                return self::convertToGlobalId($type, $id);
+            }, $ID);
+        }
+        return Relay::toGlobalId($type, $ID);
+    }
+}

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -105,6 +105,12 @@ class Ticket extends TypeBase
                 'price',
                 esc_html__('Final calculated price for ticket', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'prices',
+                ['list_of' => 'Price'],
+                'prices',
+                esc_html__('The related ticket prices.', 'event_espresso')
+            ),
             new GraphQLField(
                 'sold',
                 'Int',
@@ -184,13 +190,13 @@ class Ticket extends TypeBase
             ),
             new GraphQLOutputField(
                 'parent',
-                'Ticket',
+                $this->name(),
                 null,
                 esc_html__('The parent ticket of the current ticket', 'event_espresso')
             ),
             new GraphQLInputField(
                 'parent',
-                'Int',
+                'ID',
                 null,
                 esc_html__('The parent ticket ID', 'event_espresso')
             ),

--- a/core/services/graphql/fields/GraphQLField.php
+++ b/core/services/graphql/fields/GraphQLField.php
@@ -46,6 +46,11 @@ class GraphQLField implements GraphQLFieldInterface
     protected $resolver;
 
     /**
+     * @var array $args
+     */
+    protected $args;
+
+    /**
      * @var array $caps
      */
     protected $caps;
@@ -77,6 +82,7 @@ class GraphQLField implements GraphQLFieldInterface
         $description = '',
         callable $formatter = null,
         callable $resolver = null,
+        array $args = [],
         array $caps = []
     ) {
         $this->name = $name;
@@ -85,7 +91,17 @@ class GraphQLField implements GraphQLFieldInterface
         $this->description = $description;
         $this->formatter = $formatter;
         $this->resolver = $resolver;
+        $this->args = $args;
         $this->caps = $caps;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function args()
+    {
+        return $this->args;
     }
 
 

--- a/core/services/graphql/types/TypeBase.php
+++ b/core/services/graphql/types/TypeBase.php
@@ -17,6 +17,7 @@ use ReflectionException;
 use WPGraphQL\Model\Post;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Type\Object\RootQuery;
 
 /**
  * Class TypeBase
@@ -233,11 +234,9 @@ abstract class TypeBase implements TypeInterface
      */
     public function resolveField($source, $args, AppContext $context, ResolveInfo $info)
     {
-        $source = $this->getModel($source);
-        if ($source instanceof EE_Base_Class) {
-            return $this->field_resolver->resolve($source, $args, $context, $info);
-        }
-        return null;
+        $source = $source instanceof RootQuery ? $source : $this->getModel($source);
+
+        return $this->field_resolver->resolve($source, $args, $context, $info);
     }
 
 

--- a/docs/GraphQL-API/query/eventRelations.md
+++ b/docs/GraphQL-API/query/eventRelations.md
@@ -1,6 +1,6 @@
 # Event relations query examples
 
-Using the below query, you can get the relational data for he entities inside an event by passing the event ID.
+Using the below query, you can get the relational data for the entities inside an event by passing the event ID.
 
 ```gql
 query getEvetRelationalData($id: Int!) {
@@ -8,7 +8,7 @@ query getEvetRelationalData($id: Int!) {
 }
 ```
 
-### Query variables
+## Query variables
 
 ```json
 {

--- a/docs/GraphQL-API/query/eventRelations.md
+++ b/docs/GraphQL-API/query/eventRelations.md
@@ -1,0 +1,48 @@
+# Event relations query examples
+
+Using the below query, you can get the relational data for he entities inside an event by passing the event ID.
+
+```gql
+query getEvetRelationalData($id: Int!) {
+  eventRelations(eventId: $id)
+}
+```
+
+### Query variables
+
+```json
+{
+  "id": 22
+}
+```
+
+The returned data for the field is a JSON encoded string with the following structure:
+
+```json
+{
+  datetimes: {
+    "YTydBYryt": {
+      tickets: [ "JHGbUYBuytb", "jhTURYTbb" ]
+    },
+    "JHBGRFHBF": {
+      tickets: [ "JHFBGYFGFNYT", "SDRVERDVT" ]
+    }
+  },
+  tickets: {
+    "JHFBGYFGFNYT": {
+      datetimes: [ "YTydBYryt", "JHBGRFHBF" ],
+      prices: [ "JHBFYFTY", "GNDTRBN" ]
+    },
+    "jhTURYTbb": {
+      datetimes: [ "JHBGRFHBF", "SDRVERDVT" ],
+      prices: [ "JHBUHFVY", "JHGBJH" ]
+    }
+  },
+  prices: {
+    "JHBFYYT": {
+      tickets: [ "JHFBGYFGFNYT", "SDRVERDVT" ],
+      priceTypes: [ "KUJNF", "JKBHKJI" ],
+    }
+  }
+}
+```

--- a/docs/GraphQL-API/query/eventRelations.md
+++ b/docs/GraphQL-API/query/eventRelations.md
@@ -20,28 +20,28 @@ The returned data for the field is a JSON encoded string with the following stru
 
 ```json
 {
-  datetimes: {
+  "datetimes": {
     "YTydBYryt": {
-      tickets: [ "JHGbUYBuytb", "jhTURYTbb" ]
+      "tickets": [ "JHGbUYBuytb", "jhTURYTbb" ]
     },
     "JHBGRFHBF": {
-      tickets: [ "JHFBGYFGFNYT", "SDRVERDVT" ]
+      "tickets": [ "JHFBGYFGFNYT", "SDRVERDVT" ]
     }
   },
-  tickets: {
+  "tickets": {
     "JHFBGYFGFNYT": {
-      datetimes: [ "YTydBYryt", "JHBGRFHBF" ],
-      prices: [ "JHBFYFTY", "GNDTRBN" ]
+      "datetimes": [ "YTydBYryt", "JHBGRFHBF" ],
+      "prices": [ "JHBFYFTY", "GNDTRBN" ]
     },
     "jhTURYTbb": {
-      datetimes: [ "JHBGRFHBF", "SDRVERDVT" ],
-      prices: [ "JHBUHFVY", "JHGBJH" ]
+      "datetimes": [ "JHBGRFHBF", "SDRVERDVT" ],
+      "prices": [ "JHBUHFVY", "JHGBJH" ]
     }
   },
-  prices: {
+  "prices": {
     "JHBFYYT": {
-      tickets: [ "JHFBGYFGFNYT", "SDRVERDVT" ],
-      priceTypes: [ "KUJNF", "JKBHKJI" ],
+      "tickets": [ "JHFBGYFGFNYT", "SDRVERDVT" ],
+      "priceTypes": [ "KUJNF", "JKBHKJI" ],
     }
   }
 }


### PR DESCRIPTION
This PR takes care of handling the relational data in GQL queries. Fixes #1894.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
