### PR TITLE
Write tests for Application Relations provider

### DIFF
--- a/assets/prototype/application/services/context/RelationsProvider.tsx
+++ b/assets/prototype/application/services/context/RelationsProvider.tsx
@@ -9,11 +9,11 @@ import { ProviderProps } from './types';
 
 const RelationsContext = createContext<RelationsManager | null>(null);
 
-const { Provider } = RelationsContext;
+const { Provider, Consumer: RelationsConsumer } = RelationsContext;
 
 const RelationsProvider: React.FunctionComponent<ProviderProps> = ({ children }): JSX.Element => {
 	const relations = useRelationsManager();
 	return <Provider value={relations}>{children}</Provider>;
 };
 
-export { RelationsContext, RelationsProvider };
+export { RelationsContext, RelationsProvider, RelationsConsumer };

--- a/assets/prototype/application/services/context/test/RelationsProvider.test.tsx
+++ b/assets/prototype/application/services/context/test/RelationsProvider.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { RelationsProvider, RelationsConsumer } from '../RelationsProvider';
+import { RelationsManager, RelationalData } from '../../apollo/relations';
+import { ApolloMockedProvider } from '../../../../domain/eventEditor/context';
+
+describe('RelationsProvider', () => {
+	it('checks for relationsProvider functions', () => {
+		let relationsProvider: RelationsManager = null;
+		const consumer = (
+			<RelationsProvider>
+				<RelationsConsumer>
+					{(_relationsProvider_): JSX.Element => {
+						relationsProvider = _relationsProvider_;
+						return null;
+					}}
+				</RelationsConsumer>
+			</RelationsProvider>
+		);
+		render(consumer);
+
+		expect(relationsProvider.addRelation).toBeInstanceOf(Function);
+		expect(relationsProvider.dropRelations).toBeInstanceOf(Function);
+		expect(relationsProvider.getData).toBeInstanceOf(Function);
+		expect(relationsProvider.getRelations).toBeInstanceOf(Function);
+		expect(relationsProvider.removeRelation).toBeInstanceOf(Function);
+		expect(relationsProvider.setData).toBeInstanceOf(Function);
+		expect(relationsProvider.updateRelations).toBeInstanceOf(Function);
+	});
+
+	it('checks for relationsProvider data from global context', () => {
+		let relationalData: RelationalData = null;
+		const consumer = (
+			<RelationsConsumer>
+				{(relationsProvider): JSX.Element => {
+					relationalData = relationsProvider.getData();
+					return null;
+				}}
+			</RelationsConsumer>
+		);
+
+		render(consumer, { wrapper: ApolloMockedProvider() });
+
+		expect(relationalData).toHaveProperty('datetimes');
+		expect(relationalData).toHaveProperty('tickets');
+		expect(relationalData).toHaveProperty('prices');
+	});
+});


### PR DESCRIPTION
This PR:
- Updates exports in `RelationsProvider.tsx`
- Adds tests for Application RelationsProvider
- Closes #2139 