### PR TITLE
Combine DOM dump data

### DIFF
--- a/assets/prototype/domain/eventEditor/context/EventEditorEventIdProvider.tsx
+++ b/assets/prototype/domain/eventEditor/context/EventEditorEventIdProvider.tsx
@@ -1,7 +1,6 @@
 /**
  * External imports
  */
-import { getWeekYearWithOptions } from 'date-fns/fp';
 import pathOr from 'ramda/src/pathOr';
 import React, { createContext } from 'react';
 import useToaster from '../../../application/services/toaster/useToaster';
@@ -12,7 +11,7 @@ const { Provider } = EventEditorEventIdContext;
 
 const EventEditorEventIdProvider = ({ children }) => {
 	const toaster = useToaster();
-	const eventId = pathOr<number>(0, ['eeEditorEventData', 'eventId'], window);
+	const eventId = pathOr<number>(0, ['eeEditorData', 'event', 'dbId'], window);
 
 	if (!eventId) {
 		toaster.error('Event ID is empty or invalid.');

--- a/assets/prototype/domain/eventEditor/context/test/data.ts
+++ b/assets/prototype/domain/eventEditor/context/test/data.ts
@@ -46,6 +46,7 @@ export const relationalData: RelationalData = {
 	},
 };
 
+// Add only what's needed
 export const event: EventData = {
 	dbId: eventId,
 	relations: relationalData,

--- a/assets/prototype/domain/eventEditor/context/test/data.ts
+++ b/assets/prototype/domain/eventEditor/context/test/data.ts
@@ -1,4 +1,5 @@
 import '../../types';
+import { EventData } from '../../types';
 import { RelationalData } from '../../../../application/services/apollo/relations';
 import { nodes as datetimes } from '../../data/queries/datetimes/test/data';
 import { nodes as tickets } from '../../data/queries/tickets/test/data';
@@ -43,4 +44,9 @@ export const relationalData: RelationalData = {
 			priceTypes: [priceTypes[3].id],
 		},
 	},
+};
+
+export const event: EventData = {
+	dbId: eventId,
+	relations: relationalData,
 };

--- a/assets/prototype/domain/eventEditor/context/test/useDomTestData.ts
+++ b/assets/prototype/domain/eventEditor/context/test/useDomTestData.ts
@@ -1,12 +1,11 @@
 import { useEffect } from 'react';
-import { eventId, relationalData } from './data';
+import { event } from './data';
 
 import { mockEeJsData } from '../../../../application/services/config/test/data';
 
 const useDomTestData = () => {
 	// Set the DOM data
-	window.eeEditorEventData = { eventId };
-	window.eeEditorGQLData = { relations: relationalData };
+	window.eeEditorData = { event };
 	window.eejsdata = { data: mockEeJsData };
 
 	// For Housekeeping
@@ -15,8 +14,7 @@ const useDomTestData = () => {
 		// when the context component is unmounted
 		// to avoid any unexpected results.
 		return () => {
-			delete window.eeEditorEventData;
-			delete window.eeEditorGQLData;
+			delete window.eeEditorData;
 			delete window.eejsdata;
 		};
 	}, []);

--- a/assets/prototype/domain/eventEditor/context/test/useSetRelationalData.ts
+++ b/assets/prototype/domain/eventEditor/context/test/useSetRelationalData.ts
@@ -5,7 +5,7 @@ import './data';
 const useSetRelationalData = (): void => {
 	const { setData } = useRelations();
 	useEffect(() => {
-		setData(window.eeEditorGQLData.relations);
+		setData(window.eeEditorData.event.relations);
 	}, []);
 };
 export default useSetRelationalData;

--- a/assets/prototype/domain/eventEditor/data/queries/useCacheRehydrationData.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/useCacheRehydrationData.ts
@@ -1,9 +1,18 @@
 import { pathOr } from 'ramda';
-import { GQLDOMData } from '../../types';
+import { EventData } from '../../types';
+import { CurrentUserProps, GeneralSettings } from '../../../../application/valueObjects/config/types';
 
-const useCacheRehydrationData = (): GQLDOMData => {
-	const data = pathOr<GQLDOMData>(null, ['eeEditorGQLData'], window);
-	return data;
+interface RehydrationData extends EventData {
+	currentUser?: CurrentUserProps;
+	generalSettings?: GeneralSettings;
+}
+
+const useCacheRehydrationData = (): RehydrationData => {
+	const eventData = pathOr<EventData>(null, ['eeEditorData', 'event'], window);
+	const currentUser = pathOr<CurrentUserProps>(null, ['eeEditorData', 'currentUser'], window);
+	const generalSettings = pathOr<GeneralSettings>(null, ['eeEditorData', 'generalSettings'], window);
+
+	return { ...eventData, currentUser, generalSettings };
 };
 
 export default useCacheRehydrationData;

--- a/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/TicketPriceCalculatorModal.js
+++ b/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/TicketPriceCalculatorModal.js
@@ -5,7 +5,7 @@ import TicketPriceCalculatorForm from './TicketPriceCalculatorForm';
 import useTicketPriceCalculatorFormDecorator from './hooks/useTicketPriceCalculatorFormDecorator';
 import useTicketPriceCalculatorFormMutators from './hooks/useTicketPriceCalculatorFormMutators';
 import useOnSubmitPrices from './hooks/useOnSubmitPrices';
-import defaultNewPriceModifier from '../../../shared/entities/prices/defaultNewPriceModifier';
+import { defaultNewPriceModifier } from '../../../shared/entities/prices/defaultNewPriceModifier';
 import { sortByPriceOrderIdAsc } from '../../../shared/predicates/prices/sortingPredicates';
 import { copyPriceFields } from '../../../shared/predicates/prices/updatePredicates';
 import { copyTicketFields } from '../../../shared/predicates/tickets/updatePredicates';

--- a/assets/prototype/domain/eventEditor/types.ts
+++ b/assets/prototype/domain/eventEditor/types.ts
@@ -3,18 +3,20 @@ import { JsDataProps } from '../../application/services/config/types';
 import { CurrentUserProps, GeneralSettings } from '../../application/valueObjects/config/types';
 import { DatetimeEdge, TicketEdge, PriceEdge, PriceTypeEdge } from './data/types';
 
-export interface EditorDOMData {
-	eventId: number;
-}
-
-export interface GQLDOMData {
+export interface EventData {
+	dbId: number;
 	datetimes?: DatetimeEdge;
 	tickets?: TicketEdge;
 	prices?: PriceEdge;
 	priceTypes?: PriceTypeEdge;
+	relations?: RelationalData;
+}
+
+export interface EEEditorData {
+	event: EventData;
+	graphqlEndpoint?: string;
 	currentUser?: CurrentUserProps;
 	generalSettings?: GeneralSettings;
-	relations?: RelationalData;
 }
 
 export interface EEJSData {
@@ -23,9 +25,7 @@ export interface EEJSData {
 
 declare global {
 	interface Window {
-		eeEditorEventData: EditorDOMData;
-		eeEditorGQLData: GQLDOMData;
+		eeEditorData: EEEditorData;
 		eejsdata: EEJSData;
-		graphqlEndpoint: string;
 	}
 }

--- a/assets/prototype/infrastructure/services/apollo/Apollo.ts
+++ b/assets/prototype/infrastructure/services/apollo/Apollo.ts
@@ -3,7 +3,7 @@ import ApolloClient from 'apollo-client';
 import { InMemoryCache, InMemoryCacheConfig, CacheResolver, CacheResolverMap } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
 
-const graphqlEndpoint = pathOr<string>('', ['graphqlEndpoint'], window);
+const graphqlEndpoint = pathOr<string>('', ['eeEditorData', 'graphqlEndpoint'], window);
 const nonce = pathOr<string>('', ['eejsdata', 'data', 'eejs_api_nonce'], window);
 
 const getResolver = (type: string): CacheResolver => {

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -1,7 +1,7 @@
 <?php
 
 use EventEspresso\core\domain\services\admin\events\default_settings\AdvancedEditorAdminFormSection;
-use EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorEntityData;
+use EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorData;
 use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -24,7 +24,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
     protected $advanced_editor_admin_form;
 
     /**
-     * @var AdvancedEditorEntityData
+     * @var AdvancedEditorData
      */
     protected $advanced_editor_data;
 
@@ -255,7 +255,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 );
             }
             $admin_config = $this->loader->getShared('EE_Admin_Config');
-            // load handler for GraphQL requests and AdvancedEditorEntityData
+            // load handler for GraphQL requests and AdvancedEditorData
             if (($action === 'edit' || $action === 'create_new')
                 && $admin_config instanceof EE_Admin_Config
                 && class_exists('WPGraphQL')
@@ -268,7 +268,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                     );
                     $graphQL_manager->init();
                     $this->advanced_editor_data = $this->loader->getShared(
-                        'EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorEntityData',
+                        'EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorData',
                         [$this->_cpt_model_obj]
                     );
                 } catch (Exception $exception) {

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -898,16 +898,9 @@ class EE_Dependency_Map
             'EventEspresso\core\domain\services\admin\events\default_settings\AdvancedEditorAdminFormSection'  => [
                 'EE_Admin_Config' => EE_Dependency_Map::load_from_cache
             ],
-            'EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorEntityData'  => [
+            'EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorData'  => [
                 'EE_Event'        => EE_Dependency_Map::not_registered,
-                'EventEspresso\core\domain\services\converters\RestApiSpoofer' => EE_Dependency_Map::load_from_cache,
                 'EE_Admin_Config' => EE_Dependency_Map::load_from_cache,
-                'EEM_Datetime'    => EE_Dependency_Map::load_from_cache,
-                'EEM_Event'       => EE_Dependency_Map::load_from_cache,
-                'EEM_Price'       => EE_Dependency_Map::load_from_cache,
-                'EEM_Price_Type'  => EE_Dependency_Map::load_from_cache,
-                'EEM_Ticket'      => EE_Dependency_Map::load_from_cache,
-                'EEM_Venue'       => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\core\services\graphql\GraphQLManager' => [
                 'EventEspresso\core\services\graphql\TypesManager'  => EE_Dependency_Map::load_from_cache,

--- a/core/domain/services/admin/events/editor/AdvancedEditorData.php
+++ b/core/domain/services/admin/events/editor/AdvancedEditorData.php
@@ -4,25 +4,18 @@ namespace EventEspresso\core\domain\services\admin\events\editor;
 
 use DomainException;
 use EE_Admin_Config;
-use EE_Datetime;
 use EE_Error;
 use EE_Event;
 use EEM_Datetime;
-use EEM_Event;
 use EEM_Price;
 use EEM_Price_Type;
 use EEM_Ticket;
-use EE_Ticket;
 use EEM_Venue;
 use EventEspresso\core\domain\services\assets\EspressoEditorAssetManager;
-use EventEspresso\core\domain\services\converters\RestApiSpoofer;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\ModelConfigurationException;
-use EventEspresso\core\exceptions\RestPasswordIncorrectException;
-use EventEspresso\core\exceptions\RestPasswordRequiredException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
-use EventEspresso\core\libraries\rest_api\RestException;
 use InvalidArgumentException;
 use ReflectionException;
 use WP_Post;
@@ -30,14 +23,14 @@ use WPGraphQL\Router;
 use GraphQLRelay\Relay;
 
 /**
- * Class AdvancedEditorEntityData
+ * Class AdvancedEditorData
  * Description
  *
  * @package EventEspresso\core\domain\services\admin\events\editor
  * @author  Brent Christensen
  * @since   $VID:$
  */
-class AdvancedEditorEntityData
+class AdvancedEditorData
 {
 
     /**
@@ -51,78 +44,23 @@ class AdvancedEditorEntityData
     protected $event;
 
     /**
-     * @var RestApiSpoofer
-     */
-    protected $spoofer;
-
-    /**
      * @var EE_Admin_Config
      */
     protected $admin_config;
-
-    /**
-     * @var EEM_Datetime $datetime_model
-     */
-    protected $datetime_model;
-
-    /**
-     * @var EEM_Event $event_model
-     */
-    protected $event_model;
-
-    /**
-     * @var EEM_Price $price_model
-     */
-    protected $price_model;
-
-    /**
-     * @var EEM_Price_Type $price_type_model
-     */
-    protected $price_type_model;
-
-    /**
-     * @var EEM_Ticket $ticket_model
-     */
-    protected $ticket_model;
-    /**
-     * @var EEM_Venue $venue_model
-     */
-    protected $venue_model;
 
 
     /**
      * AdvancedEditorAdminForm constructor.
      *
      * @param EE_Event        $event
-     * @param RestApiSpoofer  $spoofer
      * @param EE_Admin_Config $admin_config
-     * @param EEM_Datetime    $datetime_model
-     * @param EEM_Event       $event_model
-     * @param EEM_Price       $price_model
-     * @param EEM_Price_Type  $price_type_model
-     * @param EEM_Ticket      $ticket_model
-     * @param EEM_Venue       $venue_model
      */
     public function __construct(
         EE_Event $event,
-        RestApiSpoofer $spoofer,
-        EE_Admin_Config $admin_config,
-        EEM_Datetime $datetime_model,
-        EEM_Event $event_model,
-        EEM_Price $price_model,
-        EEM_Price_Type $price_type_model,
-        EEM_Ticket $ticket_model,
-        EEM_Venue $venue_model
+        EE_Admin_Config $admin_config
     ) {
         $this->event = $event;
         $this->admin_config = $admin_config;
-        $this->spoofer = $spoofer;
-        $this->datetime_model = $datetime_model;
-        $this->event_model = $event_model;
-        $this->price_model = $price_model;
-        $this->price_type_model = $price_type_model;
-        $this->ticket_model = $ticket_model;
-        $this->venue_model = $venue_model;
         add_action('admin_enqueue_scripts', [$this, 'loadScriptsStyles']);
     }
 
@@ -134,9 +72,6 @@ class AdvancedEditorEntityData
      * @throws InvalidInterfaceException
      * @throws ModelConfigurationException
      * @throws ReflectionException
-     * @throws RestException
-     * @throws RestPasswordIncorrectException
-     * @throws RestPasswordRequiredException
      * @throws UnexpectedEntityException
      * @throws DomainException
      * @since $VID:$
@@ -152,21 +87,16 @@ class AdvancedEditorEntityData
                     ? $post->ID
                     : $eventId;
             }
-            $graphqlEndpoint = class_exists('WPGraphQL') ? trailingslashit(site_url()) . Router::$route : '';
-            $graphqlEndpoint = esc_url($graphqlEndpoint);
             if ($eventId) {
-                $data = $this->getAllEventData($eventId);
+                $data = $this->getEditorData($eventId);
                 $data = wp_json_encode($data);
-                $GQLdata = $this->getGraphQLData($eventId);
-                $GQLdata = wp_json_encode($GQLdata);
                 add_action(
                     'admin_footer',
-                    static function () use ($data, $graphqlEndpoint) {
+                    static function () use ($data) {
                         wp_add_inline_script(
                             EspressoEditorAssetManager::JS_HANDLE_EDITOR,
                             "
-var eeEditorEventData={$data};
-var graphqlEndpoint='{$graphqlEndpoint}';
+var eeEditorData={$data};
 ",
                             'before'
                         );
@@ -174,13 +104,11 @@ var graphqlEndpoint='{$graphqlEndpoint}';
                 );
                 add_action(
                     'admin_footer',
-                    static function () use ($data, $GQLdata, $graphqlEndpoint) {
+                    static function () use ($data) {
                         wp_add_inline_script(
                             EspressoEditorAssetManager::JS_HANDLE_EDITOR_PROTOTYPE,
                             "
-var eeEditorEventData={$data};
-var eeEditorGQLData={$GQLdata};
-var graphqlEndpoint='{$graphqlEndpoint}';
+var eeEditorData={$data};
 ",
                             'before'
                         );
@@ -194,67 +122,29 @@ var graphqlEndpoint='{$graphqlEndpoint}';
     /**
      * @param int $eventId
      * @return array
-     * @throws DomainException
      * @throws EE_Error
-     * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws ModelConfigurationException
-     * @throws ReflectionException
-     * @throws RestException
-     * @throws RestPasswordIncorrectException
-     * @throws RestPasswordRequiredException
      * @throws UnexpectedEntityException
-     * @since $VID:$
-     */
-    protected function getEventDates($eventId)
-    {
-        return $this->spoofer->getApiResults(
-            $this->datetime_model,
-            [
-                [
-                    'EVT_ID'      => $eventId,
-                    'DTT_deleted' => ['IN', [true, false]]
-                ]
-            ]
-        );
-    }
-
-
-    /**
-     * @param int $eventId
-     * @param array $eventDates
-     * @throws DomainException
-     * @throws EE_Error
      * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
-     * @throws ModelConfigurationException
      * @throws ReflectionException
-     * @throws RestException
-     * @throws RestPasswordIncorrectException
-     * @throws RestPasswordRequiredException
-     * @throws UnexpectedEntityException
+     * @throws DomainException
      * @since $VID:$
      */
-    protected function addDefaultEntities($eventId, array $eventDates = [])
+    protected function getEditorData($eventId)
     {
-        $default_dates = $this->datetime_model->create_new_blank_datetime();
-        if (is_array($default_dates) && isset($default_dates[0]) && $default_dates[0] instanceof EE_Datetime) {
-            $default_date = $default_dates[0];
-            $default_date->save();
-            $default_date->_add_relation_to($eventId, 'Event');
-            $default_tickets = $this->ticket_model->get_all_default_tickets();
-            $default_prices = $this->price_model->get_all_default_prices();
-            foreach ($default_tickets as $default_ticket) {
-                $default_ticket->save();
-                $default_ticket->_add_relation_to($default_date, 'Datetime');
-                foreach ($default_prices as $default_price) {
-                    $default_price->save();
-                    $default_price->_add_relation_to($default_ticket, 'Ticket');
-                }
-            }
-        }
+        $event = $this->getEventGraphQLData($eventId);
+        $event['dbId'] = $eventId;
+
+        $graphqlEndpoint = class_exists('WPGraphQL') ? trailingslashit(site_url()) . Router::$route : '';
+        $graphqlEndpoint = esc_url($graphqlEndpoint);
+
+        $currentUser = $this->getGraphQLCurrentUser();
+
+        $generalSettings = $this->getGraphQLGeneralSettings();
+
+        return compact('event', 'graphqlEndpoint', 'currentUser', 'generalSettings');
     }
 
 
@@ -263,7 +153,7 @@ var graphqlEndpoint='{$graphqlEndpoint}';
      * @return array
      * @since $VID:$
      */
-    protected function getGraphQLData($eventId)
+    protected function getEventGraphQLData($eventId)
     {
         $datetimes = $this->getGraphQLDatetimes($eventId);
 
@@ -285,13 +175,9 @@ var graphqlEndpoint='{$graphqlEndpoint}';
 
         $priceTypes = $this->getGraphQLPriceTypes();
 
-        $currentUser = $this->getGraphQLCurrentUser();
-
-        $generalSettings = $this->getGraphQLGeneralSettings();
-
         $relations = $this->getRelationalData($eventId);
 
-        return compact('datetimes', 'tickets', 'prices', 'priceTypes', 'currentUser', 'generalSettings', 'relations');
+        return compact('datetimes', 'tickets', 'prices', 'priceTypes', 'relations');
     }
 
 
@@ -666,147 +552,5 @@ QUERY;
             }, $ID);
         }
         return Relay::toGlobalId($type, $ID);
-    }
-
-
-    /**
-     * @param int $eventId
-     * @return array
-     * @throws EE_Error
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
-     * @throws ModelConfigurationException
-     * @throws RestPasswordIncorrectException
-     * @throws RestPasswordRequiredException
-     * @throws UnexpectedEntityException
-     * @throws RestException
-     * @throws InvalidArgumentException
-     * @throws ReflectionException
-     * @throws DomainException
-     * @since $VID:$
-     */
-    protected function getAllEventData($eventId)
-    {
-        // these should ultimately be extracted out into their own classes (one per model)
-        $event = $this->spoofer->getOneApiResult(
-            $this->event_model,
-            [['EVT_ID' => $eventId]]
-        );
-        if (! (is_array($event) && isset($event['EVT_ID']) && $event['EVT_ID'] === $eventId)) {
-            return [];
-        }
-        $eventDates = $this->getEventDates($eventId);
-        if ((! is_array($eventDates) || empty($eventDates))
-            || (isset($_REQUEST['action']) && $_REQUEST['action'] === 'create_new')
-        ) {
-            $this->addDefaultEntities($eventId);
-            $eventDates = $this->getEventDates($eventId);
-        }
-
-        $event = [$eventId => $event];
-        $relations = [
-            'event'    => [
-                $eventId => [
-                    'datetime' => []
-                ]
-            ],
-            'datetime' => [],
-            'ticket'   => [],
-            'price'    => [],
-        ];
-
-        $datetimes = [];
-        $eventDateTickets = [];
-        if (is_array($eventDates)) {
-            foreach ($eventDates as $eventDate) {
-                if (isset($eventDate['DTT_ID']) && $eventDate['DTT_ID']) {
-                    $DTT_ID = $eventDate['DTT_ID'];
-                    $datetimes[ $DTT_ID ] = $eventDate;
-                    $relations['event'][ $eventId ]['datetime'][] = $DTT_ID;
-                    $eventDateTickets[ $DTT_ID ] = $this->spoofer->getApiResults(
-                        $this->ticket_model,
-                        [[
-                            'Datetime.DTT_ID' => $DTT_ID,
-                            'TKT_deleted' => ['IN', [true, false]]
-                        ]]
-                    );
-                }
-            }
-        }
-
-        $prices = [];
-        $tickets = [];
-        if (is_array($eventDateTickets)) {
-            foreach ($eventDateTickets as $DTT_ID => $dateTickets) {
-                if (is_array($dateTickets)) {
-                    $relations['datetime'][ $DTT_ID ]['ticket'] = [];
-                    foreach ($dateTickets as $ticket) {
-                        if (isset($ticket['TKT_ID']) && $ticket['TKT_ID']) {
-                            $TKT_ID = $ticket['TKT_ID'];
-                            $tickets[ $TKT_ID ] = $ticket;
-                            $relations['datetime'][ $DTT_ID ]['ticket'][] = $TKT_ID;
-                            $ticketPrices[ $TKT_ID ] = $this->spoofer->getApiResults(
-                                $this->price_model,
-                                [['Ticket.TKT_ID' => $TKT_ID]]
-                            );
-                            if (is_array($ticketPrices[ $TKT_ID ])) {
-                                $relations['ticket'][ $TKT_ID ]['price'] = [];
-                                foreach ($ticketPrices[ $TKT_ID ] as $ticketPrice) {
-                                    $PRC_ID = $ticketPrice['PRC_ID'];
-                                    $prices[ $PRC_ID ] = $ticketPrice;
-                                    $relations['ticket'][ $TKT_ID ]['price'][] = $PRC_ID;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        $price_type_results = $this->spoofer->getApiResults(
-            $this->price_type_model,
-            [['PRT_deleted' => false]]
-        );
-        $price_types = [];
-        foreach ($price_type_results as $price_type) {
-            $price_types[ $price_type['PRT_ID'] ] = $price_type;
-        }
-        $venue = $this->spoofer->getOneApiResult(
-            $this->venue_model,
-            [['Event.EVT_ID' => $eventId]]
-        );
-        if (is_array($venue) && isset($venue['VNU_ID'])) {
-            $relations['event'][ $eventId ]['venue'] = [ $venue['VNU_ID'] ];
-            $venue = [$venue['VNU_ID'] => $venue];
-        }
-
-        $schemas = [
-            'event'      => $this->spoofer->getModelSchema('events'),
-            'datetime'   => $this->spoofer->getModelSchema('datetimes'),
-            'ticket'     => $this->spoofer->getModelSchema('tickets'),
-            'price'      => $this->spoofer->getModelSchema('prices'),
-            'price_type' => $this->spoofer->getModelSchema('price_types'),
-            'venue'      => $this->spoofer->getModelSchema('venues'),
-        ];
-
-        $tktRegCount = [];
-        foreach ($tickets as $ticket) {
-            $tkt_instance = $this->ticket_model->get_one_by_ID($ticket['TKT_ID']);
-
-            $tktRegCount[ $ticket['TKT_ID'] ] = $tkt_instance instanceof EE_Ticket ?
-            $tkt_instance->count_registrations()
-            : 0;
-        }
-        return [
-            'eventId'         => $eventId,
-            'event'           => $event,
-            'datetime'        => $datetimes,
-            'ticket'          => $tickets,
-            'price'           => $prices,
-            'price_type'      => $price_types,
-            'venue'           => $venue,
-            'schemas'         => $schemas,
-            'relations'       => $relations,
-            'tktRegCount'     => $tktRegCount,
-        ];
     }
 }

--- a/core/domain/services/graphql/types/RootQuery.php
+++ b/core/domain/services/graphql/types/RootQuery.php
@@ -12,7 +12,7 @@ use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
 use EventEspresso\core\services\graphql\types\TypeBase;
 use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
-use EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorEntityData;
+use EventEspresso\core\domain\services\admin\events\editor\AdvancedEditorData;
 use GraphQL\Error\UserError;
 use WPGraphQL\AppContext;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -93,6 +93,6 @@ class RootQuery extends TypeBase
 
         $eventId = absint($args['eventId']);
 
-        return json_encode(AdvancedEditorEntityData::getRelationalData($eventId));
+        return json_encode(AdvancedEditorData::getRelationalData($eventId));
     }
 }


### PR DESCRIPTION
This PR updates/combines the DOM data required for editor. The new shape of the data can be seen in `/domain/eventEditor/types.ts`

```ts
interface EventData {
	dbId: number;
	datetimes?: DatetimeEdge;
	tickets?: TicketEdge;
	prices?: PriceEdge;
	priceTypes?: PriceTypeEdge;
	relations?: RelationalData;
}

interface EEEditorData {
	event: EventData;
	graphqlEndpoint?: string;
	currentUser?: CurrentUserProps;
	generalSettings?: GeneralSettings;
}
```
The reason for:
- Creating `EventData ` and moving its related data into `EEEditorData.event` is to make room for future event related data.
- Using `dbId` instead of just `id` or `eventId` is to make it consistent with current shape of EDTR entities and leave `id` for GUID if we ever need that.

Completes #2144 

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
