### PR TITLE
Minor PHP 7.4 fixes

### DIFF
--- a/core/EE_Error.core.php
+++ b/core/EE_Error.core.php
@@ -866,13 +866,13 @@ class EE_Error extends Exception
         // check for success messages
         if (self::$_espresso_notices['success'] && ! empty(self::$_espresso_notices['success'])) {
             // combine messages
-            $success_messages .= implode(self::$_espresso_notices['success'], '<br />');
+            $success_messages .= implode('<br />', self::$_espresso_notices['success']);
             $print_scripts = true;
         }
         // check for attention messages
         if (self::$_espresso_notices['attention'] && ! empty(self::$_espresso_notices['attention'])) {
             // combine messages
-            $attention_messages .= implode(self::$_espresso_notices['attention'], '<br />');
+            $attention_messages .= implode('<br />', self::$_espresso_notices['attention']);
             $print_scripts = true;
         }
         // check for error messages
@@ -881,7 +881,7 @@ class EE_Error extends Exception
                 ? __('The following errors have occurred:<br />', 'event_espresso')
                 : __('An error has occurred:<br />', 'event_espresso');
             // combine messages
-            $error_messages .= implode(self::$_espresso_notices['errors'], '<br />');
+            $error_messages .= implode('<br />', self::$_espresso_notices['errors']);
             $print_scripts = true;
         }
         if ($format_output) {

--- a/core/admin/EE_Admin_Page_CPT.core.php
+++ b/core/admin/EE_Admin_Page_CPT.core.php
@@ -267,7 +267,7 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
         foreach ($current_metaboxes as $box_context) {
             foreach ($box_context as $box_details) {
                 foreach ($box_details as $box) {
-                    if (is_array($box['callback'])
+                    if (is_array($box) && is_array($box['callback'])
                         && (
                             $box['callback'][0] instanceof EE_Admin_Page
                             || $box['callback'][0] instanceof EE_Admin_Hooks


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
I was getting these notices logged on a PHP 7.4 server when adding and saving an event:
`PHP Notice:  Trying to access array offset on value of type bool in wp-content/plugins/32-core/core/admin/EE_Admin_Page_CPT.core.php on line 270`

`PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /wp-content/plugins/32-core/core/EE_Error.core.php on line 875`

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Add, edit, and save an event. No errors or logged PHP notices.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
