### PR TITLE
Avoid PHPUnit warnings because tests make no assertions

### DIFF
--- a/tests/testcases/core/db_models/EEM_Base_Test.php
+++ b/tests/testcases/core/db_models/EEM_Base_Test.php
@@ -63,6 +63,7 @@ class EEM_Base_Test extends EE_UnitTestCase
 
     /**
      * Verifies that for each model, the tables it claims to require have been installed
+     * @doesNotPerformAssertions
      */
     public function test_model_tables_exist()
     {

--- a/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
+++ b/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
@@ -364,6 +364,7 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
      * object in the data sent to the parsers.
      *
      * @group 7659
+     * * @doesNotPerformAssertions
      */
     public function test_invalid_attendee_obj_EE_Attendee_Shortcodes()
     {

--- a/tests/testcases/core/helpers/EEH_TemplateTest.php
+++ b/tests/testcases/core/helpers/EEH_TemplateTest.php
@@ -20,6 +20,9 @@
  */
 class EEH_TemplateTest extends PHPUnit_Framework_TestCase {
 
+    /**
+     * @doesNotPerformAssertions
+     */
 	public function test() {
 
 	}

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Model_Matching_Query_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Model_Matching_Query_Validation_Strategy_Test.php
@@ -6,7 +6,21 @@
  * and open the template in the editor.
  */
 
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+
 class EE_Model_Matching_Query_Validation_Strategy_Test extends EE_UnitTestCase {
+
+    /**
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws EE_Validation_Error
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @doesNotPerformAssertions
+     */
 	public function test_valid() {
 		$validator = new EE_Model_Matching_Query_Validation_Strategy(
 			'',
@@ -33,7 +47,13 @@ class EE_Model_Matching_Query_Validation_Strategy_Test extends EE_UnitTestCase {
 		//and the id exists
 		$validator->validate( $ev->ID() );
 	}
-	
+
+    /**
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws EE_Validation_Error
+     * @doesNotPerformAssertions
+     */
 	public function test_valid__treating_input_as_other_field() {
 		$validator = new EE_Model_Matching_Query_Validation_Strategy(
 			'',

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Plaintext_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Plaintext_Validation_Strategy_Test.php
@@ -35,6 +35,9 @@ class EE_Plaintext_Validation_Strategy_Test extends EE_UnitTestCase{
 		}
 	}
 
+    /**
+     * @doesNotPerformAssertions
+     */
 	function test_validate__pass(){
 		$this->_validator->validate( 'just some text; no html anywhere' );
 	}

--- a/tests/testcases/modules/EE_CheckoutTest.php
+++ b/tests/testcases/modules/EE_CheckoutTest.php
@@ -26,7 +26,9 @@ class EE_CheckoutTest extends EE_UnitTestCase {
 	}
 
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
 	public function test_add_reg_step() {
 	}
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Fixes some PHPUnit tests that had warnings because they made no assertions. Only the test files are affected.
Addresses https://github.com/eventespresso/event-espresso-core/issues/1007

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Unit tests should have no more output like the following:
> There were 7 risky tests:
> 1) EEM_Base_Test::test_model_tables_exist
This test did not perform any assertions
> 2) EEH_Parse_Shortcodes_Test::test_invalid_attendee_obj_EE_Attendee_Shortcodes
This test did not perform any assertions
> 3) EEH_TemplateTest::test
This test did not perform any assertions
> 4) EE_Model_Matching_Query_Validation_Strategy_Test::test_valid
This test did not perform any assertions
> 5) EE_Model_Matching_Query_Validation_Strategy_Test::test_valid__treating_input_as_other_field
This test did not perform any assertions
> 6) EE_Plaintext_Validation_Strategy_Test::test_validate__pass
This test did not perform any assertions
> 7) EE_CheckoutTest::test_add_reg_step
This test did not perform any assertions

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
