### PR TITLE
Restore the status flag setters

### DIFF
--- a/assets/prototype/domain/eventEditor/containers/queries/useFetchPriceTypes.js
+++ b/assets/prototype/domain/eventEditor/containers/queries/useFetchPriceTypes.js
@@ -1,16 +1,34 @@
 import { useQuery } from '@apollo/react-hooks';
+import { useEffect } from '@wordpress/element';
 import { GET_PRICE_TYPES } from './priceTypes';
 import useInitToaster from '../../../../infrastructure/services/toaster/useInitToaster';
+import useStatus from '../../../../infrastructure/services/status/useStatus';
 
 const useFetchPriceTypes = () => {
 	console.log('%c useFetchPriceTypes: ', 'color: deeppink; font-size: 14px;');
+
+	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 
 	const { onCompleted, onError, initializationNotices } = useInitToaster({
 		loadingMessage: `initializing price types`,
 		successMessage: 'price types initialized',
 	});
 
-	const { data, error, loading } = useQuery(GET_PRICE_TYPES, { onCompleted, onError });
+	const { data, error, loading } = useQuery(GET_PRICE_TYPES, {
+		onCompleted: (data) => {
+			setIsLoaded('priceTypes', true);
+			onCompleted(data);
+		},
+		onError: (error) => {
+			setIsError('priceTypes', true);
+			onError(error);
+		},
+	});
+
+	useEffect(() => {
+		setIsLoading('priceTypes', loading);
+	}, [loading]);
+
 	initializationNotices(loading, error);
 
 	return {

--- a/assets/prototype/domain/eventEditor/containers/queries/useFetchPrices.js
+++ b/assets/prototype/domain/eventEditor/containers/queries/useFetchPrices.js
@@ -1,9 +1,13 @@
 import { useQuery } from '@apollo/react-hooks';
+import { useEffect } from '@wordpress/element';
 import { GET_PRICES } from './prices';
 import useInitToaster from '../../../../infrastructure/services/toaster/useInitToaster';
+import useStatus from '../../../../infrastructure/services/status/useStatus';
 
 const useFetchPrices = ({ ticketIn = [] }) => {
 	console.log('%c useFetchPrices: ', 'color: deeppink; font-size: 14px;');
+
+	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 
 	const { onCompleted, onError, initializationNotices } = useInitToaster({
 		loadingMessage: `initializing prices`,
@@ -17,9 +21,19 @@ const useFetchPrices = ({ ticketIn = [] }) => {
 			},
 		},
 		skip: !ticketIn.length, // do not fetch if we don't have any tickets
-		onCompleted,
-		onError,
+		onCompleted: (data) => {
+			setIsLoaded('prices', true);
+			onCompleted(data);
+		},
+		onError: (error) => {
+			setIsError('prices', true);
+			onError(error);
+		},
 	});
+
+	useEffect(() => {
+		setIsLoading('prices', loading);
+	}, [loading]);
 
 	initializationNotices(loading, error);
 


### PR DESCRIPTION
Fixes #2020 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
