### PR TITLE
Delete transactions too (assess while generating preview)

### DIFF
--- a/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
+++ b/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
@@ -46,23 +46,17 @@ class ConfirmEventDeletionForm extends \EE_Form_Section_Proper
         }
         $this->events = $events;
         $events_inputs = [
-            'intro' => new EE_Form_Section_HTML(
-                EEH_HTML::h2(esc_html__('In order to prevent accidentally deleting the wrong events, please enter the unique URL slug of each event.', 'event_espresso'))
-            )
         ];
         foreach ($events as $event) {
-             $events_inputs[ $event->ID() ] = new \EE_Text_Input(
-                 [
-                    'html_label_text' => esc_html(
-                        sprintf(
-                            __('Please enter the URL slug of "%1$s" (hint: it’s "%2$s")', 'event_espresso'),
-                            $event->name(),
-                            $event->slug()
-                        )
-                    ),
-                    'required' => false
-                 ]
-             );
+             $events_inputs[ $event->ID() ] = new EE_Checkbox_Multi_Input(
+                [
+                    'yes' => $event->name(),
+                ],
+                [
+                    'html_label_text' => esc_html__('Please confirm you wish to delete:', 'event_espresso'),
+                    'required' => true
+                ]
+            );
         }
         $events_subsection->add_subsections($events_inputs);
         $options_array['subsections']['backup'] = new EE_Checkbox_Multi_Input(
@@ -75,24 +69,6 @@ class ConfirmEventDeletionForm extends \EE_Form_Section_Proper
             ]
         );
         parent::__construct($options_array);
-    }
-
-    public function _validate()
-    {
-        parent::_validate();
-        $events_subsection = $this->get_proper_subsection('events');
-        foreach ($this->events as $event) {
-            $event_input = $events_subsection->get_input($event->ID());
-            if ((string) $event_input->normalized_value() !== $event->slug()) {
-                $event_input->add_validation_error(
-                    sprintf(
-                        esc_html__('You entered the incorrect URL slug for the event "%1$s". Please enter it again (use "%2$s") to confirm you are deleting the correct event.', 'event_espresso'),
-                        $event->name(),
-                        $event->slug()
-                    )
-                );
-            }
-        }
     }
 }
 // End of file ConfirmEventDeletionForm.php

--- a/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
+++ b/admin_pages/events/form_sections/ConfirmEventDeletionForm.php
@@ -12,7 +12,8 @@ use EventEspresso\core\exceptions\UnexpectedEntityException;
 /**
  * Class ConfirmEventDeletionForm
  *
- * Description
+ * Special form that requests the user confirm they want to delete the specified events, and have made a database
+ * backup.
  *
  * @package     Event Espresso
  * @author         Mike Nelson
@@ -48,7 +49,7 @@ class ConfirmEventDeletionForm extends \EE_Form_Section_Proper
         $events_inputs = [
         ];
         foreach ($events as $event) {
-             $events_inputs[ $event->ID() ] = new EE_Checkbox_Multi_Input(
+            $events_inputs[ $event->ID() ] = new EE_Checkbox_Multi_Input(
                 [
                     'yes' => $event->name(),
                 ],

--- a/admin_pages/events/templates/event_preview_deletion.template.php
+++ b/admin_pages/events/templates/event_preview_deletion.template.php
@@ -67,7 +67,7 @@ if ($reg_count > count($registrations)) {
     <?php
 }
 ?>
-<p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events. You can delete the contacts afterwards if you like.', 'event_espresso'); ?></p>
+<p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events.', 'event_espresso'); ?></p>
 <ul>
     <?php
     foreach ($registrations as $registration) {

--- a/admin_pages/events/templates/event_preview_deletion.template.php
+++ b/admin_pages/events/templates/event_preview_deletion.template.php
@@ -67,7 +67,13 @@ if ($reg_count > count($registrations)) {
     <?php
 }
 ?>
-<p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events.', 'event_espresso'); ?></p>
+<?php
+if ($reg_count > 0) {
+    ?>
+    <p><?php esc_html_e('Note: contacts will not be deleted, only their registrations for the enumerated events.', 'event_espresso'); ?></p>
+    <?php
+}
+?>
 <ul>
     <?php
     foreach ($registrations as $registration) {

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -1082,7 +1082,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
             );
         }
 
-        $this->_template_args['txn_details']['registration_session']['value'] 
+        $this->_template_args['txn_details']['registration_session']['value']
             = $this->_transaction->primary_registration() instanceof EE_Registration
             ? $this->_transaction->primary_registration()->session_ID()
             : null;

--- a/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
+++ b/core/libraries/batch/JobHandlers/PreviewEventDeletion.php
@@ -9,6 +9,7 @@ use EEM_Price;
 use EEM_Registration;
 use EEM_Ticket;
 use EEM_Transaction;
+use EETests\bootstrap\CoreLoader;
 use EventEspresso\core\exceptions\InvalidClassException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;

--- a/core/services/orm/tree_traversal/ModelObjNode.php
+++ b/core/services/orm/tree_traversal/ModelObjNode.php
@@ -41,8 +41,9 @@ class ModelObjNode extends BaseNode
      * We don't pass the model objects because this needs to serialize to something tiny for effiency.
      * @param $model_obj_id
      * @param EEM_Base $model
+     * @param array $dont_traverse_models array of model names we DON'T want to traverse.
      */
-    public function __construct($model_obj_id, EEM_Base $model, array $dont_traverse_models = []])
+    public function __construct($model_obj_id, EEM_Base $model, array $dont_traverse_models = [])
     {
         $this->id = $model_obj_id;
         $this->model = $model;

--- a/core/services/orm/tree_traversal/RelationNode.php
+++ b/core/services/orm/tree_traversal/RelationNode.php
@@ -53,8 +53,19 @@ class RelationNode extends BaseNode
      */
     protected $nodes;
 
-    public function __construct($main_model_obj_id, EEM_Base $main_model, EEM_Base $related_model, array $dont_traverse_models = [])
-    {
+    /**
+     * RelationNode constructor.
+     * @param $main_model_obj_id
+     * @param EEM_Base $main_model
+     * @param EEM_Base $related_model
+     * @param array $dont_traverse_models array of model names we DON'T want to traverse
+     */
+    public function __construct(
+        $main_model_obj_id,
+        EEM_Base $main_model,
+        EEM_Base $related_model,
+        array $dont_traverse_models = []
+    ) {
         $this->id = $main_model_obj_id;
         $this->main_model = $main_model;
         $this->related_model = $related_model;

--- a/docs/G--Model-System/tree-traversal.md
+++ b/docs/G--Model-System/tree-traversal.md
@@ -1,0 +1,176 @@
+# Model Object Tree Traversal
+Event Espresso model objects (representing database rows) can depend on other model objects through their foreign keys.
+Those model objects can in turn depend on others. This can make a fairly wide tree of dependencies. This articles documents
+some classes that help traversing that tree, whose first application is performing "cascading deletions" (instead of just
+deleting a single model object, also recursively delete all its dependent model objects.)
+
+Here's an example of a model object dependency tree.
+
+```
+Event 1 has dependents:
+-Datetime 1 has dependents:
+--Datetime Ticket 1
+--Datetime Ticket 2
+-Registration 1 has dependents:
+--Answer 1
+--Answer 2
+--Registration_Payment 1
+-Registration 2 has dependents:
+--Answer 3
+--Answer 4
+--Registraiton_Payment 2
+-Event Venue 1
+-Event_Message_Template 1
+-Event_Message_Template 2
+-Event_Message_Template 3
+-Event_Message_Template 4
+-Event_Message_Template 5
+-Event_Message_Template 6
+-Event_Message_Template 7
+-Event_Message_Template 8
+-Event_Question_Group
+-Term_Relationship 1
+-Term_Relationship 2
+-Term_Relationship 3
+
+etc...
+```
+The situation gets worse considering add-ons may define other model objects which are also related.
+
+As you might guess, discovering all the model objects that depend on a particular model object can take quite a few database queries,
+so it's often best to perform these as part of a batch process.
+
+These classes are in the namespace (and corresponding folder) `\EventEspresso\core\services\orm\tree_traversal\`
+
+## ModelObjNode
+This class wraps a single model object, and contains the logic for discovering its dependent model objects. It can do this
+all at once, or across multiple method invocations. Eg
+
+```php
+// Given a transaction model object...
+$t = EEM_Transaction::instance()->get_one();
+
+// Create a ModelObjNode around it.
+$transaction_node = new ModelObjNode($t->ID(), $t->get_model());
+
+// Then request it discover 10 of its dependent model objects. If we wanted to get all of them at once, we could pass INF constant.
+$transaction_node->visit(10);
+
+// And see what they are (the returned array is indexed first by model name whose value is an array of IDs.)
+$model_names_and_ids = $transaction_node->getIds();
+
+// You can do whatever you want with them, like display them, or delete them. 
+// Let's delete them.
+foreach($model_names_and_ids as $model_name => $ids){
+    $model = EE_Registry::instance()->load_model($model_name); 
+    $model->delete_permanently(
+        [
+            [
+                $model->primary_key_name() => ['IN', $ids]
+            ]
+        ],
+        false // Don't block if there are dependent model objects. They're all on the chopping block!
+    );
+}
+```
+
+Also, `ModelObjNode`s are meant to be easily serializable, so the following code is fine:
+```php
+// Given a transaction model object...
+$t = EEM_Transaction::instance()->get_one();
+
+// Create a ModelObjNode around it.
+$transaction_node = new ModelObjNode($t->ID(), $t->get_model());
+
+// Then request it discover 10 of its dependent model objects. If we wanted to get all of them at once, we could pass INF constant.
+$transaction_node->visit(10);
+
+// Serialize the transaction node.
+$t_serialized = serialize($transaction_node);
+
+// Unserialize it.
+$transaction_node_unserialized = unserialize($t_serialized);
+
+// Keep using it to grab the next 10 rows (ie: 11-20).
+// It will pick up where it left off exploring the tree
+$transaction_node_unserialized->visit(10);
+```
+
+`ModelObjNode::visit()` identifies all the model object's dependent model objects.
+`ModelObjNode::toArray()` returns an array representation of the tree of dependent model objects. This may be helpful in
+visualizing the tree and in displaying it as a tree.
+`ModelObjNode::getIds()` returns a 2D array, whose top-keys are the names of dependent model objects, and whose value is an array of their IDs.
+Useful if you want to organize the tree by model type.
+
+### A note about internal details of ModelObjNode::visit()
+`ModelObjNode::visit()` internally does the following:
+
+* Create a `RelationNode` for each of the model's `EE_Has_Many_Relation`s and the join models for `EE_HABTM_Relation`s
+(eg on `EEM_Transaction`, it would make one for `Registration`, `Payment`, `Line_Item`, `Message`, `Extra_Meta`, etc)
+* Call `visit()` on each of them, which
+* Finds all of the model objects across that relation (eg when called on the `RelationNode` for `Registration`, 
+it finds all the registrations related to the original transaction)
+* For each of those related model objects, create a `ModelObjNode` and calls `visit()` on it (recurses)
+
+So `RelationNode` is only expected to be used internally.
+
+## NodeGroupDao
+
+If there could be hundreds of dependent model objects, you'll probably need to call `ModelObjNode::visit()` multiple 
+times across multiple HTTP requests. This requires saving state between requests.
+The `ModelObjNode`s are designed to be quite small when serialized. 
+`NodeGroupDao` helps with saving `ModelObjNode`s across multiple requests by saving state to the WordPress Options table.
+It has methods for generating a unique code to be used in the option name, serializing a group of `ModelObjNode`s to the
+database, fetching a group of serialized `ModelObjNode`s from the database, and deleting the group of nodes from the database.
+E.g.,
+
+```php 
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$code = $nodeGroupDao->generateGroupCode();
+$some_obj_to_traverse = [
+    EEM_Event::instance()->get_one(),
+    EEM_Venue::instance()->get_one()
+];
+// Store those ModelObjNodes to the DB.
+$nodeGroupDao->persistModelObjNodesGroup($some_obj_to_traverse, $code);
+
+```
+
+Then, on a subsequent request, using the `$code` (which you can put in the session, querystring, etc) you can retrieve
+those same `ModelObjNode`s and continue using them, like so:
+
+```php
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$some_obj_to_traverse = $nodeGroupDao->getModelObjNodesInGroup($code);
+
+// And now you can continue using the ModelObjNodes
+foreach($some_obj_to_traverse as $model_obj_node){
+    $model_obj_node->visit(100);
+}
+// And optionally store them again...
+$nodeGroupDao->persistModelObjNodesGroup($some_obj_to_traverse, $code);
+```
+
+Or you could get the actual model object IDs later, and delete it.
+
+```php
+$nodeGroupDao = LoaderFactory::getLoader()->getShared('\EventEspresso\core\services\orm\tree_traversal\NodeGroupDao');
+$models_and_ids = $nodeGroupDao->getModelsAndIdsFromGroup($code);
+
+// Do whatever you want with those model objects, like deleting them.
+foreach($models_and_ids as $model_name => $ids){
+    $model = EE_Registry::instance()->load_model($model_name); 
+    $model->delete_permanently(
+        [
+            [
+                $model->primary_key_name() => ['IN', $ids]
+            ]
+        ],
+        false // Don't block if there are dependent model objects. They're all on the chopping block!
+    );
+}
+
+// And remove the option (which can be several MBs if it contains thousands of model objects.)
+$nodeGroupDao->deleteModelObjNodesInGroup($code);
+```
+

--- a/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/ModelObjNodeTest.php
@@ -204,12 +204,12 @@ class ModelObjNodeTest extends EE_UnitTestCase
         // Asserts that the serialized model object node stays small. Less than 125 would be great (half of it is taken
         // up by the classname
 //        echo serialize($e_node);
-        $this->assertLessThan(152, strlen(serialize($e_node)));
+        $this->assertLessThan(153, strlen(serialize($e_node)));
 
         // Also check that the fully discovered node isn't too big.
         $e_node->visit(100);
 //        echo serialize($e_node);
-        $this->assertLessThan(158, strlen(serialize($e_node)));
+        $this->assertLessThan(159, strlen(serialize($e_node)));
     }
 
     public function testDontVisitModelsDirectChildren()

--- a/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
+++ b/tests/testcases/core/services/orm/tree_traversal/RelationNodeTest.php
@@ -105,7 +105,7 @@ class RelationNodeTest extends EE_UnitTestCase
         $e = $this->new_model_obj_with_dependencies('Event');
         $e_node = new RelationNode($e->ID(), $e->get_model(), EEM_Event_Venue::instance());
         // echo serialize($e_node);
-        $this->assertLessThan(201, strlen(serialize($e_node)));
+        $this->assertLessThan(202, strlen(serialize($e_node)));
     }
 }
 // End of file RelationNodeTest.php


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Same objective as https://github.com/eventespresso/event-espresso-core/pull/2225 but figures out which transactions to delete when generating the preview page. This seems like a less hacky approach (although it does require doing a direct DB query because it uses a subquery).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create two events, named "event A" and "event B"
* Register for just "event A". Notice the new transaction's ID in the `wp_esp_transaction` table
* After completing that registration, use MER to register for both. Notice the new transaction's ID in the `wp_esp_transaction` table again
* Trash and then permanently delete "event a"
* Notice that the older transaction (the one with registrations for only "event A", none ofr "event B") was deleted; but the newer transaction (the one with registrations for both "event A" and "event B") was left intact.
* [ ] It's also good to test this with a very large dataset. I used it on a cheap shared host to delete an event with about 1500 registrations and it worked ok

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
