### PR TITLE
Refactor RelationsSelector and update Date and Ticket edit modal. Closes 1944.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"esbenp.prettier-vscode"
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-	"recommendations": [
-		"esbenp.prettier-vscode"
-	]
+	"recommendations": ["esbenp.prettier-vscode"]
 }

--- a/assets/prototype/domain/eventEditor/containers/mutations/useUpdateDateMutation.js
+++ b/assets/prototype/domain/eventEditor/containers/mutations/useUpdateDateMutation.js
@@ -20,7 +20,7 @@ const useUpdateDateMutation = ({ id = 0 }) => {
 	toaster.loading(loading, toasterMessage);
 	toaster.error(error);
 
-	const getVariables = ({ endDate, description, name, startDate }) => {
+	const getVariables = ({ endDate, description, name, startDate, tickets }) => {
 		const variables = {
 			input: {
 				clientMutationId: 'xyz',
@@ -29,14 +29,15 @@ const useUpdateDateMutation = ({ id = 0 }) => {
 				...(description && { description }),
 				...(name && { name }),
 				...(startDate && { startDate }),
+				...(tickets && { tickets }),
 			},
 		};
 
 		return variables;
 	};
 
-	const updateHandler = ({ endDate, description, name, startDate }) => {
-		const variables = getVariables({ endDate, description, name, startDate });
+	const updateHandler = ({ endDate, description, name, startDate, tickets }) => {
+		const variables = getVariables({ endDate, description, name, startDate, tickets });
 
 		updateDate({
 			variables,

--- a/assets/prototype/domain/eventEditor/containers/mutations/useUpdateDateMutation.js
+++ b/assets/prototype/domain/eventEditor/containers/mutations/useUpdateDateMutation.js
@@ -20,24 +20,14 @@ const useUpdateDateMutation = ({ id = 0 }) => {
 	toaster.loading(loading, toasterMessage);
 	toaster.error(error);
 
-	const getVariables = ({ endDate, description, name, startDate, tickets }) => {
+	const updateHandler = (fields) => {
 		const variables = {
 			input: {
 				clientMutationId: 'xyz',
 				id,
-				...(endDate && { endDate }),
-				...(description && { description }),
-				...(name && { name }),
-				...(startDate && { startDate }),
-				...(tickets && { tickets }),
+				...fields,
 			},
 		};
-
-		return variables;
-	};
-
-	const updateHandler = ({ endDate, description, name, startDate, tickets }) => {
-		const variables = getVariables({ endDate, description, name, startDate, tickets });
 
 		updateDate({
 			variables,

--- a/assets/prototype/domain/eventEditor/datesList/AddNewDateModal.js
+++ b/assets/prototype/domain/eventEditor/datesList/AddNewDateModal.js
@@ -8,12 +8,12 @@ const AddNewDateModal = ({ eventId, tickets, handleClose, isOpen }) => {
 
 	return (
 		<FormModal
-			tickets={tickets}
 			FormComponent={formComponent}
 			initialValues={{}}
 			onSubmit={createDate}
 			onClose={handleClose}
 			isOpen={isOpen}
+			tickets={tickets}
 		/>
 	);
 };

--- a/assets/prototype/domain/eventEditor/datesList/DateForm.js
+++ b/assets/prototype/domain/eventEditor/datesList/DateForm.js
@@ -59,7 +59,7 @@ const formatSecondaryField = (ticketPrice, toString = false) => {
 	return toString ? renderToString(<Currency quantity={ticketPrice} />, null) : <Currency quantity={ticketPrice} />;
 };
 
-const DateForm = ({ formReset, tickets = [], title }) => {
+const DateForm = ({ formReset, relatedTickets, tickets = [], title }) => {
 	const { id } = useContext(DateTimeContext);
 	const { description = '', name = '' } = useDateItem({ id });
 
@@ -95,6 +95,7 @@ const DateForm = ({ formReset, tickets = [], title }) => {
 						name={'tickets'}
 						render={({ input }) => (
 							<RelationsSelector
+								defaultRelatedItems={relatedTickets}
 								items={tickets}
 								itemType={'ticket'}
 								displayFields={['name', 'price']}

--- a/assets/prototype/domain/eventEditor/datesList/DatesList.js
+++ b/assets/prototype/domain/eventEditor/datesList/DatesList.js
@@ -42,7 +42,7 @@ const DatesList = ({ datetimes, error, eventId, loading, tickets }) => {
 		<>
 			<div style={listStyle}>
 				{datetimes.map((date) => (
-					<DateCard eventId={eventId} id={date.id} key={date.id} />
+					<DateCard eventId={eventId} id={date.id} key={date.id} tickets={tickets} />
 				))}
 			</div>
 			{btnRow}

--- a/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
+++ b/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
@@ -1,5 +1,4 @@
 import { useState } from '@wordpress/element';
-import * as R from 'ramda';
 import moment from 'moment';
 import { Button, Card, EditableText, Elevation, H4, H6, Popover } from '@blueprintjs/core/lib/esm';
 import DateTimeProvider from '../../../../infrastructure/services/contextProviders/DateTimeProvider';

--- a/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
+++ b/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
@@ -1,4 +1,5 @@
 import { useState } from '@wordpress/element';
+import * as R from 'ramda';
 import moment from 'moment';
 import { Button, Card, EditableText, Elevation, H4, H6, Popover } from '@blueprintjs/core/lib/esm';
 import DateTimeProvider from '../../../../infrastructure/services/contextProviders/DateTimeProvider';
@@ -33,14 +34,14 @@ const idStyle = {
 	top: '.5em',
 };
 
-const DateCard = ({ eventId, id }) => {
+const DateCard = ({ eventId, id, tickets }) => {
 	const date = useDateItem({ id });
 
 	const onFieldUpdate = useUpdateDateMutation({ id });
 	const { getRelations } = useRelations();
 
-	// get related tickets for this datetime
-	const relatedTickets = getRelations({
+	// get related ticket IDs for this datetime
+	const relatedTicketIds = getRelations({
 		entity: 'datetimes',
 		entityId: id,
 		relation: 'tickets',
@@ -54,7 +55,7 @@ const DateCard = ({ eventId, id }) => {
 	return (
 		<DateTimeProvider id={id}>
 			<Card elevation={Elevation.ONE} style={cardStyle}>
-				<EditDate position='top' />
+				<EditDate position='top' relatedTickets={relatedTicketIds} tickets={tickets} />
 				<div>
 					<div style={idStyle}>
 						{date.datetimeId} {':'} {date.id}
@@ -103,9 +104,9 @@ const DateCard = ({ eventId, id }) => {
 				</div>
 				<div>
 					{'Related Tickets: '}{' '}
-					{relatedTickets.map((ticketId) => (
-						<TicketId key={ticketId} id={ticketId} />
-					))}
+					{relatedTicketIds.map((ticketId) => {
+						return ticketId ? <TicketId key={ticketId} id={ticketId} /> : null;
+					})}
 				</div>
 				<DeleteDateButton eventId={eventId} id={date.id} />
 			</Card>

--- a/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
+++ b/assets/prototype/domain/eventEditor/datesList/dateCard/DateCard.js
@@ -55,20 +55,8 @@ const DateCard = ({ eventId, id, tickets }) => {
 		<DateTimeProvider id={id}>
 			<Card elevation={Elevation.ONE} style={cardStyle}>
 				<EditDate position='top' relatedTickets={relatedTicketIds} tickets={tickets} />
-				<div>
-					<div style={idStyle}>
-						{date.datetimeId} {':'} {date.id}
-					</div>
-					<H4>
-						<EditableText
-							placeholder='Edit title...'
-							defaultValue={date.name}
-							onCancel={(value) => console.log(value)}
-							onConfirm={(name) => onFieldUpdate({ name })}
-							minWidth={'320px'}
-							selectAllOnFocus
-						/>
-					</H4>
+				<div style={idStyle}>
+					{date.datetimeId} {':'} {date.id}
 				</div>
 				<H4>
 					<EditableText

--- a/assets/prototype/domain/eventEditor/datesList/dateCard/EditDate.js
+++ b/assets/prototype/domain/eventEditor/datesList/dateCard/EditDate.js
@@ -1,10 +1,10 @@
 import EditDateButton from './EditDateButton';
 import EditDateModal from './EditDateModal';
 
-const EditDate = ({ position }) => (
+const EditDate = ({ position, relatedTickets, tickets }) => (
 	<>
 		<EditDateButton position={position} />
-		<EditDateModal />
+		<EditDateModal relatedTickets={relatedTickets} tickets={tickets} />
 	</>
 );
 

--- a/assets/prototype/domain/eventEditor/datesList/dateCard/EditDateModal.js
+++ b/assets/prototype/domain/eventEditor/datesList/dateCard/EditDateModal.js
@@ -4,16 +4,13 @@ import DateForm from '../DateForm';
 import { DateTimeContext } from '../../../../infrastructure/services/contextProviders/DateTimeProvider';
 import useUpdateDateMutation from '../../containers/mutations/useUpdateDateMutation';
 
-const EditDateModal = () => {
-	const { id, isOpen, onClose, relatedTickets } = useContext(DateTimeContext);
-	const tickets = relatedTickets.map((id) => {
-		// we need to get here full ticket objects
-		return id;
-	});
-
+const EditDateModal = ({ relatedTickets, tickets }) => {
+	const { id, isOpen, onClose } = useContext(DateTimeContext);
 	const onFieldUpdate = useUpdateDateMutation({ id });
 
-	const formComponent = (props) => <DateForm {...props} tickets={tickets} title='Update date' />;
+	const formComponent = (props) => (
+		<DateForm {...props} relatedTickets={relatedTickets} tickets={tickets} title='Update date' />
+	);
 	const onSubmit = (fields) => onFieldUpdate(fields);
 
 	return (

--- a/assets/prototype/domain/eventEditor/ticketsList/TicketForm.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/TicketForm.js
@@ -47,9 +47,11 @@ const relationsStyle = {
 	width: '60%',
 };
 
-const TicketForm = ({ datetimes, formReset, title }) => {
+const TicketForm = ({ datetimes, formReset, relatedDates, title }) => {
 	const { id } = useContext(TicketContext);
 	const { description = '', name = '', price = '' } = useTicketItem({ id });
+
+	console.log('relatedDatesrelatedDates'.relatedDates);
 
 	return (
 		<>
@@ -97,6 +99,7 @@ const TicketForm = ({ datetimes, formReset, title }) => {
 						name={'datetimes'}
 						render={({ input }) => (
 							<RelationsSelector
+								defaultRelatedItems={relatedDates}
 								items={datetimes}
 								itemType={'datetime'}
 								displayFields={['name', 'startDate']}

--- a/assets/prototype/domain/eventEditor/ticketsList/TicketForm.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/TicketForm.js
@@ -51,8 +51,6 @@ const TicketForm = ({ datetimes, formReset, relatedDates, title }) => {
 	const { id } = useContext(TicketContext);
 	const { description = '', name = '', price = '' } = useTicketItem({ id });
 
-	console.log('relatedDatesrelatedDates'.relatedDates);
-
 	return (
 		<>
 			<H2 style={hdrStyle}>{title}</H2>

--- a/assets/prototype/domain/eventEditor/ticketsList/TicketsList.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/TicketsList.js
@@ -79,7 +79,7 @@ const TicketsList = ({ tickets, datetimes, error, loading, loadingDates }) => {
 			<Fragment>
 				<div style={listStyle}>
 					{tickets.map((ticket) => (
-						<TicketCard datetimeIn={datetimeIn} id={ticket.id} key={ticket.id} />
+						<TicketCard datetimeIn={datetimeIn} id={ticket.id} key={ticket.id} datetimes={datetimes} />
 					))}
 				</div>
 				{btnRow}

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicket.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicket.js
@@ -1,10 +1,10 @@
 import EditTicketButton from './EditTicketButton';
 import EditTicketModal from './EditTicketModal';
 
-const EditTicket = ({ position }) => (
+const EditTicket = ({ datetimes, position, relatedDates }) => (
 	<>
 		<EditTicketButton position={position} />
-		<EditTicketModal />
+		<EditTicketModal datetimes={datetimes} relatedDates={relatedDates} />
 	</>
 );
 

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicketModal.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicketModal.js
@@ -4,11 +4,13 @@ import TicketForm from '../TicketForm';
 import { TicketContext } from '../../../../infrastructure/services/contextProviders/TicketProvider';
 import useUpdateTicketMutation from '../../containers/mutations/useUpdateTicketMutation';
 
-const EditTicketModal = () => {
-	const { id, isOpen, onClose, relatedDates } = useContext(TicketContext);
+const EditTicketModal = ({ datetimes, relatedDates }) => {
+	const { id, isOpen, onClose } = useContext(TicketContext);
 	const onFieldUpdate = useUpdateTicketMutation({ id });
 
-	const formComponent = (props) => <TicketForm {...props} dates={relatedDates} title='Update ticket' />;
+	const formComponent = (props) => (
+		<TicketForm {...props} datetimes={datetimes} relatedDates={relatedDates} title='Update ticket' />
+	);
 	const onSubmit = (fields) => onFieldUpdate(fields);
 
 	return (

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicketModal.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketCard/EditTicketModal.js
@@ -6,14 +6,9 @@ import useUpdateTicketMutation from '../../containers/mutations/useUpdateTicketM
 
 const EditTicketModal = () => {
 	const { id, isOpen, onClose, relatedDates } = useContext(TicketContext);
-	const dates = relatedDates.map((id) => {
-		// we need to get here full ticket objects
-		return id;
-	});
-
 	const onFieldUpdate = useUpdateTicketMutation({ id });
 
-	const formComponent = (props) => <TicketForm {...props} dates={dates} title='Update ticket' />;
+	const formComponent = (props) => <TicketForm {...props} dates={relatedDates} title='Update ticket' />;
 	const onSubmit = (fields) => onFieldUpdate(fields);
 
 	return (

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketCard/TicketCard.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketCard/TicketCard.js
@@ -38,7 +38,7 @@ const priceStyle = {
 	color: 'grey',
 };
 
-const TicketCard = ({ datetimeIn, id }) => {
+const TicketCard = ({ datetimes, datetimeIn, id }) => {
 	const ticket = useTicketItem({ id });
 	const updateTicketField = useUpdateTicketMutation({ id });
 	const { getRelations } = useRelations();
@@ -52,7 +52,7 @@ const TicketCard = ({ datetimeIn, id }) => {
 	return (
 		<TicketProvider id={id}>
 			<Card elevation={Elevation.ONE} style={cardStyle}>
-				<EditTicket position='top' />
+				<EditTicket datetimes={datetimes} position='top' relatedDates={relatedDates} />
 				<div>
 					<div style={idStyle}>
 						{ticket.ticketId} {':'} {ticket.id}

--- a/assets/prototype/domain/shared/RelationsSelector.js
+++ b/assets/prototype/domain/shared/RelationsSelector.js
@@ -2,10 +2,11 @@ import { useEffect, useState } from '@wordpress/element';
 import { Button, MenuItem } from '@blueprintjs/core/lib/esm';
 import { MultiSelect } from '@blueprintjs/select';
 
-const transformRelatedItemsArrayToObject = (array) =>
-	array.reduce((acc, cur) => {
-		acc[cur.id] = cur;
-		return acc;
+const transformRelatedItemsArrayToObject = (items) =>
+	items.reduce((relatedItems, relatedItem) => {
+		relatedItems[relatedItem.id] = relatedItem;
+
+		return relatedItems;
 	}, {});
 
 /**
@@ -169,7 +170,7 @@ const RelationsSelector = ({
 		primary = formatPrimaryField(primary, format, true);
 		secondary = secondary ? secondary : secondaryField(relatedItem);
 		secondary = formatSecondaryField(secondary, format, true);
-		return `${primary} : ${secondary}`;
+		return `${itemId}) ${primary} : ${secondary}`;
 	};
 
 	/**


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves issue: https://github.com/eventespresso/event-espresso-core/issues/1944
Has been done:
- RelationsSelector refactored to receive default values.
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
