### PR TITLE
Run EVENT_META_* values through do_shortcode

### DIFF
--- a/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
@@ -236,6 +236,7 @@ class EE_Event_Shortcodes extends EE_Shortcodes
 
         if (strpos($shortcode, '[EVENT_META_*') !== false) {
             // Strip the shortcode itself from $shortcode leaving any attributes set.
+            // Removing the * is correct here as _* is used to indiciate a dynamic shortcode.
             $shortcode = str_replace('[EVENT_META_*', '', $shortcode);
             $shortcode = trim(str_replace(']', '', $shortcode));
             // Get any attributes set on this shortcode.

--- a/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
@@ -101,9 +101,13 @@ class EE_Event_Shortcodes extends EE_Shortcodes
                 'This will return the Twitter URL for the event if you have it set via custom field in your event, otherwise it will use the Twitter URL set in "Your Organization Settings". To set the facebook url in your event, add a custom field with the key as <code>event_twitter</code> and the value as your facebook url',
                 'event_espresso'
             ),
-            '[EVENT_META_*]'                          => __(
-                'This is a special dynamic shortcode. After the "*", add the exact name for your custom field, if there is a value set for that custom field within the event then it will be output in place of this shortcode.',
-                'event_espresso'
+            '[EVENT_META_*]'                          => sprintf(
+                __(
+                    'This is a special dynamic shortcode. After the "*", add the exact name for your custom field, if there is a value set for that custom field within the event then it will be output in place of this shortcode. If you use shortcodes within your custom fields set %1$sdo_shortcode=true%2$s at the end of the shortcode to run the value through the do_shortcode function. ',
+                    'event_espresso'
+                ),
+                '<code>',
+                '</code>'
             ),
             '[REGISTRATION_LIST_TABLE_FOR_EVENT_URL]' => __(
                 'This parses to the url for the registration list table filtered by registrations for this event.',

--- a/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
@@ -250,7 +250,7 @@ class EE_Event_Shortcodes extends EE_Shortcodes
             }
             // Add a filter to allow all instances of EVENT_META_* to run through do_shortcode, default to false.
             // Check if a do_shortcode attribute was set to true and if so run $event_meta through that function.
-            if (apply_filters('FHEE__EE_Event_Shortcodes___parser__event_meta_do_shortcode', false)
+            if (apply_filters('FHEE__EventEspresso_core_libraries_shortcodes_EE_Event_Shortcodes___parser__event_meta_do_shortcode', false)
                 || !empty($attrs['do_shortcode']) && filter_var($attrs['do_shortcode'], FILTER_VALIDATE_BOOLEAN)
             ) {
                 return do_shortcode($event_meta);


### PR DESCRIPTION
See Daniel's initial PR for this to get an idea of why #2199 

This PR adds the ability to run your custom meta fields through do_shortcode using either an attribute set on `EVENT_META_*` or a filter:

`add_filter('FHEE__EventEspresso_core_libraries_shortcodes_EE_Event_Shortcodes___parser__event_meta_do_shortcode', '__return_true');`

~The filter name seems a little different from the norm and I'm more than happy to change it.~

## How has this been tested
Create a shortcode on your site:

```
function tw_ee_my_shortcode(){
	return 'This is some shortcode text';
}
add_shortcode( 'my_shortcode', 'tw_ee_my_shortcode' );
```

Or use whatever shortcode you already have if preferred.

Set that on a custom field within your event.

Example - https://monosnap.com/file/pW63fDb5ggVnW2DFYew5W07jAqu8Bv

Now edit a message template (Reg Approved) and add a call to EVENT_META_* anywhere that it is valid, obviously calling your custom meta field.

Example - https://monosnap.com/file/5YuiBTegWepIBTkQ7vLNIBQ52tMshw

Trigger a registration approved message however you see fit, I use Event Espresso -> Events -> {hover over event name} -> Registrations.

Click 'Resend Registration Details', generate and then preview the message, it should NOT parse the shortcode as is.

Add this to the site:

`add_filter('FHEE__EventEspresso_core_libraries_shortcodes_EE_Event_Shortcodes___parser__event_meta_do_shortcode', '__return_true');`

Retrigger, generate and preview the message again, the shortcode should parse.

Remove the above, edit the shortcode to have `do_shortcode=true`

Re-test, the shortcode should parse.

Any 'truthy' value on do_shortcode should work, 'falsey' values should not.

Confirm that `[EVENT_META_*something]` and `[EVENT_META_* something]` (with and without the  do_shortcode attribute) work as expected (it makes a difference with how the shortcode attributes parsed which is why the shortcode is stripped first)

----

Confirm the Help text (top tab on the right) shows the update text for EVENT_META_* and that it makes sense.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
