### PR TITLE
Ensure GraphQLManager is Loaded for EDTR closes #2025

### DIFF
--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1200,7 +1200,7 @@ final class EE_System implements ResettableInterface
         // builders require these even on the front-end
         require_once EE_PUBLIC . 'template_tags.php';
         // load handler for GraphQL requests
-        if (class_exists('WPGraphQL') /* && $this->request->isGQL() */) {
+        if (class_exists('WPGraphQL')  && $this->request->isGQL() ) {
             try {
                 $graphQL_manager = $this->loader->getShared(
                     'EventEspresso\core\services\graphql\GraphQLManager'

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1200,7 +1200,7 @@ final class EE_System implements ResettableInterface
         // builders require these even on the front-end
         require_once EE_PUBLIC . 'template_tags.php';
         // load handler for GraphQL requests
-        if (class_exists('WPGraphQL')  && $this->request->isGQL() ) {
+        if (class_exists('WPGraphQL') && $this->request->isGQL()) {
             try {
                 $graphQL_manager = $this->loader->getShared(
                     'EventEspresso\core\services\graphql\GraphQLManager'


### PR DESCRIPTION
plz see #2025

In order to run GraphQL logic Server Side, @manzoorwanijk had commented out the `isGQL()` check in `EE_System` which would then allow that to run, but on **EVERY** request.

The work in this PR, re-enables that check so that GQL logic is not running needlessly on requests where it is not needed, but then adds additional logic to the Events Admin logic where the EDTR is loaded to ensure that the `GraphQLManager1 is also loaded.