### PR TITLE
Registration report - convert filename spaces to '-' and add a filter

### DIFF
--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -125,7 +125,13 @@ class RegistrationsReport extends JobHandlerFile
      */
     protected function get_filename()
     {
-        return sprintf("event-espresso-registrations-%s.csv", str_replace(':', '-', current_time('mysql')));
+        return apply_filters(
+            'FHEE__EventEspressoBatchRequest__JobHandlers__RegistrationsReport__get_filename',
+            sprintf(
+                "event-espresso-registrations-%s.csv",
+                str_replace(array(':', ' '), '-', current_time('mysql'))
+            )
+        );
     }
 
 


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/error-exporting-reports/

mysql datetime format includes a space between date and time.

We've never had an issue with this but if you use Firefox to automatically open the .csv in Excel it chokes on the space.

It shows an error like: 

> Sorry, we couldn't find {path}\event-espresso-registrations-2020-01-17.xlsx. Is it possible it was moved, renamed or deleted?

https://monosnap.com/file/W2Hj1HpuPelfrd18v0ERCjBrXmcXmE

When you click ok it shows another:

> Sorry, we couldn't find 12-55-27.xlsx. Is it possible it was moved, renamed or deleted?

Converting the space fixes this and the file automatically opens.

I've also applied a filter in case anyone wants to change the filename, to say something like `eventsmart-registrations-` (Hat tip @joshfeck)

## How has this been tested

Using master with Firefox, auto open a registration CSV in excel.
(It fails for me on Windows, not sure if it will on MAC)

Either way if you view the filename it will have a space between the date and time.

Switch to this branch and repeat, this time that space should be a `-`

Then add this function to your site:

```
add_filter(
    'FHEE__EventEspressoBatchRequest__JobHandlers__RegistrationsReport__get_filename',
    'tw_ee_csv_filename'
);

function tw_ee_csv_filename( $filname ) {
	return sprintf(
        "testing-registrations-%s.csv",
        str_replace(array(':', ' '), '-', current_time('mysql'))
    );
}
```

Repeat and you should have a 'testing-registrations-{datetime}.csv` file and again, that can auto open.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
