### PR TITLE
Load all entities on rehydration | Closes #2317

### DIFF
--- a/core/domain/services/admin/events/editor/AdvancedEditorData.php
+++ b/core/domain/services/admin/events/editor/AdvancedEditorData.php
@@ -252,8 +252,8 @@ var eeEditorData={$data};
     {
         $field_key = lcfirst($this->namespace) . 'Datetimes';
         $query = <<<QUERY
-        query GET_DATETIMES(\$where: {$this->namespace}RootQueryDatetimesConnectionWhereArgs) {
-            {$field_key}(where: \$where) {
+        query GET_DATETIMES(\$where: {$this->namespace}RootQueryDatetimesConnectionWhereArgs, \$first: Int, \$last: Int ) {
+            {$field_key}(where: \$where, first: \$first, last: \$last) {
                 nodes {
                     id
                     dbId
@@ -282,7 +282,7 @@ QUERY;
         $data = [
             'operation_name' => 'GET_DATETIMES',
             'variables' => [
-                'first' => 50,
+                'first' => 100,
                 'where' => [
                     'eventId' => $eventId,
                 ],
@@ -304,8 +304,8 @@ QUERY;
     {
         $field_key = lcfirst($this->namespace) . 'Tickets';
         $query = <<<QUERY
-        query GET_TICKETS(\$where: {$this->namespace}RootQueryTicketsConnectionWhereArgs) {
-            {$field_key}(where: \$where) {
+        query GET_TICKETS(\$where: {$this->namespace}RootQueryTicketsConnectionWhereArgs, \$first: Int, \$last: Int ) {
+            {$field_key}(where: \$where, first: \$first, last: \$last) {
                 nodes {
                     id
                     dbId
@@ -337,6 +337,7 @@ QUERY;
         $data = [
             'operation_name' => 'GET_TICKETS',
             'variables' => [
+                'first' => 100,
                 'where' => [
                     'datetimeIn' => $datetimeIn,
                 ],
@@ -358,8 +359,8 @@ QUERY;
     {
         $field_key = lcfirst($this->namespace) . 'Prices';
         $query = <<<QUERY
-        query GET_PRICES(\$where: {$this->namespace}RootQueryPricesConnectionWhereArgs) {
-            {$field_key}(where: \$where) {
+        query GET_PRICES(\$where: {$this->namespace}RootQueryPricesConnectionWhereArgs, \$first: Int, \$last: Int ) {
+            {$field_key}(where: \$where, first: \$first, last: \$last) {
                 nodes {
                     id
                     dbId
@@ -384,6 +385,7 @@ QUERY;
         $data = [
             'operation_name' => 'GET_PRICES',
             'variables' => [
+                'first' => 100,
                 'where' => [
                     'ticketIn' => $ticketIn,
                 ],
@@ -404,8 +406,8 @@ QUERY;
     {
         $field_key = lcfirst($this->namespace) . 'PriceTypes';
         $query = <<<QUERY
-        query GET_PRICES {
-            {$field_key} {
+        query GET_PRICE_TYPES(\$where: {$this->namespace}RootQueryPriceTypesConnectionWhereArgs, \$first: Int, \$last: Int ) {
+            {$field_key}(where: \$where, first: \$first, last: \$last) {
                 nodes {
                     id
                     dbId
@@ -424,7 +426,11 @@ QUERY;
         }
 QUERY;
         $data = [
-            'operation_name' => 'GET_PRICES',
+            'operation_name' => 'GET_PRICE_TYPES',
+            'variables' => [
+                'first' => 100,
+                'where' => [],
+            ],
             'query' => $query,
         ];
 

--- a/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
@@ -23,11 +23,11 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
      */
     protected function getLimit()
     {
-        $this->args['first'] = ! empty($this->args['first']) ? absint($this->args['first']) : 0;
-        $this->args['last'] = ! empty($this->args['last']) ? absint($this->args['last']) : 0;
+        $first = ! empty($this->args['first']) ? absint($this->args['first']) : null;
+        $last  = ! empty($this->args['last']) ? absint($this->args['last']) : null;
 
         $limit = min(
-            max($this->args['first'], $this->args['last'], 10),
+            max($first, $last, 10),
             $this->query_amount
         );
         $limit++;
@@ -57,10 +57,10 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
                 $query_args['order_by'][ $orderby_input['field'] ] = $orderby_input['order'];
             }
         } elseif ($offset) {
-            $compare = $this->args['last'] ? '<' : '>';
-            $where_params[ $primary_key ] = [$compare, $offset];
+            $compare                      = $this->args['last'] ? '<' : '>';
+            $where_params[ $primary_key ] = [ $compare, $offset ];
         }
-        return [$query_args, $where_params];
+        return [ $query_args, $where_params ];
     }
 
 
@@ -119,7 +119,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
     protected function convertGlobalId($ID)
     {
         if (is_array($ID)) {
-            return array_map([$this, 'convertGlobalId'], $ID);
+            return array_map([ $this, 'convertGlobalId' ], $ID);
         }
         $parts = Relay::fromGlobalId($ID);
         return ! empty($parts['id']) ? $parts['id'] : null;


### PR DESCRIPTION
This PR:
- Adds `$first` and `$last` args to rehydration queries
- Closes #2317

After this PR, all the entities (max 100) will be loaded into EDTR including trashed.