### PR TITLE
Migrate `useRect()` hook from EDTR v1 to Prototype; closes #2261.

### DIFF
--- a/assets/prototype/application/hooks/useRect.js
+++ b/assets/prototype/application/hooks/useRect.js
@@ -1,0 +1,63 @@
+import { useLayoutEffect, useCallback, useState } from 'react';
+const { addEventListener, removeEventListener } = window;
+
+const useRect = (ref) => {
+	const [rect, setRect] = useState(getRect(ref ? ref.current : null));
+
+	const handleResize = useCallback(() => {
+		if (!ref.current) {
+			return;
+		}
+
+		// Update client rect
+		setRect(getRect(ref.current));
+	}, [ref]);
+
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) {
+			return;
+		}
+
+		handleResize();
+		// eslint-disable-next-line
+		if (ResizeObserver && typeof ResizeObserver === 'function') {
+			// eslint-disable-next-line
+			let resizeObserver = new ResizeObserver(() => handleResize());
+			resizeObserver.observe(element);
+
+			return () => {
+				if (!resizeObserver) {
+					return;
+				}
+				resizeObserver.disconnect();
+				resizeObserver = null;
+			};
+		}
+		// Browser support, remove freely
+		addEventListener('resize', handleResize);
+
+		return () => {
+			removeEventListener('resize', handleResize);
+		};
+	}, [ref.current]);
+
+	return rect;
+};
+
+function getRect(element) {
+	if (!element) {
+		return {
+			bottom: 0,
+			height: 0,
+			left: 0,
+			right: 0,
+			top: 0,
+			width: 0,
+		};
+	}
+
+	return element.getBoundingClientRect();
+}
+
+export default useRect;

--- a/assets/prototype/application/ui/components/display/entityList/filterBar/Collapsible.js
+++ b/assets/prototype/application/ui/components/display/entityList/filterBar/Collapsible.js
@@ -9,7 +9,7 @@ import { __ } from '@eventespresso/i18n';
 /**
  * Internal dependencies
  */
-import { useRect } from '@eventespresso/hooks';
+import { useRect } from '../../../../../hooks/useRect';
 
 /**
  * Collapsible

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -93,16 +93,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-value-objects': pathToEDTRv1 + 'vo/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'valueObjects'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-editor': pathToEDTRv1 + 'editor/index.js',
 		},
 		module: moduleConfigWithJsAndCssRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -83,16 +83,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-helpers': pathToEDTRv1 + 'data/helpers/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'helpers'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-editor': pathToEDTRv1 + 'editor/index.js',
 		},
 		module: moduleConfigWithJsAndCssRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -84,16 +84,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-hooks': pathToEDTRv1 + 'hooks/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'hooks'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-validators': pathToEDTRv1 + 'eejs/validators/index.js',
 		},
 		module: moduleConfigWithJsRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -74,16 +74,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-validators': pathToEDTRv1 + 'eejs/validators/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'validators'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-data-stores': pathToEDTRv1 + 'data/index.js',
 		},
 		module: moduleConfigWithJsAndCssRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -136,26 +136,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-hocs': pathToEDTRv1 + 'higher-order-components/index.js',
-		},
-		module: moduleConfigWithJsAndCssRules,
-		output: {
-			library: ['eejs', 'hocs'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
-			'eventespresso-editor-hocs': pathToEDTRv1 + 'editor-hocs/index.js',
-		},
-		module: moduleConfigWithJsAndCssRules,
-		output: {
-			library: ['eejs', 'editorHocs'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-editor': pathToEDTRv1 + 'editor/index.js',
 		},
 		module: moduleConfigWithJsAndCssRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -146,16 +146,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-components': pathToEDTRv1 + 'components/index.js',
-		},
-		module: moduleConfigWithJsAndCssRules,
-		output: {
-			library: ['eejs', 'components'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-editor-hocs': pathToEDTRv1 + 'editor-hocs/index.js',
 		},
 		module: moduleConfigWithJsAndCssRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -74,16 +74,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-utils': pathToEDTRv1 + 'utils/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'utils'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
 			'eventespresso-validators': pathToEDTRv1 + 'eejs/validators/index.js',
 		},
 		module: moduleConfigWithJsRules,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -103,29 +103,6 @@ const config = [
 	},
 	{
 		entry: {
-			'eventespresso-model': pathToEDTRv1 + 'data/model/index.js',
-		},
-		module: moduleConfigWithJsRules,
-		output: {
-			library: ['eejs', 'model'],
-			libraryTarget: 'this',
-		},
-	},
-	{
-		entry: {
-			'eventespresso-model-schema': pathToEDTRv1 + 'data/eventespresso/schema/index.js',
-		},
-		output: {
-			library: ['eejs', 'modelSchema'],
-			libraryTarget: 'this',
-		},
-		module: moduleConfigWithJsAndCssRules,
-		watchOptions: {
-			poll: 1000,
-		},
-	},
-	{
-		entry: {
 			'eventespresso-value-objects': pathToEDTRv1 + 'vo/index.js',
 		},
 		module: moduleConfigWithJsRules,


### PR DESCRIPTION
## Problem this Pull Request solves
- Removed `@eventespresso/hooks` from webpack config
  - Refactored code to follow the update from :point_up: 
- Closes #2261.
