### PR TITLE
remove server server option (so users could switch to or from akamai …

### DIFF
--- a/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
+++ b/caffeinated/payment_methods/Aim/EEG_Aim.gateway.php
@@ -34,8 +34,6 @@ class EEG_Aim extends EE_Onsite_Gateway
 
     protected $_transaction_key;
 
-    protected $_server;
-
     protected $_currencies_supported = array(
         'AUD',
         'USD',
@@ -151,28 +149,6 @@ class EEG_Aim extends EE_Onsite_Gateway
 
 
     /**
-     * TEMPORARY CALLBACK! Do not use
-     * Callback which filters the server url. This is added so site admins can revert to using
-     * the old AIM server in case Akamai service breaks their integration.
-     * Using Akamai will, however, be mandatory on June 30th 2016 Authorize.net
-     * (see http://www.authorize.net/support/akamaifaqs/#firewall?utm_campaign=April%202016%20Technical%20Updates%20for%20Merchants.html&utm_medium=email&utm_source=Eloqua&elqTrackId=46103bdc375c411a979c2f658fc99074&elq=7026706360154fee9b6d588b27d8eb6a&elqaid=506&elqat=1&elqCampaignId=343)
-     * Once that happens, this will be obsolete and WILL BE REMOVED.
-     *
-     * @param string $url
-     * @param EEG_Aim $gateway_object
-     * @return string
-     */
-    public function possibly_use_deprecated_aim_server($url, EEG_Aim $gateway_object)
-    {
-        if ($gateway_object->_server === 'authorize.net' && ! $gateway_object->_debug_mode) {
-            return 'https://secure.authorize.net/gateway/transact.dll';
-        } else {
-            return $url;
-        }
-    }
-
-
-    /**
      * Asks the gateway to do whatever it does to process the payment. Onsite gateways will
      * usually send a request directly to the payment provider and update the payment's status based on that;
      * whereas offsite gateways will usually just update the payment with the URL and query parameters to use
@@ -190,7 +166,6 @@ class EEG_Aim extends EE_Onsite_Gateway
      */
     public function do_direct_payment($payment, $billing_info = null)
     {
-        add_filter('FHEE__EEG_Aim___get_server_url', array($this, 'possibly_use_deprecated_aim_server'), 10, 2);
         // Enable test mode if needed
         // 4007000000027  <-- test successful visa
         // 4222222222222  <-- test failure card number

--- a/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
+++ b/caffeinated/payment_methods/Aim/EE_PMT_Aim.pm.php
@@ -193,21 +193,6 @@ class EE_PMT_Aim extends EE_PMT_Base
                             'html_help_text' => __('Note: if fields are excluded they cannot be required.', 'event_espresso')
                         )
                     ),
-                    'server' => new EE_Select_Input(
-                        apply_filters(
-                            'FHEE__EE_PMT_Aim__generate_new_settings_form__server_select_input__options',
-                            array(
-                                'akamai' => __('Authorize.net/Akamai (default)', 'event_espresso'),
-                                'authorize.net' => __('Authorize.net (deprecated)', 'event_espresso'),
-                            ),
-                            $this
-                        ),
-                        array(
-                            'html_label_text' => __('Server', 'event_espresso'),
-                            'html_help_text' => __('The Gateway Server where payment requests will be sent', 'event_espresso')
-                        )
-                    )
-                        
                 )
             )
         );

--- a/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
+++ b/caffeinated/payment_methods/Aim/help_tabs/payment_methods_overview_aim.help_tab.php
@@ -75,13 +75,6 @@
         ); ?>
     </li>
     <li>
-        <strong><?php esc_html_e('Server', 'event_espresso'); ?></strong>
-        <?php esc_html_e(
-            'Use this setting to change the server where Authorize.net AIM requests are sent. Change this to "Authorize.net/Akamai" before June 30th 2016 to verify your server will work with Authorize.net\'s servers which will be in use after that date.',
-            'event_espresso'
-        ); ?>
-    </li>
-    <li>
         <strong><?php esc_html_e('Button Image URL', 'event_espresso'); ?></strong><br/>
         <?php esc_html_e('Change the image that is used for this payment gateway.', 'event_espresso'); ?>
     </li>


### PR DESCRIPTION
…server). The setting hasnt applied since 2016


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Removes the "server" option in Authorize.net as it hasn't been necessary since 2016 when they moved to Akamai (and now that[ they're moving OFF Akamai, it especially doesn't make sense](https://github.com/eventespresso/event-espresso-core/issues/1569)!)
This removes the option from the payment settings form, the help tab, and makes it so it's no longer used in the gateway class code.
All API calls are just sent to Authorize.net's normal API servers: 
SANDBOX: `https://test.authorize.net/gateway/transact.dll`, 
LIVE: `https://secure2.authorize.net/gateway/transact.dll`

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Make a payment with AIM in debug mode. It should work fine as usual.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
