### PR TITLE
Casc/initial ui

### DIFF
--- a/admin_pages/events/Events_Admin_List_Table.class.php
+++ b/admin_pages/events/Events_Admin_List_Table.class.php
@@ -145,11 +145,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             return '';
         }
         $this->_dtt = $item->primary_datetime(); // set this for use in other columns
-        // does event have any attached registrations?
-        $regs = $item->count_related('Registration');
-        return $regs > 0 && $this->_view === 'trash'
-            ? '<span class="ee-lock-icon"></span>'
-            : sprintf(
+       return sprintf(
                 '<input type="checkbox" name="EVT_IDs[]" value="%s" />',
                 $item->ID()
             );

--- a/admin_pages/events/Events_Admin_List_Table.class.php
+++ b/admin_pages/events/Events_Admin_List_Table.class.php
@@ -145,10 +145,10 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             return '';
         }
         $this->_dtt = $item->primary_datetime(); // set this for use in other columns
-       return sprintf(
-                '<input type="checkbox" name="EVT_IDs[]" value="%s" />',
-                $item->ID()
-            );
+        return sprintf(
+            '<input type="checkbox" name="EVT_IDs[]" value="%s" />',
+            $item->ID()
+        );
     }
 
 
@@ -313,11 +313,11 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
                                                  . esc_html__('Restore from Trash', 'event_espresso')
                                                  . '</a>';
             }
-            if ( EE_Registry::instance()->CAP->current_user_can(
-                    'ee_delete_event',
-                    'espresso_events_delete_event',
-                    $item->ID()
-                )
+            if (EE_Registry::instance()->CAP->current_user_can(
+                'ee_delete_event',
+                'espresso_events_delete_event',
+                $item->ID()
+            )
             ) {
                 $actions['delete'] = '<a href="' . $delete_event_link . '"'
                                      . ' title="' . esc_attr__('Delete Permanently', 'event_espresso') . '">'

--- a/admin_pages/events/Events_Admin_List_Table.class.php
+++ b/admin_pages/events/Events_Admin_List_Table.class.php
@@ -313,8 +313,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
                                                  . esc_html__('Restore from Trash', 'event_espresso')
                                                  . '</a>';
             }
-            if ($item->count_related('Registration') === 0
-                && EE_Registry::instance()->CAP->current_user_can(
+            if ( EE_Registry::instance()->CAP->current_user_can(
                     'ee_delete_event',
                     'espresso_events_delete_event',
                     $item->ID()

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -519,15 +519,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                     'order'      => 15,
                     'persistent' => false,
                 ),
-//                'help_tabs'     => array(
-//                    'add_category_help_tab' => array(
-//                        'title'    => esc_html__('Add New Event Category', 'event_espresso'),
-//                        'filename' => 'events_add_category',
-//                    ),
-//                ),
-//                'help_tour'     => array('Event_Add_Category_Help_Tour'),
-//                'metaboxes'     => array('_publish_post_box'),
-//                'require_nonce' => false,
             )
         );
     }

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2183,7 +2183,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function deleteEventsAndDependentData($event_ids){
+    protected function deleteEventsAndDependentData($event_ids)
+    {
         // Call me an optimist.
         $success = true;
         $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', array());
@@ -2231,7 +2232,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
         // Find all the dependent model objects we want to delete.
         $ids_to_delete = [];
-        foreach ($model_objects_to_delete as $model_object_to_delete){
+        foreach ($model_objects_to_delete as $model_object_to_delete) {
             $node = new ModelObjNode($model_object_to_delete);
             $node->visit(9999);
             $ids_to_delete = array_replace_recursive($ids_to_delete, $node->getIds());
@@ -2256,12 +2257,12 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                     $where_conditions['OR'][ 'AND*' . $index_primary_key_string ] = $keys_n_values;
                 }
             }
-            if( !$model->delete_permanently(
+            if (!$model->delete_permanently(
                 [
                     $where_conditions
                 ],
                 false
-            )){
+            )) {
                 $success = false;
             }
         }
@@ -2269,7 +2270,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             unset($espresso_no_ticket_prices[ $event_id ]);
         }
         // Fire a legacy action.
-        foreach ($event_ids as $event_id){
+        foreach ($event_ids as $event_id) {
             do_action('AHEE__Events_Admin_Page___permanently_delete_event__after_event_deleted', $event_id);
         }
         update_option('ee_no_ticket_prices', $espresso_no_ticket_prices);

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2114,12 +2114,12 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _delete_events()
     {
-        $EVT_IDs = isset($this->_req_data['EVT_IDs']) ? (array)$this->_req_data['EVT_IDs'] : array();
+        $EVT_IDs = isset($this->_req_data['EVT_IDs']) ? (array) $this->_req_data['EVT_IDs'] : array();
         $args = [
             'action' => 'preview_deletion',
         ];
-        foreach($EVT_IDs as $EVT_ID){
-            $args['EVT_IDs[]'] = (int)$EVT_ID;
+        foreach ($EVT_IDs as $EVT_ID) {
+            $args['EVT_IDs[]'] = (int) $EVT_ID;
         }
         wp_safe_redirect(
             EE_Admin_Page::add_query_args_and_nonce(
@@ -2135,12 +2135,12 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function previewDeletion()
     {
-        $EVT_IDs = isset($this->_req_data['EVT_IDs']) ? (array)$this->_req_data['EVT_IDs'] : array();
+        $EVT_IDs = isset($this->_req_data['EVT_IDs']) ? (array) $this->_req_data['EVT_IDs'] : array();
         $confirm_deletion_args = [
             'action' => 'confirm_deletion',
         ];
-        foreach($EVT_IDs as $EVT_ID){
-            $confirm_deletion_args['EVT_IDs[]'] = (int)$EVT_ID;
+        foreach ($EVT_IDs as $EVT_ID) {
+            $confirm_deletion_args['EVT_IDs[]'] = (int) $EVT_ID;
         }
         $this->_template_args['admin_page_content'] = EEH_Template::display_template(
             EVENTS_TEMPLATE_PATH . 'event_preview_deletion.template.php',
@@ -2166,7 +2166,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             $ids_to_delete = $node->getIds();
             foreach ($ids_to_delete as $model_name => $ids) {
                 $model = EE_Registry::instance()->load_model($model_name);
-                if($model->has_primary_key_field()){
+                if ($model->has_primary_key_field()) {
                     $where_conditions = [
                         $model->primary_key_name() => [
                             'IN',
@@ -2177,9 +2177,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                     $where_conditions = [
                         'OR' => []
                     ];
-                    foreach($ids as $index_primary_key_string){
+                    foreach ($ids as $index_primary_key_string) {
                         $keys_n_values = $model->parse_index_primary_key_string($index_primary_key_string);
-                        $where_conditions['OR']['AND*' . $index_primary_key_string ] = $keys_n_values;
+                        $where_conditions['OR'][ 'AND*' . $index_primary_key_string ] = $keys_n_values;
                     }
                 }
                 $success = $model->delete_permanently(

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1922,7 +1922,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      */
     public function delete_cpt_item($post_id)
     {
-        throw new EE_Error(esc_html__('Please contact Event Espresso support with the details of what you did to produce this error.', 'event_espresso'));
+        throw new EE_Error(esc_html__('Please contact Event Espresso support with the details of the steps taken to produce this error.', 'event_espresso'));
         $this->_req_data['EVT_ID'] = $post_id;
         $this->_delete_event();
     }

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2087,6 +2087,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     {
         // determine the event id and set to array.
         $EVT_ID = isset($this->_req_data['EVT_ID']) ? absint($this->_req_data['EVT_ID']) : null;
+        // @todo: prepare the contents of the deletion preview page via a batch job, then redirect to the preview page.
         wp_safe_redirect(
             EE_Admin_Page::add_query_args_and_nonce(
                 [
@@ -2114,6 +2115,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         foreach ($EVT_IDs as $EVT_ID) {
             $args['EVT_IDs[]'] = (int) $EVT_ID;
         }
+        // @todo: prepare the contents of the deletion preview page via a batch job, then redirect to the preview page.
         wp_safe_redirect(
             EE_Admin_Page::add_query_args_and_nonce(
                 $args,

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2198,7 +2198,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                     ]
                 ]
             );
-            $related_non_globa_prices = EEM_Price::instance()->get_all_deleted_and_undeleted(
+            $related_non_global_prices = EEM_Price::instance()->get_all_deleted_and_undeleted(
                 [
                     [
                         'PRC_is_default' => false,
@@ -2218,7 +2218,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 $model_objects_to_delete,
                 [$event],
                 $related_non_global_tickets,
-                $related_non_globa_prices,
+                $related_non_global_prices,
                 $related_message_templates
             );
         }

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1,5 +1,7 @@
 <?php
 
+use EventEspresso\core\services\orm\tree_traversal\ModelObjNode;
+
 /**
  * Events_Admin_Page
  * This contains the logic for setting up the Events related pages.
@@ -2155,15 +2157,25 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
     protected function confirmDeletion()
     {
-        echo "event deleted here";
+        $event_ids = isset($this->_req_data['EVT_IDs']) ? $this->_req_data['EVT_IDs'] : array();
 
-        // code from original _delete_event, which I assume we want to keep
         $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', array());
-        // remove this event from the list of events with no prices
-        if (isset($espresso_no_ticket_prices[ $EVT_ID ])) {
-            unset($espresso_no_ticket_prices[ $EVT_ID ]);
+        foreach($event_ids as $event_id){
+            $node = new ModelObjNode(EEM_Event::instance()->get_one_by_ID($event_id));
+            $node->visit(9999);
+            if (isset($espresso_no_ticket_prices[ $event_id ])) {
+                unset($espresso_no_ticket_prices[ $event_id ]);
+            }
         }
         update_option('ee_no_ticket_prices', $espresso_no_ticket_prices);
+        $this->redirect_after_action(
+            true,
+            esc_html__('Events', 'event_espresso'),
+            esc_html__('deleted', 'event_espresso'),
+            [
+                'action' => 'default'
+            ]
+        );
     }
 
     /**

--- a/admin_pages/events/templates/event_preview_deletion.template.php
+++ b/admin_pages/events/templates/event_preview_deletion.template.php
@@ -1,0 +1,5 @@
+<h2><?php esc_html_e('Please Confirm You Want to Permanently Delete the Following Data', 'event_espresso'); ?></h2>
+A bunch of events
+<form action="<?php echo $form_url;?>" method="POST">
+    <input type="submit" value="<?php echo esc_attr(esc_html__('Confirm', 'event_espresso')); ?>">
+</form>


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This ticket adds the initial user interface for permanently deleting events even when they have registrations. It doesn't use the batch system (leaving that for after). So this UI won't handle deleting events with thousands of registrations. But it can handle deleting hundreds, so I'd like to have this finished first (so we have something releasable), then integrate the batch system hoping there's budget for it.
This is basically the bare minimum for https://github.com/eventespresso/event-espresso-core/issues/1905
Initially, the controller code also has the job of dictating that the following items should also be deleted (even though their model structure doesn't indicate that they're dependent on events to exist; it's more part of the UI (or maybe business logic) that they're dependent on events):
* [x] tickets (non-global ones)
* [x] prices (non-global ones)
* [x] message types (non-global ones)

## What HAS NOT been done yet
I hope to still 
* on the preview page, confirm all the data that will be deleted
* have users confirm they're deleting the right events (probably by asking them to re-enter the events' names in text boxes)
* use the batch system for generating the preview page (and probably performing the deletion)
* tidy up the code
* move logic into business classes

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create an event 
* and add all the related things you can think of (using just EE core for now) like registrations, new tickets, price modifiers, custom message templates, event categories, a venue, checkins for those registrations, etc.
* Then trash the event. 
* Then delete it permanently. 
* In the database, verify the events was deleted, and its datetimes, tickets, the tickets' prices (except default prices, those stay), message template "groups", term_relationship entries, registrations, answers, checkins, etc.
* In the UI, verify no other events, events' datetimes, events tickets, default tickets,  questions, question groups, message templates, etc were deleted. Also, the transactions, line items, and payments should STAY for now. (That's for another project.)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
