### PR TITLE
if the current page is the alternative reg page, then show the ticket selector

### DIFF
--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -228,7 +228,10 @@ class DisplayTicketSelector
             return $this->noTicketAvailableMessage();
         }
         // redirecting to another site for registration ??
-        $external_url = (string) $this->event->external_url();
+        $external_url = (string) $this->event->external_url() 
+            && $this->event->external_url() !== get_the_permalink()
+            ? $this->event->external_url()
+            : '';
         // if redirecting to another site for registration, then we don't load the TS
         $ticket_selector = $external_url
             ? $this->externalEventRegistration()
@@ -640,7 +643,10 @@ class DisplayTicketSelector
             __('Register Now', 'event_espresso'),
             $this->event
         );
-        $external_url = $this->event->external_url();
+        $external_url = (string) $this->event->external_url() 
+            && $this->event->external_url() !== get_the_permalink()
+            ? $this->event->external_url()
+            : '';
         $html = EEH_HTML::div(
             '',
             'ticket-selector-submit-' . $this->event->ID() . '-btn-wrap',

--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -228,7 +228,7 @@ class DisplayTicketSelector
             return $this->noTicketAvailableMessage();
         }
         // redirecting to another site for registration ??
-        $external_url = (string) $this->event->external_url() 
+        $external_url = (string) $this->event->external_url()
             && $this->event->external_url() !== get_the_permalink()
             ? $this->event->external_url()
             : '';
@@ -643,7 +643,7 @@ class DisplayTicketSelector
             __('Register Now', 'event_espresso'),
             $this->event
         );
-        $external_url = (string) $this->event->external_url() 
+        $external_url = (string) $this->event->external_url()
             && $this->event->external_url() !== get_the_permalink()
             ? $this->event->external_url()
             : '';


### PR DESCRIPTION
see #1994


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
see #1994
## How has this been tested
- [x] Deactivate MER -or- please be sure to switch to the branch in MER that has the same name as this one
- [x] Copy a ticket selector shortcode for an event
- [x] in the same event, set the Alternative Reg URL to a page on the same site
- [x] edit that page and paste in the ticket selector shortcode, update page
- [x] visit that page
- [x] Select some tickets and click the register now button

<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
