### PR TITLE
Check-ins page: Add error proofing and display error message if no valid REG ID is passed

### DIFF
--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -796,6 +796,14 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
         $reg_id = isset($this->_req_data['_REG_ID']) ? $this->_req_data['_REG_ID'] : null;
         /** @var EE_Registration $registration */
         $registration = EEM_Registration::instance()->get_one_by_ID($reg_id);
+        if (! $registration instanceof EE_Registration) {
+            throw new EE_Error(
+                sprintf(
+                    esc_html__('An EE_Registration object could not be retrieved for the given ID (%d)', 'event_espresso'),
+                    $reg_id
+                )
+            );
+        }
         $attendee = $registration->attendee();
         $this->_admin_page_title .= $this->get_action_link_or_button(
             'new_registration',

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -799,7 +799,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
         if (! $registration instanceof EE_Registration) {
             throw new EE_Error(
                 sprintf(
-                    esc_html__('An EE_Registration object could not be retrieved for the given ID (%d)', 'event_espresso'),
+                    esc_html__('An error occurred. There is no registration with ID (%d)', 'event_espresso'),
                     $reg_id
                 )
             );


### PR DESCRIPTION
## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This PR doesn't solve a problem. What it does do is it will display an error message instead of a fatal error on the check ins page if an invalid REG ID is passed.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->


This can be tested by going to Event Espresso > Registrations > Event Check-In, then select an event. Then check in an attendee. Then refresh the page. After the page loads, you'll see timestamp of the check-in, then click on the timestamp. You've now tested the functionality of viewing the check in records. Now, to test the error message, change the `_REG_ID` in URL so it's an invalid reg ID. The page should load an error message (and not a fatal error like it would with master branch).


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
