### PR TITLE
Avoid fatal errors when permanently deleting registrations

### DIFF
--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -2712,7 +2712,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         // first we start with the transaction... ultimately, we WILL not delete permanently if there are any related
         // registrations on the transaction that are NOT trashed.
         $TXN = $REG->get_first_related('Transaction');
-        if(! $TXN instanceof EE_Transaction) {
+        if (! $TXN instanceof EE_Transaction) {
             EE_Error::add_error(
                 sprintf(
                     esc_html__(

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -2712,6 +2712,21 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         // first we start with the transaction... ultimately, we WILL not delete permanently if there are any related
         // registrations on the transaction that are NOT trashed.
         $TXN = $REG->get_first_related('Transaction');
+        if(! $TXN instanceof EE_Transaction) {
+            EE_Error::add_error(
+                sprintf(
+                    esc_html__(
+                        'Unable to permanently delete registration %d because its related transaction has already been deleted. If you can restore the related transaction to the database then this registration can be deleted.',
+                        'event_espresso'
+                    ),
+                    $REG->id()
+                ),
+                __FILE__,
+                __FUNCTION__,
+                __LINE__
+            );
+            return false;
+        }
         $REGS = $TXN->get_many_related('Registration');
         $all_trashed = true;
         foreach ($REGS as $registration) {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

This doesn't fully solve the problem (the problem being there's a registration without a transaction) but it does avoid a fatal error and displays an error message instead. I'm not sure how some sites are ending up with registrations without transactions, but we've seen more than a few reports lately. Including:
https://eventespresso.com/topic/error-message-when-trying-to-delete-something-in-the-trash/
https://eventespresso.com/topic/permanently-delete-from-trash-errors/
https://eventespresso.com/topic/error-from-word-press/
https://eventespresso.com/topic/500-errors-critical-error-on-wordpress/?view=all#post-306784

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Trash a registration 
- [x] directly manipulate the database and remove the related transaction's row in the db (or give it a new TXN ID if you want to change it back later)
- [x] Go to Event Espresso > Registrations > Trash and try to permanently delete the registration

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
