### PR TITLE
Migrations: Don't check for EE shortcodes in attachments or menu items too

### DIFF
--- a/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_shortcodes.dmsstage.php
+++ b/core/data_migration_scripts/4_1_0_stages/EE_DMS_4_1_0_shortcodes.dmsstage.php
@@ -54,6 +54,6 @@ class EE_DMS_4_1_0_shortcodes extends EE_Data_Migration_Script_Stage
 
     private function _sql_to_only_select_non_drafts()
     {
-        return " WHERE post_type NOT IN ('revision','auto-draft') ";
+        return " WHERE post_type NOT IN ('revision','auto-draft','attachment','nav_menu_item') ";
     }
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
There was a support request where the user was trying to migrate from EE3 to EE4 and this was the error in the migration:

```
[_feedback_message] => Migrated 50 records successfully during Shortcodes
[_priority] => 10
[_records_to_migrate] => 83926
[_records_migrated] => 105
[_status] => status_fatal_error
[_pretty_name] => Data Migration from Event Espresso 3 to Event Espresso 4.1.0
```

The site in question has no WP posts, and has about 30 WP pages (along with some custom post types). The bulk of the shortcode records to migrate were attachment posts. This PR will help make the shortcode part of the migration be more efficient because we know EE shortcodes will not be in attachment posts or nav menu items. 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
I tested an EE3 to EE4 migration locally using the site's _posts table imported onto a local site. The shortcode part of the migration took much less time with this branch.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
