### PR TITLE
Casc/dont traverse models

### DIFF
--- a/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
+++ b/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
@@ -12,7 +12,8 @@ use EventEspresso\core\exceptions\UnexpectedEntityException;
 /**
  * Class ConfirmEventDeletionForm
  *
- * Description
+ * Special form that requests the user confirm they want to delete the specified events, and have made a database
+ * backup.
  *
  * @package     Event Espresso
  * @author         Mike Nelson
@@ -46,23 +47,17 @@ class ConfirmEventDeletionForm extends \EE_Form_Section_Proper
         }
         $this->events = $events;
         $events_inputs = [
-            'intro' => new EE_Form_Section_HTML(
-                EEH_HTML::h2(esc_html__('In order to prevent accidentally deleting the wrong events, please enter the unique URL slug of each event.', 'event_espresso'))
-            )
         ];
         foreach ($events as $event) {
-             $events_inputs[ $event->ID() ] = new \EE_Text_Input(
-                 [
-                    'html_label_text' => esc_html(
-                        sprintf(
-                            __('Please enter the URL slug of "%1$s" (hint: it’s "%2$s")', 'event_espresso'),
-                            $event->name(),
-                            $event->slug()
-                        )
-                    ),
-                    'required' => false
-                 ]
-             );
+            $events_inputs[ $event->ID() ] = new EE_Checkbox_Multi_Input(
+                [
+                    'yes' => $event->name(),
+                ],
+                [
+                    'html_label_text' => esc_html__('Please confirm you wish to delete:', 'event_espresso'),
+                    'required' => true
+                ]
+            );
         }
         $events_subsection->add_subsections($events_inputs);
         $options_array['subsections']['backup'] = new EE_Checkbox_Multi_Input(
@@ -75,24 +70,6 @@ class ConfirmEventDeletionForm extends \EE_Form_Section_Proper
             ]
         );
         parent::__construct($options_array);
-    }
-
-    public function _validate()
-    {
-        parent::_validate();
-        $events_subsection = $this->get_proper_subsection('events');
-        foreach ($this->events as $event) {
-            $event_input = $events_subsection->get_input($event->ID());
-            if ((string) $event_input->normalized_value() !== $event->slug()) {
-                $event_input->add_validation_error(
-                    sprintf(
-                        esc_html__('You entered the incorrect URL slug for the event "%1$s". Please enter it again (use "%2$s") to confirm you are deleting the correct event.', 'event_espresso'),
-                        $event->name(),
-                        $event->slug()
-                    )
-                );
-            }
-        }
     }
 }
 // End of file ConfirmEventDeletionForm.php

--- a/admin_pages/events/templates/event_preview_deletion.template.php
+++ b/admin_pages/events/templates/event_preview_deletion.template.php
@@ -67,7 +67,13 @@ if ($reg_count > count($registrations)) {
     <?php
 }
 ?>
-<p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events. You can delete the contacts afterwards if you like.', 'event_espresso'); ?></p>
+<?php
+if ($reg_count > 0) {
+    ?>
+    <p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events.', 'event_espresso'); ?></p>
+    <?php
+}
+?>
 <ul>
     <?php
     foreach ($registrations as $registration) {

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -1043,8 +1043,9 @@ class Transactions_Admin_Page extends EE_Admin_Page
         $this->_template_args['line_item_table'] = $Line_Item_Display->display_line_item(
             $this->_transaction->total_line_item()
         );
-        $this->_template_args['REG_code'] = $this->_transaction->primary_registration()->reg_code();
-
+        $this->_template_args['REG_code'] = $this->_transaction->primary_registration() instanceof EE_Registration
+            ? $this->_transaction->primary_registration()->reg_code()
+            : null;
         // process taxes
         $taxes = $this->_transaction->line_items(array(array('LIN_type' => EEM_Line_Item::type_tax)));
         $this->_template_args['taxes'] = ! empty($taxes) ? $taxes : false;
@@ -1081,9 +1082,10 @@ class Transactions_Admin_Page extends EE_Admin_Page
             );
         }
 
-        $this->_template_args['txn_details']['registration_session']['value'] = $this->_transaction
-            ->primary_registration()
-            ->session_ID();
+        $this->_template_args['txn_details']['registration_session']['value']
+            = $this->_transaction->primary_registration() instanceof EE_Registration
+            ? $this->_transaction->primary_registration()->session_ID()
+            : null;
         $this->_template_args['txn_details']['registration_session']['label'] = esc_html__(
             'Registration Session',
             'event_espresso'

--- a/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
+++ b/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
@@ -2,10 +2,17 @@
 
 namespace EventEspressoBatchRequest\JobHandlers;
 
+use EE_Base_Class;
+use EE_Error;
 use EEM_Event;
 use EEM_Price;
+use EEM_Registration;
 use EEM_Ticket;
+use EEM_Transaction;
+use EETests\bootstrap\CoreLoader;
 use EventEspresso\core\exceptions\InvalidClassException;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\orm\tree_traversal\ModelObjNode;
 use EventEspresso\core\services\orm\tree_traversal\NodeGroupDao;
@@ -13,6 +20,8 @@ use EventEspressoBatchRequest\Helpers\BatchRequestException;
 use EventEspressoBatchRequest\Helpers\JobParameters;
 use EventEspressoBatchRequest\Helpers\JobStepResponse;
 use EventEspressoBatchRequest\JobHandlerBaseClasses\JobHandler;
+use InvalidArgumentException;
+use ReflectionException;
 
 /**
  * Class EventDeletion
@@ -32,17 +41,23 @@ class PreviewEventDeletion extends JobHandler
      * @var NodeGroupDao
      */
     protected $model_obj_node_group_persister;
+
     public function __construct(NodeGroupDao $model_obj_node_group_persister)
     {
         $this->model_obj_node_group_persister = $model_obj_node_group_persister;
     }
 
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+
     /**
      *
      * @param JobParameters $job_parameters
-     * @throws BatchRequestException
      * @return JobStepResponse
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function create_job(JobParameters $job_parameters)
     {
@@ -51,7 +66,6 @@ class PreviewEventDeletion extends JobHandler
         // Find all the root nodes to delete (this isn't just events, because there's other data, like related tickets,
         // prices, message templates, etc, whose model definition doesn't make them dependent on events. But,
         // we have no UI to access them independent of events, so they may as well get deleted too.)
-        $model_objects_to_delete = [];
         $roots = [];
         foreach ($event_ids as $event_id) {
             $roots[] = new ModelObjNode(
@@ -67,6 +81,13 @@ class PreviewEventDeletion extends JobHandler
                     ]
                 ]
             );
+            foreach ($related_non_global_tickets as $ticket) {
+                $roots[] = new ModelObjNode(
+                    $ticket->ID(),
+                    $ticket->get_model(),
+                    ['Registration']
+                );
+            }
             $related_non_global_prices = EEM_Price::instance()->get_all_deleted_and_undeleted(
                 [
                     [
@@ -75,19 +96,33 @@ class PreviewEventDeletion extends JobHandler
                     ]
                 ]
             );
-            $roots = array_merge(
-                $roots,
-                // Dont have ticket nodes also traverse registrations, its unnecessary because
-                // registrations also depend on events so they will already get traversed.
-                $this->createModelObjNodes($related_non_global_tickets, ['Registration']),
-                $this->createModelObjNodes($related_non_global_prices)
+            foreach ($related_non_global_prices as $price) {
+                $roots[] = new ModelObjNode(
+                    $price->ID(),
+                    $price->get_model()
+                );
+            }
+        }
+        $transactions_ids = $this->getTransactionsToDelete($event_ids);
+        foreach ($transactions_ids as $transaction_id) {
+            $roots[] = new ModelObjNode(
+                $transaction_id,
+                EEM_Transaction::instance(),
+                ['Registration']
             );
         }
         $job_parameters->add_extra_data('roots', $roots);
         // Set an estimate of how long this will take (we're discovering as we go, so it seems impossible to give
         // an accurate count.)
-        $estimated_work_per_model_obj = 100;
-        $job_parameters->set_job_size(count($roots) * $estimated_work_per_model_obj);
+        $estimated_work_per_model_obj = 10;
+        $count_regs = EEM_Registration::instance()->count(
+            [
+                [
+                    'EVT_ID' => ['IN', $event_ids]
+                ]
+            ]
+        );
+        $job_parameters->set_job_size((count($roots) + $count_regs) * $estimated_work_per_model_obj);
         return new JobStepResponse(
             $job_parameters,
             esc_html__('Generating preview of data to be deleted...', 'event_espresso')
@@ -98,6 +133,12 @@ class PreviewEventDeletion extends JobHandler
      * @since $VID:$
      * @param EE_Base_Class[] $model_objs
      * @param array $dont_traverse_models
+     * @return array
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     protected function createModelObjNodes($model_objs, array $dont_traverse_models = [])
     {
@@ -110,6 +151,54 @@ class PreviewEventDeletion extends JobHandler
             );
         }
         return $nodes;
+    }
+
+    /**
+     * Gets all the transactions related to these events that aren't related to other events. They'll be deleted too.
+     * (Ones that are related to other events can stay around until those other events are deleted too.)
+     * @since $VID:$
+     * @param $event_ids
+     * @return array of transaction IDs
+     */
+    protected function getTransactionsToDelete($event_ids)
+    {
+        if (empty($event_ids)) {
+            return [];
+        }
+        global $wpdb;
+        $event_ids = array_map(
+            'intval',
+            $event_ids
+        );
+        $imploded_sanitized_event_ids = implode(',', $event_ids);
+        // Select transactions with registrations for the events $event_ids which also don't have registrations
+        // for any events NOT in $event_ids.
+        // Notice the outer query searched for transactions whose registrations ARE in $event_ids,
+        // whereas the inner query checks if the outer query's transaction has any registrations that are
+        // NOT IN $event_ids (ie, don't have registrations for events we're not just about to delete.)
+        return array_map(
+            'intval',
+            $wpdb->get_col(
+                "SELECT 
+                      DISTINCT t.TXN_ID
+                    FROM 
+                      {$wpdb->prefix}esp_transaction t INNER JOIN 
+                      {$wpdb->prefix}esp_registration r ON t.TXN_ID=r.TXN_ID
+                    WHERE
+                       r.EVT_ID IN ({$imploded_sanitized_event_ids})
+                       AND NOT EXISTS 
+                       (
+                         SELECT 
+                           t.TXN_ID
+                         FROM 
+                           {$wpdb->prefix}esp_transaction tsub INNER JOIN 
+                           {$wpdb->prefix}esp_registration rsub ON tsub.TXN_ID=rsub.TXN_ID
+                         WHERE
+                           tsub.TXN_ID=t.TXN_ID AND
+                           rsub.EVT_ID NOT IN ({$imploded_sanitized_event_ids})
+                       )"
+            )
+        );
     }
 
     /**
@@ -130,7 +219,7 @@ class PreviewEventDeletion extends JobHandler
             if ($units_processed >= $batch_size) {
                 break;
             }
-            if (! $root_node instanceof ModelObjNode) {
+            if (!$root_node instanceof ModelObjNode) {
                 throw new InvalidClassException('ModelObjNode');
             }
             if ($root_node->isComplete()) {

--- a/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
+++ b/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
@@ -99,7 +99,7 @@ class PreviewEventDeletion extends JobHandler
      * @param EE_Base_Class[] $model_objs
      * @param array $dont_traverse_models
      */
-    protected function createModelObjNodes($model_objs, $dont_traverse_models = [])
+    protected function createModelObjNodes($model_objs, array $dont_traverse_models = [])
     {
         $nodes = [];
         foreach ($model_objs as $model_obj) {

--- a/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
+++ b/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
@@ -79,7 +79,7 @@ class PreviewEventDeletion extends JobHandler
                 $roots,
                 // Dont have ticket nodes also traverse registrations, its unnecessary because
                 // registrations also depend on events so they will already get traversed.
-                $this->createModelObjNodes($related_non_global_tickets,['Registration']),
+                $this->createModelObjNodes($related_non_global_tickets, ['Registration']),
                 $this->createModelObjNodes($related_non_global_prices)
             );
         }
@@ -102,7 +102,7 @@ class PreviewEventDeletion extends JobHandler
     protected function createModelObjNodes($model_objs, $dont_traverse_models = [])
     {
         $nodes = [];
-        foreach($model_objs as $model_obj){
+        foreach ($model_objs as $model_obj) {
             $nodes[] = new ModelObjNode(
                 $model_obj->ID(),
                 $model_obj->get_model(),

--- a/core/services/orm/tree_traversal/BaseNode.php
+++ b/core/services/orm/tree_traversal/BaseNode.php
@@ -35,6 +35,13 @@ abstract class BaseNode
      * @var boolean
      */
     protected $complete;
+
+
+    /**
+     * @var array of model names we don't want to traverse
+     */
+    protected $dont_traverse_models;
+
     /**
      * Whether this item has already been initialized
      */
@@ -107,8 +114,10 @@ abstract class BaseNode
     public function __sleep()
     {
         $this->c = $this->complete;
+        $this->dtm = $this->dont_traverse_models;
         return [
-            'c'
+            'c',
+            'dtm'
         ];
     }
 
@@ -119,6 +128,7 @@ abstract class BaseNode
     public function __wakeup()
     {
         $this->complete = $this->c;
+        $this->dont_traverse_models = $this->dtm;
     }
 }
 // End of file BaseNode.php

--- a/core/services/orm/tree_traversal/ModelObjNode.php
+++ b/core/services/orm/tree_traversal/ModelObjNode.php
@@ -42,10 +42,11 @@ class ModelObjNode extends BaseNode
      * @param $model_obj_id
      * @param EEM_Base $model
      */
-    public function __construct($model_obj_id, EEM_Base $model)
+    public function __construct($model_obj_id, EEM_Base $model, $dont_traverse_models = array())
     {
         $this->id = $model_obj_id;
         $this->model = $model;
+        $this->dont_traverse_models = $dont_traverse_models;
     }
 
     /**
@@ -62,10 +63,28 @@ class ModelObjNode extends BaseNode
     {
         $this->nodes = [];
         foreach ($this->model->relation_settings() as $relationName => $relation) {
+            // Make sure this isn't one of the models we were told to not traverse into.
+            if(in_array($relationName,$this->dont_traverse_models)){
+                continue;
+            }
             if ($relation instanceof EE_Has_Many_Relation) {
-                $this->nodes[ $relationName ] = new RelationNode($this->id, $this->model, $relation->get_other_model());
-            } elseif ($relation instanceof EE_HABTM_Relation) {
-                $this->nodes[ $relation->get_join_model()->get_this_model_name() ] = new RelationNode($this->id, $this->model, $relation->get_join_model());
+                $this->nodes[ $relationName ] = new RelationNode(
+                    $this->id,
+                    $this->model,
+                    $relation->get_other_model(),
+                    $this->dont_traverse_models
+                );
+            } elseif ($relation instanceof EE_HABTM_Relation &&
+                ! in_array(
+                    $relation->get_join_model()->get_this_model_name(),
+                    $this->dont_traverse_models
+                )) {
+                $this->nodes[ $relation->get_join_model()->get_this_model_name() ] = new RelationNode(
+                    $this->id,
+                    $this->model,
+                    $relation->get_join_model(),
+                    $this->dont_traverse_models
+                );
             }
         }
         ksort($this->nodes);

--- a/core/services/orm/tree_traversal/ModelObjNode.php
+++ b/core/services/orm/tree_traversal/ModelObjNode.php
@@ -64,7 +64,7 @@ class ModelObjNode extends BaseNode
         $this->nodes = [];
         foreach ($this->model->relation_settings() as $relationName => $relation) {
             // Make sure this isn't one of the models we were told to not traverse into.
-            if(in_array($relationName,$this->dont_traverse_models)){
+            if (in_array($relationName, $this->dont_traverse_models)) {
                 continue;
             }
             if ($relation instanceof EE_Has_Many_Relation) {

--- a/core/services/orm/tree_traversal/ModelObjNode.php
+++ b/core/services/orm/tree_traversal/ModelObjNode.php
@@ -41,8 +41,9 @@ class ModelObjNode extends BaseNode
      * We don't pass the model objects because this needs to serialize to something tiny for effiency.
      * @param $model_obj_id
      * @param EEM_Base $model
+     * @param array $dont_traverse_models array of model names we DON'T want to traverse.
      */
-    public function __construct($model_obj_id, EEM_Base $model, array $dont_traverse_models = []])
+    public function __construct($model_obj_id, EEM_Base $model, array $dont_traverse_models = [])
     {
         $this->id = $model_obj_id;
         $this->model = $model;

--- a/core/services/orm/tree_traversal/ModelObjNode.php
+++ b/core/services/orm/tree_traversal/ModelObjNode.php
@@ -42,7 +42,7 @@ class ModelObjNode extends BaseNode
      * @param $model_obj_id
      * @param EEM_Base $model
      */
-    public function __construct($model_obj_id, EEM_Base $model, $dont_traverse_models = array())
+    public function __construct($model_obj_id, EEM_Base $model, array $dont_traverse_models = []])
     {
         $this->id = $model_obj_id;
         $this->model = $model;

--- a/core/services/orm/tree_traversal/RelationNode.php
+++ b/core/services/orm/tree_traversal/RelationNode.php
@@ -53,8 +53,19 @@ class RelationNode extends BaseNode
      */
     protected $nodes;
 
-    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model, array $dont_traverse_models = [])
-    {
+    /**
+     * RelationNode constructor.
+     * @param $main_model_obj_id
+     * @param EEM_Base $main_model
+     * @param EEM_Base $related_model
+     * @param array $dont_traverse_models array of model names we DON'T want to traverse
+     */
+    public function __construct(
+        $main_model_obj_id,
+        EEM_Base $main_model,
+        EEM_Base $related_model,
+        array $dont_traverse_models = []
+    ) {
         $this->id = $main_model_obj_id;
         $this->main_model = $main_model;
         $this->related_model = $related_model;

--- a/core/services/orm/tree_traversal/RelationNode.php
+++ b/core/services/orm/tree_traversal/RelationNode.php
@@ -53,12 +53,13 @@ class RelationNode extends BaseNode
      */
     protected $nodes;
 
-    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model)
+    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model, $dont_traverse_models = [])
     {
         $this->id = $main_model_obj_id;
         $this->main_model = $main_model;
         $this->related_model = $related_model;
         $this->nodes = [];
+        $this->dont_traverse_models = $dont_traverse_models;
     }
 
 
@@ -91,7 +92,7 @@ class RelationNode extends BaseNode
 
             // Add entity nodes for each of the model objects we fetched.
             foreach ($related_model_objs as $related_model_obj) {
-                $entity_node = new ModelObjNode($related_model_obj->ID(), $related_model_obj->get_model());
+                $entity_node = new ModelObjNode($related_model_obj->ID(), $related_model_obj->get_model(), $this->dont_traverse_models);
                 $this->nodes[ $related_model_obj->ID() ] = $entity_node;
                 $new_item_nodes[ $related_model_obj->ID() ] = $entity_node;
             }

--- a/core/services/orm/tree_traversal/RelationNode.php
+++ b/core/services/orm/tree_traversal/RelationNode.php
@@ -53,7 +53,7 @@ class RelationNode extends BaseNode
      */
     protected $nodes;
 
-    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model, $dont_traverse_models = [])
+    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model, array $dont_traverse_models = [])
     {
         $this->id = $main_model_obj_id;
         $this->main_model = $main_model;

--- a/docs/G--Model-System/tree-traversal.md
+++ b/docs/G--Model-System/tree-traversal.md
@@ -1,0 +1,176 @@
+# Model Object Tree Traversal
+Event Espresso model objects (representing database rows) can depend on other model objects through their foreign keys.
+Those model objects can in turn depend on others. This can make a fairly wide tree of dependencies. This articles documents
+some classes that help traversing that tree, whose first application is performing "cascading deletions" (instead of just
+deleting a single model object, also recursively delete all its dependent model objects.)
+
+Here's an example of a model object dependency tree.
+
+```
+Event 1 has dependents:
+-Datetime 1 has dependents:
+--Datetime Ticket 1
+--Datetime Ticket 2
+-Registration 1 has dependents:
+--Answer 1
+--Answer 2
+--Registration_Payment 1
+-Registration 2 has dependents:
+--Answer 3
+--Answer 4
+--Registraiton_Payment 2
+-Event Venue 1
+-Event_Message_Template 1
+-Event_Message_Template 2
+-Event_Message_Template 3
+-Event_Message_Template 4
+-Event_Message_Template 5
+-Event_Message_Template 6
+-Event_Message_Template 7
+-Event_Message_Template 8
+-Event_Question_Group
+-Term_Relationship 1
+-Term_Relationship 2
+-Term_Relationship 3
+
+etc...
+```
+The situation gets worse considering add-ons may define other model objects which are also related.
+
+As you might guess, discovering all the model objects that depend on a particular model object can take quite a few database queries,
+so it's often best to perform these as part of a batch process.
+
+These classes are in the namespace (and corresponding folder) `\EventEspresso\core\services\orm\tree_traversal\`
+
+## ModelObjNode
+This class wraps a single model object, and contains the logic for discovering its dependent model objects. It can do this
+all at once, or across multiple method invocations. Eg
+
+```php
+// Given a transaction model object...
+$t = EEM_Transaction::instance()->get_one();
+
+// Create a ModelObjNode around it.
+$transaction_node = new ModelObjNode($t->ID(), $t->get_model());
+
+// Then request it discover 10 of its dependent model objects. If we wanted to get all of them at once, we could pass INF constant.
+$transaction_node->visit(10);
+
+// And see what they are (the returned array is indexed first by model name whose value is an array of IDs.)
+$model_names_and_ids = $transaction_node->getIds();
+
+// You can do whatever you want with them, like display them, or delete them. 
+// Let's delete them.
+foreach($model_names_and_ids as $model_name => $ids){
+    $model = EE_Registry::instance()->load_model($model_name); 
+    $model->delete_permanently(
+        [
+            [
+                $model->primary_key_name() => ['IN', $ids]
+            ]
+        ],
+        false // Don't block if there are dependent model objects. They're all on the chopping block!
+    );
+}
+```
+
+Also, `ModelObjNode`s are meant to be easily serializable, so the following code is fine:
+```php
+// Given a transaction model object...
+$t = EEM_Transaction::instance()->get_one();
+
+// Create a ModelObjNode around it.
+$transaction_node = new ModelObjNode($t->ID(), $t->get_model());
+
+// Then request it discover 10 of its dependent model objects. If we wanted to get all of them at once, we could pass INF constant.
+$transaction_node->visit(10);
+
+// Serialize the transaction node.
+$t_serialized = serialize($transaction_node);
+
+// Unserialize it.
+$transaction_node_unserialized = unserialize($t_serialized);
+
+// Keep using it to grab the next 10 rows (ie: 11-20).
+// It will pick up where it left off exploring the tree
+$transaction_node_unserialized->visit(10);
+```
+
+`ModelObjNode::visit()` identifies all the model object's dependent model objects.
+`ModelObjNode::toArray()` returns an array representation of the tree of dependent model objects. This may be helpful in
+visualizing the tree and in displaying it as a tree.
+`ModelObjNode::getIds()` returns a 2D array, whose top-keys are the names of dependent model objects, and whose value is an array of their IDs.
+Useful if you want to organize the tree by model type.
+
+### A note about internal details of ModelObjNode::visit()
+`ModelObjNode::visit()` internally does the following:
+
+* Create a `RelationNode` for each of the model's `EE_Has_Many_Relation`s and the join models for `EE_HABTM_Relation`s
+(eg on `EEM_Transaction`, it would make one for `Registration`, `Payment`, `Line_Item`, `Message`, `Extra_Meta`, etc)
+* Call `visit()` on each of them, which
+* Finds all of the model objects across that relation (eg when called on the `RelationNode` for `Registration`, 
+it finds all the registrations related to the original transaction)
+* For each of those related model objects, create a `ModelObjNode` and calls `visit()` on it (recurses)
+
+So `RelationNode` is only expected to be used internally.
+
+## NodeGroupDao
+
+If there could be hundreds of dependent model objects, you'll probably need to call `ModelObjNode::visit()` multiple 
+times across multiple HTTP requests. This requires saving state between requests.
+The `ModelObjNode`s are designed to be quite small when serialized. 
+`NodeGroupDao` helps with saving `ModelObjNode`s across multiple requests by saving state to the WordPress Options table.
+It has methods for generating a unique code to be used in the option name, serializing a group of `ModelObjNode`s to the
+database, fetching a group of serialized `ModelObjNode`s from the database, and deleting the group of nodes from the database.
+E.g.,
+
+```php 
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$code = $nodeGroupDao->generateGroupCode();
+$some_obj_to_traverse = [
+    EEM_Event::instance()->get_one(),
+    EEM_Venue::instance()->get_one()
+];
+// Store those ModelObjNodes to the DB.
+$nodeGroupDao->persistModelObjNodesGroup($some_obj_to_traverse, $code);
+
+```
+
+Then, on a subsequent request, using the `$code` (which you can put in the session, querystring, etc) you can retrieve
+those same `ModelObjNode`s and continue using them, like so:
+
+```php
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$some_obj_to_traverse = $nodeGroupDao->getModelObjNodesInGroup($code);
+
+// And now you can continue using the ModelObjNodes
+foreach($some_obj_to_traverse as $model_obj_node){
+    $model_obj_node->visit(100);
+}
+// And optionally store them again...
+$nodeGroupDao->persistModelObjNodesGroup($some_obj_to_traverse, $code);
+```
+
+Or you could get the actual model object IDs later, and delete it.
+
+```php
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$models_and_ids = $nodeGroupDao->getModelsAndIdsFromGroup($code);
+
+// Do whatever you want with those model objects, like deleting them.
+foreach($models_and_ids as $model_name => $ids){
+    $model = EE_Registry::instance()->load_model($model_name); 
+    $model->delete_permanently(
+        [
+            [
+                $model->primary_key_name() => ['IN', $ids]
+            ]
+        ],
+        false // Don't block if there are dependent model objects. They're all on the chopping block!
+    );
+}
+
+// And remove the option (which can be several MBs if it contains thousands of model objects.)
+$nodeGroupDao->deleteModelObjNodesInGroup($code);
+```
+

--- a/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
@@ -204,12 +204,12 @@ class ModelObjNodeTest extends EE_UnitTestCase
         // Asserts that the serialized model object node stays small. Less than 125 would be great (half of it is taken
         // up by the classname
 //        echo serialize($e_node);
-        $this->assertLessThan(152, strlen(serialize($e_node)));
+        $this->assertLessThan(153, strlen(serialize($e_node)));
 
         // Also check that the fully discovered node isn't too big.
         $e_node->visit(100);
 //        echo serialize($e_node);
-        $this->assertLessThan(158, strlen(serialize($e_node)));
+        $this->assertLessThan(159, strlen(serialize($e_node)));
     }
 
     public function testDontVisitModelsDirectChildren()

--- a/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
@@ -204,12 +204,64 @@ class ModelObjNodeTest extends EE_UnitTestCase
         // Asserts that the serialized model object node stays small. Less than 125 would be great (half of it is taken
         // up by the classname
 //        echo serialize($e_node);
-        $this->assertLessThan(138, strlen(serialize($e_node)));
+        $this->assertLessThan(152, strlen(serialize($e_node)));
 
         // Also check that the fully discovered node isn't too big.
         $e_node->visit(100);
 //        echo serialize($e_node);
-        $this->assertLessThan(144, strlen(serialize($e_node)));
+        $this->assertLessThan(158, strlen(serialize($e_node)));
+    }
+
+    public function testDontVisitModelsDirectChildren()
+    {
+        $e = $this->new_model_obj_with_dependencies('Event');
+        $d = $this->new_model_obj_with_dependencies(
+            'Datetime',
+            [
+                'EVT_ID' => $e->ID()
+            ]
+        );
+        $t = $this->new_model_obj_with_dependencies('Ticket');
+        $d->_add_relation_to($t, 'Ticket');
+        $r = $this->new_model_obj_with_dependencies(
+            'Registration',
+            [
+                'EVT_ID' => $e->ID(),
+                'TKT_ID' => $t->ID()
+            ]
+        );
+        $e_node = new ModelObjNode($e->ID(), $e->get_model(), ['Registration']);
+        $e_node->visit(1000);
+        $ids_found = $e_node->getIds();
+        $this->assertArrayNotHasKey('Registration', $ids_found);
+        $this->assertArrayHasKey('Datetime',$ids_found);
+        $this->assertArrayHasKey('Datetime_Ticket',$ids_found);
+    }
+
+    public function testDontVisitModelsIndirectChildren()
+    {
+        $e = $this->new_model_obj_with_dependencies('Event');
+        $d = $this->new_model_obj_with_dependencies(
+            'Datetime',
+            [
+                'EVT_ID' => $e->ID()
+            ]
+        );
+        $t = $this->new_model_obj_with_dependencies('Ticket');
+        $d->_add_relation_to($t, 'Ticket');
+        $r = $this->new_model_obj_with_dependencies(
+            'Registration',
+            [
+                'EVT_ID' => $e->ID(),
+                'TKT_ID' => $t->ID()
+            ]
+        );
+        $e_node = new ModelObjNode($e->ID(), $e->get_model(), ['Datetime_Ticket']);
+        $e_node->visit(1000);
+        $ids_found = $e_node->getIds();
+        $this->assertArrayHasKey('Registration', $ids_found);
+        $this->assertArrayHasKey('Datetime',$ids_found);
+        $this->assertArrayNotHasKey('Datetime_Ticket',$ids_found);
     }
 }
 // End of file EntityNodeTest.php

--- a/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
@@ -105,7 +105,7 @@ class RelationNodeTest extends EE_UnitTestCase
         $e = $this->new_model_obj_with_dependencies('Event');
         $e_node = new RelationNode($e->ID(), $e->get_model(), EEM_Event_Venue::instance());
         // echo serialize($e_node);
-        $this->assertLessThan(201, strlen(serialize($e_node)));
+        $this->assertLessThan(202, strlen(serialize($e_node)));
     }
 }
 // End of file RelationNodeTest.php

--- a/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
@@ -105,7 +105,7 @@ class RelationNodeTest extends EE_UnitTestCase
         $e = $this->new_model_obj_with_dependencies('Event');
         $e_node = new RelationNode($e->ID(), $e->get_model(), EEM_Event_Venue::instance());
         // echo serialize($e_node);
-        $this->assertLessThan(188, strlen(serialize($e_node)));
+        $this->assertLessThan(201, strlen(serialize($e_node)));
     }
 }
 // End of file RelationNodeTest.php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Makes the cascading deletion of events more efficient by avoiding repeatedly traversing registrations. 
Registrations depend (ie, have a foreign key to) both events and tickets, and `PreviewEventDeletion` used both an event and its indirectly-related tickets are root nodes, registrations used to get traversed twice (which took up extra CPU and disk space when they got stored.)
This can make the individual `ModelObjNode`s serialize about a tenth bigger, but it can avoid unnecessarily traversing almost half the number of model objects.
This should also help with https://github.com/eventespresso/event-espresso-core/pull/2225#discussion_r367101270 because there is no need to re-traverse registrations (and their answers) when deleting a transaction.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] On master, trash an event with registrations.
* Click to "permanently delete" it
* Run the DB query `select option_name, char_length(option_value) as c from wp_options WHERE option_name like 'ee_deletion_%' order by option_id desc limit 1;` to see the size of the most-recent option storing information about what will be deleted
* DON'T actually delete the event
* [ ] Repeat the the above steps, but with this branch. Note that the size of the wp_option should be significantly smaller.
* Now verify when you delete the event, its registrations were correctly deleted too.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
