### PR TITLE
Close the div at the correct location (after the reg form not before it)

### DIFF
--- a/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
+++ b/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
@@ -74,7 +74,6 @@ if (count($registrations) > 0) {
                 </tbody>
             </table>
         </div>
-    </div>
 
     <?php
     // Display the forms below the table.
@@ -83,6 +82,9 @@ if (count($registrations) > 0) {
             // Attendee Questions.
             $reg_form = EE_Template_Layout::get_subform_name($registration->reg_url_link());
             echo ${$reg_form};
+    ?>
+    </div>
+<?php
         } // if ( $registration instanceof EE_Registration )
     } // end foreach ( $registrations as $registration )
 


### PR DESCRIPTION
This fixes a mistake in the newish attendee_info_single.template.php template where the div that's supposed to wrap the reg form is instead closed before the reg form. This change just follows how it's done in the original attendee_info_main.template.php

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Register 1 ticket, view the source of the reg form or use the inspector. The div should close after the form now.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
