### PR TITLE
Fix GraphQL Errors When Updating Entity Relations fixes #1993

### DIFF
--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useOnSubmitPrices.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useOnSubmitPrices.js
@@ -14,6 +14,22 @@ const PRICE_INPUT_FIELDS = [
 	'wpUser',
 ];
 
+const parseBooleanField = (value) => {
+	value = typeof value === 'string' ? value.toLowerCase().trim() : value;
+	switch (value) {
+		case 'true':
+		case 'yes':
+		case '1':
+			return true;
+		case 'false':
+		case 'no':
+		case '0':
+			return false;
+		default:
+			return Boolean(value);
+	}
+};
+
 const useOnSubmitPrices = (existingPrices) => {
 	const { createEntity, updateEntity, deleteEntity } = useEntityMutator('Price');
 	const { updateEntity: updateTicket } = useEntityMutator('Ticket');
@@ -35,10 +51,8 @@ const useOnSubmitPrices = (existingPrices) => {
 			const normalizedPriceFields = {
 				...input,
 				amount: parseFloat(price.amount || 0),
-				isDefault: !! price.isDefault,
+				isDefault: parseBooleanField(price.isDefault),
 				order: parseInt(price.order, 10),
-				overrides: parseInt(price.overrides, 10),
-				parent: parseInt(price.parent, 10),
 			};
 			// if it's a newly added price
 			if (!id) {
@@ -59,7 +73,7 @@ const useOnSubmitPrices = (existingPrices) => {
 		const normalizedTicketFields = {
 			...ticket,
 			price: parseFloat(ticket.price || 0),
-			reverseCalculate: !! ticket.reverseCalculate,
+			reverseCalculate: parseBooleanField(ticket.reverseCalculate),
 		};
 		// Finally update the ticket price relation
 		updateTicket({ ...normalizedTicketFields, prices: updatedPrices });

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useOnSubmitPrices.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useOnSubmitPrices.js
@@ -31,11 +31,20 @@ const useOnSubmitPrices = (existingPrices) => {
 				return;
 			}
 			const { id, ...input } = pick(PRICE_INPUT_FIELDS, price);
+
+			const normalizedPriceFields = {
+				...input,
+				amount: parseFloat(price.amount || 0),
+				isDefault: !! price.isDefault,
+				order: parseInt(price.order, 10),
+				overrides: parseInt(price.overrides, 10),
+				parent: parseInt(price.parent, 10),
+			};
 			// if it's a newly added price
 			if (!id) {
-				createEntity({ ...input, ticketId: ticket.id });
+				createEntity({ ...normalizedPriceFields, ticketId: ticket.id });
 			} else {
-				updateEntity({ id, ...input });
+				updateEntity({ id, ...normalizedPriceFields });
 			}
 			updatedPrices.push(id);
 		});
@@ -47,8 +56,13 @@ const useOnSubmitPrices = (existingPrices) => {
 			deleteEntity({ id });
 		});
 
+		const normalizedTicketFields = {
+			...ticket,
+			price: parseFloat(ticket.price || 0),
+			reverseCalculate: !! ticket.reverseCalculate,
+		};
 		// Finally update the ticket price relation
-		updateTicket({ ...ticket, prices: updatedPrices });
+		updateTicket({ ...normalizedTicketFields, prices: updatedPrices });
 	};
 };
 

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
@@ -1,7 +1,7 @@
 /**
  * Internal imports
  */
-import {useCallback} from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal imports
@@ -9,8 +9,8 @@ import {useCallback} from '@wordpress/element';
 import calculateBasePrice from './calculateBasePrice';
 import calculateTicketTotal from './calculateTicketTotal';
 
-const useTicketPriceCalculator = () => useCallback(
-	(state, action) => {
+const useTicketPriceCalculator = () => {
+	useCallback((state, action) => {
 		switch (action.type) {
 			case 'CALCULATE_BASE_PRICE':
 				return calculateBasePrice(state);
@@ -19,9 +19,7 @@ const useTicketPriceCalculator = () => useCallback(
 			default:
 				return state;
 		}
-	},
-	[]
-);
-
+	}, []);
+};
 
 export default useTicketPriceCalculator;

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
@@ -1,18 +1,27 @@
 /**
  * Internal imports
  */
+import {useCallback} from '@wordpress/element';
+
+/**
+ * Internal imports
+ */
 import calculateBasePrice from './calculateBasePrice';
 import calculateTicketTotal from './calculateTicketTotal';
 
-const useTicketPriceCalculator = (state, action) => {
-	switch (action.type) {
-		case 'CALCULATE_BASE_PRICE':
-			return calculateBasePrice(state);
-		case 'CALCULATE_TICKET_TOTAL/':
-			return calculateTicketTotal(state);
-		default:
-			return state;
-	}
-};
+const useTicketPriceCalculator = () => useCallback(
+	(state, action) => {
+		switch (action.type) {
+			case 'CALCULATE_BASE_PRICE':
+				return calculateBasePrice(state);
+			case 'CALCULATE_TICKET_TOTAL/':
+				return calculateTicketTotal(state);
+			default:
+				return state;
+		}
+	},
+	[]
+);
+
 
 export default useTicketPriceCalculator;

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculator.js
@@ -14,7 +14,7 @@ const useTicketPriceCalculator = () => useCallback(
 		switch (action.type) {
 			case 'CALCULATE_BASE_PRICE':
 				return calculateBasePrice(state);
-			case 'CALCULATE_TICKET_TOTAL/':
+			case 'CALCULATE_TICKET_TOTAL':
 				return calculateTicketTotal(state);
 			default:
 				return state;

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculatorFormDecorator.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculatorFormDecorator.js
@@ -48,7 +48,7 @@ const useTicketPriceCalculatorFormDecorator = () => {
 	);
 	const updateTicketTotal = useCallback(
 		(formData) => {
-			const result = calculator(formData, { type: 'CALCULATE_TICKET_TOTAL/' });
+			const result = calculator(formData, { type: 'CALCULATE_TICKET_TOTAL' });
 			const newTicketTotal = getValue('ticket.price', result);
 			return { ['ticket.price']: parseFloat(newTicketTotal || 0) };
 		},
@@ -75,7 +75,6 @@ const useTicketPriceCalculatorFormDecorator = () => {
 			updates: (value, name, formData) => {
 				const pricePath = name.replace('.priceType', '');
 				const price = getValue(pricePath, formData);
-				console.log('>>>> createDecorator', { price, priceTypes });
 				const priceType = getBasePriceType(price, priceTypes);
 				const updatedPrice = {
 					...price,

--- a/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculatorFormDecorator.js
+++ b/assets/prototype/domain/eventEditor/ticketsList/ticketPriceCalculator/hooks/useTicketPriceCalculatorFormDecorator.js
@@ -42,7 +42,7 @@ const useTicketPriceCalculatorFormDecorator = () => {
 		(formData) => {
 			const result = calculator(formData, { type: 'CALCULATE_BASE_PRICE' });
 			const newBasePrice = getValue('prices[0].amount', result);
-			return { ['prices[0].amount']: newBasePrice };
+			return { ['prices[0].amount']: parseFloat(newBasePrice || 0) };
 		},
 		[calculator]
 	);
@@ -50,7 +50,7 @@ const useTicketPriceCalculatorFormDecorator = () => {
 		(formData) => {
 			const result = calculator(formData, { type: 'CALCULATE_TICKET_TOTAL/' });
 			const newTicketTotal = getValue('ticket.price', result);
-			return { ['ticket.price']: newTicketTotal };
+			return { ['ticket.price']: parseFloat(newTicketTotal || 0) };
 		},
 		[calculator]
 	);

--- a/core/domain/services/graphql/mutators/DatetimeUpdate.php
+++ b/core/domain/services/graphql/mutators/DatetimeUpdate.php
@@ -94,10 +94,9 @@ class DatetimeUpdate
                     new RuntimeException(
                         sprintf(
                             esc_html__(
-                                'The Datetime failed to update because of the following error(s):%1$s%2$s',
+                                'The Datetime failed to update because of the following error(s): %1$s',
                                 'event_espresso'
                             ),
-                            '<br/>',
                             $exception->getMessage()
                         )
                     )

--- a/core/domain/services/graphql/mutators/DatetimeUpdate.php
+++ b/core/domain/services/graphql/mutators/DatetimeUpdate.php
@@ -8,12 +8,15 @@ use EventEspresso\core\domain\services\graphql\types\Datetime;
 use EventEspresso\core\domain\services\graphql\data\mutations\DatetimeMutation;
 
 use EE_Error;
+use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
+use Exception;
 use InvalidArgumentException;
 use ReflectionException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use RuntimeException;
 use WPGraphQL\AppContext;
 use GraphQL\Error\UserError;
 use GraphQLRelay\Relay;
@@ -61,6 +64,7 @@ class DatetimeUpdate
 
             if ($id) {
                 $entity = $model->get_one_by_ID($id);
+                $id = $entity->ID();
             }
 
             /**
@@ -83,13 +87,24 @@ class DatetimeUpdate
             }
 
             // Update the entity
-            $result = $entity->save($args);
-
-            if (empty($result)) {
-                throw new UserError(esc_html__('The object failed to update but no error was provided', 'event_espresso'));
+            try {
+                $entity->save($args);
+            } catch (Exception $exception) {
+                new ExceptionStackTraceDisplay(
+                    new RuntimeException(
+                        sprintf(
+                            esc_html__(
+                                'The Datetime failed to update because of the following error(s):%1$s%2$s',
+                                'event_espresso'
+                            ),
+                            '<br/>',
+                            $exception->getMessage()
+                        )
+                    )
+                );
             }
 
-            if (! empty($tickets)) {
+            if ($id && ! empty($tickets)) {
                 DatetimeMutation::setRelatedTickets($entity, $tickets);
             }
 

--- a/core/domain/services/graphql/mutators/PriceUpdate.php
+++ b/core/domain/services/graphql/mutators/PriceUpdate.php
@@ -86,10 +86,9 @@ class PriceUpdate
                     new RuntimeException(
                         sprintf(
                             esc_html__(
-                                'The Price failed to update because of the following error(s):%1$s%2$s',
+                                'The Price failed to update because of the following error(s): %1$s',
                                 'event_espresso'
                             ),
-                            '<br/>',
                             $exception->getMessage()
                         )
                     )

--- a/core/domain/services/graphql/mutators/TicketUpdate.php
+++ b/core/domain/services/graphql/mutators/TicketUpdate.php
@@ -99,10 +99,9 @@ class TicketUpdate
                     new RuntimeException(
                         sprintf(
                             esc_html__(
-                                'The Ticket failed to update because of the following error(s):%1$s%2$s',
+                                'The Ticket failed to update because of the following error(s): %1$s',
                                 'event_espresso'
                             ),
-                            '<br/>',
                             $exception->getMessage()
                         )
                     )


### PR DESCRIPTION
plz see #1993

There were a couple of issues happening that resulted in errors appearing in the GQL responses:

 - `DatetimeUpdate`, `TicketUpdate`, and `PriceUpdate` we were using the return value from `EE_Base_Class::save()` to determine whether the update was successful, but entities don't save if there were no changes made to them and that method returns `0`. The solution was simply to wrap the calls to `save()` in a try catch block and handle any actual errors that occur.

 - in `useOnSubmitPrices` values were getting submitted that were not of the correct type, such as `"false"` (string)  instead of `false` (boolean), so the solution was to normalize any values we know could cause problems.

- also fixed a couple other places where values were being set to ensure they were the correct data type

- also fixed another hook related problem in the ticket price calculator