### PR TITLE
Typefy centralized mutator

### DIFF
--- a/assets/prototype/application/hooks/useIfMounted.ts
+++ b/assets/prototype/application/hooks/useIfMounted.ts
@@ -17,3 +17,5 @@ const useIfMounted = () => {
 
 	return ifMounted;
 };
+
+export default useIfMounted;

--- a/assets/prototype/application/services/apollo/mutations/index.ts
+++ b/assets/prototype/application/services/apollo/mutations/index.ts
@@ -1,0 +1,3 @@
+export { default as useEntityMutator } from './useEntityMutator';
+
+export { EntityType } from './types';

--- a/assets/prototype/application/services/apollo/mutations/types.ts
+++ b/assets/prototype/application/services/apollo/mutations/types.ts
@@ -1,20 +1,39 @@
 import { MutationOptions } from 'apollo-client';
-type MutationInput = {
+import { DataProxy } from 'apollo-cache';
+
+export type MutationInput = {
 	[key: string]: any;
 };
-type BackwardSubscription = {
-	onCompleted?: () => void;
-	onError?: () => void;
+
+export type OnMutationCompletedFn = (data: any) => void;
+
+export type OnMutationErrorFn = (error: Error) => void;
+
+type OnUpdateFnOptions = {
+	proxy: DataProxy;
+	entity: any;
 };
+
+export type OnUpdateFn = (options: OnUpdateFnOptions) => void;
+
+export interface BackwardSubscription {
+	onCompleted?: OnMutationCompletedFn;
+	onError?: OnMutationErrorFn;
+}
 export interface EntityMutator {
-	createEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => void;
-	updateEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => void;
-	deleteEntity: (input?: MutationInput, subscriptions?: BackwardSubscription) => void;
+	createEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => MutationResult;
+	updateEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => MutationResult;
+	deleteEntity: (input?: MutationInput, subscriptions?: BackwardSubscription) => MutationResult;
+}
+
+export interface CustomMutationOptions extends MutationOptions {
+	onCompleted?: OnMutationCompletedFn;
+	onError?: OnMutationErrorFn;
 }
 
 type MutationGetter = (input: MutationInput) => MutationOptions;
 
-type MutationResult = {
+export type MutationResult = {
 	loading: boolean;
 	error?: any;
 	data?: any;
@@ -25,5 +44,32 @@ export interface EntityMutation {
 	getCreateMutation: MutationGetter;
 	getUpdateMutation: MutationGetter;
 	getDeleteMutation: MutationGetter;
-	mutate: (input: MutationOptions) => MutationResult;
+	mutate: (options: CustomMutationOptions) => MutationResult;
+}
+
+export interface Mutators {
+	datetimeMutator: Mutator;
+	ticketMutator: Mutator;
+	priceMutator: Mutator;
+}
+
+export interface MutatorGeneratedObject {
+	onUpdate?: OnUpdateFn;
+	optimisticResponse: any;
+	variables: any;
+}
+
+export type Mutator = (mutationType: string, input: MutationInput) => MutatorGeneratedObject;
+
+export enum MutationType {
+	Create = 'CREATE',
+	Update = 'UPDATE',
+	Delete = 'DELETE',
+}
+
+export enum EntityType {
+	Datetime = 'Datetime',
+	Ticket = 'Ticket',
+	Price = 'Price',
+	PriceType = 'PriceType',
 }

--- a/assets/prototype/application/services/apollo/mutations/types.ts
+++ b/assets/prototype/application/services/apollo/mutations/types.ts
@@ -59,7 +59,7 @@ export interface MutatorGeneratedObject {
 	variables: any;
 }
 
-export type Mutator = (mutationType: string, input: MutationInput) => MutatorGeneratedObject;
+export type Mutator = (mutationType: MutationType, input: MutationInput) => MutatorGeneratedObject;
 
 export enum MutationType {
 	Create = 'CREATE',

--- a/assets/prototype/application/services/apollo/mutations/types.ts
+++ b/assets/prototype/application/services/apollo/mutations/types.ts
@@ -1,0 +1,29 @@
+import { MutationOptions } from 'apollo-client';
+type MutationInput = {
+	[key: string]: any;
+};
+type BackwardSubscription = {
+	onCompleted?: () => void;
+	onError?: () => void;
+};
+export interface EntityMutator {
+	createEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => void;
+	updateEntity: (input: MutationInput, subscriptions?: BackwardSubscription) => void;
+	deleteEntity: (input?: MutationInput, subscriptions?: BackwardSubscription) => void;
+}
+
+type MutationGetter = (input: MutationInput) => MutationOptions;
+
+type MutationResult = {
+	loading: boolean;
+	error?: any;
+	data?: any;
+	called: boolean;
+};
+
+export interface EntityMutation {
+	getCreateMutation: MutationGetter;
+	getUpdateMutation: MutationGetter;
+	getDeleteMutation: MutationGetter;
+	mutate: (input: MutationOptions) => MutationResult;
+}

--- a/assets/prototype/application/services/apollo/mutations/useEntityMutator.ts
+++ b/assets/prototype/application/services/apollo/mutations/useEntityMutator.ts
@@ -1,19 +1,25 @@
 import useEntityMutation from './useEntityMutation';
-import { ucfirst } from '../../../utils';
+import {
+	EntityMutator,
+	MutationInput,
+	BackwardSubscription,
+	MutationResult,
+	CustomMutationOptions,
+	EntityType,
+} from './types';
 
 /**
  * @param {string} type Entity type name
  * @param {string} id   Entity id
  */
-const useEntityMutator = (type, id = '') => {
-	const _type = ucfirst(type.toLowerCase());
-	const { getCreateMutation, getUpdateMutation, getDeleteMutation, mutate } = useEntityMutation(_type, id);
+const useEntityMutator = (type: EntityType, id: string = ''): EntityMutator => {
+	const { getCreateMutation, getUpdateMutation, getDeleteMutation, mutate } = useEntityMutation(type, id);
 
 	/**
 	 * @param {object} input the entity properties for the mutation input
 	 * @param {object} subscriptions
 	 */
-	const createEntity = (input, subscriptions = {}) => {
+	const createEntity = (input: MutationInput, subscriptions: BackwardSubscription = {}): MutationResult => {
 		return subscribeAndMutate(getCreateMutation(input), subscriptions);
 	};
 
@@ -21,7 +27,7 @@ const useEntityMutator = (type, id = '') => {
 	 * @param {object} input the entity properties for the mutation input
 	 * @param {object} subscriptions
 	 */
-	const updateEntity = (input, subscriptions = {}) => {
+	const updateEntity = (input: MutationInput, subscriptions: BackwardSubscription = {}): MutationResult => {
 		return subscribeAndMutate(getUpdateMutation(input), subscriptions);
 	};
 
@@ -29,15 +35,18 @@ const useEntityMutator = (type, id = '') => {
 	 * @param {object} input the entity properties for the mutation input
 	 * @param {object} subscriptions
 	 */
-	const deleteEntity = (input = {}, subscriptions = {}) => {
+	const deleteEntity = (input: MutationInput = {}, subscriptions: BackwardSubscription = {}): MutationResult => {
 		return subscribeAndMutate(getDeleteMutation(input), subscriptions);
 	};
 
 	/**
 	 * @param {object} options
-	 * @param {object} subscriptions Component subscriptions = {onComplete, onError}
+	 * @param {object} subscriptions Component subscriptions
 	 */
-	const subscribeAndMutate = (options, subscriptions = {}) => {
+	const subscribeAndMutate = (
+		options: CustomMutationOptions,
+		subscriptions: BackwardSubscription
+	): MutationResult => {
 		// These are backward subscriptions towards components
 		// i.e. when a component wants to be notified
 		const { onCompleted: bwdOnCompleted, onError: bwdOnError } = subscriptions;
@@ -45,7 +54,7 @@ const useEntityMutator = (type, id = '') => {
 		// i.e. when an entity mutator wants to be notified
 		const { onCompleted: fwdOnCompleted, onError: fwdOnError, ...mutationOptions } = options;
 
-		const onCompleted = (data) => {
+		const onCompleted = (data: any): void => {
 			if (typeof bwdOnCompleted === 'function') {
 				bwdOnCompleted(data);
 			}
@@ -54,7 +63,7 @@ const useEntityMutator = (type, id = '') => {
 			}
 		};
 
-		const onError = (error) => {
+		const onError = (error: Error): void => {
 			if (typeof bwdOnError === 'function') {
 				bwdOnError(error);
 			}

--- a/assets/prototype/application/services/apollo/mutations/useMutators.ts
+++ b/assets/prototype/application/services/apollo/mutations/useMutators.ts
@@ -1,11 +1,12 @@
 import useDatetimeMutator from '../../../../domain/eventEditor/data/mutations/datetimes/useDatetimeMutator';
 import useTicketMutator from '../../../../domain/eventEditor/data/mutations/tickets/useTicketMutator';
 import usePriceMutator from '../../../../domain/eventEditor/data/mutations/prices/usePriceMutator';
+import { Mutators, Mutator } from './types';
 
-const useMutators = () => {
-	const datetimeMutator = useDatetimeMutator();
-	const ticketMutator = useTicketMutator();
-	const priceMutator = usePriceMutator();
+const useMutators = (): Mutators => {
+	const datetimeMutator: Mutator = useDatetimeMutator();
+	const ticketMutator: Mutator = useTicketMutator();
+	const priceMutator: Mutator = usePriceMutator();
 
 	return {
 		datetimeMutator,

--- a/assets/prototype/domain/eventEditor/datetimes/dateCard/DateCard.js
+++ b/assets/prototype/domain/eventEditor/datetimes/dateCard/DateCard.js
@@ -9,7 +9,7 @@ import { MomentDateRange } from '../../../shared/dateRangeInput/momentDate';
 import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '../../../shared/defaultDates';
 
 import useDateItem from '../../data/queries/datetimes/useDateItem';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useRelations from '../../../../application/services/apollo/relations/useRelations';
 import useStatus from '../../../../application/services/apollo/status/useStatus';
 import TicketId from '../../tickets/TicketId';
@@ -39,7 +39,7 @@ const DateCard = ({ id }) => {
 	const date = useDateItem({ id });
 	const { isLoaded } = useStatus();
 
-	const { updateEntity } = useEntityMutator('Datetime', id);
+	const { updateEntity } = useEntityMutator(EntityType.Datetime, id);
 
 	const { getRelations } = useRelations();
 

--- a/assets/prototype/domain/eventEditor/datetimes/dateCard/DeleteDateButton.tsx
+++ b/assets/prototype/domain/eventEditor/datetimes/dateCard/DeleteDateButton.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Button } from '@blueprintjs/core';
 
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 
 const DeleteDateButton = ({ id }) => {
-	const { deleteEntity } = useEntityMutator('Datetime', id);
+	const { deleteEntity } = useEntityMutator(EntityType.Datetime, id);
 
 	return (
 		<div

--- a/assets/prototype/domain/eventEditor/datetimes/dateCard/EditDateModal.js
+++ b/assets/prototype/domain/eventEditor/datetimes/dateCard/EditDateModal.js
@@ -2,12 +2,12 @@ import { useContext } from '@wordpress/element';
 import FormModal from '../../../../application/ui/components/forms/FormModal';
 import DateForm from '../dateForm/DateForm';
 import { DateTimeContext } from '../../context/DateTimeProvider';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useTickets from '../../data/queries/tickets/useTickets';
 
 const EditDateModal = ({ relatedTickets }) => {
 	const { id, isOpen, onClose } = useContext(DateTimeContext);
-	const { updateEntity } = useEntityMutator('Datetime', id);
+	const { updateEntity } = useEntityMutator(EntityType.Datetime, id);
 	const tickets = useTickets();
 
 	const formComponent = (props) => (

--- a/assets/prototype/domain/eventEditor/datetimes/dateList/AddNewDateModal.js
+++ b/assets/prototype/domain/eventEditor/datetimes/dateList/AddNewDateModal.js
@@ -1,10 +1,10 @@
 import DateForm from '../dateForm/DateForm';
 import FormModal from '../../../../application/ui/components/forms/FormModal';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useTickets from '../../data/queries/tickets/useTickets';
 
 const AddNewDateModal = ({ handleClose, isOpen }) => {
-	const { createEntity } = useEntityMutator('Datetime');
+	const { createEntity } = useEntityMutator(EntityType.Datetime);
 	const tickets = useTickets();
 	const formComponent = (props) => <DateForm {...props} tickets={tickets} title='New Date Details' />;
 

--- a/assets/prototype/domain/eventEditor/tickets/hooks/useDeleteTicketHandler.js
+++ b/assets/prototype/domain/eventEditor/tickets/hooks/useDeleteTicketHandler.js
@@ -1,11 +1,11 @@
 import { useCallback } from '@wordpress/element';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useTicketPrices from '../../data/queries/tickets/useTicketPrices';
 
 const useDeleteTicketHandler = ({ id }) => {
-	const { deleteEntity: deleteTicket } = useEntityMutator('Ticket');
+	const { deleteEntity: deleteTicket } = useEntityMutator(EntityType.Ticket);
 	const relatedPrices = useTicketPrices(id);
-	const { deleteEntity: deletePrice } = useEntityMutator('Price');
+	const { deleteEntity: deletePrice } = useEntityMutator(EntityType.Price);
 
 	return useCallback(() => {
 		const subscriptions = {

--- a/assets/prototype/domain/eventEditor/tickets/ticketCard/EditTicketModal.js
+++ b/assets/prototype/domain/eventEditor/tickets/ticketCard/EditTicketModal.js
@@ -2,13 +2,13 @@ import { useContext } from '@wordpress/element';
 import FormModal from '../../../../application/ui/components/forms/FormModal';
 import TicketForm from '../ticketForm/TicketForm';
 import { TicketContext } from '../../context/TicketProvider';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useDatetimes from '../../data/queries/datetimes/useDatetimes';
 
 const EditTicketModal = ({ relatedDates }) => {
 	const { id, isOpen, onClose } = useContext(TicketContext);
 	const datetimes = useDatetimes();
-	const { updateEntity } = useEntityMutator('Ticket', id);
+	const { updateEntity } = useEntityMutator(EntityType.Ticket, id);
 
 	const formComponent = (props) => (
 		<TicketForm {...props} datetimes={datetimes} relatedDates={relatedDates} title='Update ticket' />

--- a/assets/prototype/domain/eventEditor/tickets/ticketCard/TicketCard.js
+++ b/assets/prototype/domain/eventEditor/tickets/ticketCard/TicketCard.js
@@ -5,7 +5,7 @@ import DeleteTicketButton from './DeleteTicketButton';
 import TicketPriceCalculatorButton from '../ticketPriceCalculator/TicketPriceCalculatorButton';
 import useTicketItem from '../../data/queries/tickets/useTicketItem';
 import CurrencyInput from '../../../../application/ui/components/input/CurrencyInput';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useRelations from '../../../../application/services/apollo/relations/useRelations';
 import useStatus from '../../../../application/services/apollo/status/useStatus';
 import DatetimeId from '../../datetimes/DatetimeId';
@@ -41,7 +41,7 @@ const priceStyle = {
 const TicketCard = ({ id }) => {
 	const ticket = useTicketItem({ id });
 	const { isLoaded } = useStatus();
-	const { updateEntity } = useEntityMutator('Ticket', id);
+	const { updateEntity } = useEntityMutator(EntityType.Ticket, id);
 	const { getRelations } = useRelations();
 	// get related datetimes for this datetime
 	const relatedDates = getRelations({

--- a/assets/prototype/domain/eventEditor/tickets/ticketList/AddNewTicketModal.js
+++ b/assets/prototype/domain/eventEditor/tickets/ticketList/AddNewTicketModal.js
@@ -1,10 +1,10 @@
 import TicketForm from '../ticketForm/TicketForm';
 import FormModal from '../../../../application/ui/components/forms/FormModal';
-import useEntityMutator from '../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../application/services/apollo/mutations';
 import useDatetimes from '../../data/queries/datetimes/useDatetimes';
 
 const AddNewTicketModal = ({ handleClose, isOpen }) => {
-	const { createEntity } = useEntityMutator('Ticket');
+	const { createEntity } = useEntityMutator(EntityType.Ticket);
 	const datetimes = useDatetimes();
 	const formComponent = (props) => <TicketForm {...props} title='New Ticket Details' />;
 

--- a/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.js
+++ b/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.js
@@ -1,5 +1,5 @@
 import { pick, difference } from 'ramda';
-import useEntityMutator from '../../../../../application/services/apollo/mutations/useEntityMutator';
+import { useEntityMutator, EntityType } from '../../../../../application/services/apollo/mutations';
 
 const PRICE_INPUT_FIELDS = [
 	'id',
@@ -31,8 +31,8 @@ const parseBooleanField = (value) => {
 };
 
 const useOnSubmitPrices = (existingPrices) => {
-	const { createEntity, updateEntity, deleteEntity } = useEntityMutator('Price');
-	const { updateEntity: updateTicket } = useEntityMutator('Ticket');
+	const { createEntity, updateEntity, deleteEntity } = useEntityMutator(EntityType.Price);
+	const { updateEntity: updateTicket } = useEntityMutator(EntityType.Ticket);
 	const existingPriceIds = existingPrices.map(({ id }) => id);
 
 	// Async to make sure that prices are handled before updating the ticket.


### PR DESCRIPTION
This PR adds TS types for centralized mutators. It also creates enum to select a proper entity type to mutate.
Completes #2062 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
