### PR TITLE
Created utility to Convert To & From UTC; closes #1943.

### DIFF
--- a/assets/prototype/application/hooks/useTimeZoneTime.ts
+++ b/assets/prototype/application/hooks/useTimeZoneTime.ts
@@ -1,7 +1,7 @@
 import { zonedTimeToUtc, utcToZonedTime } from 'date-fns-tz';
-import useConfig from '../../application/services/config/useConfig';
+import useConfig from '../services/config/useConfig';
 
-const useZonedTime = () => {
+const useTimeZoneTime = () => {
 	const { timezone } = useConfig();
 
 	const zonedTimeToUtcCb = (date: Date | string | number) => {
@@ -18,4 +18,4 @@ const useZonedTime = () => {
 	};
 };
 
-export default useZonedTime;
+export default useTimeZoneTime;

--- a/assets/prototype/application/hooks/useTimeZoneTime.ts
+++ b/assets/prototype/application/hooks/useTimeZoneTime.ts
@@ -4,17 +4,17 @@ import useConfig from '../services/config/useConfig';
 const useTimeZoneTime = () => {
 	const { timezone } = useConfig();
 
-	const zonedTimeToUtcCb = (date: Date | string | number) => {
+	const localTimeToUtc = (date: Date | string | number) => {
 		return zonedTimeToUtc(date, timezone);
 	};
 
-	const utcToZonedTimeCb = (isoDate: Date | string | number) => {
+	const utcToLocalTime = (isoDate: Date | string | number) => {
 		return utcToZonedTime(isoDate, timezone);
 	};
 
 	return {
-		zonedTimeToUtc: zonedTimeToUtcCb,
-		utcToZonedTime: utcToZonedTimeCb,
+		localTimeToUtc,
+		utcToLocalTime,
 	};
 };
 

--- a/assets/prototype/application/hooks/useZonedTime.ts
+++ b/assets/prototype/application/hooks/useZonedTime.ts
@@ -1,0 +1,21 @@
+import { zonedTimeToUtc, utcToZonedTime } from 'date-fns-tz';
+import useConfig from '../../application/services/config/useConfig';
+
+const useZonedTime = () => {
+	const { timezone } = useConfig();
+
+	const zonedTimeToUtcCb = (date: Date | string | number) => {
+		return zonedTimeToUtc(date, timezone);
+	};
+
+	const utcToZonedTimeCb = (isoDate: Date | string | number) => {
+		return utcToZonedTime(isoDate, timezone);
+	};
+
+	return {
+		zonedTimeToUtc: zonedTimeToUtcCb,
+		utcToZonedTime: utcToZonedTimeCb,
+	};
+};
+
+export default useZonedTime;

--- a/assets/prototype/application/services/config/useConfig.js
+++ b/assets/prototype/application/services/config/useConfig.js
@@ -1,6 +1,0 @@
-import { useContext } from 'react';
-import { ConfigContext } from '../context/ConfigProvider';
-
-const useConfig = () => useContext(ConfigContext);
-
-export default useConfig;

--- a/assets/prototype/application/services/config/useConfig.ts
+++ b/assets/prototype/application/services/config/useConfig.ts
@@ -1,12 +1,12 @@
 import { useContext } from 'react';
 import { ConfigContext } from '../context/ConfigProvider';
 
-type useConfigReturnType = {
+type ConfigReturnType = {
 	dateFormat: string;
 	timeFormat: string;
 	timezone: string;
 };
 
-const useConfig = (): useConfigReturnType => useContext(ConfigContext);
+const useConfig = (): ConfigReturnType => useContext(ConfigContext);
 
 export default useConfig;

--- a/assets/prototype/application/services/config/useConfig.ts
+++ b/assets/prototype/application/services/config/useConfig.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ConfigContext } from '../context/ConfigProvider';
+
+type useConfigReturnType = {
+	dateFormat: string;
+	timeFormat: string;
+	timezone: string;
+};
+
+const useConfig = (): useConfigReturnType => useContext(ConfigContext);
+
+export default useConfig;

--- a/assets/prototype/application/services/config/useConfigProvider.ts
+++ b/assets/prototype/application/services/config/useConfigProvider.ts
@@ -2,7 +2,7 @@ import useConfig from './useConfig';
 import getDateTimeFormat from '../../valueObjects/dateTime/getDateTimeFormat';
 
 type useConfigProviderProps = {
-	dateTimeFormat: boolean;
+	dateTimeFormat?: boolean;
 };
 
 /**

--- a/assets/prototype/application/services/context/ConfigProvider.js
+++ b/assets/prototype/application/services/context/ConfigProvider.js
@@ -24,7 +24,7 @@ const ConfigProvider = ({ children }) => {
 
 	const generalSettings = propOr({}, 'generalSettings', generalSettingsData);
 	const currentUser = propOr({}, 'viewer', currentUserData);
-	const { dateFormat, timeFormat } = pick(['dateFormat', 'timeFormat', 'timezone'], generalSettings);
+	const { dateFormat, timeFormat, timezone } = pick(['dateFormat', 'timeFormat', 'timezone'], generalSettings);
 
 	const currentUserProps = pick(
 		[
@@ -42,7 +42,7 @@ const ConfigProvider = ({ children }) => {
 		],
 		currentUser
 	);
-	const value = { dateFormat, timeFormat, ...currentUserProps };
+	const value = { dateFormat, timeFormat, timezone, ...currentUserProps };
 
 	return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,6 +5626,11 @@
 			"integrity": "sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg==",
 			"dev": true
 		},
+		"date-fns-tz": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.8.tgz",
+			"integrity": "sha512-BWoRepQOHUx3GxcIn2zmhttL23sB1ogMpucECFyEN0jWv+AmEzatZvBaX1/J9ALQ46jK9/Fo73HmHejpgNEyaQ=="
+		},
 		"debug": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"apollo-link-http": "^1.5.16",
 		"classnames": "^2.2.6",
 		"cuid": "^2.1.6",
+		"date-fns-tz": "^1.0.8",
 		"decimal.js-light": "^2.5.0",
 		"final-form": "^4.18.6",
 		"final-form-arrays": "^3.0.2",


### PR DESCRIPTION
## Problem this Pull Request solves
Solves: https://github.com/eventespresso/event-espresso-core/issues/1943
With few adjustments:
- It is pulls `timezone` from `ConfigContext`, but I didn't wanted to add to much responsability on that context and extracted the logic into a custom hook.
- Based on [date-fn docs](https://date-fns.org/v2.8.1/docs/Time-Zones) I've used `date-fns-tz` which might make into the `date-fns` core. Check [here](https://github.com/date-fns/date-fns/pull/707).
- As mentioned in the first bullet point I've created custom hook, the intention being to abstract away external dependency and to pull `timezone` from the config, this will make the UI component less agnostic of underlying details.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
