### PR TITLE
Typefy Apollo query functions / Add more types

### DIFF
--- a/assets/prototype/application/services/apollo/mutations/useEntityMutation.ts
+++ b/assets/prototype/application/services/apollo/mutations/useEntityMutation.ts
@@ -27,7 +27,7 @@ const DEFAULT_RESULT: MutationResult = { called: false, loading: false };
  * @param {string} type Entity type name
  * @param id
  */
-const useEntityMutation = (type: EntityType, id: string = ''): EntityMutation => {
+const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 	const client = useApolloClient();
 	const [result, setResult] = useState(DEFAULT_RESULT);
 	const mutators = useMutators();
@@ -38,7 +38,7 @@ const useEntityMutation = (type: EntityType, id: string = ''): EntityMutation =>
 	 */
 	const getMutation = (mutationType: MutationType): any => {
 		// For example "CREATE_DATETIME"
-		const mutation: string = `${mutationType}_${type.toUpperCase()}`;
+		const mutation = `${mutationType}_${type.toUpperCase()}`;
 		return mutations[mutation];
 	};
 
@@ -48,7 +48,7 @@ const useEntityMutation = (type: EntityType, id: string = ''): EntityMutation =>
 	 */
 	const getMutationOptions = (mutationType: MutationType, input: MutationInput = {}): OperationVariables => {
 		// e.g. "datetimeMutator"
-		const key: string = `${type.toLowerCase()}Mutator`;
+		const key = `${type.toLowerCase()}Mutator`;
 		const mutator: Mutator = mutators[key];
 		/**
 		 * options = {
@@ -80,7 +80,7 @@ const useEntityMutation = (type: EntityType, id: string = ''): EntityMutation =>
 		 */
 		return (proxy: DataProxy, result: FetchResult): void => {
 			// e.g. "createDatetime", "updateTicket"
-			const mutationName: string = `${mutationType.toLowerCase()}Espresso${type}`;
+			const mutationName = `${mutationType.toLowerCase()}Espresso${type}`;
 			// Example result: { data: { deletePrice: { price : {...} } } }
 			const path: string[] = ['data', mutationName, `espresso${type}`];
 			const entity: any = pathOr({}, path, result);

--- a/assets/prototype/application/services/apollo/mutations/useEntityMutator.ts
+++ b/assets/prototype/application/services/apollo/mutations/useEntityMutator.ts
@@ -12,7 +12,7 @@ import {
  * @param {string} type Entity type name
  * @param {string} id   Entity id
  */
-const useEntityMutator = (type: EntityType, id: string = ''): EntityMutator => {
+const useEntityMutator = (type: EntityType, id?: string): EntityMutator => {
 	const { getCreateMutation, getUpdateMutation, getDeleteMutation, mutate } = useEntityMutation(type, id);
 
 	/**

--- a/assets/prototype/application/valueObjects/config/types.ts
+++ b/assets/prototype/application/valueObjects/config/types.ts
@@ -10,6 +10,10 @@ export interface CurrencyProps {
 	subunits?: number;
 }
 
+export interface Viewer {
+	viewer: CurrentUserProps;
+}
+
 export interface CurrentUserProps {
 	id: string;
 	description: string;
@@ -22,6 +26,10 @@ export interface CurrentUserProps {
 	locale: string;
 	userId: number;
 	username: string;
+}
+
+export interface GeneralSettingsData {
+	generalSettings: GeneralSettings;
 }
 
 export interface GeneralSettings {

--- a/assets/prototype/domain/eventEditor/context/test/TestContextProviders.tsx
+++ b/assets/prototype/domain/eventEditor/context/test/TestContextProviders.tsx
@@ -7,6 +7,7 @@ import { useDomTestData } from './';
 import useResetApolloCache from './useResetApolloCache';
 import useSetGlobalStatusFlags from './useSetGlobalStatusFlags';
 import useSetRelationalData from './useSetRelationalData';
+import { MockedResponse } from './types';
 
 /**
  * A top level provider wrapped by Apollo MockedProvider.
@@ -14,7 +15,7 @@ import useSetRelationalData from './useSetRelationalData';
  * @param {ReactElement} children The element that should be wrapped.
  * @returns {ReactElement} The wrapped element.
  */
-export const ApolloMockedProvider = (mocks = []) => ({ children }) => {
+export const ApolloMockedProvider = (mocks: ReadonlyArray<MockedResponse> = []) => ({ children }) => {
 	return (
 		<MockedProvider mocks={mocks} cache={cache}>
 			<ApolloAwareWrapper>{children}</ApolloAwareWrapper>

--- a/assets/prototype/domain/eventEditor/context/test/data.ts
+++ b/assets/prototype/domain/eventEditor/context/test/data.ts
@@ -6,7 +6,7 @@ import { nodes as tickets } from '../../data/queries/tickets/test/data';
 import { nodes as prices } from '../../data/queries/prices/test/data';
 import { nodes as priceTypes } from '../../data/queries/priceTypes/test/data';
 
-export const eventId: number = 100;
+export const eventId = 100;
 
 /**
  * See the structure of returned data in `/docs/GraphQL-API/query/eventRelations.md`

--- a/assets/prototype/domain/eventEditor/context/test/types.ts
+++ b/assets/prototype/domain/eventEditor/context/test/types.ts
@@ -1,0 +1,7 @@
+import { ResultFunction, MockedResponse as ApolloMockedResponse } from '@apollo/react-testing';
+import { ExecutionResult } from 'graphql';
+
+export interface MockedResponse extends ApolloMockedResponse {
+	result?: ExecutionResult;
+	newData?: ResultFunction<ExecutionResult>;
+}

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/createDatetime.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/createDatetime.test.ts
@@ -70,10 +70,10 @@ describe('createDatetime', () => {
 		act(() => {
 			mutationResult.current.mutator.createEntity(testInput);
 		});
-		
+
 		// wait for mutation promise to resolve
 		await waitForNextMutationUpdate();
-		
+
 		const cache = mutationResult.current.client.extract();
 		const { result: cacheResult } = renderHook(
 			() => {

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/data.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/data.ts
@@ -1,9 +1,12 @@
+import { GraphQLRequest } from 'apollo-link';
 import { pickBy } from 'ramda';
+import { ExecutionResult } from 'graphql';
+
 import { nodes as datetimes } from '../../../queries/datetimes/test/data';
-import { ReadQueryOptions } from '../../../queries/types';
 import { MutationInput, MutationType } from '../../../../../../application/services/apollo/mutations/types';
 import { ucFirst } from '../../../../../../application/utilities/text/changeCase';
 import { eventId } from '../../../../context';
+import { MockedResponse } from '../../../../context/test/types';
 import { mutations } from '../../';
 
 export const mockedDatetimes = {
@@ -12,7 +15,10 @@ export const mockedDatetimes = {
 	[MutationType.Delete]: { id: datetimes[0].id, __typename: datetimes[0].__typename },
 };
 
-export const getMutationMocks = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMutationMocks = (
+	mutationInput: MutationInput,
+	mutationType: MutationType
+): ReadonlyArray<MockedResponse> => {
 	return [
 		{
 			request: getMockRequest(mutationInput, mutationType),
@@ -21,7 +27,7 @@ export const getMutationMocks = (mutationInput: MutationInput, mutationType: Mut
 	];
 };
 
-export const getMockRequest = (mutationInput: MutationInput, mutationType: MutationType): ReadQueryOptions => {
+export const getMockRequest = (mutationInput: MutationInput, mutationType: MutationType): GraphQLRequest => {
 	const input: MutationInput = {
 		clientMutationId: `${mutationType}_DATETIME`,
 		...mutationInput,
@@ -40,7 +46,7 @@ export const getMockRequest = (mutationInput: MutationInput, mutationType: Mutat
 	};
 };
 
-export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType): ExecutionResult => {
 	// make sure that tickets don't go into the result
 	const input = pickBy<MutationInput, MutationInput>(
 		(_, key) => Object.keys(mockedDatetimes[mutationType]).includes(key),

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/data.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/data.ts
@@ -29,7 +29,7 @@ export const getMockRequest = (mutationInput: MutationInput, mutationType: Mutat
 	if (mutationType === MutationType.Create) {
 		input.eventId = eventId; // required for createDatetime
 	} else if (!input.id) {
-		input.id = mockedDatetimes[mutationType].id
+		input.id = mockedDatetimes[mutationType].id;
 	}
 
 	return {

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/updateDatetime.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/test/updateDatetime.test.ts
@@ -121,7 +121,7 @@ describe('updateDatetime', () => {
 			}
 		);
 
-		const tempTicketId: string = 'temp-tkt-id';
+		const tempTicketId = 'temp-tkt-id';
 
 		act(() => {
 			// add relation between mockedDatetime and a random ticket id

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/updateTicketCache.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/updateTicketCache.ts
@@ -2,6 +2,7 @@ import { queries } from '../../queries';
 const { GET_TICKETS } = queries;
 import { CacheUpdaterFnArgs } from '../types';
 import { ReadQueryOptions, WriteQueryOptions } from '../../queries/types';
+import { TicketsList } from '../../types';
 
 const updateTicketCache = ({ proxy, datetimeIn, datetimeId, remove = false }: CacheUpdaterFnArgs): void => {
 	const queryOptions: ReadQueryOptions = {
@@ -12,10 +13,10 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, remove = false }: Ca
 			},
 		},
 	};
-	let data: any;
+	let data: TicketsList;
 	// Read the existing data from cache.
 	try {
-		data = proxy.readQuery(queryOptions);
+		data = proxy.readQuery<TicketsList>(queryOptions);
 	} catch (error) {
 		data = null;
 	}
@@ -41,7 +42,7 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, remove = false }: Ca
 
 	// write the data to cache without
 	// mutating the cache directly
-	proxy.writeQuery(writeOptions);
+	proxy.writeQuery<TicketsList>(writeOptions);
 };
 
 export default updateTicketCache;

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/useDatetimeMutator.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/useDatetimeMutator.ts
@@ -13,8 +13,8 @@ import {
 	MutatorGeneratedObject,
 } from '../../../../../application/services/apollo/mutations/types';
 import { ReadQueryOptions } from '../../queries/types';
-import { DEFAULT_ENTITY_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
-import { Datetime, DatetimeEdge } from '../../types';
+import { DEFAULT_DATETIME_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
+import { Datetime, DatetimeEdge, DatetimesList } from '../../types';
 import { DatetimeMutationCallbackFn } from '../types';
 
 /**
@@ -53,13 +53,13 @@ const useDatetimeMutator = (): Mutator => {
 
 		const onUpdate = ({ proxy, entity: datetime }: OnUpdateFnOptions<Datetime>): void => {
 			// Read the existing data from cache.
-			let data: any;
+			let data: DatetimesList;
 			try {
-				data = proxy.readQuery(options);
+				data = proxy.readQuery<DatetimesList>(options);
 			} catch (error) {
-				data = {};
+				data = null;
 			}
-			const datetimes = pathOr<DatetimeEdge>(DEFAULT_LIST_DATA('Datetimes'), ['espressoDatetimes'], data);
+			const datetimes = pathOr<DatetimeEdge>(DEFAULT_LIST_DATA, ['espressoDatetimes'], data);
 			const { tickets = [] } = input;
 
 			switch (mutationType) {

--- a/assets/prototype/domain/eventEditor/data/mutations/datetimes/useUpdateDatetimeCache.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/datetimes/useUpdateDatetimeCache.ts
@@ -1,7 +1,7 @@
 import useDatetimeQueryOptions from '../../queries/datetimes/useDatetimeQueryOptions';
 import { CacheUpdaterFn, CacheUpdaterFnArgs } from '../types';
 import { ReadQueryOptions, WriteQueryOptions } from '../../queries/types';
-import { Datetime } from '../../types';
+import { Datetime, DatetimesList } from '../../types';
 
 const useUpdateDatetimeCache = (): CacheUpdaterFn => {
 	const queryOptions: ReadQueryOptions = useDatetimeQueryOptions();
@@ -24,7 +24,7 @@ const useUpdateDatetimeCache = (): CacheUpdaterFn => {
 				},
 			},
 		};
-		proxy.writeQuery(writeOptions);
+		proxy.writeQuery<DatetimesList>(writeOptions);
 	};
 
 	return updateDatetimeCache;

--- a/assets/prototype/domain/eventEditor/data/mutations/prices/test/createPrice.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/prices/test/createPrice.test.ts
@@ -13,7 +13,7 @@ import { nodes as priceTypes } from '../../../queries/priceTypes/test/data';
 import { MutationInput } from '../../../../../../application/services/apollo/mutations/types';
 
 describe('createPrice', () => {
-	let testInput: MutationInput = { name: 'New Test Price', desc: 'New Test Desc' };
+	const testInput: MutationInput = { name: 'New Test Price', desc: 'New Test Desc' };
 	const mockedPrice = mockedPrices.CREATE;
 
 	const ticketId = tickets[0].id;

--- a/assets/prototype/domain/eventEditor/data/mutations/prices/test/data.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/prices/test/data.ts
@@ -1,9 +1,12 @@
 import { pickBy, omit } from 'ramda';
+import { ExecutionResult } from 'graphql';
+
 import { nodes as prices } from '../../../queries/prices/test/data';
 import { ReadQueryOptions } from '../../../queries/types';
 import { MutationInput, MutationType } from '../../../../../../application/services/apollo/mutations/types';
 import { ucFirst } from '../../../../../../application/utilities/text/changeCase';
 import { mutations } from '../../';
+import { MockedResponse } from '../../../../context/test/types';
 
 export const mockedPrices = {
 	[MutationType.Create]: { ...prices[0], id: prices[0].id + '-alpha' }, // make sure to change the ID to make it different}
@@ -11,7 +14,10 @@ export const mockedPrices = {
 	[MutationType.Delete]: { id: prices[0].id, __typename: prices[0].__typename },
 };
 
-export const getMutationMocks = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMutationMocks = (
+	mutationInput: MutationInput,
+	mutationType: MutationType
+): ReadonlyArray<MockedResponse> => {
 	return [
 		{
 			request: getMockRequest(mutationInput, mutationType),
@@ -40,7 +46,7 @@ export const getMockRequest = (mutationInput: MutationInput, mutationType: Mutat
 	};
 };
 
-export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType): ExecutionResult => {
 	// make sure that prices don't go into the result
 	const input = pickBy<MutationInput, MutationInput>(
 		(_, key) => Object.keys(mockedPrices[mutationType]).includes(key),

--- a/assets/prototype/domain/eventEditor/data/mutations/prices/usePriceMutator.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/prices/usePriceMutator.ts
@@ -13,9 +13,9 @@ import {
 	MutatorGeneratedObject,
 } from '../../../../../application/services/apollo/mutations/types';
 import { ReadQueryOptions } from '../../queries/types';
-import { Price, PriceEdge } from '../../types';
+import { Price, PriceEdge, PricesList } from '../../types';
 import { PriceMutationCallbackFn } from '../types';
-import { DEFAULT_ENTITY_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
+import { DEFAULT_PRICE_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
 
 /**
  *
@@ -51,13 +51,13 @@ const usePriceMutator = (): Mutator => {
 
 		const onUpdate = ({ proxy, entity: price }: OnUpdateFnOptions<Price>): void => {
 			// Read the existing data from cache.
-			let data: any;
+			let data: PricesList;
 			try {
-				data = proxy.readQuery(options);
+				data = proxy.readQuery<PricesList>(options);
 			} catch (error) {
-				data = {};
+				data = null;
 			}
-			const prices = pathOr<PriceEdge>(DEFAULT_LIST_DATA('Prices'), ['espressoPrices'], data);
+			const prices = pathOr<PriceEdge>(DEFAULT_LIST_DATA, ['espressoPrices'], data);
 
 			switch (mutationType) {
 				case MutationType.Create:

--- a/assets/prototype/domain/eventEditor/data/mutations/prices/useUpdatePriceCache.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/prices/useUpdatePriceCache.ts
@@ -1,7 +1,7 @@
 import usePriceQueryOptions from '../../queries/prices/usePriceQueryOptions';
 import { CacheUpdaterFn, CacheUpdaterFnArgs } from '../types';
 import { ReadQueryOptions, WriteQueryOptions } from '../../queries/types';
-import { Price } from '../../types';
+import { Price, PricesList } from '../../types';
 
 const useUpdatePriceCache = (): CacheUpdaterFn => {
 	const queryOptions: ReadQueryOptions = usePriceQueryOptions();
@@ -22,7 +22,7 @@ const useUpdatePriceCache = (): CacheUpdaterFn => {
 				},
 			},
 		};
-		proxy.writeQuery(writeOptions);
+		proxy.writeQuery<PricesList>(writeOptions);
 	};
 
 	return updatePriceCache;

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/data.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/data.ts
@@ -1,10 +1,13 @@
 import { pickBy } from 'ramda';
+import { ExecutionResult } from 'graphql';
+
 import { nodes as tickets } from '../../../queries/tickets/test/data';
 import { edge as priceEdge } from '../../../queries/prices/test/data';
 import { ReadQueryOptions } from '../../../queries/types';
 import { MutationInput, MutationType } from '../../../../../../application/services/apollo/mutations/types';
 import { ucFirst } from '../../../../../../application/utilities/text/changeCase';
 import { mutations } from '../../';
+import { MockedResponse } from '../../../../context/test/types';
 
 const prices = { ...priceEdge, __typename: 'EspressoTicketPricesConnectionEdge' };
 
@@ -14,7 +17,10 @@ export const mockedTickets = {
 	[MutationType.Delete]: { id: tickets[0].id, __typename: tickets[0].__typename },
 };
 
-export const getMutationMocks = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMutationMocks = (
+	mutationInput: MutationInput,
+	mutationType: MutationType
+): ReadonlyArray<MockedResponse> => {
 	return [
 		{
 			request: getMockRequest(mutationInput, mutationType),
@@ -40,7 +46,7 @@ export const getMockRequest = (mutationInput: MutationInput, mutationType: Mutat
 	};
 };
 
-export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType) => {
+export const getMockResult = (mutationInput: MutationInput, mutationType: MutationType): ExecutionResult => {
 	// make sure that tickets don't go into the result
 	const input = pickBy<MutationInput, MutationInput>(
 		(_, key) => Object.keys(mockedTickets[mutationType]).includes(key),

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/test/updateTicket.test.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/test/updateTicket.test.ts
@@ -123,7 +123,7 @@ describe('updateTicket', () => {
 			}
 		);
 
-		const tempDatetimeId: string = 'temp-dtt-id';
+		const tempDatetimeId = 'temp-dtt-id';
 
 		act(() => {
 			// add relation between mockedTicket and a random datetime id
@@ -228,7 +228,7 @@ describe('updateTicket', () => {
 			}
 		);
 
-		const tempPriceId: string = 'temp-price-id';
+		const tempPriceId = 'temp-price-id';
 
 		act(() => {
 			// add relation between mockedTicket and a random price id

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/updatePriceCache.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/updatePriceCache.ts
@@ -1,11 +1,11 @@
 import { assocPath, pathOr } from 'ramda';
-import { queries, DEFAULT_ENTITY_LIST_DATA } from '../../queries';
+import { queries, DEFAULT_PRICE_LIST_DATA } from '../../queries';
 import { CacheUpdaterFnArgs } from '../types';
 import { ReadQueryOptions, WriteQueryOptions } from '../../queries/types';
-import { Price } from '../../types';
+import { Price, PricesList } from '../../types';
 const { GET_PRICES } = queries;
 
-const updatePriceCache = ({ proxy, prices = {}, ticketIn, ticketId, remove = false }: CacheUpdaterFnArgs): void => {
+const updatePriceCache = ({ proxy, prices = null, ticketIn, ticketId, remove = false }: CacheUpdaterFnArgs): void => {
 	const queryOptions: ReadQueryOptions = {
 		query: GET_PRICES,
 		variables: {
@@ -14,13 +14,13 @@ const updatePriceCache = ({ proxy, prices = {}, ticketIn, ticketId, remove = fal
 			},
 		},
 	};
-	let data: any;
+	let data: PricesList;
 	// Read the existing data from cache.
 	try {
-		data = proxy.readQuery(queryOptions);
+		data = proxy.readQuery<PricesList>(queryOptions);
 	} catch (error) {
 		data = {
-			espressoPrices: DEFAULT_ENTITY_LIST_DATA('Prices'),
+			espressoPrices: DEFAULT_PRICE_LIST_DATA,
 		};
 	}
 
@@ -30,7 +30,7 @@ const updatePriceCache = ({ proxy, prices = {}, ticketIn, ticketId, remove = fal
 
 	if (!remove && priceNodes.length) {
 		const existingPrices: Price[] = pathOr<Price[]>([], pathToNodes, data);
-		data = assocPath(pathToNodes, [...existingPrices, ...priceNodes], data);
+		data = assocPath<Price[], PricesList>(pathToNodes, [...existingPrices, ...priceNodes], data);
 	}
 	const nodes = pathOr<Price[]>([], pathToNodes, data);
 	// if there are no prices
@@ -49,7 +49,7 @@ const updatePriceCache = ({ proxy, prices = {}, ticketIn, ticketId, remove = fal
 			},
 		},
 	};
-	proxy.writeQuery(writeOptions);
+	proxy.writeQuery<PricesList>(writeOptions);
 };
 
 export default updatePriceCache;

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/useTicketMutator.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/useTicketMutator.ts
@@ -13,8 +13,8 @@ import {
 	MutatorGeneratedObject,
 } from '../../../../../application/services/apollo/mutations/types';
 import { ReadQueryOptions } from '../../queries/types';
-import { DEFAULT_ENTITY_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
-import { Ticket, TicketEdge, Price } from '../../types';
+import { DEFAULT_TICKET_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
+import { Ticket, TicketEdge, Price, TicketsList } from '../../types';
 import { TicketMutationCallbackFn } from '../types';
 
 /**
@@ -51,13 +51,13 @@ const useTicketMutator = (): Mutator => {
 			const { prices, ...ticket } = entity;
 
 			// Read the existing data from cache.
-			let data: any;
+			let data: TicketsList;
 			try {
-				data = proxy.readQuery(options);
+				data = proxy.readQuery<TicketsList>(options);
 			} catch (error) {
-				data = {};
+				data = null;
 			}
-			const tickets = pathOr<TicketEdge>(DEFAULT_LIST_DATA('Tickets'), ['espressoTickets'], data);
+			const tickets = pathOr<TicketEdge>(DEFAULT_LIST_DATA, ['espressoTickets'], data);
 			const { datetimes: datetimeIds = [] } = input;
 
 			const priceIds = pathOr<Price[]>([], ['nodes'], prices).map(({ id }: Price) => id);

--- a/assets/prototype/domain/eventEditor/data/mutations/tickets/useUpdateTicketCache.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/tickets/useUpdateTicketCache.ts
@@ -1,7 +1,7 @@
 import useTicketQueryOptions from '../../queries/tickets/useTicketQueryOptions';
 import { CacheUpdaterFn, CacheUpdaterFnArgs } from '../types';
 import { ReadQueryOptions, WriteQueryOptions } from '../../queries/types';
-import { Ticket } from '../../types';
+import { Ticket, TicketsList } from '../../types';
 
 const useUpdateTicketCache = (): CacheUpdaterFn => {
 	const queryOptions: ReadQueryOptions = useTicketQueryOptions();
@@ -22,7 +22,7 @@ const useUpdateTicketCache = (): CacheUpdaterFn => {
 				},
 			},
 		};
-		proxy.writeQuery(writeOptions);
+		proxy.writeQuery<TicketsList>(writeOptions);
 	};
 
 	return updateTicketCache;

--- a/assets/prototype/domain/eventEditor/data/mutations/types.ts
+++ b/assets/prototype/domain/eventEditor/data/mutations/types.ts
@@ -1,4 +1,5 @@
 import { DataProxy } from 'apollo-cache';
+
 import { Datetime, DatetimeEdge, Ticket, TicketEdge, Price, PriceEdge } from '../types';
 
 export interface MutationCallbackFnArgs {

--- a/assets/prototype/domain/eventEditor/data/queries/currentUser/useCurrentUser.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/currentUser/useCurrentUser.ts
@@ -3,21 +3,21 @@ import { useApolloClient } from '@apollo/react-hooks';
 
 import { GET_CURRENT_USER } from './';
 import { ReadQueryOptions } from '../types';
-import { CurrentUserProps } from '../../../../../application/valueObjects/config/types';
+import { CurrentUserProps, Viewer } from '../../../../../application/valueObjects/config/types';
 /**
  * A custom react hook for retrieving CurrentUser
  */
 const useCurrentUser = (): CurrentUserProps => {
 	const client = useApolloClient();
-	let data: any;
+	let data: Viewer;
 
 	try {
 		const options: ReadQueryOptions = {
 			query: GET_CURRENT_USER,
 		};
-		data = client.readQuery(options);
+		data = client.readQuery<Viewer>(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
 	return pathOr<CurrentUserProps>(null, ['viewer'], data);
 };

--- a/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimeItem.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimeItem.ts
@@ -4,9 +4,14 @@ import { GET_DATETIME } from './';
 import { Datetime } from '../../types';
 import { EntityItemProps, ReadQueryOptions } from '../types';
 
+type DatetimeItemData = {
+	datetime: Datetime;
+};
+
 const useDatetimeItem = ({ id }: EntityItemProps): Datetime => {
 	const client = useApolloClient();
-	let data: any, datetime: Datetime;
+
+	let data: DatetimeItemData, datetime: Datetime;
 
 	const queryOptions: ReadQueryOptions = {
 		query: GET_DATETIME,
@@ -16,8 +21,8 @@ const useDatetimeItem = ({ id }: EntityItemProps): Datetime => {
 	};
 
 	try {
-		data = client.readQuery(queryOptions);
-		datetime = propOr<Datetime, string, any>(null, 'datetime', data);
+		data = client.readQuery<DatetimeItemData>(queryOptions);
+		datetime = propOr<Datetime, DatetimeItemData, Datetime>(null, 'datetime', data);
 	} catch (error) {
 		// may be do something with the error
 	}

--- a/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/datetimes/useDatetimes.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import { useApolloClient } from '@apollo/react-hooks';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import useDatetimeQueryOptions from './useDatetimeQueryOptions';
-import { Datetime } from '../../types';
+import { Datetime, DatetimesList } from '../../types';
 import { ReadQueryOptions } from '../types';
 
 const useDatetimes = (): Datetime[] => {
@@ -12,12 +12,12 @@ const useDatetimes = (): Datetime[] => {
 	if (!isLoaded(TypeName.datetimes)) {
 		return [];
 	}
-	let data: any;
+	let data: DatetimesList;
 
 	try {
-		data = client.readQuery(options);
+		data = client.readQuery<DatetimesList>(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
 
 	return R.pathOr<Datetime[]>([], ['espressoDatetimes', 'nodes'], data);

--- a/assets/prototype/domain/eventEditor/data/queries/datetimes/useFetchDatetimes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/datetimes/useFetchDatetimes.ts
@@ -7,7 +7,7 @@ import useDatetimeQueryOptions from './useDatetimeQueryOptions';
 import { FetchEntitiesResult, ReadQueryOptions } from '../types';
 import { DatetimesList } from '../../types';
 
-const useFetchDatetimes = (): FetchEntitiesResult => {
+const useFetchDatetimes = (): FetchEntitiesResult<DatetimesList> => {
 	const [initialized, setInitialized] = useState(false);
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 	const options: ReadQueryOptions = useDatetimeQueryOptions();

--- a/assets/prototype/domain/eventEditor/data/queries/datetimes/useFetchDatetimes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/datetimes/useFetchDatetimes.ts
@@ -5,6 +5,7 @@ import useToaster from '../../../../../application/services/toaster/useToaster';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import useDatetimeQueryOptions from './useDatetimeQueryOptions';
 import { FetchEntitiesResult, ReadQueryOptions } from '../types';
+import { DatetimesList } from '../../types';
 
 const useFetchDatetimes = (): FetchEntitiesResult => {
 	const [initialized, setInitialized] = useState(false);
@@ -14,7 +15,7 @@ const useFetchDatetimes = (): FetchEntitiesResult => {
 	const toaster = useToaster();
 	const toasterMessage = 'initializing datetimes';
 
-	const { data, error, loading } = useQuery(GET_DATETIMES, {
+	const { data, error, loading } = useQuery<DatetimesList>(GET_DATETIMES, {
 		...options,
 		onCompleted: (): void => {
 			setIsLoaded(TypeName.datetimes, true);

--- a/assets/prototype/domain/eventEditor/data/queries/generalSettings/useGeneralSettings.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/generalSettings/useGeneralSettings.ts
@@ -3,13 +3,13 @@ import { useApolloClient } from '@apollo/react-hooks';
 
 import { GET_GENERAL_SETTINGS } from './';
 import { ReadQueryOptions } from '../types';
-import { GeneralSettings } from '../../../../../application/valueObjects/config/types';
+import { GeneralSettings, GeneralSettingsData } from '../../../../../application/valueObjects/config/types';
 /**
  * A custom react hook for retrieving GeneralSettings
  */
 const useGeneralSettings = (): GeneralSettings => {
 	const client = useApolloClient();
-	let data: any;
+	let data: GeneralSettingsData;
 
 	try {
 		const options: ReadQueryOptions = {
@@ -17,7 +17,7 @@ const useGeneralSettings = (): GeneralSettings => {
 		};
 		data = client.readQuery(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
 	return pathOr<GeneralSettings>(null, ['generalSettings'], data);
 };

--- a/assets/prototype/domain/eventEditor/data/queries/index.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/index.ts
@@ -5,7 +5,7 @@ import { GET_PRICE_TYPE, GET_PRICE_TYPES } from './priceTypes';
 import { GET_CURRENT_USER } from './currentUser';
 import { GET_GENERAL_SETTINGS } from './generalSettings';
 
-import { EntityListName } from './types';
+import { EntityEdge, DatetimeEdge, TicketEdge, PriceEdge, PriceTypeEdge } from '../types';
 
 export const queries = {
 	/* datetimes */
@@ -25,9 +25,27 @@ export const queries = {
 	GET_GENERAL_SETTINGS,
 };
 
-export const DEFAULT_ENTITY_LIST_DATA = (entity: EntityListName) => {
-	return {
-		nodes: [],
-		__typename: `EspressoRootQuery${entity}Connection`,
-	};
+export const DEFAULT_ENTITY_LIST_DATA: EntityEdge = {
+	nodes: [],
+	__typename: '',
+};
+
+export const DEFAULT_DATETIME_LIST_DATA: DatetimeEdge = {
+	...DEFAULT_ENTITY_LIST_DATA,
+	__typename: 'EspressoRootQueryDatetimesConnection',
+};
+
+export const DEFAULT_TICKET_LIST_DATA: TicketEdge = {
+	...DEFAULT_ENTITY_LIST_DATA,
+	__typename: 'EspressoRootQueryTicketsConnection',
+};
+
+export const DEFAULT_PRICE_LIST_DATA: PriceEdge = {
+	...DEFAULT_ENTITY_LIST_DATA,
+	__typename: 'EspressoRootQueryPricesConnection',
+};
+
+export const DEFAULT_PRICE_TYPE_LIST_DATA: PriceTypeEdge = {
+	...DEFAULT_ENTITY_LIST_DATA,
+	__typename: 'EspressoRootQueryPriceTypesConnection',
 };

--- a/assets/prototype/domain/eventEditor/data/queries/priceTypes/useFetchPriceTypes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/priceTypes/useFetchPriceTypes.ts
@@ -6,7 +6,7 @@ import { useStatus, TypeName } from '../../../../../application/services/apollo/
 import { FetchEntitiesResult } from '../types';
 import { PriceTypesList } from '../../types';
 
-const useFetchPriceTypes = (): FetchEntitiesResult => {
+const useFetchPriceTypes = (): FetchEntitiesResult<PriceTypesList> => {
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 
 	const { onCompleted, onError, initializationNotices } = useInitToaster({

--- a/assets/prototype/domain/eventEditor/data/queries/priceTypes/useFetchPriceTypes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/priceTypes/useFetchPriceTypes.ts
@@ -4,6 +4,7 @@ import { GET_PRICE_TYPES } from './';
 import useInitToaster from '../../../../../application/services/toaster/useInitToaster';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import { FetchEntitiesResult } from '../types';
+import { PriceTypesList } from '../../types';
 
 const useFetchPriceTypes = (): FetchEntitiesResult => {
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
@@ -13,7 +14,7 @@ const useFetchPriceTypes = (): FetchEntitiesResult => {
 		successMessage: 'price types initialized',
 	});
 
-	const { data, error, loading } = useQuery(GET_PRICE_TYPES, {
+	const { data, error, loading } = useQuery<PriceTypesList>(GET_PRICE_TYPES, {
 		onCompleted: (): void => {
 			setIsLoaded(TypeName.priceTypes, true);
 			onCompleted();

--- a/assets/prototype/domain/eventEditor/data/queries/priceTypes/usePriceTypes.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/priceTypes/usePriceTypes.ts
@@ -5,7 +5,7 @@ import usePriceTypeQueryOptions from './usePriceTypeQueryOptions';
 import { entitiesWithGuIdInArray } from '../../../../shared/predicates/shared/selectionPredicates';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import { ReadQueryOptions } from '../types';
-import { PriceType, EntityId } from '../../types';
+import { PriceType, PriceTypesList, EntityId } from '../../types';
 /**
  * A custom react hook for retrieving all the priceTypes from cache
  * limited to the ids passed in `include`
@@ -19,14 +19,14 @@ const usePriceTypes = (include: EntityId[] = []): PriceType[] => {
 	if (!isLoaded(TypeName.priceTypes)) {
 		return [];
 	}
-	let data: any;
+	let data: PriceTypesList;
 
 	try {
-		data = client.readQuery(options);
+		data = client.readQuery<PriceTypesList>(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
-	const priceTypes: PriceType[] = pathOr([], ['espressoPriceTypes', 'nodes'], data);
+	const priceTypes = pathOr<PriceType[]>([], ['espressoPriceTypes', 'nodes'], data);
 	return include.length ? entitiesWithGuIdInArray(priceTypes, include) : priceTypes;
 };
 

--- a/assets/prototype/domain/eventEditor/data/queries/prices/useFetchPrices.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/prices/useFetchPrices.ts
@@ -5,19 +5,20 @@ import useInitToaster from '../../../../../application/services/toaster/useInitT
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import usePriceQueryOptions from './usePriceQueryOptions';
 import useTicketIds from '../tickets/useTicketIds';
-import { FetchEntitiesResult, ReadQueryOptions } from '../types';
+import { FetchEntitiesResult } from '../types';
+import { PricesList } from '../../types';
 
 const useFetchPrices = (): FetchEntitiesResult => {
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
-	const options: ReadQueryOptions = usePriceQueryOptions();
-	const ticketIn: string[] = useTicketIds();
+	const options = usePriceQueryOptions();
+	const ticketIn = useTicketIds();
 
 	const { onCompleted, onError, initializationNotices } = useInitToaster({
 		loadingMessage: `initializing prices`,
 		successMessage: 'prices initialized',
 	});
 
-	const { data, error, loading } = useQuery(GET_PRICES, {
+	const { data, error, loading } = useQuery<PricesList>(GET_PRICES, {
 		...options,
 		skip: !ticketIn.length, // do not fetch if we don't have any tickets
 		onCompleted: (): void => {

--- a/assets/prototype/domain/eventEditor/data/queries/prices/useFetchPrices.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/prices/useFetchPrices.ts
@@ -8,7 +8,7 @@ import useTicketIds from '../tickets/useTicketIds';
 import { FetchEntitiesResult } from '../types';
 import { PricesList } from '../../types';
 
-const useFetchPrices = (): FetchEntitiesResult => {
+const useFetchPrices = (): FetchEntitiesResult<PricesList> => {
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 	const options = usePriceQueryOptions();
 	const ticketIn = useTicketIds();

--- a/assets/prototype/domain/eventEditor/data/queries/prices/usePrices.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/prices/usePrices.ts
@@ -5,7 +5,7 @@ import { entitiesWithGuIdInArray } from '../../../../shared/predicates/shared/se
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import usePriceQueryOptions from './usePriceQueryOptions';
 import { ReadQueryOptions } from '../types';
-import { Price, EntityId } from '../../types';
+import { Price, PricesList, EntityId } from '../../types';
 /**
  * A custom react hook for retrieving all the prices from cache
  * limited to the ids passed in `include`
@@ -19,12 +19,12 @@ const usePrices = (include: EntityId[] = []): Price[] => {
 	if (!isLoaded(TypeName.prices)) {
 		return [];
 	}
-	let data: any;
+	let data: PricesList;
 
 	try {
-		data = client.readQuery(options);
+		data = client.readQuery<PricesList>(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
 
 	const prices = pathOr<Price[]>([], ['espressoPrices', 'nodes'], data);

--- a/assets/prototype/domain/eventEditor/data/queries/tickets/useFetchTickets.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/tickets/useFetchTickets.ts
@@ -9,7 +9,7 @@ import { FetchEntitiesResult, ReadQueryOptions } from '../types';
 import { EntityId } from '../../types';
 import { TicketsList } from '../../types';
 
-const useFetchTickets = (): FetchEntitiesResult => {
+const useFetchTickets = (): FetchEntitiesResult<TicketsList> => {
 	const [initialized, setInitialized] = useState(false);
 	const { setIsLoading, setIsLoaded, setIsError } = useStatus();
 	const options: ReadQueryOptions = useTicketQueryOptions();

--- a/assets/prototype/domain/eventEditor/data/queries/tickets/useFetchTickets.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/tickets/useFetchTickets.ts
@@ -7,6 +7,7 @@ import useTicketQueryOptions from './useTicketQueryOptions';
 import useDatetimeIds from '../datetimes/useDatetimeIds';
 import { FetchEntitiesResult, ReadQueryOptions } from '../types';
 import { EntityId } from '../../types';
+import { TicketsList } from '../../types';
 
 const useFetchTickets = (): FetchEntitiesResult => {
 	const [initialized, setInitialized] = useState(false);
@@ -17,7 +18,7 @@ const useFetchTickets = (): FetchEntitiesResult => {
 	const toaster = useToaster();
 	const toasterMessage = 'initializing tickets';
 
-	const { data, error, loading } = useQuery(GET_TICKETS, {
+	const { data, error, loading } = useQuery<TicketsList>(GET_TICKETS, {
 		...options,
 		skip: !datetimeIn.length, // do not fetch if we don't have any datetimes
 		onCompleted: (): void => {

--- a/assets/prototype/domain/eventEditor/data/queries/tickets/useTicketItem.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/tickets/useTicketItem.ts
@@ -4,9 +4,13 @@ import { GET_TICKET } from './';
 import { Ticket } from '../../types';
 import { EntityItemProps, ReadQueryOptions } from '../types';
 
+type TicketItemData = {
+	ticket: Ticket;
+};
+
 const useTicketItem = ({ id }: EntityItemProps): Ticket => {
 	const client = useApolloClient();
-	let data: any;
+	let data: TicketItemData;
 	let ticket: Ticket;
 
 	const queryOptions: ReadQueryOptions = {
@@ -17,8 +21,8 @@ const useTicketItem = ({ id }: EntityItemProps): Ticket => {
 	};
 
 	try {
-		data = client.readQuery(queryOptions);
-		ticket = propOr<Ticket, string, any>(null, 'ticket', data);
+		data = client.readQuery<TicketItemData>(queryOptions);
+		ticket = propOr<Ticket, TicketItemData, Ticket>(null, 'ticket', data);
 	} catch (error) {
 		// may be do something with the error
 	}

--- a/assets/prototype/domain/eventEditor/data/queries/tickets/useTickets.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/tickets/useTickets.ts
@@ -4,7 +4,7 @@ import { useApolloClient } from '@apollo/react-hooks';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 import useTicketQueryOptions from './useTicketQueryOptions';
 import { ReadQueryOptions } from '../types';
-import { Ticket } from '../../types';
+import { Ticket, TicketsList } from '../../types';
 
 const useTickets = (): Ticket[] => {
 	const options: ReadQueryOptions = useTicketQueryOptions();
@@ -13,12 +13,12 @@ const useTickets = (): Ticket[] => {
 	if (!isLoaded(TypeName.tickets)) {
 		return [];
 	}
-	let data: any;
+	let data: TicketsList;
 
 	try {
-		data = client.readQuery(options);
+		data = client.readQuery<TicketsList>(options);
 	} catch (error) {
-		data = {};
+		data = null;
 	}
 
 	return pathOr<Ticket[]>([], ['espressoTickets', 'nodes'], data);

--- a/assets/prototype/domain/eventEditor/data/queries/types.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/types.ts
@@ -13,8 +13,8 @@ export interface EntityItemProps {
 	id: EntityId;
 }
 
-export interface FetchEntitiesResult {
-	data: any;
+export interface FetchEntitiesResult<Data> {
+	data: Data;
 	error: Error;
 	loading: boolean;
 }

--- a/assets/prototype/domain/eventEditor/data/queries/useCacheRehydration.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/useCacheRehydration.ts
@@ -7,8 +7,16 @@ import { ConfigDataProps } from '../../../../application/services/config';
 import useConfig from '../../../../application/services/config/useConfig';
 import { useStatus, TypeName } from '../../../../application/services/apollo/status';
 import useEventId from './events/useEventId';
-import { queries, DEFAULT_ENTITY_LIST_DATA as DEFAULT_DATA } from './';
+import {
+	queries,
+	DEFAULT_DATETIME_LIST_DATA,
+	DEFAULT_TICKET_LIST_DATA,
+	DEFAULT_PRICE_LIST_DATA,
+	DEFAULT_PRICE_TYPE_LIST_DATA,
+} from './';
 import { WriteQueryOptions } from './types';
+import { Datetime, DatetimesList, Ticket, TicketsList, PricesList, PriceTypesList } from '../types';
+import { Viewer, GeneralSettingsData } from '../../../../application/valueObjects/config/types';
 
 const { GET_TICKETS, GET_DATETIMES, GET_PRICE_TYPES, GET_PRICES, GET_CURRENT_USER, GET_GENERAL_SETTINGS } = queries;
 
@@ -18,10 +26,10 @@ const useCacheRehydration = (): void => {
 	const { setData } = useRelations();
 	const { setConfig } = useConfig();
 	const {
-		datetimes: espressoDatetimes = DEFAULT_DATA('Datetimes'),
-		tickets: espressoTickets = DEFAULT_DATA('Tickets'),
-		prices: espressoPrices = DEFAULT_DATA('Prices'),
-		priceTypes: espressoPriceTypes = DEFAULT_DATA('PriceTypes'),
+		datetimes: espressoDatetimes = DEFAULT_DATETIME_LIST_DATA,
+		tickets: espressoTickets = DEFAULT_TICKET_LIST_DATA,
+		prices: espressoPrices = DEFAULT_PRICE_LIST_DATA,
+		priceTypes: espressoPriceTypes = DEFAULT_PRICE_TYPE_LIST_DATA,
 		currentUser,
 		generalSettings,
 		relations,
@@ -41,7 +49,7 @@ const useCacheRehydration = (): void => {
 			espressoPriceTypes,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<PriceTypesList>(writeQueryOptions);
 
 	/* Rehydrate datetimes */
 	writeQueryOptions = {
@@ -55,10 +63,10 @@ const useCacheRehydration = (): void => {
 			espressoDatetimes,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<DatetimesList>(writeQueryOptions);
 
 	/* Rehydrate tickets */
-	const datetimeIn = pathOr([], ['nodes'], espressoDatetimes).map(({ id }) => id);
+	const datetimeIn = pathOr<Datetime[]>([], ['nodes'], espressoDatetimes).map(({ id }) => id);
 	writeQueryOptions = {
 		query: GET_TICKETS,
 		variables: {
@@ -70,10 +78,10 @@ const useCacheRehydration = (): void => {
 			espressoTickets,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<TicketsList>(writeQueryOptions);
 
 	/* Rehydrate prices */
-	const ticketIn = pathOr([], ['nodes'], espressoTickets).map(({ id }) => id);
+	const ticketIn = pathOr<Ticket[]>([], ['nodes'], espressoTickets).map(({ id }) => id);
 	writeQueryOptions = {
 		query: GET_PRICES,
 		variables: {
@@ -85,7 +93,7 @@ const useCacheRehydration = (): void => {
 			espressoPrices,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<PricesList>(writeQueryOptions);
 
 	/* Rehydrate current user */
 	writeQueryOptions = {
@@ -94,7 +102,7 @@ const useCacheRehydration = (): void => {
 			viewer: currentUser,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<Viewer>(writeQueryOptions);
 	setConfig((config: ConfigDataProps) => ({ ...config, currentUser }));
 
 	/* Rehydrate general settings */
@@ -104,7 +112,7 @@ const useCacheRehydration = (): void => {
 			generalSettings,
 		},
 	};
-	client.writeQuery(writeQueryOptions);
+	client.writeQuery<GeneralSettingsData>(writeQueryOptions);
 	setConfig((config: ConfigDataProps) => ({ ...config, generalSettings }));
 
 	/* Rehydrate relations */

--- a/assets/prototype/domain/eventEditor/data/types.ts
+++ b/assets/prototype/domain/eventEditor/data/types.ts
@@ -7,9 +7,9 @@ export interface Entity {
 	__typename?: string;
 }
 
-export interface EntityEdge {
-	nodes?: Entity[];
-	__typename?: string;
+export interface EntityEdge<E = Entity, ConnectionTypeName = string> {
+	nodes: E[];
+	__typename: ConnectionTypeName;
 }
 
 export enum DatetimeStatus {
@@ -40,8 +40,10 @@ export interface Datetime extends Entity {
 	status?: DatetimeStatus;
 }
 
-export interface DatetimeEdge extends EntityEdge {
-	nodes?: Datetime[];
+export type DatetimeEdge<Connection = 'EspressoRootQueryDatetimesConnection'> = EntityEdge<Datetime, Connection>;
+
+export interface DatetimesList {
+	espressoDatetimes: DatetimeEdge;
 }
 
 export interface Price extends Entity {
@@ -58,8 +60,10 @@ export interface Price extends Entity {
 	priceTypeOrder?: number;
 }
 
-export interface PriceEdge extends EntityEdge {
-	nodes?: Price[];
+export type PriceEdge = EntityEdge<Price, 'EspressoRootQueryPricesConnection'>;
+
+export interface PricesList {
+	espressoPrices: PriceEdge;
 }
 
 export interface Ticket extends Entity {
@@ -83,8 +87,10 @@ export interface Ticket extends Entity {
 	uses?: number;
 }
 
-export interface TicketEdge extends EntityEdge {
-	nodes?: Ticket[];
+export type TicketEdge = EntityEdge<Ticket, 'EspressoRootQueryTicketsConnection'>;
+
+export interface TicketsList {
+	espressoTickets: TicketEdge;
 }
 
 export enum PriceBasetype {
@@ -104,6 +110,8 @@ export interface PriceType extends Entity {
 	order?: number;
 }
 
-export interface PriceTypeEdge extends EntityEdge {
-	nodes?: PriceType[];
+export type PriceTypeEdge = EntityEdge<PriceType, 'EspressoRootQueryPriceTypesConnection'>;
+
+export interface PriceTypesList {
+	espressoPriceTypes: PriceTypeEdge;
 }


### PR DESCRIPTION
This PR:
- Adds generics to Apollo query functions like `readQuery` and `writeQuery`
- Separates default entity list data (e.g. used in Rehydration etc.)
- Adds types for entity lists
Closes #2185 