### PR TITLE
Write tests for Application Status Provider

### DIFF
--- a/assets/prototype/application/services/apollo/status/useStatusManager.ts
+++ b/assets/prototype/application/services/apollo/status/useStatusManager.ts
@@ -33,7 +33,7 @@ const useStatusManager = (): StatusManager => {
 	 * @param {string}  typeName  The plural type name like "datetimes", "tickets", "prices"
 	 * @param {boolean} value Value of the flag
 	 */
-	const setIsLoading: StatusSetter = (typeName: TypeName, value: boolean = true): void => {
+	const setIsLoading: StatusSetter = (typeName: TypeName, value = true): void => {
 		dispatch({
 			type: 'SET_IS_LOADING',
 			typeName,
@@ -56,7 +56,7 @@ const useStatusManager = (): StatusManager => {
 	 * @param {string} typeName The plural type name like "datetimes", "tickets", "prices"
 	 * @param {boolean} value Value of the flag
 	 */
-	const setIsLoaded: StatusSetter = (typeName: TypeName, value: boolean = true): void => {
+	const setIsLoaded: StatusSetter = (typeName: TypeName, value = true): void => {
 		dispatch({
 			type: 'SET_IS_LOADED',
 			typeName,
@@ -79,7 +79,7 @@ const useStatusManager = (): StatusManager => {
 	 * @param {string} typeName The plural type name like "datetimes", "tickets", "prices"
 	 * @param {boolean} value Value of the flag
 	 */
-	const setIsError: StatusSetter = (typeName: TypeName, value: boolean = true): void => {
+	const setIsError: StatusSetter = (typeName: TypeName, value = true): void => {
 		dispatch({
 			type: 'SET_IS_ERROR',
 			typeName,

--- a/assets/prototype/application/services/context/ConfigProvider.tsx
+++ b/assets/prototype/application/services/context/ConfigProvider.tsx
@@ -4,14 +4,14 @@
 import React, { createContext, useState } from 'react';
 import { useConfigData, ConfigDataProps, Config } from '../config';
 import { CurrentUser, DateTimeFormats } from '../../valueObjects/config';
-
+import { ProviderProps } from './types';
 import { useCurrentUser, useGeneralSettings } from '../../../domain/shared/data/queries';
 
 export const ConfigContext = createContext<Config | null>(null);
 
 const { Provider } = ConfigContext;
 
-const ConfigProvider = ({ children }) => {
+const ConfigProvider: React.FunctionComponent<ProviderProps> = ({ children }): JSX.Element => {
 	const ConfigData = useConfigData();
 	const currentUser = useCurrentUser();
 	const generalSettings = useGeneralSettings();

--- a/assets/prototype/application/services/context/RelationsProvider.tsx
+++ b/assets/prototype/application/services/context/RelationsProvider.tsx
@@ -2,14 +2,16 @@
  * External imports
  */
 import React, { createContext } from 'react';
+
 import useRelationsManager from '../apollo/relations/useRelationsManager';
 import { RelationsManager } from '../apollo/relations';
+import { ProviderProps } from './types';
 
 const RelationsContext = createContext<RelationsManager | null>(null);
 
 const { Provider } = RelationsContext;
 
-const RelationsProvider = ({ children }) => {
+const RelationsProvider: React.FunctionComponent<ProviderProps> = ({ children }): JSX.Element => {
 	const relations = useRelationsManager();
 	return <Provider value={relations}>{children}</Provider>;
 };

--- a/assets/prototype/application/services/context/StatusProvider.tsx
+++ b/assets/prototype/application/services/context/StatusProvider.tsx
@@ -2,16 +2,18 @@
  * External imports
  */
 import React, { createContext } from 'react';
+
 import useStatusManager from '../apollo/status/useStatusManager';
 import { StatusManager } from '../apollo/status';
+import { ProviderProps } from './types';
 
 const StatusContext = createContext<StatusManager | null>(null);
 
-const { Provider } = StatusContext;
+const { Provider, Consumer: StatusConsumer } = StatusContext;
 
-const StatusProvider = ({ children }) => {
+const StatusProvider: React.FunctionComponent<ProviderProps> = ({ children }): JSX.Element => {
 	const statusManager = useStatusManager();
 	return <Provider value={statusManager}>{children}</Provider>;
 };
 
-export { StatusContext, StatusProvider };
+export { StatusContext, StatusProvider, StatusConsumer };

--- a/assets/prototype/application/services/context/ToastProvider.tsx
+++ b/assets/prototype/application/services/context/ToastProvider.tsx
@@ -4,14 +4,16 @@
 import React, { createContext } from 'react';
 import { Position, Toaster } from '@blueprintjs/core';
 
-const ToastContext = createContext();
+import { ProviderProps } from './types';
+
+const ToastContext = createContext(null);
 
 const toaster = Toaster.create({
 	maxToasts: 6,
 	position: Position.BOTTOM_RIGHT,
 });
 
-const ToastProvider = (props) => {
+const ToastProvider: React.FunctionComponent<ProviderProps> = (props): JSX.Element => {
 	return <ToastContext.Provider value={toaster}>{props.children}</ToastContext.Provider>;
 };
 

--- a/assets/prototype/application/services/context/test/StatusProvider.test.tsx
+++ b/assets/prototype/application/services/context/test/StatusProvider.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { StatusProvider, StatusConsumer } from '../StatusProvider';
+import { TypeName, StatusManager } from '../../apollo/status';
+
+describe('StatusProvider', () => {
+	it('checks for statusProvider setter functions', () => {
+		let statusProvider: StatusManager = null;
+		const consumer = (
+			<StatusProvider>
+				<StatusConsumer>
+					{(_statusProvider_): JSX.Element => {
+						statusProvider = _statusProvider_;
+						return null;
+					}}
+				</StatusConsumer>
+			</StatusProvider>
+		);
+		render(consumer);
+		expect(statusProvider.setIsLoading).toBeInstanceOf(Function);
+		expect(statusProvider.setIsLoaded).toBeInstanceOf(Function);
+		expect(statusProvider.setIsError).toBeInstanceOf(Function);
+	});
+
+	it('checks for isLoading datetimes', () => {
+		const consumer = (
+			<StatusProvider>
+				<StatusConsumer>
+					{(statusProvider): JSX.Element => {
+						const value = JSON.stringify(statusProvider.isLoading(TypeName.datetimes));
+						return <span>{`Is Loading datetimes: ${value}`}</span>;
+					}}
+				</StatusConsumer>
+			</StatusProvider>
+		);
+		const { getByText } = render(consumer);
+		expect(getByText(/^Is Loading/).textContent).toBe('Is Loading datetimes: false');
+	});
+
+	it('checks for isLoaded priceTypes', () => {
+		const consumer = (
+			<StatusProvider>
+				<StatusConsumer>
+					{(statusProvider): JSX.Element => {
+						const value = JSON.stringify(statusProvider.isLoaded(TypeName.priceTypes));
+						return <span>{`Is Loaded priceTypes: ${value}`}</span>;
+					}}
+				</StatusConsumer>
+			</StatusProvider>
+		);
+		const { getByText } = render(consumer);
+		expect(getByText(/^Is Loaded/).textContent).toBe('Is Loaded priceTypes: false');
+	});
+
+	it('checks for isError tickets', () => {
+		const consumer = (
+			<StatusProvider>
+				<StatusConsumer>
+					{(statusProvider): JSX.Element => {
+						const value = JSON.stringify(statusProvider.isError(TypeName.tickets));
+						return <span>{`Is isError tickets: ${value}`}</span>;
+					}}
+				</StatusConsumer>
+			</StatusProvider>
+		);
+		const { getByText } = render(consumer);
+		expect(getByText(/^Is isError/).textContent).toBe('Is isError tickets: false');
+	});
+});

--- a/assets/prototype/application/services/context/types.ts
+++ b/assets/prototype/application/services/context/types.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export interface ProviderProps {
+	children: React.ReactNode;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,6 +2100,12 @@
 				"any-observable": "^0.3.0"
 			}
 		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+			"dev": true
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2139,6 +2145,107 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.3.tgz",
 			"integrity": "sha512-80uoGtphTH3vDZlJgE2xJh3qBWMAlCXq8wN8WLOxHJjms0A38vkbXOXiYMIabgnIJVc1vCcZVQa2pHt+X3AF5Q=="
+		},
+		"@testing-library/dom": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.11.0.tgz",
+			"integrity": "sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"@types/testing-library__dom": "^6.0.0",
+				"aria-query": "3.0.0",
+				"pretty-format": "^24.9.0",
+				"wait-for-expect": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				}
+			}
+		},
+		"@testing-library/jest-dom": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
+			"integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.1",
+				"chalk": "^2.4.1",
+				"css": "^2.2.3",
+				"css.escape": "^1.5.1",
+				"jest-diff": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"lodash": "^4.17.11",
+				"pretty-format": "^24.0.0",
+				"redent": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				}
+			}
+		},
+		"@testing-library/react": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.4.0.tgz",
+			"integrity": "sha512-XdhDWkI4GktUPsz0AYyeQ8M9qS/JFie06kcSnUVcpgOwFjAu9vhwR83qBl+lw9yZWkbECjL8Hd+n5hH6C0oWqg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.7.6",
+				"@testing-library/dom": "^6.11.0",
+				"@types/testing-library__react": "^9.1.2"
+			}
 		},
 		"@testing-library/react-hooks": {
 			"version": "3.2.1",
@@ -2408,6 +2515,45 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
+		},
+		"@types/testing-library__dom": {
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.11.1.tgz",
+			"integrity": "sha512-ImChHtQqmjwraRLqBC2sgSQFtczeFvBmBcfhTYZn/3KwXbyD07LQykEQ0xJo7QHc1GbVvf7pRyGaIe6PkCdxEw==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				}
+			}
+		},
+		"@types/testing-library__react": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
+			"integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+			"dev": true,
+			"requires": {
+				"@types/react-dom": "*",
+				"@types/testing-library__dom": "*"
+			}
 		},
 		"@types/testing-library__react-hooks": {
 			"version": "3.2.0",
@@ -6147,6 +6293,26 @@
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 		},
+		"css": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.5.2",
+				"urix": "^0.1.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"css-box-model": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.0.tgz",
@@ -6285,6 +6451,12 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+			"dev": true
+		},
+		"css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -6755,7 +6927,7 @@
 			}
 		},
 		"del": {
-			"version": "git+https://github.com/sindresorhus/del.git#1a0c36c83e0773fd00a2d7cabcd44da99d91dd9a",
+			"version": "git+https://github.com/sindresorhus/del.git#892ce2a1bac26c9d7daa5b4aab39f5246ddb707b",
 			"from": "git+https://github.com/sindresorhus/del.git",
 			"dev": true,
 			"requires": {
@@ -13750,6 +13922,12 @@
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 		},
+		"min-indent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+			"integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+			"dev": true
+		},
 		"mini-css-extract-plugin": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz",
@@ -19923,6 +20101,12 @@
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
+		},
+		"wait-for-expect": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
+			"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+			"dev": true
 		},
 		"wait-on": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
 		"@babel/runtime-corejs3": "^7.7.2",
 		"@graphql-codegen/cli": "^1.9.1",
 		"@graphql-codegen/typescript": "^1.9.1",
+		"@testing-library/jest-dom": "^4.2.4",
+		"@testing-library/react": "^9.4.0",
 		"@testing-library/react-hooks": "^3.2.1",
 		"@types/classnames": "^2.2.9",
 		"@types/graphql": "^14.5.0",


### PR DESCRIPTION
This PR:
- Typefies context providers inside `/application/services/context`.
- Adds tests for application status provider.
- Closes #2137 

**Note:** You need to run `npm install`.