### PR TITLE
Typefy and test application date utils | Closes #2132

### DIFF
--- a/assets/src/application/services/utilities/date/addSub.ts
+++ b/assets/src/application/services/utilities/date/addSub.ts
@@ -39,12 +39,12 @@ const addMapping = {
 	years: addYears,
 };
 
-export const add = (interval: IntervalType, date: Date, amount: number) => {
+export const add = (interval: IntervalType, date: Date | number, amount: number): Date => {
 	const func = addMapping[interval];
 	return func(date, amount);
 };
 
-export const sub = (interval: IntervalType, dirtyDate: Date, dirtyAmount: number) => {
+export const sub = (interval: IntervalType, dirtyDate: Date | number, dirtyAmount: number): Date => {
 	const func = addMapping[interval];
 	const amount = toInteger(dirtyAmount);
 	const date = toDate(dirtyDate);

--- a/assets/src/application/services/utilities/date/diff.ts
+++ b/assets/src/application/services/utilities/date/diff.ts
@@ -17,6 +17,7 @@ import {
 	differenceInSeconds,
 	differenceInWeeks,
 	differenceInYears,
+	Locale,
 } from 'date-fns';
 
 type UnitsType =
@@ -60,10 +61,21 @@ const diffMapping = {
 	years: differenceInYears,
 };
 
-const diff = (unit: UnitsType, dateLeft: Date | number, dateRight: Date | number) => {
+// only for calendarWeeks
+type DirtyOptions = {
+	locale?: Locale;
+	weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+};
+
+const diff = (
+	unit: UnitsType,
+	dateLeft: Date | number,
+	dateRight: Date | number,
+	dirtyOptions?: DirtyOptions
+): number => {
 	const func = diffMapping[unit];
 
-	return func(dateLeft, dateRight);
+	return unit === 'calendarWeeks' ? func(dateLeft, dateRight, dirtyOptions) : func(dateLeft, dateRight);
 };
 
 export default diff;

--- a/assets/src/application/services/utilities/date/sort.ts
+++ b/assets/src/application/services/utilities/date/sort.ts
@@ -5,7 +5,7 @@ type SortProps = {
 	order: 'asc' | 'desc';
 };
 
-const sort = ({ dates, order }: SortProps) => {
+const sort = ({ dates, order }: SortProps): Date[] => {
 	return order === 'asc' ? dates.sort(compareAsc) : dates.sort(compareDesc);
 };
 

--- a/assets/src/application/services/utilities/date/test/addSub/add.ISOWeekYears.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.ISOWeekYears.test.ts
@@ -1,0 +1,49 @@
+import { add } from '../../addSub';
+
+describe('add.ISOWeekYears', () => {
+	it('adds the given number of ISO week-numbering years', () => {
+		const result = add('ISOWeekYears', new Date(2010, 6 /* Jul */, 2), 5);
+		expect(result).toEqual(new Date(2015, 5 /* Jun */, 26));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('ISOWeekYears', new Date(2014, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2026, 7 /* Aug */, 31));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('ISOWeekYears', new Date(2010, 6 /* Jul */, 2), 5.6);
+		expect(result).toEqual(new Date(2015, 5 /* Jun */, 26));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('ISOWeekYears', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(10, 6 /* Jul */, 2);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(15, 5 /* Jun */, 26);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = add('ISOWeekYears', initialDate, 5);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('ISOWeekYears', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('ISOWeekYears', new Date(2010, 6 /* Jul */, 2), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.days.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.days.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.days', () => {
+	it('adds the given number of days', () => {
+		const result = add('days', new Date(2014, 8 /* Sep */, 1), 10);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 11));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('days', new Date(2014, 8 /* Sep */, 1).getTime(), 10);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 11));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('days', new Date(2014, 8 /* Sep */, 1), 10.5);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 11));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('days', date, 11);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('days', new Date(NaN), 10);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('days', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.hours.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.hours.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.hours', () => {
+	it('adds the given numbers of hours', () => {
+		const result = add('hours', new Date(2014, 6 /* Jul */, 10, 23, 0), 2);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 11, 1, 0));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('hours', new Date(2014, 6 /* Jul */, 10, 23, 0).getTime(), 26);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 12, 1, 0));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('hours', new Date(2014, 6 /* Jul */, 10, 23, 0), 2.5);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 11, 1, 0));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 23, 0);
+		add('hours', date, 10);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 23, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('hours', new Date(NaN), 2);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('hours', new Date(2014, 6 /* Jul */, 10, 23, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.milliseconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.milliseconds.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.milliseconds', () => {
+	it('adds the given number of milliseconds', () => {
+		const result = add('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 750));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0).getTime(), 500);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 500));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750.75);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 750));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0);
+		add('milliseconds', date, 250);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('milliseconds', new Date(NaN), 750);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.minutes.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.minutes.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.minutes', () => {
+	it('adds the given number of minutes', () => {
+		const result = add('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), 30);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 30));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0).getTime(), 20);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 20));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), 30.99);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 30));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 0);
+		add('minutes', date, 25);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('minutes', new Date(NaN), 30);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.months.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.months.test.ts
@@ -1,0 +1,55 @@
+import { add } from '../../addSub';
+
+describe('add.months', () => {
+	it('adds the given number of months', () => {
+		const result = add('months', new Date(2014, 8 /* Sep */, 1), 5);
+		expect(result).toEqual(new Date(2015, 1 /* Feb */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('months', new Date(2014, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2015, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('months', new Date(2014, 8 /* Sep */, 1), 5.75);
+		expect(result).toEqual(new Date(2015, 1 /* Feb */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('months', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('works well if the desired month has fewer days and the provided date is in the last day of a month', () => {
+		const date = new Date(2014, 11 /* Dec */, 31);
+		const result = add('months', date, 2);
+		expect(result).toEqual(new Date(2015, 1 /* Feb */, 28));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(0, 0 /* Jan */, 31);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(0, 1 /* Feb */, 29);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = add('months', initialDate, 1);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('months', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('months', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.quarters.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.quarters.test.ts
@@ -1,0 +1,55 @@
+import { add } from '../../addSub';
+
+describe('add.quarters', () => {
+	it('adds the given number of quarters', () => {
+		const result = add('quarters', new Date(2014, 8 /* Sep */, 1), 1);
+		expect(result).toEqual(new Date(2014, 11 /* Dec */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('quarters', new Date(2014, 8 /* Sep */, 1).getTime(), 4);
+		expect(result).toEqual(new Date(2015, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('quarters', new Date(2014, 8 /* Sep */, 1), 1.91);
+		expect(result).toEqual(new Date(2014, 11 /* Dec */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('quarters', date, 4);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('works well if the desired month has fewer days and the provided date is in the last day of a month', () => {
+		const date = new Date(2014, 11 /* Dec */, 31);
+		const result = add('quarters', date, 3);
+		expect(result).toEqual(new Date(2015, 8 /* Sep */, 30));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(-1, 10 /* Nov */, 30);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(0, 1 /* Feb */, 29);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = add('quarters', initialDate, 1);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('quarters', new Date(NaN), 1);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('quarters', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.seconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.seconds.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.seconds', () => {
+	it('adds the given number of seconds', () => {
+		const result = add('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0).getTime(), 20);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 20));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30.777);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 45, 0);
+		add('seconds', date, 15);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('seconds', new Date(NaN), 30);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.weeks.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.weeks.test.ts
@@ -1,0 +1,38 @@
+import { add } from '../../addSub';
+
+describe('add.weeks', () => {
+	it('adds the given number of weeks', () => {
+		const result = add('weeks', new Date(2014, 8 /* Sep */, 1), 4);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 29));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('weeks', new Date(2014, 8 /* Sep */, 1).getTime(), 1);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 8));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('weeks', new Date(2014, 8 /* Sep */, 1), 4.95);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 29));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('weeks', date, 2);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('weeks', new Date(NaN), 4);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('weeks', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/add.years.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/add.years.test.ts
@@ -1,0 +1,54 @@
+import { add } from '../../addSub';
+
+describe('add.years', () => {
+	it('adds the given number of years', () => {
+		const result = add('years', new Date(2014, 8 /* Sep */, 1), 5);
+		expect(result).toEqual(new Date(2019, 8 /* Sep */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = add('years', new Date(2014, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2026, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = add('years', new Date(2014, 8 /* Sep */, 1), 5.555);
+		expect(result).toEqual(new Date(2019, 8 /* Sep */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		add('years', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('handles the leap years properly', () => {
+		const result = add('years', new Date(2016, 1 /* Feb */, 29), 1);
+		expect(result).toEqual(new Date(2017, 1 /* Feb */, 28));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(0, 1 /* Feb */, 29);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(1, 1 /* Feb */, 28);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = add('years', initialDate, 1);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = add('years', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = add('years', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.ISOWeekYears.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.ISOWeekYears.test.ts
@@ -1,0 +1,49 @@
+import { sub } from '../../addSub';
+
+describe('sub.ISOWeekYears', () => {
+	it('subtracts the given number of ISO week-numbering years', () => {
+		const result = sub('ISOWeekYears', new Date(2014, 8 /* Sep */, 1), 5);
+		expect(result).toEqual(new Date(2009, 7 /* Aug */, 31));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('ISOWeekYears', new Date(2014, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2002, 8 /* Sep */, 2));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('ISOWeekYears', new Date(2014, 8 /* Sep */, 1), 5.555);
+		expect(result).toEqual(new Date(2009, 7 /* Aug */, 31));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('ISOWeekYears', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(15, 5 /* Jun */, 26);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(10, 6 /* Jul */, 2);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = sub('ISOWeekYears', initialDate, 5);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('ISOWeekYears', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('ISOWeekYears', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.days.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.days.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.days', () => {
+	it('subtracts the given number of days', () => {
+		const result = sub('days', new Date(2014, 8 /* Sep */, 1), 10);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 22));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('days', new Date(2014, 8 /* Sep */, 1).getTime(), 10);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 22));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('days', new Date(2014, 8 /* Sep */, 1), 10.85);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 22));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('days', date, 11);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('days', new Date(NaN), 10);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('days', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.hours.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.hours.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.hours', () => {
+	it('subtracts the given numbers of hours', () => {
+		const result = sub('hours', new Date(2014, 6 /* Jul */, 11, 1, 0), 2);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 23, 0));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('hours', new Date(2014, 6 /* Jul */, 12, 1, 0).getTime(), 26);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 23, 0));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('hours', new Date(2014, 6 /* Jul */, 11, 1, 0), 2.22);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 23, 0));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 23, 0);
+		sub('hours', date, 10);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 23, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('hours', new Date(NaN), 2);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('hours', new Date(2014, 6 /* Jul */, 11, 1, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.milliseconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.milliseconds.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.milliseconds', () => {
+	it('subtracts the given number of milliseconds', () => {
+		const result = sub('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 29, 250));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0).getTime(), 500);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 29, 500));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), 750.75);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 29, 250));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0);
+		sub('milliseconds', date, 250);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('milliseconds', new Date(NaN), 750);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('milliseconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 30, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.minutes.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.minutes.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.minutes', () => {
+	it('subtracts the given number of minutes', () => {
+		const result = sub('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), 30);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 11, 30));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0).getTime(), 20);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 11, 40));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), 30.4);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 11, 30));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 0);
+		sub('minutes', date, 25);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('minutes', new Date(NaN), 30);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('minutes', new Date(2014, 6 /* Jul */, 10, 12, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.months.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.months.test.ts
@@ -1,0 +1,55 @@
+import { sub } from '../../addSub';
+
+describe('sub.months', () => {
+	it('subtracts the given number of months', () => {
+		const result = sub('months', new Date(2015, 1 /* Feb */, 1), 5);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('months', new Date(2015, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('months', new Date(2015, 1 /* Feb */, 1), 5.999);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('months', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('works well if the desired month has fewer days and the provided date is in the last day of a month', () => {
+		const date = new Date(2014, 11 /* Dec */, 31);
+		const result = sub('months', date, 3);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 30));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(1, 2 /* Mar */, 31);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(1, 1 /* Feb */, 28);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = sub('months', initialDate, 1);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('months', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('months', new Date(2015, 1 /* Feb */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.quarters.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.quarters.test.ts
@@ -1,0 +1,55 @@
+import { sub } from '../../addSub';
+
+describe('sub.quarters', () => {
+	it('subtracts the given number of quarters', () => {
+		const result = sub('quarters', new Date(2014, 8 /* Sep */, 1), 3);
+		expect(result).toEqual(new Date(2013, 11 /* Dec */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('quarters', new Date(2014, 8 /* Sep */, 1).getTime(), 4);
+		expect(result).toEqual(new Date(2013, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('quarters', new Date(2014, 8 /* Sep */, 1), 3.33);
+		expect(result).toEqual(new Date(2013, 11 /* Dec */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('quarters', date, 3);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('works well if the desired month has fewer days and the provided date is in the last day of a month', () => {
+		const date = new Date(2014, 11 /* Dec */, 31);
+		const result = sub('quarters', date, 1);
+		expect(result).toEqual(new Date(2014, 8 /* Sep */, 30));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(0, 10 /* Nov */, 30);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(0, 1 /* Feb */, 29);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = sub('quarters', initialDate, 3);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('quarters', new Date(NaN), 3);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('quarters', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.seconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.seconds.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.seconds', () => {
+	it('subtracts the given number of seconds', () => {
+		const result = sub('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 44, 30));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0).getTime(), 20);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 44, 40));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), 30.5);
+		expect(result).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 44, 30));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 6 /* Jul */, 10, 12, 45, 0);
+		sub('seconds', date, 15);
+		expect(date).toEqual(new Date(2014, 6 /* Jul */, 10, 12, 45, 0));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('seconds', new Date(NaN), 30);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('seconds', new Date(2014, 6 /* Jul */, 10, 12, 45, 0), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.weeks.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.weeks.test.ts
@@ -1,0 +1,38 @@
+import { sub } from '../../addSub';
+
+describe('sub.weeks', () => {
+	it('subtracts the given number of weeks', () => {
+		const result = sub('weeks', new Date(2014, 8 /* Sep */, 1), 4);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 4));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('weeks', new Date(2014, 8 /* Sep */, 1).getTime(), 1);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 25));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('weeks', new Date(2014, 8 /* Sep */, 1), 4.2);
+		expect(result).toEqual(new Date(2014, 7 /* Aug */, 4));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('weeks', date, 2);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('weeks', new Date(NaN), 4);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('weeks', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/addSub/sub.years.test.ts
+++ b/assets/src/application/services/utilities/date/test/addSub/sub.years.test.ts
@@ -1,0 +1,54 @@
+import { sub } from '../../addSub';
+
+describe('sub.years', () => {
+	it('subtracts the given number of years', () => {
+		const result = sub('years', new Date(2014, 8 /* Sep */, 1), 5);
+		expect(result).toEqual(new Date(2009, 8 /* Sep */, 1));
+	});
+
+	it('accepts a timestamp', () => {
+		const result = sub('years', new Date(2014, 8 /* Sep */, 1).getTime(), 12);
+		expect(result).toEqual(new Date(2002, 8 /* Sep */, 1));
+	});
+
+	it('converts a fractional number to an integer', () => {
+		const result = sub('years', new Date(2014, 8 /* Sep */, 1), 5.1);
+		expect(result).toEqual(new Date(2009, 8 /* Sep */, 1));
+	});
+
+	it('does not mutate the original date', () => {
+		const date = new Date(2014, 8 /* Sep */, 1);
+		sub('years', date, 12);
+		expect(date).toEqual(new Date(2014, 8 /* Sep */, 1));
+	});
+
+	it('handles the leap years properly', () => {
+		const result = sub('years', new Date(2016, 1 /* Feb */, 29), 1);
+		expect(result).toEqual(new Date(2015, 1 /* Feb */, 28));
+	});
+
+	it('handles dates before 100 AD', () => {
+		const initialDate = new Date(0);
+		initialDate.setFullYear(0, 1 /* Feb */, 29);
+		initialDate.setHours(0, 0, 0, 0);
+		const expectedResult = new Date(0);
+		expectedResult.setFullYear(-1, 1 /* Feb */, 28);
+		expectedResult.setHours(0, 0, 0, 0);
+		const result = sub('years', initialDate, 1);
+		expect(result).toEqual(expectedResult);
+	});
+
+	it('returns `Invalid Date` if the given date is invalid', () => {
+		const result = sub('years', new Date(NaN), 5);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns `Invalid Date` if the given amount is NaN', () => {
+		const result = sub('years', new Date(2014, 8 /* Sep */, 1), NaN);
+
+		expect(result).toBeInstanceOf(Date);
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/areEqual.test.ts
+++ b/assets/src/application/services/utilities/date/test/areEqual.test.ts
@@ -1,0 +1,33 @@
+import areEqual from '../areEqual';
+
+describe('areEqual', () => {
+	it('returns true if the given dates are equal', () => {
+		const result = areEqual(new Date(1987, 1 /* Feb */, 11), new Date(1987, 1 /* Feb */, 11));
+		expect(result).toBe(true);
+	});
+
+	it('returns false if the given dates are not equal', () => {
+		const result = areEqual(new Date(1989, 6 /* Jul */, 10), new Date(1987, 1 /* Feb */, 11));
+		expect(result).toBe(false);
+	});
+
+	it('accepts a timestamp', () => {
+		const result = areEqual(new Date(1987, 1 /* Feb */, 11).getTime(), new Date(1987, 1 /* Feb */, 11).getTime());
+		expect(result).toBe(true);
+	});
+
+	it('returns false if the first date is `Invalid Date`', () => {
+		const result = areEqual(new Date(NaN), new Date(1989, 6 /* Jul */, 10));
+		expect(result).toBe(false);
+	});
+
+	it('returns false if the second date is `Invalid Date`', () => {
+		const result = areEqual(new Date(1987, 1 /* Feb */, 11), new Date(NaN));
+		expect(result).toBe(false);
+	});
+
+	it('returns false if the both dates are `Invalid Date`', () => {
+		const result = areEqual(new Date(NaN), new Date(NaN));
+		expect(result).toBe(false);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.ISOWeekYears.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.ISOWeekYears.test.ts
@@ -1,0 +1,97 @@
+import diff from '../../diff';
+
+describe('diff.ISOWeekYears', () => {
+	it('returns the number of full ISO week-numbering years between the given dates', () => {
+		const result = diff(
+			'ISOWeekYears',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(1);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'ISOWeekYears',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'ISOWeekYears',
+			new Date(2014, 6 /* Jul */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(4);
+	});
+
+	it('handles dates before 100 AD', () => {
+		const firstDate = new Date(0);
+		firstDate.setFullYear(14, 0 /* Jan */, 1);
+		firstDate.setHours(0, 0, 0, 0);
+		const secondDate = new Date(0);
+		secondDate.setFullYear(0, 0 /* Jan */, 1);
+		secondDate.setHours(0, 0, 0, 0);
+		const result = diff('ISOWeekYears', firstDate, secondDate);
+		expect(result).toBe(14);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than an ISO year, but the given dates are in different calendar years', () => {
+			const result = diff('ISOWeekYears', new Date(2012, 0 /* Jan */, 2), new Date(2012, 0 /* Jan */, 1));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('ISOWeekYears', new Date(2012, 0 /* Jan */, 1), new Date(2012, 0 /* Jan */, 2));
+			expect(result).toBe(0);
+		});
+
+		it('the ISO weeks and weekdays of the given dates are the same', () => {
+			const result = diff('ISOWeekYears', new Date(2013, 11 /* Dec */, 30), new Date(2012, 0 /* Jan */, 2));
+			expect(result).toBe(2);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'ISOWeekYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'ISOWeekYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('ISOWeekYears', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('ISOWeekYears', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('ISOWeekYears', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.businessDays.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.businessDays.test.ts
@@ -1,0 +1,109 @@
+import diff from '../../diff';
+
+describe('diff.businessDays', () => {
+	it('returns the number of business days between the given dates, excluding weekends', () => {
+		const result = diff('businessDays', new Date(2014, 6 /* Jul */, 18), new Date(2014, 0 /* Jan */, 10));
+		expect(result).toBe(135);
+	});
+
+	it('can handle long ranges', () => {
+		if (typeof this.timeout === 'function') {
+			this.timeout(500 /* 500 ms test timeout */);
+		}
+		const result = diff('businessDays', new Date(15000, 0 /* Jan */, 1), new Date(2014, 0 /* Jan */, 1));
+		expect(result).toBe(3387885);
+	});
+
+	it('the same except given first date falls on a weekend', () => {
+		const result = diff('businessDays', new Date(2019, 6 /* Jul */, 20), new Date(2019, 6 /* Jul */, 18));
+		expect(result).toBe(2);
+	});
+
+	it('the same except given second date falls on a weekend', () => {
+		const result = diff('businessDays', new Date(2019, 6 /* Jul */, 23), new Date(2019, 6 /* Jul */, 20));
+		expect(result).toBe(1);
+	});
+
+	it('the same except both given dates fall on a weekend', () => {
+		const result = diff('businessDays', new Date(2019, 6 /* Jul */, 28), new Date(2019, 6 /* Jul */, 20));
+		expect(result).toBe(5);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('businessDays', new Date(2014, 0 /* Jan */, 10), new Date(2014, 6 /* Jul */, 20));
+		expect(result).toBe(-135);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff('businessDays', new Date(2014, 6, 18).getTime(), new Date(2014, 0, 10).getTime());
+		expect(result).toBe(135);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a day, but the given dates are in different calendar days', () => {
+			const result = diff(
+				'businessDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 4, 23, 59)
+			);
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff(
+				'businessDays',
+				new Date(2014, 8 /* Sep */, 4, 23, 59),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(-1);
+		});
+
+		it('the time values of the given dates are the same', () => {
+			const result = diff(
+				'businessDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 4, 0, 0)
+			);
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'businessDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'businessDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+
+		it('returns NaN if the first date is `Invalid Date`', () => {
+			const result = diff('businessDays', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+			expect(isNaN(Number(result))).toBe(true);
+		});
+
+		it('returns NaN if the second date is `Invalid Date`', () => {
+			const result = diff('businessDays', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+			expect(isNaN(Number(result))).toBe(true);
+		});
+
+		it('returns NaN if the both dates are `Invalid Date`', () => {
+			const result = diff('businessDays', new Date(NaN), new Date(NaN));
+			expect(isNaN(Number(result))).toBe(true);
+		});
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarDays.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarDays.test.ts
@@ -1,0 +1,98 @@
+import diff from '../../diff';
+
+describe('diff.calendarDays', () => {
+	it('returns the number of calendar days between the given dates', () => {
+		const result = diff(
+			'calendarDays',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(366);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarDays',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-366);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarDays',
+			new Date(2014, 8 /* Sep */, 5, 18, 0).getTime(),
+			new Date(2014, 8 /* Sep */, 4, 6, 0).getTime()
+		);
+		expect(result).toBe(1);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a day, but the given dates are in different calendar days', () => {
+			const result = diff(
+				'calendarDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 4, 23, 59)
+			);
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff(
+				'calendarDays',
+				new Date(2014, 8 /* Sep */, 4, 23, 59),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(-1);
+		});
+
+		it('the time values of the given the given dates are the same', () => {
+			const result = diff(
+				'calendarDays',
+				new Date(2014, 8 /* Sep */, 6, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(1);
+		});
+
+		it('the given the given dates are the same', () => {
+			const result = diff(
+				'calendarDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarDays',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarDays', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarDays', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarDays', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarISOWeekYears.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarISOWeekYears.test.ts
@@ -1,0 +1,101 @@
+import diff from '../../diff';
+
+describe('diff.calendarISOWeekYears', () => {
+	it('returns the number of calendar ISO week-numbering years between the given dates', () => {
+		const result = diff(
+			'calendarISOWeekYears',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(1);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarISOWeekYears',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarISOWeekYears',
+			new Date(2014, 6 /* Jul */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(4);
+	});
+
+	it('handles dates before 100 AD', () => {
+		const firstDate = new Date(0);
+		firstDate.setFullYear(14, 0 /* Jan */, 1);
+		firstDate.setHours(0, 0, 0, 0);
+		const secondDate = new Date(0);
+		secondDate.setFullYear(0, 0 /* Jan */, 1);
+		secondDate.setHours(0, 0, 0, 0);
+		const result = diff('calendarISOWeekYears', firstDate, secondDate);
+		expect(result).toBe(15);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than an ISO year, but the given dates are in different calendar ISO years', () => {
+			const result = diff('calendarISOWeekYears', new Date(2012, 0 /* Jan */, 2), new Date(2012, 0 /* Jan */, 1));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarISOWeekYears', new Date(2012, 0 /* Jan */, 1), new Date(2012, 0 /* Jan */, 2));
+			expect(result).toBe(-1);
+		});
+
+		it('the ISO weeks and weekdays of the given dates are the same', () => {
+			const result = diff(
+				'calendarISOWeekYears',
+				new Date(2013, 11 /* Dec */, 30),
+				new Date(2012, 0 /* Jan */, 2)
+			);
+			expect(result).toBe(2);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarISOWeekYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarISOWeekYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarISOWeekYears', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarISOWeekYears', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarISOWeekYears', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarISOWeeks.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarISOWeeks.test.ts
@@ -1,0 +1,86 @@
+import diff from '../../diff';
+
+describe('diff.calendarISOWeeks', () => {
+	it('returns the number of calendar ISO weeks between the given dates', () => {
+		const result = diff(
+			'calendarISOWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0)
+		);
+		expect(result).toBe(2);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarISOWeeks',
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			new Date(2014, 6 /* Jul */, 8, 18, 0)
+		);
+		expect(result).toBe(-2);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarISOWeeks',
+			new Date(2014, 6 /* Jul */, 12).getTime(),
+			new Date(2014, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(1);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than an ISO week, but the given dates are in different calendar ISO weeks', () => {
+			const result = diff('calendarISOWeeks', new Date(2014, 6 /* Jul */, 7), new Date(2014, 6 /* Jul */, 6));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarISOWeeks', new Date(2014, 6 /* Jul */, 6), new Date(2014, 6 /* Jul */, 7));
+			expect(result).toBe(-1);
+		});
+
+		it('the days of weeks of the given dates are the same', () => {
+			const result = diff('calendarISOWeeks', new Date(2014, 6 /* Jul */, 9), new Date(2014, 6 /* Jul */, 2));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarISOWeeks',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarISOWeeks',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarISOWeeks', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarISOWeeks', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarISOWeeks', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarMonths.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarMonths.test.ts
@@ -1,0 +1,86 @@
+import diff from '../../diff';
+
+describe('diff.calendarMonths', () => {
+	it('returns the number of calendar months between the given dates', () => {
+		const result = diff(
+			'calendarMonths',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(12);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarMonths',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-12);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarMonths',
+			new Date(2014, 7 /* Aug */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(49);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a month, but the given dates are in different calendar months', () => {
+			const result = diff('calendarMonths', new Date(2014, 8 /* Sep */, 1), new Date(2014, 7 /* Aug */, 31));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarMonths', new Date(2014, 7 /* Aug */, 31), new Date(2014, 8 /* Sep */, 1));
+			expect(result).toBe(-1);
+		});
+
+		it('the days of months of the given dates are the same', () => {
+			const result = diff('calendarMonths', new Date(2014, 8 /* Sep */, 6), new Date(2014, 7 /* Aug */, 6));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarMonths',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarMonths',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarMonths', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarMonths', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarMonths', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarQuarters.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarQuarters.test.ts
@@ -1,0 +1,86 @@
+import diff from '../../diff';
+
+describe('diff.calendarQuarters', () => {
+	it('returns the number of calendar quarters between the given dates', () => {
+		const result = diff(
+			'calendarQuarters',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(4);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarQuarters',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-4);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarQuarters',
+			new Date(2014, 9 /* Oct */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(17);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a quarter, but the given dates are in different calendar quarters', () => {
+			const result = diff('calendarQuarters', new Date(2014, 6 /* Jul */, 1), new Date(2014, 5 /* Jun */, 30));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarQuarters', new Date(2014, 5 /* Jun */, 30), new Date(2014, 6 /* Jul */, 1));
+			expect(result).toBe(-1);
+		});
+
+		it('the days of months of the given dates are the same', () => {
+			const result = diff('calendarQuarters', new Date(2014, 3 /* Apr */, 6), new Date(2014, 0 /* Jan */, 6));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarQuarters',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarQuarters',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarQuarters', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarQuarters', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarQuarters', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarWeeks.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarWeeks.test.ts
@@ -1,0 +1,138 @@
+import diff from '../../diff';
+
+describe('diff.calendarWeeks', () => {
+	it('returns the number of calendar weeks between the given dates', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0)
+		);
+		expect(result).toBe(1);
+	});
+
+	it('allows to specify which day is the first day of the week', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			{ weekStartsOn: 1 }
+		);
+		expect(result).toBe(2);
+	});
+
+	it('allows to specify which day is the first day of the week in locale', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			{
+				// $ExpectedMistake
+				locale: {
+					options: { weekStartsOn: 1 },
+				},
+			}
+		);
+		expect(result).toBe(2);
+	});
+
+	it('`options.weekStartsOn` overwrites the first day of the week specified in locale', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			{
+				weekStartsOn: 1,
+				// $ExpectedMistake
+				locale: {
+					options: { weekStartsOn: 0 },
+				},
+			}
+		);
+		expect(result).toBe(2);
+	});
+
+	it('returns a positive number if the time value of the second date is smaller', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 8, 18, 0),
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			// $ExpectedMistake
+			{ weekStartsOn: 1 }
+		);
+		expect(result).toBe(2);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 5 /* Jun */, 29, 6, 0),
+			new Date(2014, 6 /* Jul */, 8, 18, 0)
+		);
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarWeeks',
+			new Date(2014, 6 /* Jul */, 12).getTime(),
+			new Date(2014, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(1);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a week, but the given dates are in different calendar weeks', () => {
+			const result = diff('calendarWeeks', new Date(2014, 6 /* Jul */, 6), new Date(2014, 6 /* Jul */, 5));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarWeeks', new Date(2014, 6 /* Jul */, 5), new Date(2014, 6 /* Jul */, 6));
+			expect(result).toBe(-1);
+		});
+
+		it('the days of weeks of the given dates are the same', () => {
+			const result = diff('calendarWeeks', new Date(2014, 6 /* Jul */, 9), new Date(2014, 6 /* Jul */, 2));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarWeeks',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarWeeks',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarWeeks', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarWeeks', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarWeeks', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.calendarYears.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.calendarYears.test.ts
@@ -1,0 +1,86 @@
+import diff from '../../diff';
+
+describe('diff.calendarYears', () => {
+	it('returns the number of calendar years between the given dates', () => {
+		const result = diff(
+			'calendarYears',
+			new Date(2012, 6 /* Jul */, 2, 18, 0),
+			new Date(2011, 6 /* Jul */, 2, 6, 0)
+		);
+		expect(result).toBe(1);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'calendarYears',
+			new Date(2011, 6 /* Jul */, 2, 6, 0),
+			new Date(2012, 6 /* Jul */, 2, 18, 0)
+		);
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'calendarYears',
+			new Date(2014, 6 /* Jul */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(4);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a year, but the given dates are in different calendar years', () => {
+			const result = diff('calendarYears', new Date(2015, 0 /* Jan */, 1), new Date(2014, 11 /* Dec */, 31));
+			expect(result).toBe(1);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('calendarYears', new Date(2014, 11 /* Dec */, 31), new Date(2015, 0 /* Jan */, 1));
+			expect(result).toBe(-1);
+		});
+
+		it('the days and months of the given dates are the same', () => {
+			const result = diff('calendarYears', new Date(2014, 8 /* Sep */, 5), new Date(2012, 8 /* Sep */, 5));
+			expect(result).toBe(2);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff(
+				'calendarYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff(
+				'calendarYears',
+				new Date(2014, 8 /* Sep */, 5, 0, 0),
+				new Date(2014, 8 /* Sep */, 5, 0, 0)
+			);
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('calendarYears', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('calendarYears', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('calendarYears', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.days.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.days.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.days', () => {
+	it('returns the number of full days between the given dates', () => {
+		const result = diff('days', new Date(2012, 6 /* Jul */, 2, 18, 0), new Date(2011, 6 /* Jul */, 2, 6, 0));
+		expect(result).toBe(366);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('days', new Date(2011, 6 /* Jul */, 2, 6, 0), new Date(2012, 6 /* Jul */, 2, 18, 0));
+		expect(result).toBe(-366);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'days',
+			new Date(2014, 8 /* Sep */, 5, 18, 0).getTime(),
+			new Date(2014, 8 /* Sep */, 4, 6, 0).getTime()
+		);
+		expect(result).toBe(1);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a day, but the given dates are in different calendar days', () => {
+			const result = diff('days', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 4, 23, 59));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('days', new Date(2014, 8 /* Sep */, 4, 23, 59), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('the time values of the given dates are the same', () => {
+			const result = diff('days', new Date(2014, 8 /* Sep */, 6, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('days', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('days', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('days', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('days', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('days', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.hours.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.hours.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.hours', () => {
+	it('returns the number of hours between the given dates', () => {
+		const result = diff('hours', new Date(2014, 6 /* Jul */, 2, 20, 0), new Date(2014, 6 /* Jul */, 2, 6, 0));
+		expect(result).toBe(14);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('hours', new Date(2014, 6 /* Jul */, 2, 6, 0), new Date(2014, 6 /* Jul */, 2, 20, 0));
+		expect(result).toBe(-14);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'hours',
+			new Date(2014, 8 /* Sep */, 5, 18, 0).getTime(),
+			new Date(2014, 8 /* Sep */, 5, 6, 0).getTime()
+		);
+		expect(result).toBe(12);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than an hour, but the given dates are in different calendar hours', () => {
+			const result = diff('hours', new Date(2014, 8 /* Sep */, 5, 12), new Date(2014, 8 /* Sep */, 5, 11, 59));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('hours', new Date(2014, 8 /* Sep */, 5, 11, 59), new Date(2014, 8 /* Sep */, 5, 12));
+			expect(result === 0).toBe(true);
+		});
+
+		it('the difference is an integral number of hours', () => {
+			const result = diff('hours', new Date(2014, 8 /* Sep */, 5, 13, 0), new Date(2014, 8 /* Sep */, 5, 12, 0));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('hours', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('hours', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('hours', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('hours', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('hours', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.milliseconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.milliseconds.test.ts
@@ -1,0 +1,56 @@
+import diff from '../../diff';
+
+describe('diff.milliseconds', () => {
+	it('returns the number of milliseconds between the given dates', () => {
+		const result = diff(
+			'milliseconds',
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20, 700),
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20, 600)
+		);
+		expect(result).toBe(100);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'milliseconds',
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20, 600),
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20, 700)
+		);
+		expect(result).toBe(-100);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'milliseconds',
+			new Date(2014, 8 /* Sep */, 5, 18, 30, 45, 500).getTime(),
+			new Date(2014, 8 /* Sep */, 5, 18, 30, 45, 500).getTime()
+		);
+		expect(result).toBe(0);
+	});
+
+	it('does not return -0 when the given dates are the same', () => {
+		function isNegativeZero(x) {
+			return x === 0 && 1 / x < 0;
+		}
+
+		const result = diff('milliseconds', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+		const resultIsNegative = isNegativeZero(result);
+		expect(resultIsNegative).toBe(false);
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('milliseconds', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('milliseconds', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('milliseconds', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.minutes.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.minutes.test.ts
@@ -1,0 +1,82 @@
+import diff from '../../diff';
+
+describe('diff.minutes', () => {
+	it('returns the number of minutes between the given dates', () => {
+		const result = diff('minutes', new Date(2014, 6 /* Jul */, 2, 12, 20), new Date(2014, 6 /* Jul */, 2, 12, 6));
+		expect(result).toBe(14);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('minutes', new Date(2014, 6 /* Jul */, 2, 12, 6), new Date(2014, 6 /* Jul */, 2, 12, 20));
+		expect(result).toBe(-14);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'minutes',
+			new Date(2014, 8 /* Sep */, 5, 18, 45).getTime(),
+			new Date(2014, 8 /* Sep */, 5, 18, 15).getTime()
+		);
+		expect(result).toBe(30);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a minute, but the given dates are in different calendar minutes', () => {
+			const result = diff(
+				'minutes',
+				new Date(2014, 8 /* Sep */, 5, 12, 12),
+				new Date(2014, 8 /* Sep */, 5, 12, 11, 59)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff(
+				'minutes',
+				new Date(2014, 8 /* Sep */, 5, 12, 11, 59),
+				new Date(2014, 8 /* Sep */, 5, 12, 12)
+			);
+			expect(result === 0).toBe(true);
+		});
+
+		it('the difference is an integral number of minutes', () => {
+			const result = diff(
+				'minutes',
+				new Date(2014, 8 /* Sep */, 5, 12, 25),
+				new Date(2014, 8 /* Sep */, 5, 12, 15)
+			);
+			expect(result).toBe(10);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('minutes', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('minutes', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('minutes', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('minutes', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('minutes', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.months.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.months.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.months', () => {
+	it('returns the number of full months between the given dates', () => {
+		const result = diff('months', new Date(2012, 6 /* Jul */, 2, 18, 0), new Date(2011, 6 /* Jul */, 2, 6, 0));
+		expect(result).toBe(12);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('months', new Date(2011, 6 /* Jul */, 2, 6, 0), new Date(2012, 6 /* Jul */, 2, 18, 0));
+		expect(result).toBe(-12);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'months',
+			new Date(2014, 7 /* Aug */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(49);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a month, but the given dates are in different calendar months', () => {
+			const result = diff('months', new Date(2014, 7 /* Aug */, 1), new Date(2014, 6 /* Jul */, 31));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('months', new Date(2014, 6 /* Jul */, 31), new Date(2014, 7 /* Aug */, 1));
+			expect(result).toBe(0);
+		});
+
+		it('the days of months of the given dates are the same', () => {
+			const result = diff('months', new Date(2014, 8 /* Sep */, 6), new Date(2014, 7 /* Aug */, 6));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('months', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('months', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('months', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('months', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('months', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.quarters.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.quarters.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.quarters', () => {
+	it('returns the number of full quarters between the given dates', () => {
+		const result = diff('quarters', new Date(2012, 6 /* Jul */, 2, 18, 0), new Date(2011, 6 /* Jul */, 2, 6, 0));
+		expect(result).toBe(4);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('quarters', new Date(2011, 6 /* Jul */, 2, 6, 0), new Date(2012, 6 /* Jul */, 2, 18, 0));
+		expect(result).toBe(-4);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'quarters',
+			new Date(2014, 9 /* Oct */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(17);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a quarter, but the given dates are in different calendar quarters', () => {
+			const result = diff('quarters', new Date(2014, 6 /* Jul */, 1), new Date(2014, 5 /* Jun */, 30));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('quarters', new Date(2014, 5 /* Jun */, 30), new Date(2014, 6 /* Jul */, 1));
+			expect(result).toBe(0);
+		});
+
+		it('the days of months of the given dates are the same', () => {
+			const result = diff('quarters', new Date(2014, 3 /* Apr */, 6), new Date(2014, 0 /* Jan */, 6));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('quarters', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('quarters', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('quarters', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('quarters', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('quarters', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.seconds.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.seconds.test.ts
@@ -1,0 +1,90 @@
+import diff from '../../diff';
+
+describe('diff.seconds', () => {
+	it('returns the number of seconds between the given dates', () => {
+		const result = diff(
+			'seconds',
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20),
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 6)
+		);
+		expect(result).toBe(14);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff(
+			'seconds',
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 6),
+			new Date(2014, 6 /* Jul */, 2, 12, 30, 20)
+		);
+		expect(result).toBe(-14);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'seconds',
+			new Date(2014, 8 /* Sep */, 5, 18, 30, 45).getTime(),
+			new Date(2014, 8 /* Sep */, 5, 18, 30, 15).getTime()
+		);
+		expect(result).toBe(30);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a second, but the given dates are in different calendar seconds', () => {
+			const result = diff(
+				'seconds',
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 12),
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 11, 999)
+			);
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff(
+				'seconds',
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 11, 999),
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 12)
+			);
+			expect(result === 0).toBe(true);
+		});
+
+		it('the difference is an integral number of seconds', () => {
+			const result = diff(
+				'seconds',
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 25),
+				new Date(2014, 8 /* Sep */, 5, 12, 30, 15)
+			);
+			expect(result).toBe(10);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('seconds', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('seconds', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('seconds', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('seconds', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('seconds', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.weeks.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.weeks.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.weeks', () => {
+	it('returns the number of full weeks between the given dates', () => {
+		const result = diff('weeks', new Date(2014, 6 /* Jul */, 8, 18, 0), new Date(2014, 5 /* Jun */, 29, 6, 0));
+		expect(result).toBe(1);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('weeks', new Date(2014, 5 /* Jun */, 29, 6, 0), new Date(2014, 6 /* Jul */, 8, 18, 0));
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'weeks',
+			new Date(2014, 6 /* Jul */, 12).getTime(),
+			new Date(2014, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(1);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a week, but the given dates are in different calendar weeks', () => {
+			const result = diff('weeks', new Date(2014, 6 /* Jul */, 6), new Date(2014, 6 /* Jul */, 5));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('weeks', new Date(2014, 6 /* Jul */, 5), new Date(2014, 6 /* Jul */, 6));
+			expect(result === 0).toBe(true);
+		});
+
+		it('days of weeks of the given dates are the same', () => {
+			const result = diff('weeks', new Date(2014, 6 /* Jul */, 9), new Date(2014, 6 /* Jul */, 2));
+			expect(result).toBe(1);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('weeks', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('weeks', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('weeks', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('weeks', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('weeks', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/diff/diff.years.test.ts
+++ b/assets/src/application/services/utilities/date/test/diff/diff.years.test.ts
@@ -1,0 +1,70 @@
+import diff from '../../diff';
+
+describe('diff.years', () => {
+	it('returns the number of full years between the given dates', () => {
+		const result = diff('years', new Date(2012, 6 /* Jul */, 2, 18, 0), new Date(2011, 6 /* Jul */, 2, 6, 0));
+		expect(result).toBe(1);
+	});
+
+	it('returns a negative number if the time value of the first date is smaller', () => {
+		const result = diff('years', new Date(2011, 6 /* Jul */, 2, 6, 0), new Date(2012, 6 /* Jul */, 2, 18, 0));
+		expect(result).toBe(-1);
+	});
+
+	it('accepts timestamps', () => {
+		const result = diff(
+			'years',
+			new Date(2014, 6 /* Jul */, 2).getTime(),
+			new Date(2010, 6 /* Jul */, 2).getTime()
+		);
+		expect(result).toBe(4);
+	});
+
+	describe('edge cases', () => {
+		it('the difference is less than a year, but the given dates are in different calendar years', () => {
+			const result = diff('years', new Date(2015, 0 /* Jan */, 1), new Date(2014, 11 /* Dec */, 31));
+			expect(result).toBe(0);
+		});
+
+		it('the same for the swapped dates', () => {
+			const result = diff('years', new Date(2014, 11 /* Dec */, 31), new Date(2015, 0 /* Jan */, 1));
+			expect(result).toBe(0);
+		});
+
+		it('the days and months of the given dates are the same', () => {
+			const result = diff('years', new Date(2014, 8 /* Sep */, 5), new Date(2012, 8 /* Sep */, 5));
+			expect(result).toBe(2);
+		});
+
+		it('the given dates are the same', () => {
+			const result = diff('years', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+			expect(result).toBe(0);
+		});
+
+		it('does not return -0 when the given dates are the same', () => {
+			function isNegativeZero(x) {
+				return x === 0 && 1 / x < 0;
+			}
+
+			const result = diff('years', new Date(2014, 8 /* Sep */, 5, 0, 0), new Date(2014, 8 /* Sep */, 5, 0, 0));
+
+			const resultIsNegative = isNegativeZero(result);
+			expect(resultIsNegative).toBe(false);
+		});
+	});
+
+	it('returns NaN if the first date is `Invalid Date`', () => {
+		const result = diff('years', new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the second date is `Invalid Date`', () => {
+		const result = diff('years', new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+
+	it('returns NaN if the both dates are `Invalid Date`', () => {
+		const result = diff('years', new Date(NaN), new Date(NaN));
+		expect(isNaN(Number(result))).toBe(true);
+	});
+});

--- a/assets/src/application/services/utilities/date/test/localToUtc.test.ts
+++ b/assets/src/application/services/utilities/date/test/localToUtc.test.ts
@@ -1,0 +1,33 @@
+import localToUtc from '../localToUtc';
+
+describe('localToUtc', () => {
+	it('returns the UTC time of the date in the time zone for a date input and IANA tz', () => {
+		const result = localToUtc(new Date(2014, 5, 25, 10, 0, 0, 123), 'America/Los_Angeles');
+		expect(result.toISOString()).toBe('2014-06-25T17:00:00.123Z');
+	});
+
+	it('returns the UTC time of the date in the time zone for a string and IANA tz', () => {
+		const result = localToUtc('2014-06-25T10:00:00.123', 'America/Los_Angeles');
+		expect(result.toISOString()).toBe('2014-06-25T17:00:00.123Z');
+	});
+
+	it('returns the UTC time of the date for a UTC input', () => {
+		const result = localToUtc(new Date(2014, 5, 25, 10, 0, 0, 123), 'UTC');
+		expect(result.toISOString()).toBe('2014-06-25T10:00:00.123Z');
+	});
+
+	it('returns the UTC time of the date in the time zone for a date input and tz offset', () => {
+		const result = localToUtc(new Date(2014, 5, 25, 10, 0, 0, 123), '+0400');
+		expect(result.toISOString()).toBe('2014-06-25T06:00:00.123Z');
+	});
+
+	it('returns the UTC time of the date in the time zone for a string and tz offset', () => {
+		const result = localToUtc('2014-06-25T10:00:00.123', '-02:00');
+		expect(result.toISOString()).toBe('2014-06-25T12:00:00.123Z');
+	});
+
+	it('returns the UTC time of the date for the Z tz', () => {
+		const result = localToUtc(new Date(2014, 5, 25, 10, 0, 0, 123), 'Z');
+		expect(result.toISOString()).toBe('2014-06-25T10:00:00.123Z');
+	});
+});

--- a/assets/src/application/services/utilities/date/test/sort.test.ts
+++ b/assets/src/application/services/utilities/date/test/sort.test.ts
@@ -1,0 +1,136 @@
+import { sprintf } from '@wordpress/i18n';
+import { reverse } from 'ramda';
+
+import sort from '../sort';
+
+const arrayToDate = (input: number[]): Date => {
+	const [year, monthIndex, ...rest] = input;
+	return new Date(year, monthIndex, ...rest);
+};
+const testCases = [
+	{
+		desc: 'sorts the dates array in %s order by year',
+		unsorted: [
+			[1995, 1],
+			[1987, 1],
+			[1982, 1],
+			[1989, 1],
+		],
+		sorted: [
+			[1982, 1],
+			[1987, 1],
+			[1989, 1],
+			[1995, 1],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by month',
+		unsorted: [
+			[2019, 3 /* Apr */],
+			[2019, 7 /* Aug */],
+			[2019, 1 /* Feb */],
+			[2019, 6 /* Jul */],
+		],
+		sorted: [
+			[2019, 1],
+			[2019, 3],
+			[2019, 6],
+			[2019, 7],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by day of the month',
+		unsorted: [
+			[2019, 8, 2],
+			[2019, 8, 19],
+			[2019, 8, 31],
+			[2019, 8, 5],
+		],
+		sorted: [
+			[2019, 8, 2],
+			[2019, 8, 5],
+			[2019, 8, 19],
+			[2019, 8, 31],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by hour of the day',
+		unsorted: [
+			[2019, 8, 2, 23],
+			[2019, 8, 2, 0],
+			[2019, 8, 2, 5],
+			[2019, 8, 2, 18],
+		],
+		sorted: [
+			[2019, 8, 2, 0],
+			[2019, 8, 2, 5],
+			[2019, 8, 2, 18],
+			[2019, 8, 2, 23],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by minute segment of the time',
+		unsorted: [
+			[2019, 8, 2, 23, 6],
+			[2019, 8, 2, 23, 58],
+			[2019, 8, 2, 23, 27],
+			[2019, 8, 2, 23, 0],
+		],
+		sorted: [
+			[2019, 8, 2, 23, 0],
+			[2019, 8, 2, 23, 6],
+			[2019, 8, 2, 23, 27],
+			[2019, 8, 2, 23, 58],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by second segment of the time',
+		unsorted: [
+			[2019, 8, 2, 23, 57, 7],
+			[2019, 8, 2, 23, 57, 0],
+			[2019, 8, 2, 23, 57, 49],
+			[2019, 8, 2, 23, 57, 13],
+		],
+		sorted: [
+			[2019, 8, 2, 23, 57, 0],
+			[2019, 8, 2, 23, 57, 7],
+			[2019, 8, 2, 23, 57, 13],
+			[2019, 8, 2, 23, 57, 49],
+		],
+	},
+	{
+		desc: 'sorts the dates array in %s order by millisecond segment of the time',
+		unsorted: [
+			[2019, 8, 2, 23, 57, 7, 100],
+			[2019, 8, 2, 23, 57, 7, 5],
+			[2019, 8, 2, 23, 57, 7, 970],
+			[2019, 8, 2, 23, 57, 7, 67],
+		],
+		sorted: [
+			[2019, 8, 2, 23, 57, 7, 5],
+			[2019, 8, 2, 23, 57, 7, 67],
+			[2019, 8, 2, 23, 57, 7, 100],
+			[2019, 8, 2, 23, 57, 7, 970],
+		],
+	},
+];
+
+describe('sort dates', () => {
+	describe('asc', () => {
+		testCases.forEach(({ desc, unsorted, sorted }) => {
+			it(sprintf(desc, 'ascending'), () => {
+				const result = sort({ dates: unsorted.map(arrayToDate), order: 'asc' });
+				expect(result).toEqual(sorted.map(arrayToDate));
+			});
+		});
+	});
+
+	describe('desc', () => {
+		testCases.forEach(({ desc, unsorted, sorted }) => {
+			it(sprintf(desc, 'descending'), () => {
+				const result = sort({ dates: unsorted.map(arrayToDate), order: 'desc' });
+				expect(result).toEqual(reverse(sorted).map(arrayToDate));
+			});
+		});
+	});
+});

--- a/assets/src/application/services/utilities/date/test/utcToLocal.test.ts
+++ b/assets/src/application/services/utilities/date/test/utcToLocal.test.ts
@@ -1,0 +1,34 @@
+import { format } from 'date-fns';
+import utcToLocal from '../utcToLocal';
+
+describe('localToUtc', () => {
+	it('returns the equivalent date at the time zone for a date string and IANA tz', () => {
+		const result = utcToLocal('2014-06-25T10:00:00.123Z', 'America/New_York');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T06:00:00.123');
+	});
+
+	it('returns the equivalent date at the time zone for a date instance and IANA tz', () => {
+		const result = utcToLocal(new Date('2014-06-25T10:00:00.123Z'), 'Europe/Paris');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T12:00:00.123');
+	});
+
+	it('returns the same date/time for UTC', () => {
+		const result = utcToLocal('2014-06-25T10:00:00.123Z', 'UTC');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T10:00:00.123');
+	});
+
+	it('returns the equivalent date at the time zone for a date string and tz offset', () => {
+		const result = utcToLocal('2014-06-25T10:00:00.123Z', '-04:00');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T06:00:00.123');
+	});
+
+	it('returns the equivalent date at the time zone for a date instance and tz offset', () => {
+		const result = utcToLocal(new Date('2014-06-25T10:00:00.123Z'), '+0200');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T12:00:00.123');
+	});
+
+	it('returns the same date/time for Z', () => {
+		const result = utcToLocal('2014-06-25T10:00:00.123Z', 'Z');
+		expect(format(result, "yyyy-MM-dd'T'HH:mm:ss.SSS")).toBe('2014-06-25T10:00:00.123');
+	});
+});

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/useDatesListFilterState/index.test.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/useDatesListFilterState/index.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import * as R from 'ramda';
-import { formatISO, subWeeks } from 'date-fns';
+
+import { sub } from '../../../../../../../application/services/utilities/date';
+import { formatISO } from 'date-fns';
 import { Datetime } from '../../../../../services/apollo/types';
 import { DatesSorted, DisplayDates, ShowDates } from '../../../../../interfaces/datetimes/types';
 import { DatetimeStatus } from '../../../../../services/apollo/types';
@@ -289,22 +291,22 @@ describe('useDatesListFilterState', () => {
 			{
 				...datetimes[1],
 				id: 'WGF0ZXRpbWU6ODM=',
-				endDate: subWeeks(new Date(), 1),
+				endDate: sub('weeks', new Date(), 1),
 			},
 			{
 				...datetimes[1],
 				id: 'RGF0ZXRpbWU6ODM=',
-				endDate: subWeeks(new Date(), 3),
+				endDate: sub('weeks', new Date(), 3),
 			},
 			{
 				...datetimes[1],
 				id: 'RGF0ZXRpbWU6ODM=',
-				endDate: subWeeks(new Date(), 6),
+				endDate: sub('weeks', new Date(), 6),
 			},
 			{
 				...datetimes[1],
 				id: 'RGF0ZXRpbWU6ODM=',
-				endDate: subWeeks(new Date(), 8),
+				endDate: sub('weeks', new Date(), 8),
 			},
 		];
 

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/recentlyExpiredOnly/index.test.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/recentlyExpiredOnly/index.test.ts
@@ -1,9 +1,9 @@
+import { formatISO } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { formatISO, subWeeks } from 'date-fns';
 import { nodes as datetimes } from '../../../../../../eventEditor/services/apollo/queries/datetimes/test/data';
-
+import { sub } from '../../../../../../../application/services/utilities/date';
 const datetime = datetimes[0];
 
 /**
@@ -23,9 +23,9 @@ describe('recentlyExpiredOnly', () => {
 
 	it('Should return an array of recentlyExpiredOnly dates', () => {
 		const filteredDates = recentlyExpiredOnly([
-			{ ...datetime, id: 'abc', endDate: formatISO(subWeeks(new Date(), 3)) },
-			{ ...datetime, id: 'def', endDate: formatISO(subWeeks(new Date(), 4)) },
-			{ ...datetime, id: 'xyz', endDate: formatISO(subWeeks(new Date(), 5)) },
+			{ ...datetime, id: 'abc', endDate: formatISO(sub('weeks', new Date(), 3)) },
+			{ ...datetime, id: 'def', endDate: formatISO(sub('weeks', new Date(), 4)) },
+			{ ...datetime, id: 'xyz', endDate: formatISO(sub('weeks', new Date(), 5)) },
 		]);
 
 		expect(filteredDates.length).toBe(2);

--- a/assets/src/domain/shared/entities/datetimes/predicates/isRecentlyExpired/index.test.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/isRecentlyExpired/index.test.ts
@@ -1,12 +1,13 @@
-import { addWeeks, formatISO, subMonths, subWeeks } from 'date-fns';
+import { formatISO } from 'date-fns';
 
 import isRecentlyExpired from './index';
 import { nodes as datetimes } from '../../../../../eventEditor/services/apollo/queries/datetimes/test/data';
+import { add, sub } from '../../../../../../application/services/utilities/date';
 
 describe('isRecentlyExpired', () => {
 	it('should return false if endDate is in the future', () => {
 		datetimes.forEach((datetime) => {
-			const newDatetime: any = { ...datetime, endDate: formatISO(addWeeks(new Date(), 1)) };
+			const newDatetime: any = { ...datetime, endDate: formatISO(add('weeks', new Date(), 1)) };
 			const result = isRecentlyExpired(newDatetime);
 			expect(result).toBe(false);
 		});
@@ -14,13 +15,13 @@ describe('isRecentlyExpired', () => {
 
 	it('should return false if endDate is more than a month ago', () => {
 		datetimes.forEach((datetime) => {
-			const newDatetime: any = { ...datetime, endDate: formatISO(subMonths(new Date(), 1)) };
+			const newDatetime: any = { ...datetime, endDate: formatISO(sub('months', new Date(), 1)) };
 			const result = isRecentlyExpired(newDatetime);
 			expect(result).toBe(false);
 		});
 
 		datetimes.forEach((datetime) => {
-			const newDatetime: any = { ...datetime, endDate: formatISO(subWeeks(new Date(), 5)) };
+			const newDatetime: any = { ...datetime, endDate: formatISO(sub('weeks', new Date(), 5)) };
 			const result = isRecentlyExpired(newDatetime);
 			expect(result).toBe(false);
 		});
@@ -28,7 +29,7 @@ describe('isRecentlyExpired', () => {
 
 	it('should return true if endDate is in the range of a month ago', () => {
 		datetimes.forEach((datetime) => {
-			const newDatetime: any = { ...datetime, endDate: formatISO(subWeeks(new Date(), 3)) };
+			const newDatetime: any = { ...datetime, endDate: formatISO(sub('weeks', new Date(), 3)) };
 			const result = isRecentlyExpired(newDatetime);
 			expect(result).toBe(true);
 		});

--- a/assets/src/domain/shared/entities/datetimes/predicates/isRecentlyExpired/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/isRecentlyExpired/index.ts
@@ -1,14 +1,9 @@
-/**
- * External dependencies
- */
-import { differenceInSeconds, parseISO } from 'date-fns';
-import { now } from '../filters';
+import { parseISO } from 'date-fns';
 
-/**
- * Internal dependencies
- */
+import { now } from '../filters';
 import { Datetime } from '../../../../../eventEditor/services/apollo/types';
 import TIME from '../../../../../../application/constants/time';
+import { diff } from '../../../../../../application/services/utilities/date';
 
 /**
  * @function
@@ -17,8 +12,8 @@ import TIME from '../../../../../../application/constants/time';
  */
 const isRecentlyExpired = ({ endDate }: Datetime): boolean => {
 	return (
-		differenceInSeconds(parseISO(endDate), now) < 0 &&
-		differenceInSeconds(parseISO(endDate), now) > TIME.MONTH_IN_SECONDS * -1
+		diff('seconds', parseISO(endDate), now) < 0 &&
+		diff('seconds', parseISO(endDate), now) > TIME.MONTH_IN_SECONDS * -1
 	);
 };
 

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/expiredOnly/index.test.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/expiredOnly/index.test.ts
@@ -1,7 +1,8 @@
-import { addWeeks, differenceInMinutes, formatISO, parseISO } from 'date-fns';
+import { formatISO, parseISO } from 'date-fns';
 
 import expiredOnly from './index';
 import { nodes as tickets } from '../../../../../../eventEditor/services/apollo/queries/tickets/test/data';
+import { diff, add } from '../../../../../../../application/services/utilities/date';
 
 describe('expiredOnly', () => {
 	it('should return an empty array if tickets are trashed', () => {
@@ -12,7 +13,7 @@ describe('expiredOnly', () => {
 
 	it('should return an empty array if tickets are not expired', () => {
 		const updatedTickets = tickets.map((ticket) => {
-			const endDate = formatISO(addWeeks(new Date(), 1));
+			const endDate = formatISO(add('weeks', new Date(), 1));
 			return { ...ticket, endDate };
 		});
 		const filteredTickets = expiredOnly(updatedTickets);
@@ -23,8 +24,8 @@ describe('expiredOnly', () => {
 		const filteredTickets = expiredOnly(tickets);
 		filteredTickets.forEach((ticket) => {
 			const endDate = parseISO(ticket.endDate);
-			const diff = differenceInMinutes(endDate, new Date()) < 0;
-			expect(diff).toBe(true);
+			const result = diff('minutes', endDate, new Date()) < 0;
+			expect(result).toBe(true);
 		});
 	});
 });

--- a/assets/src/domain/shared/entities/tickets/predicates/isExpired.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/isExpired.ts
@@ -1,19 +1,14 @@
-/**
- * External dependencies
- */
-import { differenceInMinutes, parseISO } from 'date-fns';
-import { now } from './filters';
+import { parseISO } from 'date-fns';
 
-/**
- * Internal dependencies
- */
+import { now } from './filters';
 import isValidOrTrashed from './isValidOrTrashed';
 import { Ticket } from '../../../../eventEditor/services/apollo/types';
+import { diff } from '../../../../../application/services/utilities/date';
 
 const isExpired = (ticket: Ticket, includeTrashed = false): boolean => {
 	const { endDate } = ticket;
 
-	return isValidOrTrashed(ticket, includeTrashed) && differenceInMinutes(parseISO(endDate), now) < 0;
+	return isValidOrTrashed(ticket, includeTrashed) && diff('minutes', parseISO(endDate), now) < 0;
 };
 
 export default isExpired;

--- a/assets/src/domain/shared/entities/tickets/predicates/isOnSale.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/isOnSale.ts
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
-import { differenceInMinutes, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
+
 import { now } from './filters';
 import { Ticket } from '../../../../eventEditor/services/apollo/types';
+import { diff } from '../../../../../application/services/utilities/date';
 
 const isOnSale = ({ startDate, endDate }: Ticket): boolean => {
-	return differenceInMinutes(parseISO(startDate), now) < 0 && differenceInMinutes(parseISO(endDate), now) > 0;
+	return diff('minutes', parseISO(startDate), now) < 0 && diff('minutes', parseISO(endDate), now) > 0;
 };
 
 export default isOnSale;

--- a/assets/src/domain/shared/entities/tickets/predicates/isPending.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/isPending.ts
@@ -1,7 +1,8 @@
-import { differenceInMinutes, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 
 import { now } from './filters';
 import { Ticket } from '../../../../eventEditor/services/apollo/types';
+import { diff } from '../../../../../application/services/utilities/date';
 
 /**
  * @function
@@ -10,7 +11,7 @@ import { Ticket } from '../../../../eventEditor/services/apollo/types';
  * 						but will be at some date in the future
  */
 const isPending = ({ startDate }: Ticket): boolean => {
-	return differenceInMinutes(parseISO(startDate), now) > 0;
+	return diff('minutes', parseISO(startDate), now) > 0;
 };
 
 export default isPending;


### PR DESCRIPTION
This PR:
- Improves the utility functions in `/application/services/utilities/date`
- Adds tests for the utilities.
- Updates tests and predicates to use these utilities instead of directly from `date-fns`
- Closes #2132