### PR TITLE
Write tests for application config provider

### DIFF
--- a/assets/prototype/application/services/context/ConfigProvider.tsx
+++ b/assets/prototype/application/services/context/ConfigProvider.tsx
@@ -7,9 +7,9 @@ import { CurrentUser, DateTimeFormats } from '../../valueObjects/config';
 import { ProviderProps } from './types';
 import { useCurrentUser, useGeneralSettings } from '../../../domain/shared/data/queries';
 
-export const ConfigContext = createContext<Config | null>(null);
+const ConfigContext = createContext<Config | null>(null);
 
-const { Provider } = ConfigContext;
+const { Provider, Consumer: ConfigConsumer } = ConfigContext;
 
 const ConfigProvider: React.FunctionComponent<ProviderProps> = ({ children }): JSX.Element => {
 	const ConfigData = useConfigData();
@@ -26,4 +26,4 @@ const ConfigProvider: React.FunctionComponent<ProviderProps> = ({ children }): J
 	return <Provider value={{ config, setConfig }}>{children}</Provider>;
 };
 
-export default ConfigProvider;
+export { ConfigProvider, ConfigConsumer, ConfigContext };

--- a/assets/prototype/application/services/context/test/ConfigProvider.test.tsx
+++ b/assets/prototype/application/services/context/test/ConfigProvider.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { ConfigConsumer } from '../ConfigProvider';
+import { Config } from '../../config/types';
+import { mockEeJsData } from '../../config/test/data';
+import { ApolloMockedProvider } from '../../../../domain/eventEditor/context';
+
+describe('ConfigProvider', () => {
+	it('checks for ConfigProvider setConfig function', () => {
+		let configData: Config = null;
+		const consumer = (
+			<ConfigConsumer>
+				{(_config_): JSX.Element => {
+					configData = _config_;
+					return null;
+				}}
+			</ConfigConsumer>
+		);
+		render(consumer, {
+			wrapper: ApolloMockedProvider(),
+		});
+		expect(configData.setConfig).toBeInstanceOf(Function);
+	});
+
+	it('checks for brandName in config data', () => {
+		const consumer = (
+			<ConfigConsumer>
+				{(configData): JSX.Element => {
+					const value = configData.config.brandName;
+					return <span>{`Brand name: ${value}`}</span>;
+				}}
+			</ConfigConsumer>
+		);
+		const { getByText } = render(consumer, {
+			wrapper: ApolloMockedProvider(),
+		});
+
+		expect(getByText(/^Brand name:/).textContent).toBe('Brand name: ' + mockEeJsData.brandName);
+	});
+
+	it('checks for user and site locale in config data', () => {
+		const consumer = (
+			<ConfigConsumer>
+				{(configData): JSX.Element => {
+					const userLocale = configData.config.locale.user;
+					const siteLocale = configData.config.locale.site;
+					return (
+						<>
+							<span>{`User locale: ${userLocale}`}</span>
+							<span>{`Site locale: ${siteLocale}`}</span>
+						</>
+					);
+				}}
+			</ConfigConsumer>
+		);
+		const { getByText } = render(consumer, {
+			wrapper: ApolloMockedProvider(),
+		});
+
+		expect(getByText(/^User locale:/).textContent).toBe('User locale: ' + mockEeJsData.locale.user);
+		expect(getByText(/^Site locale:/).textContent).toBe('Site locale: ' + mockEeJsData.locale.site);
+	});
+});

--- a/assets/prototype/domain/eventEditor/context/ContextProviders.js
+++ b/assets/prototype/domain/eventEditor/context/ContextProviders.js
@@ -5,7 +5,7 @@ import { getClient } from '../../../infrastructure/services/apollo/Apollo';
 import { ToastProvider } from '../../../application/services/context/ToastProvider';
 import { RelationsProvider } from '../../../application/services/context/RelationsProvider';
 import { StatusProvider } from '../../../application/services/context/StatusProvider';
-import ConfigProvider from '../../../application/services/context/ConfigProvider';
+import { ConfigProvider } from '../../../application/services/context/ConfigProvider';
 import { EventEditorEventIdProvider } from './EventEditorEventIdProvider';
 
 /**


### PR DESCRIPTION
This PR:
- Improves imports/exports of `ConfigProvider`
- Adds tests for Application ConfigProvider
- Closes #2140 