### PR TITLE
Bug/fix reg page closing div tag mismatch

### DIFF
--- a/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
+++ b/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
@@ -73,7 +73,7 @@ if (count($registrations) > 0) {
                 ?>
                 </tbody>
             </table>
-        </div>
+        </div><!-- close spco-ticket-info-dv -->
 
     <?php
     // Display the forms below the table.
@@ -82,12 +82,12 @@ if (count($registrations) > 0) {
             // Attendee Questions.
             $reg_form = EE_Template_Layout::get_subform_name($registration->reg_url_link());
             echo ${$reg_form};
-    ?>
-    </div>
-<?php
         } // if ( $registration instanceof EE_Registration )
     } // end foreach ( $registrations as $registration )
 
+    ?>
+    </div><!-- close spco-attendee-panel-dv -->
+    <?php
     echo $default_hidden_inputs;
 } // end if ( count( $registrations ) > 0 )
 

--- a/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
+++ b/modules/single_page_checkout/reg_steps/attendee_information/attendee_info_single.template.php
@@ -75,17 +75,17 @@ if (count($registrations) > 0) {
             </table>
         </div><!-- close spco-ticket-info-dv -->
 
-    <?php
-    // Display the forms below the table.
-    foreach ($registrations as $registration) {
-        if ($registration instanceof EE_Registration) {
-            // Attendee Questions.
-            $reg_form = EE_Template_Layout::get_subform_name($registration->reg_url_link());
-            echo ${$reg_form};
-        } // if ( $registration instanceof EE_Registration )
-    } // end foreach ( $registrations as $registration )
+        <?php
+        // Display the forms below the table.
+        foreach ($registrations as $registration) {
+            if ($registration instanceof EE_Registration) {
+                // Attendee Questions.
+                $reg_form = EE_Template_Layout::get_subform_name($registration->reg_url_link());
+                echo ${$reg_form};
+            } // if ( $registration instanceof EE_Registration )
+        } // end foreach ( $registrations as $registration )
 
-    ?>
+        ?>
     </div><!-- close spco-attendee-panel-dv -->
     <?php
     echo $default_hidden_inputs;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This fixes a problem that was started with commit 39e1aa3eb1ad802977d32f3c285740a9f674f1ae where the closing div was moved, but it wasn't moved far enough (it needs to be moved past or outside the loop.
![Screen Shot 2020-01-21 at 4 07 19 PM](https://user-images.githubusercontent.com/891156/72844321-429ce580-3c6a-11ea-8a94-36ff85c1dd6d.png)


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Set up an event with default questions settings, then go to the admin Add new registration page. Select a quantity of 3 tickets then proceed to attendee information step.
The layout will be corrected with this branch.
![Screen Shot 2020-01-21 at 4 08 17 PM](https://user-images.githubusercontent.com/891156/72844343-4b8db700-3c6a-11ea-91fa-a489d563edc4.png)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
