### PR TITLE
Don't release ticket reservations for transactions that are in…

### DIFF
--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -990,9 +990,6 @@ class EED_Ticket_Sales_Monitor extends EED_Module
         array $valid_reserved_ticket_line_items = array(),
         $source
     ) {
-        if (self::debug) {
-            echo self::$nl . self::$nl . __LINE__ . ') ' . __METHOD__ . '()';
-        }
         $total_tickets_released = 0;
         $sold_out_events = array();
         foreach ($tickets_with_reservations as $ticket_with_reservations) {
@@ -1005,19 +1002,11 @@ class EED_Ticket_Sales_Monitor extends EED_Module
             // the number to RELEASE. It's the same end result, just different path.
             // Begin by assuming we're going to release all the reservations on this ticket.
             $num_tix_for_expired_reservations = $ticket_with_reservations->reserved();
-            if (self::debug) {
-                echo self::$nl . ' . $ticket_with_reservations->ID(): ' . $ticket_with_reservations->ID();
-                echo self::$nl . ' . $reserved_qty: ' . $num_tix_for_expired_reservations;
-            }
             // Now reduce that number using the list of current valid reservations.
             foreach ($valid_reserved_ticket_line_items as $valid_reserved_ticket_line_item) {
                 if ($valid_reserved_ticket_line_item instanceof EE_Line_Item
                     && $valid_reserved_ticket_line_item->OBJ_ID() === $ticket_with_reservations->ID()
                 ) {
-                    if (self::debug) {
-                        echo self::$nl . ' . $valid_reserved_ticket_line_item->quantity(): '
-                             . $valid_reserved_ticket_line_item->quantity();
-                    }
                     $num_tix_for_expired_reservations -= $valid_reserved_ticket_line_item->quantity();
                 }
             }
@@ -1036,9 +1025,6 @@ class EED_Ticket_Sales_Monitor extends EED_Module
                     $sold_out_events[] = $event;
                 }
             }
-        }
-        if (self::debug) {
-            echo self::$nl . ' . $total_tickets_released: ' . $total_tickets_released;
         }
         // Double check whether sold out events should remain sold out after releasing tickets
         if ($sold_out_events !== array()) {

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -978,8 +978,12 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * whose transactions aren't complete and also aren't yet expired (ie, they're incomplete and younger than the
      * session's expiry time) to update the ticket (and their datetimes') reserved counts.
      *
-     * @param EE_Ticket[]    $tickets_with_reservations
-     * @param EE_Line_Item[] $valid_reserved_ticket_line_items
+     * @param EE_Ticket[]    $tickets_with_reservations all tickets with TKT_reserved > 0
+     * @param EE_Line_Item[] $valid_reserved_ticket_line_items all line items for tickets and incomplete transactions
+     *                       whose session has NOT expired. We will use these to determine the number of ticket
+     *                       reservations are now invalid. We don't use the list of invalid ticket line items because
+     *                       we don't know which of those have already been taken into account when reducing ticket
+     *                       reservation counts, and which haven't.
      * @return int
      * @throws UnexpectedEntityException
      * @throws DomainException

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -985,7 +985,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @throws DomainException
      * @throws EE_Error
      */
-    private static function release_reservations_for_tickets(
+    protected static function release_reservations_for_tickets(
         array $tickets_with_reservations,
         array $valid_reserved_ticket_line_items = array(),
         $source

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -1005,23 +1005,23 @@ class EED_Ticket_Sales_Monitor extends EED_Module
             // to try to avoid race conditions, so instead of just finding the number to update TO, we're going to find
             // the number to RELEASE. It's the same end result, just different path.
             // Begin by assuming we're going to release all the reservations on this ticket.
-            $num_tix_for_expired_reservations = $ticket_with_reservations->reserved();
+            $expired_reservations_count = $ticket_with_reservations->reserved();
             // Now reduce that number using the list of current valid reservations.
             foreach ($valid_reserved_ticket_line_items as $valid_reserved_ticket_line_item) {
                 if ($valid_reserved_ticket_line_item instanceof EE_Line_Item
                     && $valid_reserved_ticket_line_item->OBJ_ID() === $ticket_with_reservations->ID()
                 ) {
-                    $num_tix_for_expired_reservations -= $valid_reserved_ticket_line_item->quantity();
+                    $expired_reservations_count -= $valid_reserved_ticket_line_item->quantity();
                 }
             }
             // Only bother saving the tickets and datetimes if we're actually going to release some spots.
-            if ($num_tix_for_expired_reservations > 0) {
+            if ($expired_reservations_count > 0) {
                 $ticket_with_reservations->add_extra_meta(
                     EE_Ticket::META_KEY_TICKET_RESERVATIONS,
                     __LINE__ . ') ' . $source . '()'
                 );
-                $ticket_with_reservations->decreaseReserved($num_tix_for_expired_reservations, true, 'TicketSalesMonitor:' . __LINE__);
-                $total_tickets_released += $num_tix_for_expired_reservations;
+                $ticket_with_reservations->decreaseReserved($expired_reservations_count, true, 'TicketSalesMonitor:' . __LINE__);
+                $total_tickets_released += $expired_reservations_count;
                 $event = $ticket_with_reservations->get_related_event();
                 // track sold out events
                 if ($event instanceof EE_Event && $event->is_sold_out()) {

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -964,7 +964,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
         $ticket_line_items = EEH_Line_Item::get_ticket_line_items($total_line_item);
         foreach ($ticket_line_items as $ticket_line_item) {
             if ($ticket_line_item instanceof EE_Line_Item) {
-                $valid_reserved_tickets[$ticket_line_item->ID()] = $ticket_line_item;
+                $valid_reserved_tickets[ $ticket_line_item->ID() ] = $ticket_line_item;
             }
         }
         return $valid_reserved_tickets;

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -1017,7 +1017,6 @@ class EED_Ticket_Sales_Monitor extends EED_Module
                     __LINE__ . ') ' . $source . '()'
                 );
                 $ticket_with_reservations->decreaseReserved($num_tix_for_expired_reservations, true, 'TicketSalesMonitor:' . __LINE__);
-                $ticket_with_reservations->save();
                 $total_tickets_released += $num_tix_for_expired_reservations;
                 $event = $ticket_with_reservations->get_related_event();
                 // track sold out events

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -876,9 +876,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
                     $args[$fk->get_name()] = $fk->get_default_value();
                 }
             } elseif ($relation instanceof EE_Belongs_To_Relation) {
-                $obj = $this->new_model_obj_with_dependencies($related_model_name);
                 $fk = $model->get_foreign_key_to($related_model_name);
                 if (!isset($args[$fk->get_name()])) {
+                    $obj = $this->new_model_obj_with_dependencies($related_model_name);
                     $args[$fk->get_name()] = $obj->ID();
                 }
             }
@@ -1047,18 +1047,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * registrations, tickets, datetimes, events, attendees, questions, answers, etc).
      *
      * @param array $options         {
-     * 	@type int    $ticket_types    the number of different ticket types in this transaction. Default 1
+     * 	@type int    $ticket_types/$tickets    the number of different ticket types in this transaction. Default 1
      * 	@type int    $taxable_tickets how many of those ticket types should be taxable. Default EE_INF
+     * @type int fixed_ticket_price_modifiers the number of fixed ticket price modifiers to use on the tickets. Defaults to 1.
+     * @type string $reg_status the status of the transaction's registration. Defaults to "RAP"
+     * @type boolean $setup_reg whether to add a registration or not onto the transaction. Defaults to true
+     * @type int $tkt_qty the number of tickest available for purchase that the transaction is for
+     * @type string/int/Datetime $timestamp to use on the transaction and registration and payments etc
      * }
      * @return EE_Transaction
      * @throws \EE_Error
      */
     protected function new_typical_transaction($options = array())
     {
-        /** @var EE_Transaction $txn */
-        $txn = $this->new_model_obj_with_dependencies('Transaction', array('TXN_paid' => 0));
-        $total_line_item = EEH_Line_Item::create_total_line_item($txn->ID());
-        $total_line_item->save_this_and_descendants_to_txn($txn->ID());
         $ticket_types = isset($options['ticket_types'])
             ? $options['ticket_types']
             : $ticket_types = 1;
@@ -1080,6 +1081,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $ticket_types = isset($options['tickets'])
             ? count($options['tickets'])
             : $ticket_types;
+        $timestamp = isset($options['timestamp'])
+            ? $options['timestamp']
+            : current_time('timestamp');
+        /** @var EE_Transaction $txn */
+        $txn = $this->new_model_obj_with_dependencies(
+            'Transaction',
+            array(
+                'TXN_paid' => 0,
+                'TXN_timestamp' => $timestamp
+            )
+        );
+        $total_line_item = EEH_Line_Item::create_total_line_item($txn->ID());
+        $total_line_item->save_this_and_descendants_to_txn($txn->ID());
         $taxes = EEM_Price::instance()->get_all_prices_that_are_taxes();
         for ($i = 1; $i <= $ticket_types; $i++) {
             /** @var EE_Ticket $ticket */
@@ -1088,9 +1102,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 $reg_final_price = $ticket->price();
                 $datetime = $ticket->first_datetime();
             } else {
+
                 $ticket = $this->new_model_obj_with_dependencies(
                     'Ticket',
-                    array('TKT_price' => $i * 10, 'TKT_taxable' => $taxable_tickets-- > 0 ? true : false)
+                    array(
+                        'TKT_price' => $i * 10,
+                        'TKT_taxable' => $taxable_tickets-- > 0 ? true : false,
+                        'TKT_reserved' => $setup_reg && $reg_status === EEM_Registration::status_id_pending_payment ? 1 : 0
+                    )
                 );
                 $sum_of_sub_prices = 0;
                 for ($j = 1; $j <= $fixed_ticket_price_modifiers; $j++) {
@@ -1133,7 +1152,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
                         'EVT_ID'          => $datetime->get('EVT_ID'),
                         'REG_count'       => 1,
                         'REG_group_size'  => 1,
-                        'REG_final_price' => $reg_final_price
+                        'REG_final_price' => $reg_final_price,
+                        'REG_date' => $timestamp
                     )
                 );
             }

--- a/tests/mocks/modules/EED_Ticket_Sales_Monitor_Mock.php
+++ b/tests/mocks/modules/EED_Ticket_Sales_Monitor_Mock.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class EED_Ticket_Sales_Monitor_Mock
+ *
+ * Description
+ *
+ * @package     Event Espresso
+ * @author         Mike Nelson
+ * @since         $VID:$
+ *
+ */
+class EED_Ticket_Sales_Monitor_Mock extends EED_Ticket_Sales_Monitor
+{
+    public static function release_reservations_for_tickets(
+        array $tickets_with_reservations,
+        array $valid_reserved_ticket_line_items = array(),
+        $source = ''
+    ) {
+        return parent::release_reservations_for_tickets(
+            $tickets_with_reservations,
+            $valid_reserved_ticket_line_items,
+            $source
+        );
+    }
+
+}
+// End of file EED_Ticket_Sales_Monitor_Mock.php
+// Location: ${NAMESPACE}/EED_Ticket_Sales_Monitor_Mock.php

--- a/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
+++ b/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
@@ -1,4 +1,9 @@
 <?php
+
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
+
 defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
@@ -22,8 +27,8 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      * @throws \PHPUnit\Framework\Exception
      */
     protected function setup_cart_and_get_ticket_line_item($ticket_count = 1, $expired = false)
@@ -61,8 +66,8 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     protected function fake_expired_cart(EE_Line_Item $line_item, $timestamp = 0)
     {
@@ -82,8 +87,8 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      * @throws \PHPUnit\Framework\Exception
      */
     protected function confirm_ticket_line_item_counts($ticket_count = 1, $line_item_count = 1)
@@ -124,9 +129,9 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      * @throws \PHPUnit\Framework\Exception
      */
     protected function setup_and_validate_tickets_for_carts(array $cart_details)
@@ -196,9 +201,9 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      * @throws \PHPUnit\Framework\Exception
      */
     public function test_release_tickets_with_expired_carts()
@@ -225,9 +230,9 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      * @throws \PHPUnit\Framework\Exception
      */
     public function test_release_tickets_for_multiple_valid_carts()
@@ -255,9 +260,9 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      * @group current
      */
     public function testValidateTicketSaleTruePositive()
@@ -311,9 +316,9 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
      * @group current
      */
     public function testValidateTicketSaleTrueNegative()
@@ -512,6 +517,38 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
         $this->assertEquals(0, $d1->reserved());
         $this->assertEquals(2, $d2->reserved());
         $this->assertEquals(0, $t->reserved());
+    }
+
+    /**
+     * @since $VID:$
+     * @throws DomainException
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UnexpectedEntityException
+     */
+    public function testResetReservationCounts()
+    {
+        $this->assertEquals(0, EEM_Transaction::instance()->count());
+        // need some transactions
+        $transactions_count = 10;
+        for($i=0; $i<$transactions_count; $i++){
+            $transaction = $this->new_typical_transaction(
+                [
+                    'tkt_qty' => 5,
+                    'reg_status' => EEM_Registration::status_id_pending_payment,
+                    'setup_reg' => true,
+                    'timestamp' => current_time('timestamp') - WEEK_IN_SECONDS * 2
+                ]
+            );
+        }
+        $this->assertEquals($transactions_count, EEM_Transaction::instance()->count());
+        $a_ticket = $transaction->primary_registration()->ticket();
+        $this->assertEquals(1, $a_ticket->reserved());
+        $tickets_released = EED_Ticket_Sales_Monitor::reset_reservation_counts();
+        $this->assertEquals($transactions_count, $tickets_released);
     }
 }
 // End of file EED_Ticket_Sales_Monitor_Test.php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
If the cron task `AHEE__EE_Cron_Tasks__clean_up_junk_transactions` ran while a transaction was in progress and had tickets reserved, those reservations were getting released, would could lead to overselling. See https://github.com/eventespresso/event-espresso-core/issues/2047#issuecomment-566655969

I vaguely remember that over the past few years we've had some overselling issues. The problem this is fixing may have been the cause of them. (Specifically, that there were reservations on the ticket for registrations in progress, then the cron task would run and release the ticket reservations, and before the registrations finished up, someone else would start to register.)

As far as internal details of what changed, it's a bit confusing...
The logic in `\EED_Ticket_Sales_Monitor::reset_reservation_counts` seems to have gotten confused at some point.
There were two problems:

### 1. PHP array union overwrites based on array keys
The list of `$valid_reserved_tickets` was being built using `$valid_reserved_tickets += EED_Ticket_Sales_Monitor::get_ticket_line_items_for_grand_total($total_line_item            );`. That operator `+=` union'd `$valid_reserved_tickets` with `EED_Ticket_Sales_Monitor::get_ticket_line_items_for_grand_total()`'s results based on array **keys**. And the array was indexed **numerically**. So if `$valid_reserved_tickets` had one item, its array key was `0`. If `EED_Ticket_Sales_Monitor::get_ticket_line_items_for_grand_total()` returned an array which also had a single item, its key was also `0`. So when they were union'd, the second array's `0` was ignored.
> The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored. 
from https://www.php.net/manual/en/language.operators.array.php

So, even if there were 400 `$transactions_not_in_progress`, the `$valid_reserved_tickets` derived from them was usually just a single item.

The fix was to instead index the array using the line item's ID.

### 2. Fetching Expired Transactions instead of In-Progress Ones
`\EED_Ticket_Sales_Monitor::reset_reservation_counts` was fetching the list of expired transactions (which could never complete, and so their reservations on tickets could be released) but then it considered their tickets' reservations as "valid" by adding them to `$valid_reserved_tickets` 😵. That seems to be the opposite of what we want: the transactions are **expired**, and so their ticket reservations are **no longer** valid. 

The fix was to do the opposite: fetch the list of transactions that were still **in-progress** (ie, their session hadn't yet expired) and could be completed. Those are the transactions whose ticket reservations are still valid because they could still complete their registrations.

So in summary, on this branch, we are fetching all the in-progress transactions, and building the list of `$valid_reserved_tickets` from that, indexing the items by the ticket line item's ID in the array (rather than numerically) in order for the array `+=` operator to work as expected.

### Regarding efficiency
I originally dug into this code to see if there was a way to optimize it further. I got sidetracked fixing this bug, but I think this may also help significantly with efficiency too.
Before we were fetching the list all expired transactions (which hadn't yet been deleted). So that could have been a week's worth of transactions being fetched on every execution of the cron job. On some sites, there were hundreds or even thousands of these.
With these changes, we're instead only grabbing all the in-progress transactions. While on some sites this number can also be high, it's at least only an hour's worth of transactions instead of a week's.
So I'm guessing this means that where before we were fetching hundreds or thousands of transactions everytime the cron ran, we'll now instead be fetching dozens, so the load will be alleviated.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Besides the new unit test, 
* [x] Create an event, set a limit to 10 on its ticket
* Register 10 spots for the event in Firefox, but don't actually answer any reg details. Keep the tab open though. Notice the ticket's "Rsvd" count is now at 10.
* Execute the cron task AHEE__EE_Cron_Tasks__clean_up_junk_transactions (I use the WP CLI command wp cron event run AHEE__EE_Cron_Tasks__clean_up_junk_transactions)
* Notice that the event's "Rsvd" count is back to 0 (even though there is an active transaction for 10 of them!!!)
* In Google Chrome, go to the event and register another 10 spots. Complete the registration.
* Complete the registration you started in Firefox.
* Notice the event now has 20 tickets sold, despite having a limit of 10 on the ticket skull_and_crossbones skull_and_crossbones skull_and_crossbones. Here's a video of that on master: drive.google.com/file/d/1emSMmhy1sSPhvFaL7w6cvDT4U4MqaJnM/view
* [ ] Create another event (or two) with various tickets. Make a few registrations and have a few registrations in progress, so some of the tickets have tickets reserved. 
* Go to the maintenance -> "Reset/Delete Data" and click "Reset Ticket and Datetime Reserved Counts". The tickets' reserved counts should NOT change (on master, they'd all get set back to 0.)
* [x] Create a ticket with a limit of 10. Begin 10 registrations for that ticket, but don't answer any reg questions. So, the ticket's fully reserved.
* In another browser, try to register for that ticket. You should be prevented from doing so.
* In the DB, manually change that first transaction's `TXN_timestamp` to anything older than a week, and then run the cron task again.
* The ticket's reserved count should be set back to 0


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
