### PR TITLE
Run do_shortcode() on text in EVENT_META_* for Messages

### DIFF
--- a/espresso.php
+++ b/espresso.php
@@ -3,7 +3,7 @@
   Plugin Name:Event Espresso
   Plugin URI: http://eventespresso.com/pricing/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
   Description: Manage events, sell tickets, and receive payments from your WordPress website. Reduce event administration time, cut-out ticketing fees, and own your customer data. | <a href="https://eventespresso.com/add-ons/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Extensions</a> | <a href="https://eventespresso.com/pricing/?utm_source=plugin_activation_screen&utm_medium=link&utm_campaign=plugin_description">Sales</a> | <a href="admin.php?page=espresso_support">Support</a>
-  Version: 4.10.3.rc.025
+  Version: 4.10.3.rc.026
   Author: Event Espresso
   Author URI: http://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=wordpress_plugins_page&utm_content=support_link
   License: GPLv2
@@ -102,7 +102,7 @@ if (function_exists('espresso_version')) {
          */
         function espresso_version()
         {
-            return apply_filters('FHEE__espresso__espresso_version', '4.10.3.rc.025');
+            return apply_filters('FHEE__espresso__espresso_version', '4.10.3.rc.026');
         }
 
         /**


### PR DESCRIPTION
In case there are shortcodes in the post_meta, running do_shortcode() ensures the shortcode output is correctly parsed. Previously, shortcodes in post_meta (such as ACF wysiwyg fields) were ignored.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
THis is a very simple patch to fix an issue I discovered while trying to use EVENT_META_* shortcodes to include text that itself has a shortcode in it. 

I maintain HTML text in a custom field using ACF. I use EVENT_META_* shortcode in EMAIL message templates to render this text. Previous to this patch, shortcodes in the post_meta custom field were not being parsed. After this patch, the shortcode is correctly parsed and the post_meta field text is included with the correctly parsed shortcode.

I don't believe this will have any adverse effects because it is just a small change to allow shortcodes to be used in post_meta data.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
I modified the core and generated an email. I looked at the email - it contained no errors and carried the properly parsed shortcode output.

## Checklist

* [X] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [X] User input is adequately validated and sanitized
* [X] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [X] My code is tested.
* [X] My code follows the Event Espresso code style.
* [X] My code has proper inline documentation.
* [X] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)