### PR TITLE
Fix GraphQL dates and times for queries and mutations

### DIFF
--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -40,11 +40,11 @@ class DatetimeMutation
         }
 
         if (! empty($input['startDate'])) {
-            $args['DTT_EVT_start'] = sanitize_text_field($input['startDate']);
+            $args['DTT_EVT_start'] = new \DateTime(sanitize_text_field($input['startDate']));
         }
 
         if (! empty($input['endDate'])) {
-            $args['DTT_EVT_end'] = sanitize_text_field($input['endDate']);
+            $args['DTT_EVT_end'] = new \DateTime(sanitize_text_field($input['endDate']));
         }
 
         if (! empty($input['tickets'])) {

--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\domain\services\graphql\data\mutations;
 
 use GraphQLRelay\Relay;
+use DateTime;
 
 /**
  * Class DatetimeMutation
@@ -40,11 +41,11 @@ class DatetimeMutation
         }
 
         if (! empty($input['startDate'])) {
-            $args['DTT_EVT_start'] = new \DateTime(sanitize_text_field($input['startDate']));
+            $args['DTT_EVT_start'] = new DateTime(sanitize_text_field($input['startDate']));
         }
 
         if (! empty($input['endDate'])) {
-            $args['DTT_EVT_end'] = new \DateTime(sanitize_text_field($input['endDate']));
+            $args['DTT_EVT_end'] = new DateTime(sanitize_text_field($input['endDate']));
         }
 
         if (! empty($input['tickets'])) {

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\domain\services\graphql\data\mutations;
 
 use GraphQLRelay\Relay;
+use DateTime;
 
 /**
  * Class TicketMutation
@@ -37,11 +38,11 @@ class TicketMutation
         }
 
         if (! empty($input['startDate'])) {
-            $args['TKT_start_date'] = new \DateTime(sanitize_text_field($input['startDate']));
+            $args['TKT_start_date'] = new DateTime(sanitize_text_field($input['startDate']));
         }
 
         if (! empty($input['endDate'])) {
-            $args['TKT_end_date'] = new \DateTime(sanitize_text_field($input['endDate']));
+            $args['TKT_end_date'] = new DateTime(sanitize_text_field($input['endDate']));
         }
 
         if (! empty($input['datetimes'])) {

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -36,6 +36,14 @@ class TicketMutation
             $args['TKT_price'] = floatval($input['price']);
         }
 
+        if (! empty($input['startDate'])) {
+            $args['TKT_start_date'] = new \DateTime(sanitize_text_field($input['startDate']));
+        }
+
+        if (! empty($input['endDate'])) {
+            $args['TKT_end_date'] = new \DateTime(sanitize_text_field($input['endDate']));
+        }
+
         if (! empty($input['datetimes'])) {
             $args['datetimes'] = array_map('sanitize_text_field', (array) $input['datetimes']);
         }

--- a/core/domain/services/graphql/resolvers/FieldResolver.php
+++ b/core/domain/services/graphql/resolvers/FieldResolver.php
@@ -99,7 +99,7 @@ class FieldResolver extends ResolverBase
             // Check if the field has a key mapped to model.
             if (! empty($field->key())) {
                 $value = $source->{$field->key()}();
-                return $field->mayBeFormatValue($value);
+                return $field->mayBeFormatValue($value, $source);
             }
             switch ($fieldName) {
                 case 'id': // the global ID

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -72,40 +72,18 @@ class Datetime extends TypeBase
                 esc_html__('Description for Datetime', 'event_espresso')
             ),
             new GraphQLField(
-                'start',
-                'String',
-                'start',
-                esc_html__('Start timestamp of Event', 'event_espresso')
-            ),
-            new GraphQLField(
                 'startDate',
                 'String',
-                'start_date',
-                esc_html__('Start time/date of Event', 'event_espresso')
-            ),
-            new GraphQLField(
-                'end',
-                'String',
-                'end',
-                esc_html__('End timestamp of Event', 'event_espresso')
+                'start_date_and_time',
+                esc_html__('Start date and time of the Event', 'event_espresso'),
+                [$this, 'formatDatetime']
             ),
             new GraphQLField(
                 'endDate',
                 'String',
-                'end_date',
-                esc_html__('End time/date of Event', 'event_espresso')
-            ),
-            new GraphQLField(
-                'startTime',
-                'String',
-                'start_time',
-                esc_html__('Start time of Event', 'event_espresso')
-            ),
-            new GraphQLField(
-                'endTime',
-                'String',
-                'end_time',
-                esc_html__('End time of Event', 'event_espresso')
+                'end_date_and_time',
+                esc_html__('End date and time of the Event', 'event_espresso'),
+                [$this, 'formatDatetime']
             ),
             new GraphQLField(
                 'capacity',

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -75,13 +75,15 @@ class Ticket extends TypeBase
                 'startDate',
                 'String',
                 'start_date',
-                esc_html__('Start time/date of Ticket', 'event_espresso')
+                esc_html__('Start date and time of the Ticket', 'event_espresso'),
+                [$this, 'formatDatetime']
             ),
             new GraphQLField(
                 'endDate',
                 'String',
                 'end_date',
-                esc_html__('End time/date of Ticket', 'event_espresso')
+                esc_html__('End date and time of the Ticket', 'event_espresso'),
+                [$this, 'formatDatetime']
             ),
             new GraphQLField(
                 'min',

--- a/core/services/graphql/fields/GraphQLField.php
+++ b/core/services/graphql/fields/GraphQLField.php
@@ -2,9 +2,14 @@
 
 namespace EventEspresso\core\services\graphql\fields;
 
+use EE_Base_Class;
 use GraphQL\Type\Definition\ResolveInfo;
 use LogicException;
 use WPGraphQL\AppContext;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
 
 /**
  * Class GraphQLField
@@ -262,16 +267,21 @@ class GraphQLField implements GraphQLFieldInterface
      * Checks if the format callback is set.
      * If yes, then uses it to format the value.
      *
-     * @param mixed $value
+     * @param mixed         $value
+     * @param EE_Base_Class $source
      * @return mixed The formatted value.
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
-    public function mayBeFormatValue($value)
+    public function mayBeFormatValue($value, EE_Base_Class $source)
     {
         if (is_callable($this->formatter)) {
             // dynamic methods using $this don't play nice
             // so capture formatter to a single var first
             $formatter = $this->formatter;
-            return $formatter($value);
+            return $formatter($value, $source);
         }
         return $value;
     }

--- a/core/services/graphql/fields/GraphQLFieldInterface.php
+++ b/core/services/graphql/fields/GraphQLFieldInterface.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\services\graphql\fields;
 
+use EE_Base_Class;
 use GraphQL\Type\Definition\ResolveInfo;
 use LogicException;
 use WPGraphQL\AppContext;
@@ -106,8 +107,9 @@ interface GraphQLFieldInterface
      * Checks if the format callback is set.
      * If yes, then uses it to format the value.
      *
-     * @param mixed $value
+     * @param mixed         $value
+     * @param EE_Base_Class $source
      * @return mixed The formatted value.
      */
-    public function mayBeFormatValue($value);
+    public function mayBeFormatValue($value, EE_Base_Class $source);
 }

--- a/core/services/graphql/types/TypeBase.php
+++ b/core/services/graphql/types/TypeBase.php
@@ -267,7 +267,7 @@ abstract class TypeBase implements TypeInterface
      * Prepares a datetime value in ISO8601/RFC3339 format.
      * It is assumed that the value of $datetime is in the format
      * returned by EE_Base_Class::get_format().
-     * 
+     *
      * @param string        $datetime The datetime value.
      * @param EE_Base_Class $source   The source object.
      * @return string ISO8601/RFC3339 formatted datetime.

--- a/core/services/graphql/types/TypeBase.php
+++ b/core/services/graphql/types/TypeBase.php
@@ -18,6 +18,7 @@ use WPGraphQL\Model\Post;
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
 use WPGraphQL\Type\Object\RootQuery;
+use DateTime;
 
 /**
  * Class TypeBase
@@ -280,7 +281,7 @@ abstract class TypeBase implements TypeInterface
     public function formatDatetime($datetime, EE_Base_Class $source)
     {
         $format   = $source->get_format();
-        $datetime = \DateTime::createFromFormat($format, $datetime);
-        return $datetime->format(\DateTime::RFC3339);
+        $datetime = DateTime::createFromFormat($format, $datetime);
+        return $datetime->format(DateTime::RFC3339);
     }
 }

--- a/core/services/graphql/types/TypeBase.php
+++ b/core/services/graphql/types/TypeBase.php
@@ -261,4 +261,26 @@ abstract class TypeBase implements TypeInterface
         }
         return $this->model->get_one_by_ID($payload['id']);
     }
+
+
+    /**
+     * Prepares a datetime value in ISO8601/RFC3339 format.
+     * It is assumed that the value of $datetime is in the format
+     * returned by EE_Base_Class::get_format().
+     * 
+     * @param string        $datetime The datetime value.
+     * @param EE_Base_Class $source   The source object.
+     * @return string ISO8601/RFC3339 formatted datetime.
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    public function formatDatetime($datetime, EE_Base_Class $source)
+    {
+        $format   = $source->get_format();
+        $datetime = \DateTime::createFromFormat($format, $datetime);
+        return $datetime->format(\DateTime::RFC3339);
+    }
 }

--- a/docs/GraphQL-API/mutations/datetime.md
+++ b/docs/GraphQL-API/mutations/datetime.md
@@ -29,8 +29,8 @@ mutation createDatetime($input: CreateDatetimeInput!) {
     "clientMutationId": "xyz",
     "name": "Some name here",
     "description": "Here goes the description",
-    "startDate": "",
-    "endDate": "",
+    "startDate": "06/12/2019 10:40:00",
+    "endDate": "12/26/2019 20:40:00",
     "eventId": 22,
     "tickets": [
       "RGF0ZXJKHNUYT=",
@@ -64,8 +64,8 @@ mutation updateDatetime($input: UpdateDatetimeInput!) {
     "id": "RGF0ZXRpbWU6MTQ=",
     "name": "Some name here",
     "description": "Here goes the description",
-    "startDate": "",
-    "endDate": "",
+    "startDate": "06/12/2019 10:40:00",
+    "endDate": "12/26/2019 20:40:00",
     "event": "ZXNwcmVzc29fZXZlbnRzOjIy",
     "tickets": [
       "RGF0ZXJKHNUYT=",

--- a/docs/GraphQL-API/mutations/datetime.md
+++ b/docs/GraphQL-API/mutations/datetime.md
@@ -34,7 +34,7 @@ mutation createDatetime($input: CreateDatetimeInput!) {
     "eventId": 22,
     "tickets": [
       "RGF0ZXJKHNUYT=",
-      "UIYNFTRUYNTBYY
+      "UIYNFTRUYNTBYY"
     ]
   }
 }
@@ -69,7 +69,7 @@ mutation updateDatetime($input: UpdateDatetimeInput!) {
     "event": "ZXNwcmVzc29fZXZlbnRzOjIy",
     "tickets": [
       "RGF0ZXJKHNUYT=",
-      "UIYNFTRUYNTBYY
+      "UIYNFTRUYNTBYY"
     ]
   }
 }

--- a/docs/GraphQL-API/mutations/ticket.md
+++ b/docs/GraphQL-API/mutations/ticket.md
@@ -30,6 +30,8 @@ mutation createTicket($input: CreateTicketInput!) {
     "name": "Some name here",
     "description": "Here goes the description",
     "price": 20.5,
+    "startDate": "06/12/2019 10:40:00",
+    "endDate": "12/26/2019 20:40:00",
     "datetimes": [
       "RGF0ZXRpbWU6MTQ=",
       "JTRBYTRTUBYYBYT="
@@ -66,6 +68,8 @@ mutation updateTicket($input: UpdateTicketInput!) {
     "id": "VGlja2V0OjE5",
     "name": "Some name here",
     "description": "Here goes the description",
+    "startDate": "06/12/2019 10:40:00",
+    "endDate": "12/26/2019 20:40:00",
     "datetimes": [
       "RGF0ZXRpbWU6MTQ=",
       "JTRBYTRTUBYYBYT="


### PR DESCRIPTION
This PR fixes the issues related to dates and times for Datetimes and Tickets. It also changes the datetime output format to always use `RFC3339` format.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
