### PR TITLE
Reduce PUE load 

### DIFF
--- a/core/EE_Addon.core.php
+++ b/core/EE_Addon.core.php
@@ -88,6 +88,13 @@ abstract class EE_Addon extends EE_Configurable implements RequiresDependencyMap
      */
     protected $_main_plugin_file;
 
+    /**
+     *    This is the slug used to identify this add-on within the plugin update engine.
+     *
+     * @type string
+     */
+    protected $pue_slug;
+
 
     /**
      * @var EE_Dependency_Map $dependency_map
@@ -883,5 +890,20 @@ abstract class EE_Addon extends EE_Configurable implements RequiresDependencyMap
     public function after_registration()
     {
         // cricket chirp... cricket chirp...
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPueSlug()
+    {
+        return $this->pue_slug;
+    }
+    /**
+     * @param mixed $pue_slug
+     */
+    public function setPueSlug($pue_slug)
+    {
+        $this->pue_slug = $pue_slug;
     }
 }

--- a/core/EE_Addon.core.php
+++ b/core/EE_Addon.core.php
@@ -893,7 +893,7 @@ abstract class EE_Addon extends EE_Configurable implements RequiresDependencyMap
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getPueSlug()
     {

--- a/core/EE_Addon.core.php
+++ b/core/EE_Addon.core.php
@@ -900,7 +900,7 @@ abstract class EE_Addon extends EE_Configurable implements RequiresDependencyMap
         return $this->pue_slug;
     }
     /**
-     * @param mixed $pue_slug
+     * @param string $pue_slug
      */
     public function setPueSlug($pue_slug)
     {

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1065,6 +1065,7 @@ class EE_Register_Addon implements EEI_Plugin_API
         $addon->set_config_section(self::$_settings[ $addon_name ]['config_section']);
         $addon->set_config_class(self::$_settings[ $addon_name ]['config_class']);
         $addon->set_config_name(self::$_settings[ $addon_name ]['config_name']);
+        $addon->setPueSlug(self::$_settings[ $addon_name ]['pue_options']['pue_plugin_slug']);
         // unfortunately this can't be hooked in upon construction, because we don't have
         // the plugin mainfile's path upon construction.
         register_deactivation_hook($addon->get_main_plugin_file(), array($addon, 'deactivation'));

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1065,7 +1065,10 @@ class EE_Register_Addon implements EEI_Plugin_API
         $addon->set_config_section(self::$_settings[ $addon_name ]['config_section']);
         $addon->set_config_class(self::$_settings[ $addon_name ]['config_class']);
         $addon->set_config_name(self::$_settings[ $addon_name ]['config_name']);
-        $addon->setPueSlug(self::$_settings[ $addon_name ]['pue_options']['pue_plugin_slug']);
+        // setup the add-on's pue_slug if we have one.
+        if (! empty(self::$_settings[ $addon_name ]['pue_options']['pue_plugin_slug'])) {
+            $addon->setPueSlug(self::$_settings[ $addon_name ]['pue_options']['pue_plugin_slug']);
+        }
         // unfortunately this can't be hooked in upon construction, because we don't have
         // the plugin mainfile's path upon construction.
         register_deactivation_hook($addon->get_main_plugin_file(), array($addon, 'deactivation'));

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1663,7 +1663,7 @@ if (! class_exists('PluginUpdateEngineChecker')):
             $state = get_site_option($this->optionName);
 
             // If this is an add-on, only call home if there is an update available for it.
-            if( $this->slug !== 'event-espresso-core-reg' && isset($state->latestVersion) ) {
+            if( $this->slug !== 'event-espresso-core-reg' && !empty($state->latestVersion) ) {
                 if( version_compare($this->_installed_version, $state->latestVersion, '>=') ) {
                     return;
                 }

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1033,8 +1033,10 @@ if (! class_exists('PluginUpdateEngineChecker')):
                     $this->add_persistent_notice($response->extra_notices);
                 }
                 // This instance is for EE Core, we have a response from PUE so lets check if it contains PUE Plugin data.
-                if ($this->slug == 'event-espresso-core-reg' && isset($response->extra_data) && !empty($response->extra_data->plugins) ) {
-                    // Pull PUE pugin data from 'extra_data'.
+                if ( stripos($this->slug, 'event-espresso-core') !== false
+                    && isset($response->extra_data)
+                    && !empty($response->extra_data->plugins)
+                ) {                    // Pull PUE pugin data from 'extra_data'.
                     $plugins_array = json_decode($result['body'], true);
                     $plugins = $plugins_array['extra_data']['plugins'];
                     // Pull all of the add-ons EE has active and update the local latestVersion value of each of them.

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1048,7 +1048,7 @@ if (! class_exists('PluginUpdateEngineChecker')):
                                 continue;
                             }
                             // Have an addon state? Set the latestVersion value!
-                            $addon_state->latestVersion = $response->extra_data->plugins->{ $addon_slug };
+                            $addon_state->latestVersion = $response->extra_data->plugins->{ $addon_slug }->version;
                             update_option('external_updates-' . $addon_slug, $addon_state);
                         }
                     }

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1657,17 +1657,17 @@ if (! class_exists('PluginUpdateEngineChecker')):
         {
             $state = get_site_option($this->optionName);
 
+            // If this is an add-on, only call home if there is an update available for it.
+            if( $this->slug !== 'event-espresso-core-reg' && isset($state->latestVersion) ) {
+                if( version_compare($this->_installed_version, $state->latestVersion, '>=') ) {
+                    return;
+                }
+            }
+
             if (empty($state) || ! is_object($state)) {
                 $state = new StdClass;
                 $state->checkedVersion = '';
                 $state->update = null;
-            }
-
-            // If this is an add-on, only ping ee.com if there is an update actually available for it.
-            if( $this->slug !== 'event-espresso-core-reg' && isset($state->latestVersion) ) {
-                if( version_compare($state->latestVersion, $this->_installed_version, '<=') ) {
-                    return;
-                }
             }
 
             $state->lastCheck = time();

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1032,6 +1032,20 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 if (isset($response->extra_notices)) {
                     $this->add_persistent_notice($response->extra_notices);
                 }
+                if ($this->slug == 'event-espresso-core-reg' && isset($response->extra_data) && !empty($response->extra_data->plugins) ) {
+                    $plugins_array = json_decode($result['body'], true);
+                    $plugins = $plugins_array['extra_data']['plugins'];
+                    foreach (EE_Registry::instance()->addons as $addon) {
+                        if( isset($plugins[ $addon->getPueSlug() ]) ) {
+                            $addon_state = get_option('external_updates-' . $addon->getPueSlug());
+                            if( empty($addon_state)) {
+                                continue;
+                            }
+                            $addon_state->latestVersion = $plugins[$addon->getPueSlug()];
+                            update_option('external_updates-' . $addon->getPueSlug(), $addon_state);
+                        }
+                    }
+                }
             }
 
 

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1040,15 +1040,16 @@ if (! class_exists('PluginUpdateEngineChecker')):
                     $plugins = $plugins_array['extra_data']['plugins'];
                     // Pull all of the add-ons EE has active and update the local latestVersion value of each of them.
                     foreach (EE_Registry::instance()->addons as $addon) {
-                        if( isset($plugins[ $addon->getPueSlug() ]) ) {
-                            $addon_state = get_option('external_updates-' . $addon->getPueSlug());
+                        $addon_slug = $addon->getPueSlug();
+                        if( isset($response->extra_data->plugins->{ $addon_slug }) ) {
+                            $addon_state = get_option('external_updates-' . $addon_slug);
                             // If we don't have an addon state, get out we'll update it next time.
                             if( empty($addon_state)) {
                                 continue;
                             }
                             // Have an addon state? Set the latestVersion value!
-                            $addon_state->latestVersion = $plugins[$addon->getPueSlug()];
-                            update_option('external_updates-' . $addon->getPueSlug(), $addon_state);
+                            $addon_state->latestVersion = $response->extra_data->plugins->{ $addon_slug };
+                            update_option('external_updates-' . $addon_slug, $addon_state);
                         }
                     }
                 }

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1032,15 +1032,20 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 if (isset($response->extra_notices)) {
                     $this->add_persistent_notice($response->extra_notices);
                 }
+                // This instance is for EE Core, we have a response from PUE so lets check if it contains PUE Plugin data.
                 if ($this->slug == 'event-espresso-core-reg' && isset($response->extra_data) && !empty($response->extra_data->plugins) ) {
+                    // Pull PUE pugin data from 'extra_data'.
                     $plugins_array = json_decode($result['body'], true);
                     $plugins = $plugins_array['extra_data']['plugins'];
+                    // Pull all of the add-ons EE has active and update the local latestVersion value of each of them.
                     foreach (EE_Registry::instance()->addons as $addon) {
                         if( isset($plugins[ $addon->getPueSlug() ]) ) {
                             $addon_state = get_option('external_updates-' . $addon->getPueSlug());
+                            // If we don't have an addon state, get out we'll update it next time.
                             if( empty($addon_state)) {
                                 continue;
                             }
+                            // Have an addon state? Set the latestVersion value!
                             $addon_state->latestVersion = $plugins[$addon->getPueSlug()];
                             update_option('external_updates-' . $addon->getPueSlug(), $addon_state);
                         }

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1662,6 +1662,14 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 $state->checkedVersion = '';
                 $state->update = null;
             }
+
+            // If this is an add-on, only ping ee.com if there is an update actually available for it.
+            if( $this->slug !== 'event-espresso-core-reg' && isset($state->latestVersion) ) {
+                if( version_compare($state->latestVersion, $this->_installed_version, '<=') ) {
+                    return;
+                }
+            }
+
             $state->lastCheck = time();
             $state->checkedVersion = $this->_installed_version;
             //Save before checking in case something goes wrong

--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -546,10 +546,10 @@ if (! class_exists('PluginUpdateEngineChecker')):
             //set other properties related to version
             //is_premium?
             $premium_search_ref = is_array($slug) ? key($slug['premium']) : null;
+
             //case insensitive search in version
             $this->_is_premium = ! empty($premium_search_ref)
-                                 && preg_match("/$premium_search_ref/i", $this->_installed_version);
-
+                                 && stripos($this->_installed_version, $premium_search_ref) !== false;
 
             //wait... if slug is_string() then we'll assume this is a premium install by default
             $this->_is_premium = ! $this->_is_premium && ! is_array($slug) ? true : $this->_is_premium;
@@ -557,13 +557,12 @@ if (! class_exists('PluginUpdateEngineChecker')):
             //set pre-release flag
             $pr_search_ref = is_array($slug) && isset($slug['prerelease']) ? key($slug['prerelease']) : null;
             $this->_is_prerelease = ! empty($pr_search_ref)
-                                    && preg_match("/$pr_search_ref/i", $this->_installed_version);
+                                    && stripos($this->_installed_version, $pr_search_ref) !== false;
 
             //free_release?
             $fr_search_ref = is_array($slug) && isset($slug['free']) ? key($slug['free']) : null;
             $this->_is_freerelease = ! empty($fr_search_ref)
-                                     && preg_match("/$fr_search_ref/", $this->_installed_version);
-
+                                     && stripos($this->_installed_version, $fr_search_ref) !== false;
 
             //set slug we use
             $this->slug = $this->_is_premium && is_array($slug) ? $slug['premium'][key($slug['premium'])] : null;


### PR DESCRIPTION
PUE calls home separately for EE core and each add-on individually.

That means that if you have 10/20/30 EE plugins active on your site, when PUE initiates a call home it sends 10/20/30 GET requests home, the majority of which technically do little more than check for a new version of the plugin which doesn't sound that bad, right?

The problem is that PUE checks for an active license on each of those requests and its hammering our servers.

The change here basically adds a 'latestVersion' value to the pue state for each add-on which PUE then compares against the installed version **before** calling home for add-ons but will **always** call home for core. This branch basically does almost nothing at all without some changes to PUE itself (to include the plugin versions in the response sent back to EE when it calls home).

The changes to EE_Addon and EE_Register_Addon.lib.php set up the PUE slugs on EE_Add-ons so they can be used later.

The additional code in [PluginUpdateEngineChecker::requestInfo()](https://github.com/eventespresso/event-espresso-core/compare/ENH/reduce-pue-load?expand=1#diff-91de7c437e6013f92801e60bff591f47R1035-R1053) grabs the new 'plugins' data that will be included in the PUE response which will just be associative array with `{pue_plugin_slug} => {latestVersion}`.

If that additional data is included in the response that code loops over any add-ons you have installed on the site and saves the latestVersion locally for that add-on.

The changes to [PluginUpdateEngineChecker::checkForUpdates()](https://github.com/eventespresso/event-espresso-core/compare/ENH/reduce-pue-load?expand=1#diff-91de7c437e6013f92801e60bff591f47R1665-R1671) check for a `latestVersion` value right before calling home, if a value is set and the currently installed version number is greater than or equal to the latestVersion value we saved earlier we return out of the function, there's no update so we don't need to call home for this add-on.

----

Incase this isn't clear above, this means that in order for EE to show an update is available for any add-ons, EE core has to call home and update the local values of latestVersion on each of the installed add-ons first. Then each add-on will compare those values before they call home themsevles (if needed).

The nice thing about this is everything else works exactly how it did, when there's an update available EE calls home for that add-on and will display the No valid license notices if they don't have one etc.

---

Worst case scenario, if this breaks something with updates is that core may need to manually updated to fix it (I've gone over this many times locally and I don't think there will be an issue) but because there is only a single instance of pue-client (EE core handles PUE for all add-ons) any issues with add-ons can be fixed by updating core (for example if add-ons stop updating and update for core can be released to remove the latestVersion check and go back to the current method). I don't expected this at all but just pointing it out.

--- 

I'll go through some testing notes on this shortly but I'd like Brent to have a look over the code first incase I'm missing something.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
