### PR TITLE
Add ticket mutation tests

### DIFF
--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/createDatetime.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/createDatetime.test.ts
@@ -48,8 +48,8 @@ describe('createDatetime', () => {
 		expect(mutationData).toEqual(mockResult.data);
 		const pathToName = ['createEspressoDatetime', 'espressoDatetime', 'name'];
 
-		const nameFromMutationData = path(pathToName, mutationData);
-		const nameFromMockData = path(pathToName, mockResult.data);
+		const nameFromMutationData = path<string>(pathToName, mutationData);
+		const nameFromMockData = path<string>(pathToName, mockResult.data);
 
 		expect(nameFromMutationData).toEqual(nameFromMockData);
 	});

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/deleteDatetime.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/deleteDatetime.test.ts
@@ -46,8 +46,8 @@ describe('deleteDatetime', () => {
 		expect(mutationData).toEqual(mockResult.data);
 		const pathToId = ['deleteEspressoDatetime', 'espressoDatetime', 'name'];
 
-		const idFromMutationData = path(pathToId, mutationData);
-		const idFromMockData = path(pathToId, mockResult.data);
+		const idFromMutationData = path<string>(pathToId, mutationData);
+		const idFromMockData = path<string>(pathToId, mockResult.data);
 
 		expect(idFromMutationData).toEqual(idFromMockData);
 	});
@@ -95,6 +95,4 @@ describe('deleteDatetime', () => {
 			expect(relatedDatetimeIds).not.toContain(mockedDatetime.id);
 		});
 	});
-
-	/* @todo: Add more test cases after testing ticket mutations */
 });

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/updateDatetime.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/updateDatetime.test.ts
@@ -49,8 +49,8 @@ describe('updateDatetime', () => {
 		expect(mutationData).toEqual(mockResult.data);
 		const pathToName = ['updateEspressoDatetime', 'espressoDatetime', 'name'];
 
-		const nameFromMutationData = path(pathToName, mutationData);
-		const nameFromMockData = path(pathToName, mockResult.data);
+		const nameFromMutationData = path<string>(pathToName, mutationData);
+		const nameFromMockData = path<string>(pathToName, mockResult.data);
 
 		expect(nameFromMutationData).toEqual(nameFromMockData);
 	});

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/createTicket.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/createTicket.test.ts
@@ -1,0 +1,227 @@
+import { useApolloClient } from '@apollo/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { path } from 'ramda';
+
+import { useEntityMutator, EntityType } from '../../../../../../application/services/apollo/mutations';
+import { useRelations } from '../../../../../../application/services/apollo/relations';
+import { MutationType } from '../../../../../../application/services/apollo/mutations/types';
+import { ApolloMockedProvider } from '../../../../context';
+import { getMutationMocks, mockedTickets } from './data';
+import { nodes as datetimes } from '../../../queries/datetimes/test/data';
+import { nodes as prices } from '../../../queries/prices/test/data';
+import { MutationInput } from '../../../../../../application/services/apollo/mutations/types';
+import useTicketItem from '../../../queries/tickets/useTicketItem';
+import useTicketIds from '../../../queries/tickets/useTicketIds';
+
+describe('createTicket', () => {
+	let testInput: MutationInput = { name: 'New Test Ticket', description: 'New Test Desc' };
+	const mockedTicket = mockedTickets.CREATE;
+
+	const datetimeIds = datetimes.map(({ id }) => id);
+	const priceIds = prices.map(({ id }) => id);
+
+	let mutationMocks = getMutationMocks(testInput, MutationType.Create);
+
+	const { result: mockResult } = mutationMocks[0];
+
+	it('checks for the mutation data to be same as the mock data', async () => {
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result, waitForNextUpdate } = renderHook(() => useEntityMutator(EntityType.Ticket), {
+			wrapper,
+		});
+
+		let mutationData: any;
+
+		act(() => {
+			result.current.createEntity(testInput, {
+				onCompleted: (data: any) => {
+					mutationData = data;
+				},
+			});
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextUpdate();
+
+		expect(mutationData).toEqual(mockResult.data);
+		const pathToName = ['createEspressoTicket', 'espressoTicket', 'name'];
+
+		const nameFromMutationData = path<string>(pathToName, mutationData);
+		const nameFromMockData = path<string>(pathToName, mockResult.data);
+
+		expect(nameFromMutationData).toEqual(nameFromMockData);
+	});
+
+	it('checks for the mutation data to be same as that in the cache - useTicketItem', async () => {
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket),
+				client: useApolloClient(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.createEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		const cache = mutationResult.current.client.extract();
+		const { result: cacheResult } = renderHook(
+			() => {
+				const client = useApolloClient();
+				// restore the cache from previous render
+				client.restore(cache);
+				return useTicketItem({ id: mockedTicket.id });
+			},
+			{
+				wrapper,
+			}
+		);
+
+		const cachedTicket = cacheResult.current;
+
+		expect(cachedTicket).toEqual({ ...mockedTicket, ...testInput });
+	});
+
+	it('checks for the mutation data to be same as that in the cache - useTicketIds', async () => {
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket),
+				client: useApolloClient(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.createEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		const cache = mutationResult.current.client.extract();
+		const { result: cacheResult } = renderHook(
+			() => {
+				const client = useApolloClient();
+				// restore the cache from previous render
+				client.restore(cache);
+				return useTicketIds();
+			},
+			{
+				wrapper,
+			}
+		);
+
+		const cachedTickets = cacheResult.current;
+
+		expect(cachedTickets).toContain(mockedTicket.id);
+	});
+
+	it('checks for datetime relation update after mutation', async () => {
+		// Add related datetime Ids to the mutation input
+		testInput = { ...testInput, datetimes: datetimeIds };
+
+		mutationMocks = getMutationMocks(testInput, MutationType.Create);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.createEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to all the passed tickets
+		const relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'datetimes',
+		});
+
+		expect(datetimeIds.length).toEqual(relatedDatetimeIds.length);
+
+		expect(datetimeIds).toEqual(relatedDatetimeIds);
+
+		// check if all the passed tickets are related to the ticket
+		datetimeIds.forEach((ticketId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'datetimes',
+				entityId: ticketId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).toContain(mockedTicket.id);
+		});
+	});
+
+	it('checks for ticket relation update after mutation', async () => {
+		// Add related price Ids to the mutation input
+		testInput = { ...testInput, prices: priceIds };
+
+		mutationMocks = getMutationMocks(testInput, MutationType.Create);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.createEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to all the passed datetimes
+		const relatedPriceIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'prices',
+		});
+
+		expect(priceIds.length).toEqual(relatedPriceIds.length);
+
+		expect(priceIds).toEqual(relatedPriceIds);
+
+		// check if all the passed prices are related to the ticket
+		priceIds.forEach((ticketId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'prices',
+				entityId: ticketId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).toContain(mockedTicket.id);
+		});
+	});
+});

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/data.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/data.ts
@@ -1,0 +1,62 @@
+import { pickBy } from 'ramda';
+import { nodes as tickets } from '../../../queries/tickets/test/data';
+import { edge as priceEdge } from '../../../queries/prices/test/data';
+import { ReadQueryOptions } from '../../../queries/types';
+import { MutationInput, MutationType } from '../../../../../../application/services/apollo/mutations/types';
+import { ucFirst } from '../../../../../../application/utilities/text/changeCase';
+import { mutations } from '../../';
+
+const prices = { ...priceEdge, __typename: 'EspressoTicketPricesConnectionEdge' };
+
+export const mockedTickets = {
+	[MutationType.Create]: { ...tickets[0], id: tickets[0].id + '-alpha' }, // make sure to change the ID to make it different}
+	[MutationType.Update]: { ...tickets[0], prices },
+	[MutationType.Delete]: { id: tickets[0].id, __typename: tickets[0].__typename },
+};
+
+export const getMutationMocks = (mutationInput: MutationInput, mutationType: MutationType) => {
+	return [
+		{
+			request: getMockRequest(mutationInput, mutationType),
+			result: getMockResult(mutationInput, mutationType),
+		},
+	];
+};
+
+export const getMockRequest = (mutationInput: MutationInput, mutationType: MutationType): ReadQueryOptions => {
+	const input: MutationInput = {
+		clientMutationId: `${mutationType}_TICKET`,
+		...mutationInput,
+	};
+	if (mutationType !== MutationType.Create && !input.id) {
+		input.id = mockedTickets[mutationType].id;
+	}
+
+	return {
+		query: mutations[`${mutationType}_TICKET`],
+		variables: {
+			input,
+		},
+	};
+};
+
+export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType) => {
+	// make sure that tickets don't go into the result
+	const input = pickBy<MutationInput, MutationInput>(
+		(_, key) => Object.keys(mockedTickets[mutationType]).includes(key),
+		mutationInput
+	);
+	return {
+		data: {
+			// e.g. createEspressoTicket
+			[`${mutationType.toLowerCase()}EspressoTicket`]: {
+				// e.g. UpdateEspressoTicketPayload
+				__typename: `${ucFirst(mutationType.toLowerCase())}EspressoTicketPayload`,
+				espressoTicket:
+					MutationType.Delete === mutationType
+						? mockedTickets[mutationType]
+						: { ...mockedTickets[mutationType], ...input, prices },
+			},
+		},
+	};
+};

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/deleteTicket.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/deleteTicket.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { path } from 'ramda';
+
+import { useEntityMutator, EntityType } from '../../../../../../application/services/apollo/mutations';
+import { useRelations } from '../../../../../../application/services/apollo/relations';
+import { MutationType } from '../../../../../../application/services/apollo/mutations/types';
+import { ApolloMockedProvider } from '../../../../context';
+import { getMutationMocks, mockedTickets } from './data';
+import { nodes as datetimes } from '../../../queries/datetimes/test/data';
+import { nodes as prices } from '../../../queries/prices/test/data';
+
+describe('deleteTicket', () => {
+	const mockedTicket = mockedTickets.DELETE;
+
+	const datetimeIds = datetimes.map(({ id }) => id);
+	const priceIds = prices.map(({ id }) => id);
+
+	let mutationMocks = getMutationMocks({}, MutationType.Delete);
+
+	const { result: mockResult } = mutationMocks[0];
+
+	it('checks for the mutation data to be same as the mock data', async () => {
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result, waitForNextUpdate } = renderHook(() => useEntityMutator(EntityType.Ticket, mockedTicket.id), {
+			wrapper,
+		});
+
+		let mutationData: any;
+
+		act(() => {
+			result.current.deleteEntity(
+				{},
+				{
+					onCompleted: (data: any) => {
+						mutationData = data;
+					},
+				}
+			);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextUpdate();
+
+		expect(mutationData).toEqual(mockResult.data);
+		const pathToId = ['deleteEspressoTicket', 'espressoTicket', 'name'];
+
+		const idFromMutationData = path(pathToId, mutationData);
+		const idFromMockData = path(pathToId, mockResult.data);
+
+		expect(idFromMutationData).toEqual(idFromMockData);
+	});
+
+	it('checks for datetime relation update after mutation', async () => {
+		// Add related datetime Ids to the mutation input
+
+		mutationMocks = getMutationMocks({}, MutationType.Delete);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.deleteEntity();
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		const relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'datetimes',
+		});
+
+		expect(relatedDatetimeIds.length).toBe(0);
+
+		// check if all the passed datetimes are related to the ticket
+		datetimeIds.forEach((datetimeId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'datetimes',
+				entityId: datetimeId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).not.toContain(mockedTicket.id);
+		});
+	});
+
+	it('checks for price relation update after mutation', async () => {
+		// Add related price Ids to the mutation input
+
+		mutationMocks = getMutationMocks({}, MutationType.Delete);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.deleteEntity();
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		const relatedPriceIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'prices',
+		});
+
+		expect(relatedPriceIds.length).toBe(0);
+
+		// check if all the passed prices are related to the ticket
+		priceIds.forEach((priceId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'prices',
+				entityId: priceId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).not.toContain(mockedTicket.id);
+		});
+	});
+});

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/updateTicket.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/updateTicket.test.ts
@@ -1,0 +1,269 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { path } from 'ramda';
+
+import { useEntityMutator, EntityType } from '../../../../../../application/services/apollo/mutations';
+import { useRelations } from '../../../../../../application/services/apollo/relations';
+import { MutationType } from '../../../../../../application/services/apollo/mutations/types';
+import { ApolloMockedProvider } from '../../../../context';
+import { getMutationMocks, mockedTickets } from './data';
+import { nodes as datetimes } from '../../../queries/datetimes/test/data';
+import { nodes as prices } from '../../../queries/prices/test/data';
+import { MutationInput } from '../../../../../../application/services/apollo/mutations/types';
+import useInitTicketTestCache from '../../../queries/tickets/test/useInitTicketTestCache';
+
+describe('updateTicket', () => {
+	let testInput: MutationInput = { name: 'New Test Date', description: 'New Test Desc' };
+	const mockedTicket = mockedTickets.UPDATE;
+
+	const datetimeIds = datetimes.map(({ id }) => id);
+	const priceIds = prices.map(({ id }) => id);
+
+	let mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
+
+	const { result: mockResult } = mutationMocks[0];
+
+	it('checks for the mutation data to be same as the mock data', async () => {
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result, waitForNextUpdate } = renderHook(
+			() => {
+				useInitTicketTestCache();
+				return useEntityMutator(EntityType.Ticket, mockedTicket.id);
+			},
+			{
+				wrapper,
+			}
+		);
+
+		let mutationData: any;
+
+		act(() => {
+			result.current.updateEntity(testInput, {
+				onCompleted: (data: any) => {
+					mutationData = data;
+				},
+			});
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextUpdate();
+
+		expect(mutationData).toEqual(mockResult.data);
+		const pathToName = ['updateEspressoTicket', 'espressoTicket', 'name'];
+
+		const nameFromMutationData = path<string>(pathToName, mutationData);
+		const nameFromMockData = path<string>(pathToName, mockResult.data);
+
+		expect(nameFromMutationData).toEqual(nameFromMockData);
+	});
+
+	it('checks for datetime relation addition/update after mutation', async () => {
+		// Add related datetime Ids to the mutation input
+		testInput = { ...testInput, datetimes: datetimeIds };
+
+		mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.updateEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to all the passed datetimes
+		const relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'datetimes',
+		});
+
+		expect(datetimeIds.length).toEqual(relatedDatetimeIds.length);
+
+		expect(datetimeIds).toEqual(relatedDatetimeIds);
+
+		// check if all the passed datetimes are related to the ticket
+		datetimeIds.forEach((ticketId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'datetimes',
+				entityId: ticketId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).toContain(mockedTicket.id);
+		});
+	});
+
+	it('checks for datetime relation removal/update after mutation', async () => {
+		// Add related datetimes Ids to the mutation input
+		testInput = { ...testInput, datetimes: datetimeIds };
+
+		mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		const tempDatetimeId: string = 'temp-dtt-id';
+
+		act(() => {
+			// add relation between mockedTicket and a random datetime id
+			mutationResult.current.relationsManager.addRelation({
+				entity: 'tickets',
+				entityId: mockedTicket.id,
+				relation: 'datetimes',
+				relationId: tempDatetimeId,
+			});
+		});
+
+		// check if ticket is related to `tempDatetimeId`
+		let relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'datetimes',
+		});
+		expect(relatedDatetimeIds).toContain(tempDatetimeId);
+
+		act(() => {
+			// mutate
+			mutationResult.current.mutator.updateEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to `tempDatetimeId`
+		relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'datetimes',
+		});
+
+		// check if ticket has been removed from tempDatetimeId relation
+		expect(relatedDatetimeIds).not.toContain(tempDatetimeId);
+	});
+
+	it('checks for price relation addition/update after mutation', async () => {
+		// Add related price Ids to the mutation input
+		testInput = { ...testInput, prices: priceIds };
+
+		mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		act(() => {
+			mutationResult.current.mutator.updateEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to all the passed prices
+		const relatedPriceIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'prices',
+		});
+
+		expect(priceIds.length).toEqual(relatedPriceIds.length);
+
+		expect(priceIds).toEqual(relatedPriceIds);
+
+		// check if all the passed prices are related to the ticket
+		priceIds.forEach((ticketId) => {
+			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
+				entity: 'prices',
+				entityId: ticketId,
+				relation: 'tickets',
+			});
+
+			expect(relatedTicketIds).toContain(mockedTicket.id);
+		});
+	});
+
+	it('checks for price relation removal/update after mutation', async () => {
+		// Add related prices Ids to the mutation input
+		testInput = { ...testInput, prices: priceIds };
+
+		mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
+
+		const wrapper = ApolloMockedProvider(mutationMocks);
+
+		const { result: mutationResult, waitForNextUpdate: waitForNextMutationUpdate } = renderHook(
+			() => ({
+				mutator: useEntityMutator(EntityType.Ticket, mockedTicket.id),
+				relationsManager: useRelations(),
+			}),
+			{
+				wrapper,
+			}
+		);
+
+		const tempPriceId: string = 'temp-price-id';
+
+		act(() => {
+			// add relation between mockedTicket and a random price id
+			mutationResult.current.relationsManager.addRelation({
+				entity: 'tickets',
+				entityId: mockedTicket.id,
+				relation: 'prices',
+				relationId: tempPriceId,
+			});
+		});
+
+		// check if ticket is related to `tempPriceId`
+		let relatedPriceIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'prices',
+		});
+		expect(relatedPriceIds).toContain(tempPriceId);
+
+		act(() => {
+			// mutate
+			mutationResult.current.mutator.updateEntity(testInput);
+		});
+
+		// wait for mutation promise to resolve
+		await waitForNextMutationUpdate();
+
+		// check if ticket is related to `tempPriceId`
+		relatedPriceIds = mutationResult.current.relationsManager.getRelations({
+			entity: 'tickets',
+			entityId: mockedTicket.id,
+			relation: 'prices',
+		});
+
+		// check if ticket has been removed from tempPriceId relation
+		expect(relatedPriceIds).not.toContain(tempPriceId);
+	});
+});

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/useOnCreateTicket.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/useOnCreateTicket.ts
@@ -37,7 +37,7 @@ const useOnCreateTicket = (): TicketMutationCallbackFn => {
 			});
 
 			// Set relations with prices
-			const priceIds = pathOr([], ['nodes'], prices).map(({ id }: Price) => id);
+			const priceIds = pathOr<Price[]>([], ['nodes'], prices).map(({ id }: Price) => id);
 			updateRelations({
 				entity: 'tickets',
 				entityId: ticketId,

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/useTicketMutator.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/useTicketMutator.ts
@@ -13,8 +13,9 @@ import {
 	MutatorGeneratedObject,
 } from '../../../../../application/services/apollo/mutations/types';
 import { ReadQueryOptions } from '../../queries/types';
+import { DEFAULT_ENTITY_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
+import { Ticket, TicketEdge, Price } from '../../types';
 import { TicketMutationCallbackFn } from '../types';
-import { Ticket, Price } from '../../types';
 
 /**
  *
@@ -50,10 +51,16 @@ const useTicketMutator = (): Mutator => {
 			const { prices, ...ticket } = entity;
 
 			// Read the existing data from cache.
-			const { espressoTickets: tickets = {} } = proxy.readQuery(options);
+			let data: any;
+			try {
+				data = proxy.readQuery(options);
+			} catch (error) {
+				data = {};
+			}
+			const tickets = pathOr<TicketEdge>(DEFAULT_LIST_DATA('Tickets'), ['espressoTickets'], data);
 			const { datetimes: datetimeIds = [] } = input;
 
-			const priceIds = pathOr([], ['nodes'], prices).map(({ id }: Price) => id);
+			const priceIds = pathOr<Price[]>([], ['nodes'], prices).map(({ id }: Price) => id);
 
 			switch (mutationType) {
 				case MutationType.Create:

--- a/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimes.ts
@@ -20,7 +20,7 @@ const useDatetimes = (): Datetime[] => {
 		data = {};
 	}
 
-	return R.pathOr([], ['espressoDatetimes', 'nodes'], data);
+	return R.pathOr<Datetime[]>([], ['espressoDatetimes', 'nodes'], data);
 };
 
 export default useDatetimes;

--- a/assets/prototype/domain/eventEditor/data/queries/prices/usePrices.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/prices/usePrices.ts
@@ -27,7 +27,7 @@ const usePrices = (include: EntityId[] = []): Price[] => {
 		data = {};
 	}
 
-	const prices: Price[] = pathOr([], ['espressoPrices', 'nodes'], data);
+	const prices = pathOr<Price[]>([], ['espressoPrices', 'nodes'], data);
 	return include.length ? entitiesWithGuIdInArray(prices, include) : prices;
 };
 

--- a/assets/prototype/domain/eventEditor/data/queries/tickets/useTickets.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/tickets/useTickets.ts
@@ -21,7 +21,7 @@ const useTickets = (): Ticket[] => {
 		data = {};
 	}
 
-	return pathOr([], ['espressoTickets', 'nodes'], data);
+	return pathOr<Ticket[]>([], ['espressoTickets', 'nodes'], data);
 };
 
 export default useTickets;


### PR DESCRIPTION
This PR:
- Adds Tests for domain ticket mutations (`create`, `update` and `delete`)
- Adds TS generics to some Ramda function calls
- Closes #2124