### PR TITLE
delete transactions too if theres no other valid registrations

### DIFF
--- a/core/libraries/batch/JobHandlers/ExecuteBatchDeletion.php
+++ b/core/libraries/batch/JobHandlers/ExecuteBatchDeletion.php
@@ -171,11 +171,12 @@ class ExecuteBatchDeletion extends JobHandler
      * @throws \EE_Error
      * @throws \ReflectionException
      */
-    protected function deleteRegistrationsAndTransactions($reg_ids, $batch_size, JobParameters $job_parameters){
+    protected function deleteRegistrationsAndTransactions($reg_ids, $batch_size, JobParameters $job_parameters)
+    {
         $count_deleted = 0;
-        foreach($reg_ids as $reg_id){
+        foreach ($reg_ids as $reg_id) {
             $count_deleted += $this->deleteRegistrationAndTransaction($reg_id, $job_parameters);
-            if($count_deleted >= $batch_size){
+            if ($count_deleted >= $batch_size) {
                 return $count_deleted;
             }
         }
@@ -192,7 +193,8 @@ class ExecuteBatchDeletion extends JobHandler
      * @throws \InvalidArgumentException
      * @throws \ReflectionException
      */
-    protected function deleteRegistrationAndTransaction($reg_id, JobParameters $job_parameters){
+    protected function deleteRegistrationAndTransaction($reg_id, JobParameters $job_parameters)
+    {
         // If the registration's transaction has no other valid registrations, delete it, and its dependent data too.
         $TXN = \EEM_Transaction::instance()->get_one(
             [
@@ -202,7 +204,7 @@ class ExecuteBatchDeletion extends JobHandler
             ]
         );
         $count_deleted = 0;
-        if( $TXN instanceof EE_Transaction) {
+        if ($TXN instanceof EE_Transaction) {
             $valid_regs = $TXN->count_related(
                 'Registration',
                 [
@@ -210,14 +212,15 @@ class ExecuteBatchDeletion extends JobHandler
                         'REG_deleted' => false,
                         'Event.status' => ['!=', EEM_Event::post_status_trashed]
                     ]
-                ]);
-            if(! $valid_regs){
+                ]
+            );
+            if (! $valid_regs) {
                 // delete the transaction
                 // and its dependent data
                 $transaction_as_root_of_tree = new ModelObjNode($TXN->ID(), $TXN->get_model());
                 $transaction_as_root_of_tree->visit(1000);
                 $ids_to_delete = $transaction_as_root_of_tree->getIds();
-                foreach($ids_to_delete as $model_name => $ids){
+                foreach ($ids_to_delete as $model_name => $ids) {
                     // just grab the IDs the easy way, there's no Term_Relationship model related to transactions
                     $model_to_delete = EE_Registry::instance()->load_model($model_name);
                     $deleted_from_this_model = $model_to_delete->delete_permanently(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->
## Note to Brent
This first commit is ugly. I just wanted to first focus on getting the logic right. Next, I'll point it out in the code, I think there's definitely a clear opportunity for using the command pattern, but you may see other worthwhile code improvements.


## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
When we're deleting an event and its registrations, also deletes the registration's transaction IF there are no other registrations for other events. Also deletes the transaction's related data too (like line items, payments, messages, and extra meta.) If there are other registrations on the transaction that are for other events, the transaction is not deleted, nor are those other registrations (but the registrations for the event being deleted ARE also deleted.)
See the related discussion from https://github.com/eventespresso/event-espresso-core/issues/2194#issuecomment-573218561


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Register for a paid event. Look directly in the DB for the registration's transaction, its payment, messages, and extra metas.
* Delete that event.
* Check that the transaction, payment, messages and extra metas are also deleted.
* [ ] Use MER. Simultaneously register for two events. 
* Delete one of the events
* Double-check the transaction you just created wasn't deleted; although the registration for the deleted event should be deleted.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [x] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
