### PR TITLE
Fix event column sorting on registration check-in view

### DIFF
--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -142,7 +142,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             )
                 ? array('ATT_lname' => true)
                 : array('ATT_fname' => true),
-            'Event'    => array('Event.EVT.Name' => false),
+            'Event'    => array('Event.EVT_name' => false),
         );
         $this->_hidden_columns = array();
         $this->_evt = EEM_Event::instance()->get_one_by_ID($evt_id);


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/error-when-sorting-check-ins/?view=all#post-303080

Just a typo Event.EVT.Name => Event.EVT_name

If you go to Event Espresso -> Registrations -> Event Check-in

Click on the Event column name to sort by events, you'll get an error.

```
An EE_Error exception was thrown!   code: EEM_Base - _extract_related_model_info_from_query_param - 4003
"There is no model named 'EVT.Name' related to EEM_Event. Query param type is order_by and original query param is Event.EVT.Name"
```

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
