### PR TITLE
Add Tests for Price Type Predicates; closes #2118.

### DIFF
--- a/assets/prototype/domain/eventEditor/data/queries/priceTypes/useDefaultPriceType.ts
+++ b/assets/prototype/domain/eventEditor/data/queries/priceTypes/useDefaultPriceType.ts
@@ -1,13 +1,13 @@
 import usePriceTypes from './usePriceTypes';
 import { PriceType } from '../../types';
-import { getDefaultPriceType } from '../../../../shared/predicates/priceTypes/selectionPredicates';
+import { getDefaultPriceModifierType } from '../../../../shared/predicates/priceTypes/selectionPredicates';
 
 /**
  * A custom react hook for retrieving the default price type object.
  */
 const useDefaultPriceType = (): PriceType | null => {
 	const allPriceTypes: PriceType[] = usePriceTypes();
-	const defaultPriceType = getDefaultPriceType(allPriceTypes);
+	const defaultPriceType = getDefaultPriceModifierType(allPriceTypes);
 	return defaultPriceType ? defaultPriceType : null;
 };
 

--- a/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/formDecorators/usePriceTypeDecorator.ts
+++ b/assets/prototype/domain/eventEditor/tickets/ticketPriceCalculator/formDecorators/usePriceTypeDecorator.ts
@@ -6,13 +6,13 @@ import useTicketPriceCalculator from '../hooks/useTicketPriceCalculator';
 import { Price, PriceType } from '../../../data/types';
 import usePriceTypes from '../../../data/queries/priceTypes/usePriceTypes';
 import { getPriceType } from '../../../../shared/predicates/prices/selectionPredicates';
-import { getDefaultPriceType } from '../../../../shared/predicates/priceTypes/selectionPredicates';
+import { getDefaultPriceModifierType } from '../../../../shared/predicates/priceTypes/selectionPredicates';
 import toBoolean from '../../../../../application/utilities/converters/toBoolean';
 
 const usePriceTypeDecorator = (): Calculation => {
 	const priceTypes = usePriceTypes();
 	const getPriceTypeForPrice = getPriceType(priceTypes);
-	const defaultPriceType = getDefaultPriceType(priceTypes);
+	const defaultPriceType = getDefaultPriceModifierType(priceTypes);
 	const calculator = useTicketPriceCalculator();
 	return {
 		field: /^prices\[\d+\]\.priceType$/,

--- a/assets/prototype/domain/shared/predicates/priceTypes/index.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/index.ts
@@ -1,0 +1,1 @@
+export * from './selectionPredicates';

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -2,17 +2,17 @@
  * ?Internal dependencies
  */
 import { PriceBasetype } from '../../../../../domain/eventEditor/data/types';
-import { getDefaultPriceType } from './index';
+import { getDefaultPriceModifierType } from './index';
 import { nodes as priceTypes } from '../../../../../domain/eventEditor/data/queries/priceTypes/test/data';
 
 describe('getDefaultPriceType', () => {
 	it('should get default price type - SURCHARGE', () => {
-		const defaultPriceType = getDefaultPriceType(priceTypes);
+		const defaultPriceType = getDefaultPriceModifierType(priceTypes);
 		expect(defaultPriceType.baseType).toBe(PriceBasetype.SURCHARGE);
 	});
 
 	it('should return undefined if we pass an empty array', () => {
-		const defaultPriceType = getDefaultPriceType([]);
+		const defaultPriceType = getDefaultPriceModifierType([]);
 		expect(defaultPriceType).toBeUndefined();
 	});
 });

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -87,7 +87,9 @@ describe('isFlatFeeSurcharge', () => {
 			const { isBasePrice, isDiscount, isPercent } = priceType;
 			const basePrice = isBasePrice === true && isDiscount === false && isPercent === false;
 
-			expect(isFlatFeeSurcharge(priceType)).toBe(basePrice);
+			if (basePrice === true) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
 		});
 	});
 
@@ -96,7 +98,9 @@ describe('isFlatFeeSurcharge', () => {
 			const { isBasePrice, isDiscount, isPercent } = priceType;
 			const dollarDiscount = isBasePrice === false && isDiscount === true && isPercent === false;
 
-			expect(isFlatFeeSurcharge(priceType)).toBe(dollarDiscount);
+			if (dollarDiscount === true) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
 		});
 	});
 
@@ -105,7 +109,9 @@ describe('isFlatFeeSurcharge', () => {
 			const { isBasePrice, isDiscount, isPercent } = priceType;
 			const percentageSurcharge = isBasePrice === false && isDiscount === false && isPercent === true;
 
-			expect(isFlatFeeSurcharge(priceType)).toBe(percentageSurcharge);
+			if (percentageSurcharge === true) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
 		});
 	});
 
@@ -114,7 +120,9 @@ describe('isFlatFeeSurcharge', () => {
 			const { isBasePrice, isDiscount, isPercent } = priceType;
 			const precentageDiscount = isBasePrice === false && isDiscount === true && isPercent === true;
 
-			expect(isFlatFeeSurcharge(priceType)).toBe(precentageDiscount);
+			if (precentageDiscount === true) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
 		});
 	});
 });

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -1,5 +1,5 @@
 /**
- * ?Internal dependencies
+ * Internal dependencies
  */
 import { PriceBasetype } from '../../../../../domain/eventEditor/data/types';
 import {
@@ -114,7 +114,7 @@ describe('isFlatFeeSurcharge', () => {
 	});
 });
 
-describe('getDefaultPriceType', () => {
+describe('getDefaultPriceModifierType', () => {
 	it('should get default price type - SURCHARGE', () => {
 		const defaultPriceType = getDefaultPriceModifierType(priceTypes);
 		expect(defaultPriceType.baseType).toBe(PriceBasetype.SURCHARGE);

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -1,0 +1,18 @@
+/**
+ * ?Internal dependencies
+ */
+import { PriceBasetype } from '../../../../../domain/eventEditor/data/types';
+import { getDefaultPriceType } from './index';
+import { nodes as priceTypes } from '../../../../../domain/eventEditor/data/queries/priceTypes/test/data';
+
+describe('getDefaultPriceType', () => {
+	it('should get default price type - SURCHARGE', () => {
+		const defaultPriceType = getDefaultPriceType(priceTypes);
+		expect(defaultPriceType.baseType).toBe(PriceBasetype.SURCHARGE);
+	});
+
+	it('should return undefined if we pass an empty array', () => {
+		const defaultPriceType = getDefaultPriceType([]);
+		expect(defaultPriceType).toBeUndefined();
+	});
+});

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -19,17 +19,13 @@ import { nodes as priceTypes } from '../../../../../domain/eventEditor/data/quer
 describe('isBasePrice & isNotBasePrice', () => {
 	it('should return true if priceType is base price', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isBasePrice === true) {
-				expect(isBasePrice(priceType)).toBe(true);
-			}
+			expect(isBasePrice(priceType)).toBe(priceType.isBasePrice);
 		});
 	});
 
 	it('should return true if priceType is NOT base price', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isBasePrice === false) {
-				expect(isNotBasePrice(priceType)).toBe(true);
-			}
+			expect(isNotBasePrice(priceType)).toBe(!priceType.isBasePrice);
 		});
 	});
 });
@@ -37,17 +33,13 @@ describe('isBasePrice & isNotBasePrice', () => {
 describe('isDiscount & isNotDiscount', () => {
 	it('should return true if priceType is a discount', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isDiscount === true) {
-				expect(isDiscount(priceType)).toBe(true);
-			}
+			expect(isDiscount(priceType)).toBe(priceType.isDiscount);
 		});
 	});
 
 	it('should return true if priceType is NOT a discount', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isDiscount === false) {
-				expect(isNotDiscount(priceType)).toBe(true);
-			}
+			expect(isNotDiscount(priceType)).toBe(!priceType.isDiscount);
 		});
 	});
 });
@@ -55,17 +47,13 @@ describe('isDiscount & isNotDiscount', () => {
 describe('isPercent & isNotPercent', () => {
 	it('should return true if priceType is percent', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isPercent === true) {
-				expect(isPercent(priceType)).toBe(true);
-			}
+			expect(isPercent(priceType)).toBe(priceType.isPercent);
 		});
 	});
 
 	it('should return true if priceType is NOT percent', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isPercent === false) {
-				expect(isNotPercent(priceType)).toBe(true);
-			}
+			expect(isNotPercent(priceType)).toBe(!priceType.isPercent);
 		});
 	});
 });
@@ -73,17 +61,13 @@ describe('isPercent & isNotPercent', () => {
 describe('isTax & isNotTax', () => {
 	it('should return true if priceType is tax', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isTax === true) {
-				expect(isTax(priceType)).toBe(true);
-			}
+			expect(isTax(priceType)).toBe(priceType.isTax);
 		});
 	});
 
 	it('should return true if priceType is NOT tax', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isTax === false) {
-				expect(isNotTax(priceType)).toBe(true);
-			}
+			expect(isNotTax(priceType)).toBe(!priceType.isTax);
 		});
 	});
 });

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -81,17 +81,56 @@ describe('isFlatFeeSurcharge', () => {
 		});
 	});
 
-	it('should return false if price type is NOT flat fee surcharge', () => {
+	it('should return true if it is flatFeeSurcharge', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isBasePrice === true && priceType.isDiscount === false && priceType.isPercent === false) {
+			const flatFeeSurcharge =
+				priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === false;
+
+			if (flatFeeSurcharge) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return false if it is basePrice', () => {
+		priceTypes.forEach((priceType) => {
+			const basePrice =
+				priceType.isBasePrice === true && priceType.isDiscount === false && priceType.isPercent === false;
+
+			if (basePrice) {
 				expect(isFlatFeeSurcharge(priceType)).toBe(false);
 			}
+		});
+	});
 
-			if (priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === false) {
+	it('should return false if it is dollarDiscount', () => {
+		priceTypes.forEach((priceType) => {
+			const dollarDiscount =
+				priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === false;
+
+			if (dollarDiscount) {
 				expect(isFlatFeeSurcharge(priceType)).toBe(false);
 			}
+		});
+	});
 
-			if (priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === true) {
+	it('should return false if it is percentageSurcharge', () => {
+		priceTypes.forEach((priceType) => {
+			const percentageSurcharge =
+				priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === true;
+
+			if (percentageSurcharge) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
+		});
+	});
+
+	it('should return false if it is precentageDiscount', () => {
+		priceTypes.forEach((priceType) => {
+			const precentageDiscount =
+				priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === true;
+
+			if (precentageDiscount) {
 				expect(isFlatFeeSurcharge(priceType)).toBe(false);
 			}
 		});

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -11,6 +11,7 @@ import {
 	isNotPercent,
 	isTax,
 	isNotTax,
+	isFlatFeeSurcharge,
 	getDefaultPriceModifierType,
 } from './index';
 import { nodes as priceTypes } from '../../../../../domain/eventEditor/data/queries/priceTypes/test/data';
@@ -82,6 +83,32 @@ describe('isTax & isNotTax', () => {
 		priceTypes.forEach((priceType) => {
 			if (priceType.isTax === false) {
 				expect(isNotTax(priceType)).toBe(true);
+			}
+		});
+	});
+});
+
+describe('isFlatFeeSurcharge', () => {
+	it('should return true if price type is flat fee surcharge', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === false) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return false if price type is NOT flat fee surcharge', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isBasePrice === true && priceType.isDiscount === false && priceType.isPercent === false) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
+
+			if (priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === false) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
+			}
+
+			if (priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === true) {
+				expect(isFlatFeeSurcharge(priceType)).toBe(false);
 			}
 		});
 	});

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -75,64 +75,46 @@ describe('isTax & isNotTax', () => {
 describe('isFlatFeeSurcharge', () => {
 	it('should return true if price type is flat fee surcharge', () => {
 		priceTypes.forEach((priceType) => {
-			if (priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === false) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(true);
-			}
-		});
-	});
+			const { isBasePrice, isDiscount, isPercent } = priceType;
+			const flatFeeSurcharge = isBasePrice === false && isDiscount === false && isPercent === false;
 
-	it('should return true if it is flatFeeSurcharge', () => {
-		priceTypes.forEach((priceType) => {
-			const flatFeeSurcharge =
-				priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === false;
-
-			if (flatFeeSurcharge) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(true);
-			}
+			expect(isFlatFeeSurcharge(priceType)).toBe(flatFeeSurcharge);
 		});
 	});
 
 	it('should return false if it is basePrice', () => {
 		priceTypes.forEach((priceType) => {
-			const basePrice =
-				priceType.isBasePrice === true && priceType.isDiscount === false && priceType.isPercent === false;
+			const { isBasePrice, isDiscount, isPercent } = priceType;
+			const basePrice = isBasePrice === true && isDiscount === false && isPercent === false;
 
-			if (basePrice) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(false);
-			}
+			expect(isFlatFeeSurcharge(priceType)).toBe(basePrice);
 		});
 	});
 
 	it('should return false if it is dollarDiscount', () => {
 		priceTypes.forEach((priceType) => {
-			const dollarDiscount =
-				priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === false;
+			const { isBasePrice, isDiscount, isPercent } = priceType;
+			const dollarDiscount = isBasePrice === false && isDiscount === true && isPercent === false;
 
-			if (dollarDiscount) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(false);
-			}
+			expect(isFlatFeeSurcharge(priceType)).toBe(dollarDiscount);
 		});
 	});
 
 	it('should return false if it is percentageSurcharge', () => {
 		priceTypes.forEach((priceType) => {
-			const percentageSurcharge =
-				priceType.isBasePrice === false && priceType.isDiscount === false && priceType.isPercent === true;
+			const { isBasePrice, isDiscount, isPercent } = priceType;
+			const percentageSurcharge = isBasePrice === false && isDiscount === false && isPercent === true;
 
-			if (percentageSurcharge) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(false);
-			}
+			expect(isFlatFeeSurcharge(priceType)).toBe(percentageSurcharge);
 		});
 	});
 
 	it('should return false if it is precentageDiscount', () => {
 		priceTypes.forEach((priceType) => {
-			const precentageDiscount =
-				priceType.isBasePrice === false && priceType.isDiscount === true && priceType.isPercent === true;
+			const { isBasePrice, isDiscount, isPercent } = priceType;
+			const precentageDiscount = isBasePrice === false && isDiscount === true && isPercent === true;
 
-			if (precentageDiscount) {
-				expect(isFlatFeeSurcharge(priceType)).toBe(false);
-			}
+			expect(isFlatFeeSurcharge(priceType)).toBe(precentageDiscount);
 		});
 	});
 });

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.test.ts
@@ -2,8 +2,90 @@
  * ?Internal dependencies
  */
 import { PriceBasetype } from '../../../../../domain/eventEditor/data/types';
-import { getDefaultPriceModifierType } from './index';
+import {
+	isBasePrice,
+	isNotBasePrice,
+	isDiscount,
+	isNotDiscount,
+	isPercent,
+	isNotPercent,
+	isTax,
+	isNotTax,
+	getDefaultPriceModifierType,
+} from './index';
 import { nodes as priceTypes } from '../../../../../domain/eventEditor/data/queries/priceTypes/test/data';
+
+describe('isBasePrice & isNotBasePrice', () => {
+	it('should return true if priceType is base price', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isBasePrice === true) {
+				expect(isBasePrice(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return true if priceType is NOT base price', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isBasePrice === false) {
+				expect(isNotBasePrice(priceType)).toBe(true);
+			}
+		});
+	});
+});
+
+describe('isDiscount & isNotDiscount', () => {
+	it('should return true if priceType is a discount', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isDiscount === true) {
+				expect(isDiscount(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return true if priceType is NOT a discount', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isDiscount === false) {
+				expect(isNotDiscount(priceType)).toBe(true);
+			}
+		});
+	});
+});
+
+describe('isPercent & isNotPercent', () => {
+	it('should return true if priceType is percent', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isPercent === true) {
+				expect(isPercent(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return true if priceType is NOT percent', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isPercent === false) {
+				expect(isNotPercent(priceType)).toBe(true);
+			}
+		});
+	});
+});
+
+describe('isTax & isNotTax', () => {
+	it('should return true if priceType is tax', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isTax === true) {
+				expect(isTax(priceType)).toBe(true);
+			}
+		});
+	});
+
+	it('should return true if priceType is NOT tax', () => {
+		priceTypes.forEach((priceType) => {
+			if (priceType.isTax === false) {
+				expect(isNotTax(priceType)).toBe(true);
+			}
+		});
+	});
+});
 
 describe('getDefaultPriceType', () => {
 	it('should get default price type - SURCHARGE', () => {

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.ts
@@ -25,6 +25,6 @@ export const isNotTax = propEq('isTax', false);
 // returns true if supplied price type is a flat fee (dollar) surcharge
 export const isFlatFeeSurcharge = allPass([isNotBasePrice, isNotDiscount, isNotPercent]);
 
-export const getDefaultPriceType = (priceTypes: PriceType[]): PriceType | undefined => {
+export const getDefaultPriceModifierType = (priceTypes: PriceType[]): PriceType | undefined => {
 	return find(isFlatFeeSurcharge)(priceTypes);
 };

--- a/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.ts
+++ b/assets/prototype/domain/shared/predicates/priceTypes/selectionPredicates/index.ts
@@ -1,4 +1,12 @@
+/**
+ * External dependencies
+ */
 import { allPass, find, propEq } from 'ramda';
+
+/**
+ * Internal dependencies
+ */
+import { PriceType } from '../../../../../domain/eventEditor/data/types';
 
 // the following return `true` if price type satisfies predicate
 // is a base price ?
@@ -16,4 +24,7 @@ export const isNotTax = propEq('isTax', false);
 
 // returns true if supplied price type is a flat fee (dollar) surcharge
 export const isFlatFeeSurcharge = allPass([isNotBasePrice, isNotDiscount, isNotPercent]);
-export const getDefaultPriceType = (priceTypes) => find(isFlatFeeSurcharge)(priceTypes);
+
+export const getDefaultPriceType = (priceTypes: PriceType[]): PriceType | undefined => {
+	return find(isFlatFeeSurcharge)(priceTypes);
+};


### PR DESCRIPTION
## Problem this Pull Request solves
- Converts `selectionPredicates` to a folder with `index.ts` and `index.test.ts`
- Adds tests for `getDefaultPriceType`
- Closes https://github.com/eventespresso/event-espresso-core/issues/2118
