### PR TITLE
Cleanup TS warnings and improve types | Closes #2280

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,6 @@
 		"react/display-name": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-use-before-define": "off",
-		"@typescript-eslint/explicit-function-return-type": "off",
 		"no-unused-vars": "error"
 	},
 	"overrides": [

--- a/assets/src/application/services/apollo/mutations/useEntityMutation.ts
+++ b/assets/src/application/services/apollo/mutations/useEntityMutation.ts
@@ -16,7 +16,7 @@ import {
 	MutationInput,
 	MutationResult,
 	CustomMutationOptions,
-	Mutator,
+	Mutators,
 	MutationType,
 	EntityType,
 } from './types';
@@ -49,8 +49,8 @@ const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 	 */
 	const getMutationOptions = (mutationType: MutationType, input: MutationInput = {}): OperationVariables => {
 		// e.g. "datetimeMutator"
-		const key = `${type.toLowerCase()}Mutator`;
-		const mutator: Mutator = mutators[key];
+		const key = `${type.toLowerCase()}Mutator` as keyof Mutators;
+		const mutator = mutators[key];
 		/**
 		 * options = {
 		 *     variables,
@@ -81,8 +81,8 @@ const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 			// e.g. "createDatetime", "updateTicket"
 			const mutationName = `${mutationType.toLowerCase()}Espresso${type}`;
 			// Example result: { data: { deletePrice: { price : {...} } } }
-			const path: string[] = ['data', mutationName, `espresso${type}`];
-			const entity: any = pathOr({}, path, result);
+			const path = ['data', mutationName, `espresso${type}`];
+			const entity = pathOr<any>({}, path, result);
 
 			onUpdate({ proxy, entity });
 		};
@@ -92,8 +92,8 @@ const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 	 * @param {object} input
 	 */
 	const getCreateMutation = (input: MutationInput): MutationOptions => {
-		const mutation: any = getMutation(MutationType.Create);
-		const options: OperationVariables = getMutationOptions(MutationType.Create, input);
+		const mutation = getMutation(MutationType.Create);
+		const options = getMutationOptions(MutationType.Create, input);
 
 		return { mutation, ...options };
 	};
@@ -102,8 +102,8 @@ const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 	 * @param {object} input
 	 */
 	const getUpdateMutation = (input: MutationInput): MutationOptions => {
-		const mutation: any = getMutation(MutationType.Update);
-		const options: OperationVariables = getMutationOptions(MutationType.Update, { id, ...input });
+		const mutation = getMutation(MutationType.Update);
+		const options = getMutationOptions(MutationType.Update, { id, ...input });
 
 		return { mutation, ...options };
 	};
@@ -112,8 +112,8 @@ const useEntityMutation = (type: EntityType, id?: string): EntityMutation => {
 	 * @param {object} input
 	 */
 	const getDeleteMutation = (input: MutationInput): MutationOptions => {
-		const mutation: any = getMutation(MutationType.Delete);
-		const options: OperationVariables = getMutationOptions(MutationType.Delete, { id, ...input });
+		const mutation = getMutation(MutationType.Delete);
+		const options = getMutationOptions(MutationType.Delete, { id, ...input });
 
 		return { mutation, ...options };
 	};

--- a/assets/src/application/services/apollo/status/useStatusManager.ts
+++ b/assets/src/application/services/apollo/status/useStatusManager.ts
@@ -23,7 +23,7 @@ const useStatusManager = (): StatusManager => {
 	 *
 	 * @param {string} typeName The plural type name like "datetimes", "tickets", "prices"
 	 */
-	const isLoading: StatusGetter = (typeName: TypeName): boolean => {
+	const isLoading: StatusGetter = (typeName) => {
 		return pathOr(false, ['loading', typeName], state);
 	};
 
@@ -33,7 +33,7 @@ const useStatusManager = (): StatusManager => {
 	 * @param {string}  typeName  The plural type name like "datetimes", "tickets", "prices"
 	 * @param {boolean} value Value of the flag
 	 */
-	const setIsLoading: StatusSetter = (typeName: TypeName, value = true): void => {
+	const setIsLoading: StatusSetter = (typeName, value = true) => {
 		dispatch({
 			type: 'SET_IS_LOADING',
 			typeName,
@@ -46,7 +46,7 @@ const useStatusManager = (): StatusManager => {
 	 *
 	 * @param {string} typeName The plural type name like "datetimes", "tickets", "prices"
 	 */
-	const isLoaded: StatusGetter = (typeName: TypeName): boolean => {
+	const isLoaded: StatusGetter = (typeName) => {
 		return pathOr(false, ['completed', typeName], state);
 	};
 

--- a/assets/src/application/services/context/ConfigProvider.tsx
+++ b/assets/src/application/services/context/ConfigProvider.tsx
@@ -11,7 +11,7 @@ const ConfigContext = createContext<Config | null>(null);
 
 const { Provider, Consumer: ConfigConsumer } = ConfigContext;
 
-const ConfigProvider: React.FC<ProviderProps> = ({ children }): JSX.Element => {
+const ConfigProvider: React.FC<ProviderProps> = ({ children }) => {
 	const ConfigData = useConfigData();
 	const currentUser = useCurrentUser();
 	const generalSettings = useGeneralSettings();

--- a/assets/src/application/services/context/EditorModalProvider.tsx
+++ b/assets/src/application/services/context/EditorModalProvider.tsx
@@ -10,7 +10,7 @@ const EditorModalContext = createContext(null);
 
 const { Provider, Consumer: EditorModalConsumer } = EditorModalContext;
 
-const EditorModalProvider: React.FC<ProviderProps> = (props): JSX.Element => {
+const EditorModalProvider: React.FC<ProviderProps> = (props) => {
 	const editorModal = useEditorModalManager();
 
 	return <Provider value={editorModal}>{props.children}</Provider>;

--- a/assets/src/application/services/context/RelationsProvider.tsx
+++ b/assets/src/application/services/context/RelationsProvider.tsx
@@ -11,7 +11,7 @@ const RelationsContext = createContext<RelationsManager | null>(null);
 
 const { Provider, Consumer: RelationsConsumer } = RelationsContext;
 
-const RelationsProvider: React.FC<ProviderProps> = ({ children }): JSX.Element => {
+const RelationsProvider: React.FC<ProviderProps> = ({ children }) => {
 	const relations = useRelationsManager();
 	return <Provider value={relations}>{children}</Provider>;
 };

--- a/assets/src/application/services/context/StatusProvider.tsx
+++ b/assets/src/application/services/context/StatusProvider.tsx
@@ -11,7 +11,7 @@ const StatusContext = createContext<StatusManager | null>(null);
 
 const { Provider, Consumer: StatusConsumer } = StatusContext;
 
-const StatusProvider: React.FC<ProviderProps> = ({ children }): JSX.Element => {
+const StatusProvider: React.FC<ProviderProps> = ({ children }) => {
 	const statusManager = useStatusManager();
 	return <Provider value={statusManager}>{children}</Provider>;
 };

--- a/assets/src/application/services/context/ToastProvider.tsx
+++ b/assets/src/application/services/context/ToastProvider.tsx
@@ -13,7 +13,7 @@ const toaster = Toaster.create({
 	position: Position.BOTTOM_RIGHT,
 });
 
-const ToastProvider: React.FC<ProviderProps> = (props): JSX.Element => {
+const ToastProvider: React.FC<ProviderProps> = (props) => {
 	return <ToastContext.Provider value={toaster}>{props.children}</ToastContext.Provider>;
 };
 

--- a/assets/src/application/services/context/test/ConfigProvider.test.tsx
+++ b/assets/src/application/services/context/test/ConfigProvider.test.tsx
@@ -12,7 +12,7 @@ describe('ConfigProvider', () => {
 		let configData: Config = null;
 		const consumer = (
 			<ConfigConsumer>
-				{(_config_): JSX.Element => {
+				{(_config_) => {
 					configData = _config_;
 					return null;
 				}}
@@ -27,7 +27,7 @@ describe('ConfigProvider', () => {
 	it('checks for brandName in config data', () => {
 		const consumer = (
 			<ConfigConsumer>
-				{(configData): JSX.Element => {
+				{(configData) => {
 					const value = configData.config.brandName;
 					return <span>{`Brand name: ${value}`}</span>;
 				}}
@@ -43,7 +43,7 @@ describe('ConfigProvider', () => {
 	it('checks for user and site locale in config data', () => {
 		const consumer = (
 			<ConfigConsumer>
-				{(configData): JSX.Element => {
+				{(configData) => {
 					const userLocale = configData.config.locale.user;
 					const siteLocale = configData.config.locale.site;
 					return (

--- a/assets/src/application/services/context/test/RelationsProvider.test.tsx
+++ b/assets/src/application/services/context/test/RelationsProvider.test.tsx
@@ -12,7 +12,7 @@ describe('RelationsProvider', () => {
 		const consumer = (
 			<RelationsProvider>
 				<RelationsConsumer>
-					{(_relationsProvider_): JSX.Element => {
+					{(_relationsProvider_) => {
 						relationsProvider = _relationsProvider_;
 						return null;
 					}}
@@ -34,7 +34,7 @@ describe('RelationsProvider', () => {
 		let relationalData: RelationalData = null;
 		const consumer = (
 			<RelationsConsumer>
-				{(relationsProvider): JSX.Element => {
+				{(relationsProvider) => {
 					relationalData = relationsProvider.getData();
 					return null;
 				}}

--- a/assets/src/application/services/context/test/StatusProvider.test.tsx
+++ b/assets/src/application/services/context/test/StatusProvider.test.tsx
@@ -11,7 +11,7 @@ describe('StatusProvider', () => {
 		const consumer = (
 			<StatusProvider>
 				<StatusConsumer>
-					{(_statusProvider_): JSX.Element => {
+					{(_statusProvider_) => {
 						statusProvider = _statusProvider_;
 						return null;
 					}}
@@ -28,7 +28,7 @@ describe('StatusProvider', () => {
 		const consumer = (
 			<StatusProvider>
 				<StatusConsumer>
-					{(statusProvider): JSX.Element => {
+					{(statusProvider) => {
 						const value = JSON.stringify(statusProvider.isLoading(TypeName.datetimes));
 						return <span>{`Is Loading datetimes: ${value}`}</span>;
 					}}
@@ -43,7 +43,7 @@ describe('StatusProvider', () => {
 		const consumer = (
 			<StatusProvider>
 				<StatusConsumer>
-					{(statusProvider): JSX.Element => {
+					{(statusProvider) => {
 						const value = JSON.stringify(statusProvider.isLoaded(TypeName.priceTypes));
 						return <span>{`Is Loaded priceTypes: ${value}`}</span>;
 					}}
@@ -58,7 +58,7 @@ describe('StatusProvider', () => {
 		const consumer = (
 			<StatusProvider>
 				<StatusConsumer>
-					{(statusProvider): JSX.Element => {
+					{(statusProvider) => {
 						const value = JSON.stringify(statusProvider.isError(TypeName.tickets));
 						return <span>{`Is isError tickets: ${value}`}</span>;
 					}}

--- a/assets/src/application/services/hooks/useRect.ts
+++ b/assets/src/application/services/hooks/useRect.ts
@@ -8,7 +8,7 @@ type voidFn = () => void;
 const useRect = (ref: React.RefObject<HTMLElement>): ClientRect => {
 	const [rect, setRect] = useState(getHTMLElementClientRect(ref ? ref.current : null));
 
-	const handleResize: voidFn = useCallback(() => {
+	const handleResize = useCallback<voidFn>(() => {
 		if (!ref.current) {
 			return;
 		}
@@ -29,7 +29,7 @@ const useRect = (ref: React.RefObject<HTMLElement>): ClientRect => {
 			let resizeObserver = new ResizeObserver(() => handleResize());
 			resizeObserver.observe(element);
 
-			return () => {
+			return (): void => {
 				if (!resizeObserver) {
 					return;
 				}

--- a/assets/src/application/services/toaster/IconGraphQL.tsx
+++ b/assets/src/application/services/toaster/IconGraphQL.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const IconGraphQL: React.FC = (): JSX.Element => (
+const IconGraphQL: React.FC = () => (
 	<span className='bp3-icon ee-graphql-icon'>
 		<svg width='16' height='16' viewBox='0 0 24 24'>
 			<desc>graphql</desc>

--- a/assets/src/application/services/toaster/LoadingToast.tsx
+++ b/assets/src/application/services/toaster/LoadingToast.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Spinner } from '@blueprintjs/core';
 import { LoadingToastProps } from './types';
 
-const LoadingToastNotice: React.FC<LoadingToastProps> = ({ message }): JSX.Element => {
+const LoadingToastNotice: React.FC<LoadingToastProps> = ({ message }) => {
 	return (
 		<div
 			style={{

--- a/assets/src/application/services/utilities/text/changeCase/index.ts
+++ b/assets/src/application/services/utilities/text/changeCase/index.ts
@@ -3,7 +3,7 @@
  */
 import { is } from 'ramda';
 
-export const lcFirst = (str: string): string | undefined => {
+export const lcFirst = (str: string): string => {
 	if (is(String, str)) {
 		return str.charAt(0).toLowerCase() + str.substring(1);
 	}
@@ -11,7 +11,7 @@ export const lcFirst = (str: string): string | undefined => {
 	return undefined;
 };
 
-export const ucFirst = (str: string): string | undefined => {
+export const ucFirst = (str: string): string => {
 	if (is(String, str)) {
 		return str.charAt(0).toUpperCase() + str.substring(1);
 	}

--- a/assets/src/domain/eventEditor/hooks/test/useDatetimeContext.test.tsx
+++ b/assets/src/domain/eventEditor/hooks/test/useDatetimeContext.test.tsx
@@ -16,9 +16,7 @@ describe('useDatetimeContext', () => {
 
 	it('checks for the returned context and its data', async () => {
 		const id = 'fake-id';
-		const wrapper: React.FC<any> = ({ children }): JSX.Element => (
-			<DatetimeProvider id={id}>{children}</DatetimeProvider>
-		);
+		const wrapper: React.FC<any> = ({ children }) => <DatetimeProvider id={id}>{children}</DatetimeProvider>;
 		const { result } = renderHook(
 			() => {
 				return useDatetimeContext();

--- a/assets/src/domain/eventEditor/hooks/test/useTicketContext.test.tsx
+++ b/assets/src/domain/eventEditor/hooks/test/useTicketContext.test.tsx
@@ -16,9 +16,7 @@ describe('useTicketContext', () => {
 
 	it('checks for the returned context and is data', async () => {
 		const id = 'fake-id';
-		const wrapper: React.FC<any> = ({ children }): JSX.Element => (
-			<TicketProvider id={id}>{children}</TicketProvider>
-		);
+		const wrapper: React.FC<any> = ({ children }) => <TicketProvider id={id}>{children}</TicketProvider>;
 		const { result } = renderHook(
 			() => {
 				return useTicketContext();

--- a/assets/src/domain/eventEditor/index.tsx
+++ b/assets/src/domain/eventEditor/index.tsx
@@ -20,7 +20,7 @@ editor.className = 'ee-editor-div-prototype';
 
 container.prepend(editor);
 
-const Editor: React.FC = (): JSX.Element => (
+const Editor: React.FC = () => (
 	<ContextProviders>
 		<EventEditor />
 	</ContextProviders>

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/usePriceMutator.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/usePriceMutator.ts
@@ -12,20 +12,18 @@ import {
 	OnUpdateFnOptions,
 	MutatorGeneratedObject,
 } from '../../../../../../application/services/apollo/mutations/types';
-import { ReadQueryOptions } from '../../queries/types';
 import { Price, PriceEdge, PricesList } from '../../types';
-import { PriceMutationCallbackFn } from '../types';
 import { DEFAULT_PRICE_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
 
 /**
  *
  */
 const usePriceMutator = (): Mutator => {
-	const options: ReadQueryOptions = usePriceQueryOptions();
+	const options = usePriceQueryOptions();
 
-	const onCreatePrice: PriceMutationCallbackFn = useOnCreatePrice();
-	const onUpdatePrice: PriceMutationCallbackFn = useOnUpdatePrice();
-	const onDeletePrice: PriceMutationCallbackFn = useOnDeletePrice();
+	const onCreatePrice = useOnCreatePrice();
+	const onUpdatePrice = useOnUpdatePrice();
+	const onDeletePrice = useOnDeletePrice();
 
 	const createVariables = (mutationType: MutationType, input: MutationInput): OperationVariables => {
 		const mutationInput: MutationInput = {
@@ -43,7 +41,7 @@ const usePriceMutator = (): Mutator => {
 		// so as to properly set the relations
 		const { ticketId, ...restInput } = input;
 		const { priceType: priceTypeId } = input;
-		const variables: OperationVariables = createVariables(mutationType, restInput);
+		const variables = createVariables(mutationType, restInput);
 		/**
 		 * @todo update optimisticResponse
 		 */

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/useUpdatePriceCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/useUpdatePriceCache.ts
@@ -9,7 +9,7 @@ const useUpdatePriceCache = (): CacheUpdaterFn => {
 	const updatePriceCache = ({ proxy, prices, price, remove = false }: CacheUpdaterFnArgs): void => {
 		const { nodes = [] } = prices;
 		// remove from or add to the list
-		const newNodes: Price[] = remove ? nodes.filter(({ id }: Price) => id !== price.id) : [...nodes, price];
+		const newNodes = remove ? nodes.filter(({ id }: Price) => id !== price.id) : [...nodes, price];
 
 		// write the data to cache without
 		// mutating the cache directly

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/updatePriceCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/updatePriceCache.ts
@@ -24,12 +24,12 @@ const updatePriceCache = ({ proxy, prices = null, ticketIn, ticketId, remove = f
 		};
 	}
 
-	const newTicketIn: string[] = remove ? ticketIn.filter((id) => id !== ticketId) : [...ticketIn, ticketId];
+	const newTicketIn = remove ? ticketIn.filter((id) => id !== ticketId) : [...ticketIn, ticketId];
 	const priceNodes = pathOr<Price[]>([], ['nodes'], prices);
 	const pathToNodes = ['espressoPrices', 'nodes'];
 
 	if (!remove && priceNodes.length) {
-		const existingPrices: Price[] = pathOr<Price[]>([], pathToNodes, data);
+		const existingPrices = pathOr<Price[]>([], pathToNodes, data);
 		data = assocPath<Price[], PricesList>(pathToNodes, [...existingPrices, ...priceNodes], data);
 	}
 	const nodes = pathOr<Price[]>([], pathToNodes, data);

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
@@ -2,18 +2,18 @@ import { pathOr } from 'ramda';
 import { useRelations, RelationsManager } from '../../../../../../application/services/apollo/relations';
 import useUpdateTicketCache from './useUpdateTicketCache';
 import updatePriceCache from './updatePriceCache';
-import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs, CacheUpdaterFn } from '../types';
+import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs } from '../types';
 import { Ticket, Price } from '../../types';
 
 const useOnCreateTicket = (): TicketMutationCallbackFn => {
 	const { updateRelations, addRelation } = useRelations() as RelationsManager;
 
-	const updateTicketCache: CacheUpdaterFn = useUpdateTicketCache();
+	const updateTicketCache = useUpdateTicketCache();
 
 	const onCreateTicket = ({ proxy, datetimeIds, ticket, tickets, prices }: TicketMutationCallbackFnArgs): void => {
 		if (ticket.id) {
 			const { nodes = [] } = tickets;
-			const ticketIn: string[] = nodes.map(({ id }: Ticket) => id);
+			const ticketIn = nodes.map(({ id }: Ticket) => id);
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
@@ -1,5 +1,5 @@
 import { useRelations, RelationsManager } from '../../../../../../application/services/apollo/relations';
-import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs, CacheUpdaterFn } from '../types';
+import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs } from '../types';
 import useUpdateTicketCache from './useUpdateTicketCache';
 import updatePriceCache from './updatePriceCache';
 import { Ticket } from '../../types';
@@ -7,12 +7,12 @@ import { Ticket } from '../../types';
 const useOnDeleteTicket = (): TicketMutationCallbackFn => {
 	const { dropRelations, removeRelation } = useRelations() as RelationsManager;
 
-	const updateTicketCache: CacheUpdaterFn = useUpdateTicketCache();
+	const updateTicketCache = useUpdateTicketCache();
 
 	const onDeleteTicket = ({ proxy, tickets, ticket }: TicketMutationCallbackFnArgs): void => {
 		if (ticket.id) {
 			const { nodes = [] } = tickets;
-			const ticketIn: string[] = nodes.map(({ id }: Ticket) => id);
+			const ticketIn = nodes.map(({ id }: Ticket) => id);
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useTicketMutator.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useTicketMutator.ts
@@ -9,19 +9,17 @@ import {
 	MutationType,
 	OnUpdateFnOptions,
 } from '../../../../../../application/services/apollo/mutations/types';
-import { ReadQueryOptions } from '../../queries/types';
 import { DEFAULT_TICKET_LIST_DATA as DEFAULT_LIST_DATA } from '../../queries';
 import { Ticket, TicketEdge, Price, TicketsList } from '../../types';
-import { TicketMutationCallbackFn } from '../types';
 import useOptimisticResponse from './useOptimisticResponse';
 import useMutationVariables from './useMutationVariables';
 
 const useTicketMutator = (): Mutator => {
-	const options: ReadQueryOptions = useTicketQueryOptions();
+	const options = useTicketQueryOptions();
 
-	const onCreateTicket: TicketMutationCallbackFn = useOnCreateTicket();
-	const onUpdateTicket: TicketMutationCallbackFn = useOnUpdateTicket();
-	const onDeleteTicket: TicketMutationCallbackFn = useOnDeleteTicket();
+	const onCreateTicket = useOnCreateTicket();
+	const onUpdateTicket = useOnUpdateTicket();
+	const onDeleteTicket = useOnDeleteTicket();
 
 	const getMutationVariables = useMutationVariables();
 	const getOptimisticResponse = useOptimisticResponse();

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useUpdateTicketCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useUpdateTicketCache.ts
@@ -9,7 +9,7 @@ const useUpdateTicketCache = (): CacheUpdaterFn => {
 	const updateTicketCache = ({ proxy, tickets, ticket, remove = false }: CacheUpdaterFnArgs): void => {
 		const { nodes = [] } = tickets;
 		// remove from or add to the list
-		const newNodes: Ticket[] = remove ? nodes.filter(({ id }: Ticket) => id !== ticket.id) : [...nodes, ticket];
+		const newNodes = remove ? nodes.filter(({ id }: Ticket) => id !== ticket.id) : [...nodes, ticket];
 
 		// write the data to cache without
 		// mutating the cache directly

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useInitDatetimeTestCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useInitDatetimeTestCache.ts
@@ -1,13 +1,13 @@
 import { useApolloClient } from '@apollo/react-hooks';
 
 import useDatetimeQueryOptions from '../useDatetimeQueryOptions';
-import { ReadQueryOptions, WriteQueryOptions } from '../../types';
+import { WriteQueryOptions } from '../../types';
 import { edge } from './data';
 
 const useInitDatetimeTestCache = (espressoDatetimes = edge): void => {
 	// init hooks
 	const client = useApolloClient();
-	const queryOptions: ReadQueryOptions = useDatetimeQueryOptions();
+	const queryOptions = useDatetimeQueryOptions();
 
 	const writeQueryOptions: WriteQueryOptions = {
 		...queryOptions,

--- a/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/test/useInitPriceTypeTestCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/test/useInitPriceTypeTestCache.ts
@@ -1,13 +1,13 @@
 import { useApolloClient } from '@apollo/react-hooks';
 
 import usePriceTypeQueryOptions from '../usePriceTypeQueryOptions';
-import { ReadQueryOptions, WriteQueryOptions } from '../../types';
+import { WriteQueryOptions } from '../../types';
 import { edge } from './data';
 
 const useInitPriceTypeTestCache = (espressoPriceTypes = edge): void => {
 	// init hooks
 	const client = useApolloClient();
-	const queryOptions: ReadQueryOptions = usePriceTypeQueryOptions();
+	const queryOptions = usePriceTypeQueryOptions();
 
 	const writeQueryOptions: WriteQueryOptions = {
 		...queryOptions,

--- a/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/usePriceTypeForPrice.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/usePriceTypeForPrice.ts
@@ -12,15 +12,15 @@ import { PriceType, EntityId } from '../../types';
 const usePriceTypeForPrice = (priceId: EntityId): PriceType => {
 	const { getRelations } = useRelations();
 	// get related priceTypes for this price
-	const relatedPriceTypeIds: EntityId[] = getRelations({
+	const relatedPriceTypeIds = getRelations({
 		entity: 'prices',
 		entityId: priceId,
 		relation: 'priceTypes',
 	});
 
 	// get the default price type object
-	const defaultPriceType: PriceType = useDefaultPriceType();
-	let relatedPriceTypes: PriceType[] = usePriceTypes(relatedPriceTypeIds);
+	const defaultPriceType = useDefaultPriceType();
+	let relatedPriceTypes = usePriceTypes(relatedPriceTypeIds);
 	relatedPriceTypes = relatedPriceTypeIds.length ? relatedPriceTypes : [];
 
 	return !isEmpty(relatedPriceTypes) ? relatedPriceTypes[0] : defaultPriceType;

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/test/useInitPriceTestCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/test/useInitPriceTestCache.ts
@@ -1,13 +1,13 @@
 import { useApolloClient } from '@apollo/react-hooks';
 
 import usePriceQueryOptions from '../usePriceQueryOptions';
-import { ReadQueryOptions, WriteQueryOptions } from '../../types';
+import { WriteQueryOptions } from '../../types';
 import { edge } from './data';
 
 const useInitPriceTestCache = (espressoPrices = edge): void => {
 	// init hooks
 	const client = useApolloClient();
-	const queryOptions: ReadQueryOptions = usePriceQueryOptions();
+	const queryOptions = usePriceQueryOptions();
 
 	const writeQueryOptions: WriteQueryOptions = {
 		...queryOptions,

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useInitTicketTestCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useInitTicketTestCache.ts
@@ -1,13 +1,13 @@
 import { useApolloClient } from '@apollo/react-hooks';
 
 import useTicketQueryOptions from '../useTicketQueryOptions';
-import { ReadQueryOptions, WriteQueryOptions } from '../../types';
+import { WriteQueryOptions } from '../../types';
 import { edge } from './data';
 
 const useInitTicketTestCache = (espressoTickets = edge): void => {
 	// init hooks
 	const client = useApolloClient();
-	const queryOptions: ReadQueryOptions = useTicketQueryOptions();
+	const queryOptions = useTicketQueryOptions();
 
 	const writeQueryOptions: WriteQueryOptions = {
 		...queryOptions,

--- a/assets/src/domain/eventEditor/services/context/DatetimeContext/index.tsx
+++ b/assets/src/domain/eventEditor/services/context/DatetimeContext/index.tsx
@@ -8,7 +8,7 @@ const DEFAULT_CONTEXT = {
 
 export const DatetimeContext = createContext<EntityContextProps>(DEFAULT_CONTEXT);
 
-export const DatetimeProvider: EntityContextProvider = (props): JSX.Element => {
+export const DatetimeProvider: EntityContextProvider = (props) => {
 	const { children, id } = props;
 
 	const value: EntityContextProps = { id };

--- a/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.test.tsx
+++ b/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.test.tsx
@@ -23,7 +23,7 @@ describe('ContextProviders', () => {
 		expect(result.current).toBeInstanceOf(ApolloClient);
 	});
 
-	const StatusComponent: React.FC = (): JSX.Element => {
+	const StatusComponent: React.FC = () => {
 		const statusManager = useStatus();
 		return <span>{`Status Manager is: ${statusManager === null ? 'NULL' : 'NOT_NULL'}`}</span>;
 	};
@@ -38,7 +38,7 @@ describe('ContextProviders', () => {
 		expect(getByText('Status Manager is: NOT_NULL')).toBeInTheDocument();
 	});
 
-	const EventIdComponent = (): JSX.Element => {
+	const EventIdComponent = () => {
 		const _eventId_ = useEventId() || 0;
 		return <span>{`Event ID is: ${_eventId_}`}</span>;
 	};

--- a/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.tsx
+++ b/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.tsx
@@ -16,7 +16,7 @@ import { ContextProvider } from '../types';
  * @param {ReactElement} children The element that should be wrapped.
  * @returns {ReactElement} The wrapped element.
  */
-export const ContextProviders: ContextProvider = ({ children }): JSX.Element => {
+export const ContextProviders: ContextProvider = ({ children }) => {
 	// Make TS (TS2769) friends with ESLint (react/no-children-prop)
 	const props = {
 		client: getClient(),

--- a/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.tsx
+++ b/assets/src/domain/eventEditor/services/context/EventEditorContext/ContextProviders.tsx
@@ -36,7 +36,7 @@ export const ContextProviders: ContextProvider = ({ children }) => {
  * @param {ReactElement} children The element that should be wrapped.
  * @returns {ReactElement} The wrapped element.
  */
-export const CommonProviders: ContextProvider = ({ children }): JSX.Element => (
+export const CommonProviders: ContextProvider = ({ children }) => (
 	<ToastProvider>
 		<StatusProvider>
 			<ConfigProvider>

--- a/assets/src/domain/eventEditor/services/context/TestContext/TestContextProviders.tsx
+++ b/assets/src/domain/eventEditor/services/context/TestContext/TestContextProviders.tsx
@@ -30,7 +30,7 @@ export const ApolloMockedProvider = (mocks: ReadonlyArray<MockedResponse> = []):
  * @param {ReactElement} children The element that should be wrapped.
  * @returns {ReactElement} The wrapped element.
  */
-export const ApolloAwareWrapper: ContextProvider = ({ children }): JSX.Element => {
+export const ApolloAwareWrapper: ContextProvider = ({ children }) => {
 	// initialize DOM data
 	useDomTestData();
 	// clear Apollo cache on unmount
@@ -49,7 +49,7 @@ export const ApolloAwareWrapper: ContextProvider = ({ children }): JSX.Element =
  * @param {ReactElement} children The element that should be wrapped.
  * @returns {ReactElement} The wrapped element.
  */
-export const ContextAwareWrapper: ContextProvider = ({ children }): JSX.Element => {
+export const ContextAwareWrapper: ContextProvider = ({ children }) => {
 	useSetGlobalStatusFlags();
 	useSetRelationalData();
 	return <>{children}</>;

--- a/assets/src/domain/eventEditor/services/context/TicketContext/index.tsx
+++ b/assets/src/domain/eventEditor/services/context/TicketContext/index.tsx
@@ -8,7 +8,7 @@ const DEFAULT_CONTEXT = {
 
 export const TicketContext = createContext<EntityContextProps>(DEFAULT_CONTEXT);
 
-const TicketProvider: EntityContextProvider = ({ children, id }): JSX.Element => {
+const TicketProvider: EntityContextProvider = ({ children, id }) => {
 	const value: EntityContextProps = { id };
 
 	return <TicketContext.Provider value={value}>{children}</TicketContext.Provider>;

--- a/assets/src/domain/eventEditor/ui/EventEditor.tsx
+++ b/assets/src/domain/eventEditor/ui/EventEditor.tsx
@@ -12,7 +12,7 @@ import TicketsList from './tickets/ticketsList';
 import { EditorModal } from '../../shared/ui/editorModal';
 import { useStatus, TypeName } from '../../../application/services/apollo/status';
 
-const EventEditor: React.FC = (): JSX.Element => {
+const EventEditor: React.FC = () => {
 	useEditorInitialization();
 
 	const { isLoaded } = useStatus();

--- a/assets/src/domain/eventEditor/ui/datetimes/DatetimeIdTag.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/DatetimeIdTag.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useDatetimeItem from '../../services/apollo/queries/datetimes/useDatetimeItem';
 import { ListItemProps } from '../../interfaces/types';
 
-const DatetimeIdTag: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const DatetimeIdTag: React.FC<ListItemProps> = ({ id }) => {
 	const { dbId } = useDatetimeItem({ id }) || {};
 	return dbId ? <code>{dbId}</code> : null;
 };

--- a/assets/src/domain/eventEditor/ui/datetimes/dateCard/DateCard.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateCard/DateCard.tsx
@@ -22,7 +22,7 @@ import { InlineEditInput } from '../../../../../application/ui/input';
 import { ListItemProps } from '../../../interfaces/types';
 import { btnStyle, cardStyle, idStyle } from './styles';
 
-const DateCard: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const DateCard: React.FC<ListItemProps> = ({ id }) => {
 	const date = useDatetimeItem({ id });
 	const { isLoaded } = useStatus();
 	const { updateEntity } = useEntityMutator(EntityType.Datetime, id);

--- a/assets/src/domain/eventEditor/ui/datetimes/dateCard/DeleteDateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateCard/DeleteDateButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '@blueprintjs/core';
 import { useEntityMutator, EntityType, MutationResult } from '../../../../../application/services/apollo/mutations';
 import { ListItemProps } from '../../../interfaces/types';
 
-const DeleteDateButton: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const DeleteDateButton: React.FC<ListItemProps> = ({ id }) => {
 	const { deleteEntity } = useEntityMutator(EntityType.Datetime, id);
 
 	return (

--- a/assets/src/domain/eventEditor/ui/datetimes/dateCard/EditDateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateCard/EditDateButton.tsx
@@ -4,7 +4,7 @@ import { EditItemButtonProps } from '../../../interfaces/types';
 import { useDatetimeContext } from '../../../hooks';
 import { useEditorModal } from '../../../../../application/ui/layout/editorModal';
 
-const EditDateButton: React.FC<EditItemButtonProps> = ({ position }): JSX.Element => {
+const EditDateButton: React.FC<EditItemButtonProps> = ({ position }) => {
 	const { id: entityId } = useDatetimeContext();
 
 	const { openEditor } = useEditorModal();

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/DateForm.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/DateForm.tsx
@@ -18,7 +18,7 @@ const formatSecondaryField = (ticketPrice: number | string, toString = false): J
 	return toString ? renderToString(<Currency quantity={priceAmount} />, null) : <Currency quantity={priceAmount} />;
 };
 
-const DateForm: React.FC<DateItemFormProps> = ({ id, formReset, title }): JSX.Element => {
+const DateForm: React.FC<DateItemFormProps> = ({ id, formReset, title }) => {
 	const { description = '', name = '' } = useDatetimeItem({ id }) || {};
 	const { getRelations } = useRelations();
 	const tickets = useTickets();
@@ -61,7 +61,7 @@ const DateForm: React.FC<DateItemFormProps> = ({ id, formReset, title }): JSX.El
 				<div style={relationsStyle}>
 					<Field
 						name={'tickets'}
-						render={({ input }): JSX.Element => (
+						render={({ input }) => (
 							<RelationsSelector
 								defaultRelatedItems={relatedTicketIds}
 								items={tickets}

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/AddNewDateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/AddNewDateButton.tsx
@@ -12,7 +12,7 @@ const btnRowStyle: CSSProperties = {
 	width: '100%',
 };
 
-const AddNewDateButton: React.FC = (): JSX.Element => {
+const AddNewDateButton: React.FC = () => {
 	const { openEditor } = useEditorModal();
 
 	const onClick = (): void => {

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/List.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/List.tsx
@@ -18,7 +18,7 @@ interface ListProps {
 	datetimes: Datetime[];
 }
 
-const List: React.FC<ListProps> = ({ datetimes }): JSX.Element => {
+const List: React.FC<ListProps> = ({ datetimes }) => {
 	const header = <H3 style={{ margin: '2rem 0 .5rem' }}>{__('Dates List')}</H3>;
 
 	const datetimesList = (

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/DatesListEntityFilters.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/DatesListEntityFilters.tsx
@@ -16,7 +16,7 @@ import ShowDatesControl from './controls/ShowDatesControl';
  * @return {Object} EditorDatesListView with added DateListFilters
  */
 
-const DatesListEntityFilters: React.FC = (): JSX.Element => {
+const DatesListEntityFilters: React.FC = () => {
 	const {
 		datesSortedBy,
 		displayDates,

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/DatesListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/DatesListFilterBar.tsx
@@ -10,7 +10,7 @@ import DatesListEntityFilters from './DatesListEntityFilters';
 
  * @return {Object} EditorDatesListView with added DateListFilters
  */
-const DatesListFilterBar: React.FC = (): JSX.Element => {
+const DatesListFilterBar: React.FC = () => {
 	const listId = 'event-editor-dates-list';
 	const entityFilters = <DatesListEntityFilters />;
 

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DatesSortedControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DatesSortedControl.tsx
@@ -17,7 +17,7 @@ interface DatesSortedControlProps {
  * @param {Function} setDatesSortedBy
  * @return {Object} rendered control
  */
-const DatesSortedControl: React.FC<DatesSortedControlProps> = ({ datesSortedBy, setDatesSortedBy }): JSX.Element => {
+const DatesSortedControl: React.FC<DatesSortedControlProps> = ({ datesSortedBy, setDatesSortedBy }) => {
 	return useMemo(() => {
 		return (
 			<SelectControl

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DisplayDatesControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DisplayDatesControl.tsx
@@ -17,7 +17,7 @@ interface DisplayDatesControlProps {
  * @param {Function} setDisplayDates
  * @return {Object} rendered control
  */
-const DisplayDatesControl: React.FC<DisplayDatesControlProps> = ({ displayDates, setDisplayDates }): JSX.Element =>
+const DisplayDatesControl: React.FC<DisplayDatesControlProps> = ({ displayDates, setDisplayDates }) =>
 	useMemo<JSX.Element>(() => {
 		return (
 			<SelectControl

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/ShowDatesControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/ShowDatesControl.tsx
@@ -17,7 +17,7 @@ interface ShowDatesControlProps {
  * @param {Function} setShowDates
  * @return {Object} rendered control
  */
-const ShowDatesControl: React.FC<ShowDatesControlProps> = ({ showDates, setShowDates }): JSX.Element => {
+const ShowDatesControl: React.FC<ShowDatesControlProps> = ({ showDates, setShowDates }) => {
 	return useMemo<JSX.Element>(() => {
 		return (
 			<SelectControl

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/index.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/index.tsx
@@ -9,7 +9,7 @@ import EmptyState from '../../../../../application/ui/display/EmptyState';
 import ErrorIndicator from '../../../../../application/ui/display/ErrorIndicator';
 import LoadingIndicator from '../../../../../application/ui/display/LoadingIndicator';
 
-const DatesList: React.FC = (): JSX.Element => {
+const DatesList: React.FC = () => {
 	const datetimes = useDatetimes();
 	const noDatetimes = datetimes.length === 0;
 	const { isError, isLoading } = useStatus();

--- a/assets/src/domain/eventEditor/ui/datetimes/useAddDatetimeModal.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/useAddDatetimeModal.tsx
@@ -22,7 +22,7 @@ const useAddDatetimeModal: EditorModal = () => {
 	);
 
 	const formComponent = useCallback<React.FC<DateItemFormProps>>(
-		(props): JSX.Element => <DateForm {...props} title={__('New Datetime Details')} />,
+		(props) => <DateForm {...props} title={__('New Datetime Details')} />,
 		[]
 	);
 

--- a/assets/src/domain/eventEditor/ui/datetimes/useEditDatetimeModal.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/useEditDatetimeModal.tsx
@@ -22,7 +22,7 @@ const useEditDatetimeModal: EditorModal = (entityId) => {
 	);
 
 	const formComponent = useCallback<React.FC<DateItemFormProps>>(
-		(props): JSX.Element => (
+		(props) => (
 			// id prop is needed because modal is out of DatetimeContext
 			<DateForm {...props} id={entityId} title={__('Update datetime')} />
 		),

--- a/assets/src/domain/eventEditor/ui/tickets/TicketIdTag.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/TicketIdTag.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import useTicketItem from '../../services/apollo/queries/tickets/useTicketItem';
 import { ListItemProps } from '../../interfaces/types';
 
-const TicketIdTag: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const TicketIdTag: React.FC<ListItemProps> = ({ id }) => {
 	const { dbId } = useTicketItem({ id }) || {};
 	return dbId ? <code>{dbId}</code> : null;
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketCard/DeleteTicketButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketCard/DeleteTicketButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '@blueprintjs/core/lib/esm';
 import useDeleteTicketHandler from '../hooks/useDeleteTicketHandler';
 import { ListItemProps } from '../../../interfaces/types';
 
-const DeleteTicketButton: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const DeleteTicketButton: React.FC<ListItemProps> = ({ id }) => {
 	const handleDeleteTicket = useDeleteTicketHandler({ id });
 
 	return <Button icon={'trash'} onClick={handleDeleteTicket} minimal />;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketCard/EditTicketButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketCard/EditTicketButton.tsx
@@ -5,7 +5,7 @@ import { EditItemButtonProps } from '../../../interfaces/types';
 import { useTicketContext } from '../../../hooks';
 import { useEditorModal } from '../../../../../application/ui/layout/editorModal';
 
-const EditTicketButton: React.FC<EditItemButtonProps> = ({ position }): JSX.Element => {
+const EditTicketButton: React.FC<EditItemButtonProps> = ({ position }) => {
 	const { id: entityId } = useTicketContext();
 
 	const { openEditor } = useEditorModal();

--- a/assets/src/domain/eventEditor/ui/tickets/ticketCard/TicketCard.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketCard/TicketCard.tsx
@@ -16,7 +16,7 @@ import DatetimeIdTag from '../../datetimes/DatetimeIdTag';
 import { ListItemProps } from '../../../interfaces/types';
 import { cardStyle, idStyle, priceStyle, btnsStyle } from './styles';
 
-const TicketCard: React.FC<ListItemProps> = ({ id }): JSX.Element => {
+const TicketCard: React.FC<ListItemProps> = ({ id }) => {
 	const ticket = useTicketItem({ id });
 	const { isLoaded } = useStatus();
 	const { updateEntity } = useEntityMutator(EntityType.Ticket, id);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/TicketForm.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/TicketForm.tsx
@@ -10,7 +10,7 @@ import useRelations from '../../../../../application/services/apollo/relations/u
 import { TicketItemFormProps } from '../types';
 import { hdrStyle, lblStyle, inputStyle, divStyle, relationsStyle } from './style';
 
-const TicketForm: React.FC<TicketItemFormProps> = ({ id, formReset, title }): JSX.Element => {
+const TicketForm: React.FC<TicketItemFormProps> = ({ id, formReset, title }) => {
 	const { description = '', name = '', price = '' } = useTicketItem({ id }) || {};
 	const { getRelations } = useRelations();
 	const datetimes = useDatetimes();
@@ -67,7 +67,7 @@ const TicketForm: React.FC<TicketItemFormProps> = ({ id, formReset, title }): JS
 				<div style={relationsStyle}>
 					<Field
 						name={'datetimes'}
-						render={({ input }): JSX.Element => (
+						render={({ input }) => (
 							<RelationsSelector
 								defaultRelatedItems={relatedDatetimeIds}
 								items={datetimes}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceCalculatorForm.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceCalculatorForm.tsx
@@ -9,7 +9,7 @@ import { TpcForm } from './types';
 // just temporary
 import styles from './inlineStyles';
 
-const TicketPriceCalculatorForm: React.FC<TpcForm> = ({ form, values: { ticket } }): JSX.Element => {
+const TicketPriceCalculatorForm: React.FC<TpcForm> = ({ form, values: { ticket } }) => {
 	const reverseCalculate = Boolean(ticket.reverseCalculate);
 	const toggleCalcDir = (): void => form.mutators.toggleCalcDir();
 	return (

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceModifierRow.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceModifierRow.tsx
@@ -20,7 +20,7 @@ const TicketPriceModifierRow: React.FC<TpcModifierFormRowProps> = ({
 	price,
 	reverseCalculate,
 	fields,
-}): JSX.Element => {
+}) => {
 	const priceTypes = usePriceTypes();
 	const modifierOptions = getPriceModifiers(priceTypes);
 	return (

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceModifierRowIterator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceModifierRowIterator.tsx
@@ -4,25 +4,23 @@ import { FieldArray } from 'react-final-form-arrays';
 import TicketPriceModifierRow from './TicketPriceModifierRow';
 import { FieldArrayProps, WithRevCalc } from './types';
 
-const TicketPriceModifierRowIterator: React.FC<WithRevCalc> = ({ reverseCalculate }): JSX.Element => (
+const TicketPriceModifierRowIterator: React.FC<WithRevCalc> = ({ reverseCalculate }) => (
 	<FieldArray name={'prices'}>
 		{(props: FieldArrayProps): JSX.Element[] => {
 			const { fields } = props;
-			return fields.map(
-				(name: string, index: number): JSX.Element => {
-					const price = fields.value[index];
-					return price ? (
-						<TicketPriceModifierRow
-							key={`${price.id}:${index}`}
-							index={index}
-							name={name}
-							fields={fields}
-							price={price}
-							reverseCalculate={reverseCalculate}
-						/>
-					) : null;
-				}
-			);
+			return fields.map((name: string, index: number) => {
+				const price = fields.value[index];
+				return price ? (
+					<TicketPriceModifierRow
+						key={`${price.id}:${index}`}
+						index={index}
+						name={name}
+						fields={fields}
+						price={price}
+						reverseCalculate={reverseCalculate}
+					/>
+				) : null;
+			});
 		}}
 	</FieldArray>
 );

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceTotalRow.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/TicketPriceTotalRow.tsx
@@ -8,7 +8,7 @@ import styles from './inlineStyles';
 import { TpcFormElement } from './types';
 import { useMoneyDisplay } from '../../../../../application/services/utilities/money';
 
-const TicketPriceTotalRow: React.FC<TpcFormElement> = ({ ticket, reverseCalculate, toggleCalcDir }): JSX.Element => {
+const TicketPriceTotalRow: React.FC<TpcFormElement> = ({ ticket, reverseCalculate, toggleCalcDir }) => {
 	const { afterAmount, beforeAmount, formatAmount } = useMoneyDisplay();
 	const calcDirIcon = reverseCalculate ? 'double-chevron-up' : 'double-chevron-down';
 	const reverseCalc = reverseCalculate ? 'true' : 'false';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddPriceModifierButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddPriceModifierButton.tsx
@@ -5,7 +5,7 @@ interface AddPriceModifierButtonProps {
 	addPriceModifier: () => void;
 }
 
-const AddPriceModifierButton: React.FC<AddPriceModifierButtonProps> = ({ addPriceModifier }): JSX.Element => (
+const AddPriceModifierButton: React.FC<AddPriceModifierButtonProps> = ({ addPriceModifier }) => (
 	<Button key={'add'} icon={'add'} onClick={addPriceModifier} minimal />
 );
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddPriceModifierButtonData.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddPriceModifierButtonData.tsx
@@ -7,7 +7,7 @@ import { AddPriceModifierDataProps } from '../types';
 import usePriceTypeForPrice from '../../../../services/apollo/queries/priceTypes/usePriceTypeForPrice';
 import { Price } from '../../../../services/apollo/types';
 
-const AddPriceModifierButtonData = ({ name, price, push, reset, sort }: AddPriceModifierDataProps): JSX.Element => {
+const AddPriceModifierButtonData = ({ name, price, push, reset, sort }: AddPriceModifierDataProps) => {
 	const baseType = usePriceTypeForPrice(price.id);
 	const addPriceModifier = useCallback(() => {
 		if (Number(price.amount)) {

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
@@ -6,7 +6,7 @@ type DeletePriceModifierButtonProps = {
 	remove: (index: number) => void;
 };
 
-const DeletePriceModifierButton: React.FC<DeletePriceModifierButtonProps> = ({ index, remove }): JSX.Element => {
+const DeletePriceModifierButton: React.FC<DeletePriceModifierButtonProps> = ({ index, remove }) => {
 	return <Button key={'trash'} icon={'trash'} onClick={(): void => remove(index)} minimal />;
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/PriceModifierActions.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/PriceModifierActions.tsx
@@ -9,7 +9,7 @@ const PriceModifierActions: React.FC<TpcModifierFormRowProps> = ({
 	name,
 	price,
 	fields: { push, remove, reset, sort },
-}): JSX.Element => {
+}) => {
 	const actions = [];
 	const key = `${price.id}-${index}`;
 	if (price.id === 'NEW_PRICE') {

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/TicketPriceCalculatorButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/TicketPriceCalculatorButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '@blueprintjs/core/lib/esm';
 import { TpcButtonDataProps, TpcModalProps } from '../types';
 import { useEditorModal } from '../../../../../../application/ui/layout/editorModal';
 
-const TicketPriceCalculatorButton: React.FC<TpcButtonDataProps & TpcModalProps> = ({ ticketId }): JSX.Element => {
+const TicketPriceCalculatorButton: React.FC<TpcButtonDataProps & TpcModalProps> = ({ ticketId }) => {
 	const { openEditor } = useEditorModal();
 
 	const onClick = (): void => {

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/formDecorators/usePriceTypeDecorator.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/formDecorators/usePriceTypeDecorator.ts
@@ -18,7 +18,7 @@ const usePriceTypeDecorator = (): Calculation => {
 		isEqual: isEqual,
 		updates: (value, name, formData: TpcFormData): UpdatedTpcFormDataPath => {
 			// get the form data path for the price modifier
-			const pricePath: string = name.replace('.priceType', '');
+			const pricePath = name.replace('.priceType', '');
 			// get ALL of the price modifier data from the form data
 			const priceModifier = getFromFormData<TpcPriceModifier>(pricePath, formData);
 			// whether we are calculating the base price or ticket total

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateBasePrice.ts
@@ -24,7 +24,7 @@ const calculateBasePrice = (state: TpcFormData): TpcFormData => {
 	const justModifiers = filter<TpcPriceModifier>(notNewPrice, withoutBasePrice);
 	const sortedModifiers = sortByPriceOrderIdDesc(justModifiers);
 	// now extract the value for "total" or set to 0
-	const ticketTotal = propOr(0, 'price', ticket);
+	const ticketTotal = propOr<number, Ticket, number>(0, 'price', ticket);
 	const newBasePrice = reduce<TpcPriceModifier, number>(basePriceCalculator, ticketTotal, sortedModifiers);
 	const newPrices = updateBasePriceAmount<TpcPriceModifier>({
 		prices: state.prices,

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateBasePrice.ts
@@ -21,10 +21,10 @@ const calculateBasePrice = (state: TpcFormData): TpcFormData => {
 	// we're calculating the base price so we don't want to include it in the calculations
 	const withoutBasePrice = filter<TpcPriceModifier>(isNotBasePrice, allPrices);
 	// and the last element should be the "NEW_PRICE" row and we don't want it either
-	const justModifiers: TpcPriceModifier[] = filter<TpcPriceModifier>(notNewPrice, withoutBasePrice);
-	const sortedModifiers: TpcPriceModifier[] = sortByPriceOrderIdDesc(justModifiers);
+	const justModifiers = filter<TpcPriceModifier>(notNewPrice, withoutBasePrice);
+	const sortedModifiers = sortByPriceOrderIdDesc(justModifiers);
 	// now extract the value for "total" or set to 0
-	const ticketTotal: number = propOr(0, 'price', ticket);
+	const ticketTotal = propOr(0, 'price', ticket);
 	const newBasePrice = reduce<TpcPriceModifier, number>(basePriceCalculator, ticketTotal, sortedModifiers);
 	const newPrices = updateBasePriceAmount<TpcPriceModifier>({
 		prices: state.prices,

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateTicketTotal.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/calculateTicketTotal.ts
@@ -13,15 +13,15 @@ const calculateTicketTotal = (state: TpcFormData): TpcFormData => {
 	if (!ticket) {
 		return state;
 	}
-	const allPrices: TpcPriceModifier[] = pathOr<TpcPriceModifier[]>(null, ['prices'], state);
+	const allPrices = pathOr<TpcPriceModifier[]>(null, ['prices'], state);
 	if (!allPrices) {
 		return state;
 	}
 	// we're calculating the ticket total but the last element
 	// should be the "NEW_PRICE" row and we don't want it
-	const modifiers: TpcPriceModifier[] = filter<TpcPriceModifier>(notNewPrice, allPrices);
-	const sortedModifiers: TpcPriceModifier[] = sortByPriceOrderIdAsc(modifiers);
-	const newTicketTotal: number = reduce(ticketTotalCalculator, 0, sortedModifiers);
+	const modifiers = filter<TpcPriceModifier>(notNewPrice, allPrices);
+	const sortedModifiers = sortByPriceOrderIdAsc(modifiers);
+	const newTicketTotal = reduce(ticketTotalCalculator, 0, sortedModifiers);
 	const tickets: Ticket[] = updateTicketPriceForTicket({
 		tickets: [ticket],
 		guid: ticket.id,

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
@@ -14,7 +14,7 @@ interface PriceAmountInputProps {
 	reverseCalculate: boolean;
 }
 
-const PriceAmountInput: React.FC<PriceAmountInputProps> = ({ name, price, reverseCalculate }): JSX.Element => {
+const PriceAmountInput: React.FC<PriceAmountInputProps> = ({ name, price, reverseCalculate }) => {
 	const { currency, formatAmount } = useMoneyDisplay();
 	const sign = price.isPercent ? percentSign : currency.sign;
 	let b4Price = '';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceDescriptionInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceDescriptionInput.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import styles from '../inlineStyles';
 import { PriceInputProps } from '../types';
 
-const PriceDescriptionInput: React.FC<PriceInputProps> = ({ name, price }): JSX.Element => {
+const PriceDescriptionInput: React.FC<PriceInputProps> = ({ name, price }) => {
 	return (
 		<Field
 			type={'text'}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceIdInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceIdInput.tsx
@@ -3,7 +3,7 @@ import { Field } from 'react-final-form';
 
 import { PriceInputProps } from '../types';
 
-const PriceIdInput: React.FC<PriceInputProps> = ({ name, price }): JSX.Element => {
+const PriceIdInput: React.FC<PriceInputProps> = ({ name, price }) => {
 	return (
 		<>
 			<Field type={'hidden'} component={'input'} initialValue={price.id} name={`${name}.id`} />

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceNameInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceNameInput.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import styles from '../inlineStyles';
 import { PriceInputProps } from '../types';
 
-const PriceNameInput: React.FC<PriceInputProps> = ({ name, price }): JSX.Element => {
+const PriceNameInput: React.FC<PriceInputProps> = ({ name, price }) => {
 	return (
 		<Field
 			type={'text'}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceTypeInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceTypeInput.tsx
@@ -13,7 +13,7 @@ interface PriceTypeInputProps {
 	modifierOptions: PriceType[];
 }
 
-const PriceTypeInput: React.FC<PriceTypeInputProps> = ({ name, price, priceTypes, modifierOptions }): JSX.Element => {
+const PriceTypeInput: React.FC<PriceTypeInputProps> = ({ name, price, priceTypes, modifierOptions }) => {
 	const relatedPriceType = usePriceTypeForPrice(price.id);
 	const options = price.isBasePrice ? priceTypes : modifierOptions;
 	return (
@@ -24,13 +24,11 @@ const PriceTypeInput: React.FC<PriceTypeInputProps> = ({ name, price, priceTypes
 			disabled={price.isBasePrice}
 			style={styles.input}
 		>
-			{options.map(
-				(option: PriceType): JSX.Element => (
-					<option key={option.id} value={option.id}>
-						{option.name}
-					</option>
-				)
-			)}
+			{options.map((option: PriceType) => (
+				<option key={option.id} value={option.id}>
+					{option.name}
+				</option>
+			))}
 		</Field>
 	);
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/List.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/List.tsx
@@ -24,7 +24,7 @@ interface ListProps {
 	tickets: Ticket[];
 }
 
-const List: React.FC<ListProps> = ({ tickets }): JSX.Element => {
+const List: React.FC<ListProps> = ({ tickets }) => {
 	const header = <H3 style={{ margin: '2rem 0 .5rem' }}>{__('Tickets List')}</H3>;
 
 	const ticketList = (

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/TicketListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/TicketListFilterBar.tsx
@@ -9,7 +9,7 @@ import TicketsListEntityFilters from './TicketsListEntityFilters';
  *
  * @return {Object} EditorTicketsListView with added TicketListFilters
  */
-const TicketListFilterBar: React.FC = (): JSX.Element => {
+const TicketListFilterBar: React.FC = () => {
 	const listId = 'event-editor-tickets-list';
 	const entityFilters = <TicketsListEntityFilters />;
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/TicketsListEntityFilters.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/TicketsListEntityFilters.tsx
@@ -14,7 +14,7 @@ import './style.css';
  *
  * @return {Object} EditorTicketsListView with added TicketListFilters
  */
-const TicketsListEntityFilters: React.FC = (): JSX.Element => {
+const TicketsListEntityFilters: React.FC = () => {
 	const {
 		displayTicketDate,
 		isChained,

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/ShowTicketsControl.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/ShowTicketsControl.tsx
@@ -24,11 +24,7 @@ interface ShowDatesControlProps {
  * @param {Function} setShowTickets
  * @return {Object} rendered control
  */
-const ShowTicketsControl: React.FC<ShowDatesControlProps> = ({
-	isChained,
-	setShowTickets,
-	showTickets,
-}): JSX.Element => {
+const ShowTicketsControl: React.FC<ShowDatesControlProps> = ({ isChained, setShowTickets, showTickets }) => {
 	return React.useMemo(() => {
 		return (
 			<SelectControl

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
@@ -19,7 +19,7 @@ interface TicketsChainedButtonProps {
  * @param {Function} toggleIsChained
  * @return {Object} rendered control
  */
-const TicketsChainedButton: React.FC<TicketsChainedButtonProps> = ({ isChained, toggleIsChained }): JSX.Element => {
+const TicketsChainedButton: React.FC<TicketsChainedButtonProps> = ({ isChained, toggleIsChained }) => {
 	return (
 		<IconButton
 			label={isChained ? __('showing tickets for above dates only') : __('showing tickets for all event dates')}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsSortedByControl.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsSortedByControl.tsx
@@ -22,10 +22,7 @@ interface TicketsSortedByControlProps {
  * @param {string} sortTicketsBy
  * @return {Object} rendered control
  */
-const TicketsSortedByControl: React.FC<TicketsSortedByControlProps> = ({
-	setSortTicketsBy,
-	sortTicketsBy,
-}): JSX.Element => {
+const TicketsSortedByControl: React.FC<TicketsSortedByControlProps> = ({ setSortTicketsBy, sortTicketsBy }) => {
 	return React.useMemo(() => {
 		return (
 			<SelectControl

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/index.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/index.tsx
@@ -15,7 +15,7 @@ import List from './List';
 import useTickets from '../../../services/apollo/queries/tickets/useTickets';
 import { useStatus, TypeName } from '../../../../../application/services/apollo/status';
 
-const TicketsList: React.FC = (): JSX.Element => {
+const TicketsList: React.FC = () => {
 	const tickets = useTickets();
 	const noTickets = tickets.length === 0;
 	const { isError, isLoading } = useStatus();

--- a/assets/src/domain/eventEditor/ui/tickets/useAddTicketModal.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/useAddTicketModal.tsx
@@ -22,7 +22,7 @@ const useAddTicketModal: EditorModal = () => {
 	);
 
 	const formComponent = useCallback<React.FC<TicketItemFormProps>>(
-		(props): JSX.Element => <TicketForm {...props} title={__('New Ticket Details')} />,
+		(props) => <TicketForm {...props} title={__('New Ticket Details')} />,
 		[]
 	);
 

--- a/assets/src/domain/eventEditor/ui/tickets/useEditTicketModal.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/useEditTicketModal.tsx
@@ -22,7 +22,7 @@ const useEditTicketModal: EditorModal = (entityId) => {
 	);
 
 	const formComponent = useCallback<React.FC<TicketItemFormProps>>(
-		(props): JSX.Element => (
+		(props) => (
 			// id prop is needed because modal is out of TicketContext
 			<TicketForm {...props} id={entityId} title={__('Update ticket')} />
 		),

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/aboveCapacity/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/aboveCapacity/index.ts
@@ -9,7 +9,7 @@ type AboveCapacityProps = {
 	dates: Datetime[];
 };
 
-const aboveCapacity = ({ capacity, dates }: AboveCapacityProps): Datetime[] | [] => {
+const aboveCapacity = ({ capacity, dates }: AboveCapacityProps): Datetime[] => {
 	const filterFn = (date: Datetime): boolean => !date.isTrashed && capacityAtOrAbove(date, capacity);
 
 	return dates.filter(filterFn);

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/activeOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/activeOnly/index.ts
@@ -6,9 +6,9 @@ import { is } from 'ramda';
 /**
  * Internal dependencies
  */
-import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
+import { DatetimeFilterFn } from '../types';
 
-const activeOnly = (dates: Datetime[]): Datetime[] | [] => {
+const activeOnly: DatetimeFilterFn = (dates) => {
 	return dates.filter(({ isActive }) => {
 		return is(Boolean, isActive) && isActive;
 	});

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/activeUpcoming/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/activeUpcoming/index.ts
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
+import { DatetimeFilterFn } from '../types';
 
-const activeUpcoming = (dates: Datetime[]): Datetime[] | [] => {
+const activeUpcoming: DatetimeFilterFn = (dates) => {
 	return dates.filter(({ isActive, isUpcoming }) => isActive || isUpcoming);
 };
 

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/allDates/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/allDates/index.ts
@@ -6,9 +6,10 @@ import { is } from 'ramda';
 /**
  * Internal dependencies
  */
+import { DatetimeFilterFn } from '../types';
 import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
 
-const allDates = (dates: Datetime[]): Datetime[] | [] => {
+const allDates: DatetimeFilterFn = (dates) => {
 	const withoutTrashed = ({ isTrashed }: Datetime): boolean => {
 		return is(Boolean, isTrashed) && !isTrashed;
 	};

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/belowCapacity/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/belowCapacity/index.ts
@@ -9,7 +9,7 @@ type BelowCapacityProps = {
 	dates: Datetime[];
 };
 
-const belowCapacity = ({ capacity, dates }: BelowCapacityProps): Datetime[] | [] => {
+const belowCapacity = ({ capacity, dates }: BelowCapacityProps): Datetime[] => {
 	return dates.filter((date) => filter({ capacity, date }));
 };
 

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/expiredOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/expiredOnly/index.ts
@@ -8,8 +8,9 @@ import { is } from 'ramda';
  */
 import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
 import { isTrashed } from '../../../../../services/predicates';
+import { DatetimeFilterFn } from '../types';
 
-const expiredOnly = (dates: Datetime[]): Datetime[] | [] => {
+const expiredOnly: DatetimeFilterFn = (dates) => {
 	const filterFn = (date: Datetime): boolean => {
 		return is(Boolean, date.isExpired) && date.isExpired && !isTrashed(date);
 	};

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/index.ts
@@ -30,7 +30,7 @@ interface FilterDates {
  * @param {string} showDates    value for the "showDates" filter
  * @return {Array}         filtered dateEntities array
  */
-const filters = ({ dates, show = ShowDates.activeUpcoming }: FilterDates) => {
+const filters = ({ dates, show = ShowDates.activeUpcoming }: FilterDates): Datetime[] => {
 	switch (show) {
 		case ShowDates.above50Capacity:
 			return aboveCapacity({ dates, capacity: 50 });

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/nextActiveUpcomingOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/nextActiveUpcomingOnly/index.ts
@@ -7,9 +7,9 @@ import { head } from 'ramda';
  * Internal dependencies
  */
 import activeUpcoming from '../activeUpcoming';
-import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
+import { DatetimeFilterFn } from '../types';
 
-const nextActiveUpcomingOnly = (dates: Datetime[]): Datetime[] | [] => {
+const nextActiveUpcomingOnly: DatetimeFilterFn = (dates) => {
 	const activeUpcomingDates = activeUpcoming(dates);
 	const firstActiveUpcomingDates = head(activeUpcomingDates);
 

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/recentlyExpiredOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/recentlyExpiredOnly/index.ts
@@ -3,8 +3,9 @@
  */
 import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
 import isRecentlyExpired from '../../isRecentlyExpired';
+import { DatetimeFilterFn } from '../types';
 
-const recentlyExpiredOnly = (dates: Datetime[]): Datetime[] | [] => {
+const recentlyExpiredOnly: DatetimeFilterFn = (dates) => {
 	const filterFn = (date: Datetime): boolean => {
 		return isRecentlyExpired(date) && !date.isTrashed;
 	};

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/soldOutOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/soldOutOnly/index.ts
@@ -5,8 +5,9 @@ import capacityAtOrAbove from '../../capacityAtOrAbove';
 import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
 import { isTrashed } from '../../../../../services/predicates';
 import validStatus from '../../validStatus';
+import { DatetimeFilterFn } from '../types';
 
-const soldOutOnly = (dates: Datetime[]): Datetime[] | [] => {
+const soldOutOnly: DatetimeFilterFn = (dates) => {
 	const filterFn = (date: Datetime): boolean => {
 		return !isTrashed(date) && ((validStatus(date) && date.isSoldOut) || capacityAtOrAbove(date, 100));
 	};

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/trashedOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/trashedOnly/index.ts
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
 import { isTrashed } from '../../../../../services/predicates';
+import { DatetimeFilterFn } from '../types';
 
-const trashedOnly = (dates: Datetime[]): Datetime[] | [] => {
+const trashedOnly: DatetimeFilterFn = (dates) => {
 	return dates.filter(isTrashed);
 };
 

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/types.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/types.ts
@@ -1,0 +1,3 @@
+import { Datetime } from '../../../../../eventEditor/services/apollo/types';
+
+export type DatetimeFilterFn = (dates: Array<Datetime>) => Array<Datetime>;

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/upcomingOnly/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/upcomingOnly/index.ts
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { Datetime } from '../../../../../../eventEditor/services/apollo/types';
+import { DatetimeFilterFn } from '../types';
 
-const upcomingOnly = (dates: Datetime[]): Datetime[] | [] => dates.filter(({ isUpcoming }) => isUpcoming);
+const upcomingOnly: DatetimeFilterFn = (dates) => dates.filter(({ isUpcoming }) => isUpcoming);
 
 export default upcomingOnly;

--- a/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
@@ -24,7 +24,7 @@ export const isTax = propEq('isTax', true);
 export const isNotTax = propEq('isTax', false);
 
 // returns price if found in array of prices
-export const getBasePrice = (prices: Price[]): Price | undefined => find(isBasePrice)(prices);
+export const getBasePrice = (prices: Price[]): Price => find(isBasePrice)(prices);
 export const getPriceByDbId = (prices: Price[], dbId: EntityDbId): Price => findEntityByDbId(prices)(dbId);
 export const getPriceByGuid = (prices: Price[], guid: EntityId): Price => findEntityByGuid(prices)(guid);
 

--- a/assets/src/domain/shared/entities/prices/predicates/sortingPredicates.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/sortingPredicates.ts
@@ -26,7 +26,7 @@ export const sortByPriceOrderIdDesc: sortPricesFn = sortWith([descendingPriceOrd
 export const sortByPriceOrderNameAsc: sortPricesFn = sortWith([ascendingPriceOrder, ascendingPriceName]);
 export const sortByPriceOrderNameDesc: sortPricesFn = sortWith([descendingPriceOrder, descendingPriceName]);
 
-export const sortPrices = (ticket: Ticket) => <T extends Price>(prices: T[]) =>
+export const sortPrices = (ticket: Ticket) => <T extends Price>(prices: T[]): T[] =>
 	ticket.reverseCalculate ? sortByPriceOrderIdDesc(prices) : sortByPriceOrderIdAsc(prices);
 
 export default sortPrices;

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/allOnSaleAndPending/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/allOnSaleAndPending/index.ts
@@ -1,9 +1,9 @@
 import { anyPass, filter } from 'ramda';
 import isOnSale from '../../isOnSale';
 import isPending from '../../isPending';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const allOnSaleAndPending = (tickets: Ticket[]): Ticket[] => {
+const allOnSaleAndPending: TicketFilterFn = (tickets) => {
 	const isOnSaleOrIsPending = anyPass([isOnSale, isPending]);
 	const onSaleAndPending = filter(isOnSaleOrIsPending)(tickets);
 	return onSaleAndPending;

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/expiredOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/expiredOnly/index.ts
@@ -1,7 +1,7 @@
 import isExpired from '../../isExpired';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const expiredOnly = (tickets: Ticket[]): Ticket[] => {
+const expiredOnly: TicketFilterFn = (tickets) => {
 	return tickets.filter((ticket) => isExpired(ticket));
 };
 

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/nextOnSaleOrPendingOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/nextOnSaleOrPendingOnly/index.ts
@@ -8,9 +8,9 @@ import { anyPass, filter, head } from 'ramda';
  */
 import { isOnSale, isPending } from '../../index';
 import sorters from '../../sorters';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const nextOnSaleOrPendingOnly = (tickets: Ticket[]): Ticket[] => {
+const nextOnSaleOrPendingOnly: TicketFilterFn = (tickets) => {
 	const isOnSaleOrIsPending = anyPass([isOnSale, isPending]);
 	const allOnSaleAndPending = filter(isOnSaleOrIsPending)(tickets);
 	const sortedOnSaleAndPending = sorters({ tickets: allOnSaleAndPending });

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/onSaleOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/onSaleOnly/index.ts
@@ -1,7 +1,7 @@
 import isOnSale from '../../isOnSale';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const onSaleOnly = (tickets: Ticket[]): Ticket[] => {
+const onSaleOnly: TicketFilterFn = (tickets) => {
 	return tickets.filter((ticket) => isOnSale(ticket));
 };
 

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/pendingOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/pendingOnly/index.ts
@@ -1,7 +1,7 @@
 import isPending from '../../isPending';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const pendingOnly = (tickets: Ticket[]): Ticket[] => {
+const pendingOnly: TicketFilterFn = (tickets) => {
 	return tickets.filter(isPending);
 };
 

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/percentSoldBelow/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/percentSoldBelow/index.ts
@@ -15,8 +15,8 @@ type PercentSoldAtOrAboveProps = {
  * @param {number} percentage
  * @return {boolean} true if sold/qty less than than qty
  */
-const percentSoldBelow = ({ percentage, tickets }: PercentSoldAtOrAboveProps) => {
-	const filterFn = (ticket: Ticket) => {
+const percentSoldBelow = ({ percentage, tickets }: PercentSoldAtOrAboveProps): Ticket[] => {
+	const filterFn = (ticket: Ticket): boolean => {
 		const { quantity, sold } = ticket;
 
 		return (

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/soldOutOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/soldOutOnly/index.ts
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import { filterFn } from '../percentSoldAtOrAbove';
-import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const soldOutOnly = (tickets: Ticket[]): Ticket[] => {
+const soldOutOnly: TicketFilterFn = (tickets) => {
 	return tickets.filter((ticket) => {
 		return ticket.isSoldOut || filterFn({ percentage: 100, ticket });
 	});

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/trashedOnly/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/trashedOnly/index.ts
@@ -3,8 +3,9 @@
  */
 import { isTrashed } from '../../../../../services/predicates';
 import { Ticket } from '../../../../../../eventEditor/services/apollo/types';
+import { TicketFilterFn } from '../types';
 
-const trashedOnly = (tickets: Ticket[]): Ticket[] => {
+const trashedOnly: TicketFilterFn = (tickets) => {
 	return tickets.filter((ticket) => isTrashed<Ticket>(ticket));
 };
 

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/types.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/types.ts
@@ -1,0 +1,3 @@
+import { Ticket } from '../../../../../eventEditor/services/apollo/types';
+
+export type TicketFilterFn = (dates: Array<Ticket>) => Array<Ticket>;

--- a/assets/src/domain/shared/entities/tickets/predicates/selectionPredicates.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/selectionPredicates.ts
@@ -2,15 +2,17 @@ import { assoc, indexOf, map, propEq, when } from 'ramda';
 
 import { ticketFields } from './ticketFields';
 import { entityHasGuid } from '../../../services/predicates';
-
+import { Ticket } from '../../../../eventEditor/services/apollo/types';
 const NO_INDEX = -1;
 
-export const isTicketField = (val, key) => indexOf(key, ticketFields) > NO_INDEX;
+export const isTicketField = (val, key): boolean => indexOf(key, ticketFields) > NO_INDEX;
 export const isExpired = propEq('isExpired', true);
-export const updateTicketPrice = (amount) => assoc('price', amount);
-export const updateReverseCalculate = (reverseCalculate) => assoc('reverseCalculate', reverseCalculate);
+export const updateTicketPrice = (amount): ((obj: Ticket) => Record<keyof Ticket, number> & Ticket) =>
+	assoc<number, keyof Ticket>('price', amount);
+export const updateReverseCalculate = (reverseCalculate): ((obj: Ticket) => Record<keyof Ticket, number> & Ticket) =>
+	assoc<number, keyof Ticket>('reverseCalculate', reverseCalculate);
 
-export const updateTicketPriceForTicket = ({ tickets, guid, amount }) =>
+export const updateTicketPriceForTicket = ({ tickets, guid, amount }): Ticket[] =>
 	map(when(entityHasGuid(guid), updateTicketPrice(amount)), tickets);
-export const updateTicketReverseCalculate = ({ tickets, guid, reverseCalculate }) =>
+export const updateTicketReverseCalculate = ({ tickets, guid, reverseCalculate }): Ticket[] =>
 	map(when(entityHasGuid(guid), updateReverseCalculate(reverseCalculate)), tickets);

--- a/assets/src/domain/shared/entities/tickets/predicates/selectionPredicates.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/selectionPredicates.ts
@@ -5,12 +5,14 @@ import { entityHasGuid } from '../../../services/predicates';
 import { Ticket } from '../../../../eventEditor/services/apollo/types';
 const NO_INDEX = -1;
 
-export const isTicketField = (val, key): boolean => indexOf(key, ticketFields) > NO_INDEX;
+export const isTicketField = (val: any, key: keyof Ticket): boolean => indexOf(key, ticketFields) > NO_INDEX;
 export const isExpired = propEq('isExpired', true);
-export const updateTicketPrice = (amount): ((obj: Ticket) => Record<keyof Ticket, number> & Ticket) =>
+export const updateTicketPrice = (amount: number): ((obj: Ticket) => Record<keyof Ticket, number> & Ticket) =>
 	assoc<number, keyof Ticket>('price', amount);
-export const updateReverseCalculate = (reverseCalculate): ((obj: Ticket) => Record<keyof Ticket, number> & Ticket) =>
-	assoc<number, keyof Ticket>('reverseCalculate', reverseCalculate);
+export const updateReverseCalculate = (
+	reverseCalculate: boolean
+): ((obj: Ticket) => Record<keyof Ticket, boolean> & Ticket) =>
+	assoc<boolean, keyof Ticket>('reverseCalculate', reverseCalculate);
 
 export const updateTicketPriceForTicket = ({ tickets, guid, amount }): Ticket[] =>
 	map(when(entityHasGuid(guid), updateTicketPrice(amount)), tickets);

--- a/assets/src/domain/shared/ui/RelationsSelector/index.tsx
+++ b/assets/src/domain/shared/ui/RelationsSelector/index.tsx
@@ -15,7 +15,7 @@ interface RelationsSelectorProps {
 	displayFields: string[];
 	formatFields?: any;
 	placeholder: string;
-	onChange: (e: any) => void | null;
+	onChange: (e: any) => void;
 	formReset: boolean;
 	itemType: string;
 }

--- a/assets/src/domain/shared/ui/dateRangeInput/DateRangePicker.tsx
+++ b/assets/src/domain/shared/ui/dateRangeInput/DateRangePicker.tsx
@@ -17,7 +17,7 @@ interface DateRangePickerProps {
 	setRange: React.Dispatch<React.SetStateAction<[Date, Date]>>;
 }
 
-const DateRangePicker: React.FC<DateRangePickerProps> = ({ onFieldUpdate, range, setRange }): JSX.Element => {
+const DateRangePicker: React.FC<DateRangePickerProps> = ({ onFieldUpdate, range, setRange }) => {
 	const format = FORMATS.MYSQL;
 
 	const handleRangeChange = (value: [Date, Date]): void => {

--- a/assets/src/domain/shared/ui/dateRangeInput/dateDisplay.tsx
+++ b/assets/src/domain/shared/ui/dateRangeInput/dateDisplay.tsx
@@ -20,7 +20,7 @@ interface DateTagProps extends DateFCProps {
 	date: Date;
 }
 
-export const DateTag: React.FC<DateTagProps> = ({ date, withTime = false, format: formatStr }): JSX.Element => {
+export const DateTag: React.FC<DateTagProps> = ({ date, withTime = false, format: formatStr }) => {
 	const formatString = formatStr || (withTime ? FORMAT_TIME : FORMAT);
 	if (isValid(date)) {
 		return <Tag intent={Intent.SUCCESS}>{format(date, formatString)}</Tag>;
@@ -34,7 +34,7 @@ export const DateRangeDisplay: React.FC<DateRangeDisplayProps> = ({
 	range: [start, end],
 	withTime = false,
 	format,
-}): JSX.Element => {
+}) => {
 	const formatString = format || (withTime ? FORMAT_TIME : FORMAT);
 	return (
 		<div className={classNames('docs-date-range', className)}>

--- a/assets/src/domain/shared/ui/editorModal/EditorModal.tsx
+++ b/assets/src/domain/shared/ui/editorModal/EditorModal.tsx
@@ -6,7 +6,7 @@ import useEditors from './useEditors';
 
 const DEFAULT_EDITOR: EditorState = { editorId: null, entityId: '', isOpen: false };
 
-const EditorModal: React.FC = (): JSX.Element => {
+const EditorModal: React.FC = () => {
 	const { editors: editorModals } = useEditorModal();
 	const { editorId, entityId = '', isOpen } = pathOr<EditorState>(
 		DEFAULT_EDITOR,


### PR DESCRIPTION
This PR:
- Fixes some TS warnings
- Improves types
- Removes the unnecessary types where it's inferred e.g. `JSX.Element` when type is set as `React.FC`
- Closes #2280