### PR TITLE
Fix error adding relation between people and events

### DIFF
--- a/core/libraries/rest_api/controllers/model/Write.php
+++ b/core/libraries/rest_api/controllers/model/Write.php
@@ -442,8 +442,8 @@ class Write extends Base
             $join_model_obj = $relation->get_join_model()->get_one(
                 array(
                     array(
-                        $model->primary_key_name() => $model_obj->ID(),
-                        $relation->get_other_model()->primary_key_name() => $related_obj->ID()
+                        $relation->get_join_model()->get_foreign_key_to($model->get_this_model_name())->get_name() => $model_obj->ID(),
+                        $relation->get_join_model()->get_foreign_key_to($relation->get_other_model()->get_this_model_name())->get_name() => $related_obj->ID()
                     )
                 )
             );


### PR DESCRIPTION
…eign keys to them on the join model


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes an error in the REST API when adding relations between people and events. See https://github.com/eventespresso/event-espresso-core/issues/1903
The problem was the code assumed that join table's foreign keys's names matched the primary keys on the joined models, which is usually right, but not for people-event relations.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Send a request like `POST wp-json/ee/v4.8.36/events/{event-id}/people/{person-id}`. It shouldn't return an error


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
