### PR TITLE
Fix the z-index for EDTR modals; closes #2022.

### DIFF
--- a/assets/prototype/application/ui/components/forms/FormModal.js
+++ b/assets/prototype/application/ui/components/forms/FormModal.js
@@ -3,6 +3,8 @@ import { Form } from 'react-final-form';
 import { Classes, Overlay } from '@blueprintjs/core/lib/esm';
 import FormModalForm from './FormModalForm';
 
+import './styles.css';
+
 const FormModal = ({ FormComponent, initialValues, onSubmit, onClose, isOpen, ...extraProps }) => {
 	const overlayProps = {
 		autoFocus: true,

--- a/assets/prototype/application/ui/components/forms/styles.css
+++ b/assets/prototype/application/ui/components/forms/styles.css
@@ -1,0 +1,3 @@
+.bp3-overlay {
+	z-index: 1400;
+}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Fixes: https://github.com/eventespresso/event-espresso-core/issues/2022

The reason that happened was because the WP content editor tools' `z-index` was `1000`:
![image](https://user-images.githubusercontent.com/1477453/71258741-9650a200-233f-11ea-8c96-cdf5e349ad46.png)

But `blueprintjs`'s modal has it's `z-index` set to `20` (why not :smiley:  )
![image](https://user-images.githubusercontent.com/1477453/71258868-db74d400-233f-11ea-9ebf-d30443c17fd7.png)


I've overriden `20` with `1400`:

![image](https://user-images.githubusercontent.com/1477453/71258926-f6dfdf00-233f-11ea-9bc6-ca5dd058a77b.png)

It's the value I've seen in `chakra-ui`: https://github.com/chakra-ui/chakra-ui/blob/master/packages/chakra-ui-docs/pages/theme.mdx#z-index

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
