### PR TITLE
Fix tests related to timezones | Closes #2385

### DIFF
--- a/assets/src/application/services/hooks/test/useTimeZoneTime.test.tsx
+++ b/assets/src/application/services/hooks/test/useTimeZoneTime.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { formatISO } from 'date-fns';
 
 import useTimeZoneTime from '../useTimeZoneTime';
 import { ApolloMockedProvider } from '../../../../domain/eventEditor/services/context/TestContext';
@@ -14,9 +15,9 @@ describe('useTimeZoneTime', () => {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
-			const result = TZ.localTimeToUtc(testDate).toISOString();
+			const result = TZ.localTimeToUtc(testDate);
 
-			expect(result).toBe(expectedDate);
+			expect(result.toISOString()).toBe(expectedDate);
 		});
 
 		it('returns UTC date for a given local date as Date insatance', () => {
@@ -26,35 +27,35 @@ describe('useTimeZoneTime', () => {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
-			const result = TZ.localTimeToUtc(testDate).toISOString();
+			const result = TZ.localTimeToUtc(testDate);
 
-			expect(result).toBe(expectedDate);
+			expect(result.toISOString()).toBe(expectedDate);
 		});
 	});
 
 	describe('utcToLocalTime', () => {
 		it('returns local date for a given UTC date as ISO string', () => {
-			const testDate = '2020-01-28T07:30:20'; // in UTC
-			const expectedDate = '2020-01-28T13:00:20.000Z'; // in IST (5:30 ahead of UTC)
+			const testDate = '2020-01-28T07:30:20.123Z'; // in UTC
+			const expectedDate = '2020-01-28T13:00:20+5.5:30'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
-			const result = TZ.utcToLocalTime(testDate).toISOString();
+			const result = TZ.utcToLocalTime(testDate);
 
-			expect(result).toBe(expectedDate);
+			expect(formatISO(result)).toBe(expectedDate);
 		});
 
 		it('returns local date for a given UTC date as Date insatance', () => {
-			const testDate = new Date(2020, 0 /* Jan */, 28, 7, 30, 20, 0); // in UTC
-			const expectedDate = '2020-01-28T13:00:20.000Z'; // in IST (5:30 ahead of UTC)
+			const testDate = new Date('2020-01-28T07:30:20.123Z'); // in UTC
+			const expectedDate = '2020-01-28T13:00:20+5.5:30'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
-			const result = TZ.utcToLocalTime(testDate).toISOString();
+			const result = TZ.utcToLocalTime(testDate);
 
-			expect(result).toBe(expectedDate);
+			expect(formatISO(result)).toBe(expectedDate);
 		});
 	});
 });

--- a/assets/src/application/services/hooks/test/useTimeZoneTime.test.tsx
+++ b/assets/src/application/services/hooks/test/useTimeZoneTime.test.tsx
@@ -1,8 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { formatISO } from 'date-fns';
+import { format } from 'date-fns';
 
 import useTimeZoneTime from '../useTimeZoneTime';
 import { ApolloMockedProvider } from '../../../../domain/eventEditor/services/context/TestContext';
+
+const formatString = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
 describe('useTimeZoneTime', () => {
 	const wrapper = ApolloMockedProvider();
@@ -36,26 +38,26 @@ describe('useTimeZoneTime', () => {
 	describe('utcToLocalTime', () => {
 		it('returns local date for a given UTC date as ISO string', () => {
 			const testDate = '2020-01-28T07:30:20.123Z'; // in UTC
-			const expectedDate = '2020-01-28T13:00:20+5.5:30'; // in IST (5:30 ahead of UTC)
+			const expectedDate = '2020-01-28T13:00:20.123'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
 			const result = TZ.utcToLocalTime(testDate);
 
-			expect(formatISO(result)).toBe(expectedDate);
+			expect(format(result, formatString)).toBe(expectedDate);
 		});
 
 		it('returns local date for a given UTC date as Date insatance', () => {
 			const testDate = new Date('2020-01-28T07:30:20.123Z'); // in UTC
-			const expectedDate = '2020-01-28T13:00:20+5.5:30'; // in IST (5:30 ahead of UTC)
+			const expectedDate = '2020-01-28T13:00:20.123'; // in IST (5:30 ahead of UTC)
 			const {
 				result: { current: TZ },
 			} = renderHook(() => useTimeZoneTime(), { wrapper });
 
 			const result = TZ.utcToLocalTime(testDate);
 
-			expect(formatISO(result)).toBe(expectedDate);
+			expect(format(result, formatString)).toBe(expectedDate);
 		});
 	});
 });

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/onSaleOnly/index.test.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/onSaleOnly/index.test.ts
@@ -4,10 +4,9 @@ import { pipe } from 'ramda';
 import onSaleOnly from './index';
 import isOnSale from '../../isOnSale';
 import { nodes as tickets } from '../../../../../../eventEditor/services/apollo/queries/tickets/test/data';
+import { now } from '../';
 
 describe('onSaleOnly', () => {
-	const now = new Date();
-
 	it('should return an empty array if tickets are not on sale', () => {
 		const updatedTickets = tickets.map((ticket) => {
 			const startDate = formatISO(new Date(2008, 8, 18, 19, 0, 52));

--- a/assets/src/domain/shared/entities/tickets/predicates/isOnSale/index.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/isOnSale/index.ts
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
-import { parseISO } from 'date-fns';
+import { parseISO, formatISO } from 'date-fns';
 
 import { now } from '../filters';
 import { Ticket } from '@edtrServices/apollo/types';
 import { diff } from '../../../../../../application/services/utilities/date';
 
 const isOnSale = ({ startDate, endDate }: Ticket): boolean => {
-	return diff('minutes', parseISO(startDate), now) < 0 && diff('minutes', parseISO(endDate), now) > 0;
+	// make sure the dates are prepared by same functions to
+	// avoid timezone differences
+	const dateNow = parseISO(formatISO(now));
+	return diff('minutes', parseISO(startDate), now) < 0 && diff('minutes', parseISO(endDate), dateNow) > 0;
 };
 
 export default isOnSale;


### PR DESCRIPTION
This PR:
- Fixes `useTimeZoneTime` tests that failed because of no `Z` in the passed strings. `Z` is the zone designator for the zero UTC offset.
- Fixes `onSaleOnly` test for tickets which failed due to similar reasons for the two compared dates being prepared by two different functions.
- Closes #2385
