### PR TITLE
Complete server-side GQL mutations | Closes #2417

### DIFF
--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/types.ts
@@ -7,9 +7,7 @@ export interface DatetimeBaseInput {
 	event?: EntityId;
 	eventId?: number;
 	isPrimary?: boolean;
-	isSoldOut?: boolean;
 	isTrashed?: boolean;
-	length?: number;
 	name?: string;
 	order?: number;
 	parent?: string;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/types.ts
@@ -5,7 +5,6 @@ export interface TicketBaseInput {
 	description?: string;
 	endDate?: string;
 	isDefault?: boolean;
-	isFree?: boolean;
 	isRequired?: boolean;
 	isTaxable?: boolean;
 	isTrashed?: boolean;

--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -32,38 +32,61 @@ class DatetimeMutation
     {
         $args = [];
 
-        if (! empty($input['eventId'])) {
-            $args['EVT_ID'] = absint($input['eventId']);
-        } elseif (! empty($input['event'])) {
-            $parts = Relay::fromGlobalId($input['event']);
-            $args['EVT_ID'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
-        }
-
-        if (! empty($input['name'])) {
-            $args['DTT_name'] = sanitize_text_field($input['name']);
+        if (array_key_exists('capacity', $input)) {
+            $args['DTT_reg_limit'] = (int) $input['capacity'];
         }
 
         if (! empty($input['description'])) {
             $args['DTT_description'] = sanitize_text_field($input['description']);
         }
 
-        if (! empty($input['startDate'])) {
-            $args['DTT_EVT_start'] = new DateTime(sanitize_text_field($input['startDate']));
-        }
-
         if (! empty($input['endDate'])) {
             $args['DTT_EVT_end'] = new DateTime(sanitize_text_field($input['endDate']));
         }
 
-        if (! empty($input['tickets'])) {
-            $args['tickets'] = array_map('sanitize_text_field', (array) $input['tickets']);
+        if (! empty($input['eventId'])) {
+            $args['EVT_ID'] = absint($input['eventId']);
+        } elseif (! empty($input['event'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['event']));
+            $args['EVT_ID'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
+        }
+
+        if (array_key_exists('isPrimary', $input)) {
+            $args['DTT_is_primary'] = (bool) $input['isPrimary'];
         }
 
         if (array_key_exists('isTrashed', $input)) {
             $args['DTT_deleted'] = (bool) $input['isTrashed'];
         }
 
-        // Likewise the other fields...
+        if (! empty($input['name'])) {
+            $args['DTT_name'] = sanitize_text_field($input['name']);
+        }
+
+        if (array_key_exists('order', $input)) {
+            $args['DTT_order'] = (int) $input['order'];
+        }
+
+        if (! empty($input['parent'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['parent']));
+            $args['DTT_parent'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
+        }
+
+        if (array_key_exists('reserved', $input)) {
+            $args['DTT_reserved'] = (int) $input['reserved'];
+        }
+
+        if (array_key_exists('sold', $input)) {
+            $args['DTT_sold'] = (int) $input['sold'];
+        }
+
+        if (! empty($input['startDate'])) {
+            $args['DTT_EVT_start'] = new DateTime(sanitize_text_field($input['startDate']));
+        }
+
+        if (! empty($input['tickets'])) {
+            $args['tickets'] = array_map('sanitize_text_field', (array) $input['tickets']);
+        }
 
         return $args;
     }

--- a/core/domain/services/graphql/data/mutations/PriceMutation.php
+++ b/core/domain/services/graphql/data/mutations/PriceMutation.php
@@ -23,21 +23,12 @@ class PriceMutation
     {
         $args = [];
 
-        if (! empty($input['priceType'])) {
-            $parts = Relay::fromGlobalId(sanitize_text_field($input['priceType']));
-            $args['PRT_ID'] = ! empty($parts['id']) ? absint($parts['id']) : 0;
-        }
-
-        if (! empty($input['name'])) {
-            $args['PRC_name'] = sanitize_text_field($input['name']);
+        if (! empty($input['amount'])) {
+            $args['PRC_amount'] = (float) $input['amount'];
         }
 
         if (! empty($input['desc'])) {
             $args['PRC_desc'] = sanitize_text_field($input['desc']);
-        }
-
-        if (! empty($input['amount'])) {
-            $args['PRC_amount'] = (float) $input['amount'];
         }
 
         if (array_key_exists('isDefault', $input)) {
@@ -48,17 +39,31 @@ class PriceMutation
             $args['PRC_deleted'] = (bool) $input['isTrashed'];
         }
 
-        if (! empty($input['overrides'])) {
-            $args['PRC_overrides'] = (int) $input['overrides'];
+        if (! empty($input['name'])) {
+            $args['PRC_name'] = sanitize_text_field($input['name']);
         }
 
         if (! empty($input['order'])) {
             $args['PRC_order'] = (int) $input['order'];
         }
 
+        if (! empty($input['overrides'])) {
+            $args['PRC_overrides'] = (int) $input['overrides'];
+        }
+
         if (! empty($input['parent'])) {
             $parts = Relay::fromGlobalId(sanitize_text_field($input['parent']));
             $args['PRC_parent'] = ! empty($parts['id']) ? absint($parts['id']) : 0;
+        }
+
+        if (! empty($input['priceType'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['priceType']));
+            $args['PRT_ID'] = ! empty($parts['id']) ? absint($parts['id']) : 0;
+        }
+
+        if (! empty($input['wpUser'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['wpUser']));
+            $args['PRC_wp_user'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
         }
 
         return $args;

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -38,39 +38,95 @@ class TicketMutation
     {
         $args = [];
 
-        if (! empty($input['name'])) {
-            $args['TKT_name'] = sanitize_text_field($input['name']);
+        if (! empty($input['datetimes'])) {
+            $args['datetimes'] = array_map('sanitize_text_field', (array) $input['datetimes']);
         }
 
         if (! empty($input['description'])) {
             $args['TKT_description'] = sanitize_text_field($input['description']);
         }
 
-        if (! empty($input['price'])) {
-            $args['TKT_price'] = (float) $input['price'];
-        }
-
-        if (! empty($input['startDate'])) {
-            $args['TKT_start_date'] = new DateTime(sanitize_text_field($input['startDate']));
-        }
-
         if (! empty($input['endDate'])) {
             $args['TKT_end_date'] = new DateTime(sanitize_text_field($input['endDate']));
         }
 
-        if (! empty($input['datetimes'])) {
-            $args['datetimes'] = array_map('sanitize_text_field', (array) $input['datetimes']);
+        if (array_key_exists('isDefault', $input)) {
+            $args['TKT_is_default'] = (bool) $input['isDefault'];
         }
 
-        if (! empty($input['prices'])) {
-            $args['prices'] = array_map('sanitize_text_field', (array) $input['prices']);
+        if (array_key_exists('isRequired', $input)) {
+            $args['TKT_required'] = (bool) $input['isRequired'];
+        }
+
+        if (array_key_exists('isTaxable', $input)) {
+            $args['TKT_taxable'] = (bool) $input['isTaxable'];
         }
 
         if (array_key_exists('isTrashed', $input)) {
             $args['TKT_deleted'] = (bool) $input['isTrashed'];
         }
 
-        // Likewise the other fields...
+        if (array_key_exists('max', $input)) {
+            $args['TKT_max'] = (int) $input['max'];
+        }
+
+        if (array_key_exists('min', $input)) {
+            $args['TKT_min'] = (int) $input['min'];
+        }
+
+        if (! empty($input['name'])) {
+            $args['TKT_name'] = sanitize_text_field($input['name']);
+        }
+
+        if (array_key_exists('order', $input)) {
+            $args['TKT_order'] = (int) $input['order'];
+        }
+
+        if (! empty($input['parent'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['parent']));
+            $args['TKT_parent'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
+        }
+
+        if (! empty($input['price'])) {
+            $args['TKT_price'] = (float) $input['price'];
+        }
+
+        if (! empty($input['prices'])) {
+            $args['prices'] = array_map('sanitize_text_field', (array) $input['prices']);
+        }
+
+        if (array_key_exists('quantity', $input)) {
+            $args['TKT_qty'] = (int) $input['quantity'];
+        }
+
+        if (array_key_exists('reserved', $input)) {
+            $args['TKT_reserved'] = (int) $input['reserved'];
+        }
+
+        if (array_key_exists('reverseCalculate', $input)) {
+            $args['TKT_reverse_calculate'] = (bool) $input['reverseCalculate'];
+        }
+
+        if (array_key_exists('row', $input)) {
+            $args['TKT_row'] = (int) $input['row'];
+        }
+
+        if (array_key_exists('sold', $input)) {
+            $args['TKT_sold'] = (int) $input['sold'];
+        }
+
+        if (! empty($input['startDate'])) {
+            $args['TKT_start_date'] = new DateTime(sanitize_text_field($input['startDate']));
+        }
+
+        if (array_key_exists('uses', $input)) {
+            $args['TKT_uses'] = (int) $input['uses'];
+        }
+
+        if (! empty($input['wpUser'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['wpUser']));
+            $args['TKT_wp_user'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
+        }
 
         return $args;
     }

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -68,10 +68,11 @@ class Datetime extends TypeBase
                 esc_html__('The datetime ID.', 'event_espresso')
             ),
             new GraphQLField(
-                'name',
-                'String',
-                'name',
-                esc_html__('Datetime Name', 'event_espresso')
+                'capacity',
+                'Int',
+                'reg_limit',
+                esc_html__('Registration Limit for this time', 'event_espresso'),
+                [$this, 'parseInfiniteValue']
             ),
             new GraphQLField(
                 'description',
@@ -80,49 +81,88 @@ class Datetime extends TypeBase
                 esc_html__('Description for Datetime', 'event_espresso')
             ),
             new GraphQLField(
-                'startDate',
-                'String',
-                'start_date_and_time',
-                esc_html__('Start date and time of the Event', 'event_espresso'),
-                [$this, 'formatDatetime']
-            ),
-            new GraphQLField(
                 'endDate',
                 'String',
                 'end_date_and_time',
                 esc_html__('End date and time of the Event', 'event_espresso'),
                 [$this, 'formatDatetime']
             ),
-            new GraphQLField(
-                'capacity',
+            new GraphQLOutputField(
+                'event',
+                $this->namespace . 'Event',
+                null,
+                esc_html__('Event of the datetime.', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'event',
+                'ID',
+                null,
+                esc_html__('Globally unique event ID of the datetime.', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'eventId',
                 'Int',
-                'reg_limit',
-                esc_html__('Registration Limit for this time', 'event_espresso'),
-                [$this, 'parseInfiniteValue']
+                null,
+                esc_html__('Event ID of the datetime.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isActive',
+                'Boolean',
+                'is_active',
+                esc_html__('Flag indicating datetime is active', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isExpired',
+                'Boolean',
+                'is_expired',
+                esc_html__('Flag indicating datetime is expired or not', 'event_espresso')
             ),
             new GraphQLField(
-                'sold',
-                'Int',
-                'sold',
-                esc_html__('How many sales for this Datetime that have occurred', 'event_espresso')
+                'isPrimary',
+                'Boolean',
+                'is_primary',
+                esc_html__('Flag indicating datetime is primary one for event', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isSoldOut',
+                'Boolean',
+                'sold_out',
+                esc_html__(
+                    'Flag indicating whether the tickets sold for this datetime, met or exceed the registration limit',
+                    'event_espresso'
+                )
             ),
             new GraphQLField(
-                'reserved',
+                'isTrashed',
+                'Boolean',
+                null,
+                esc_html__('Flag indicating datetime has been trashed.', 'event_espresso'),
+                null,
+                [$this, 'getIsTrashed']
+            ),
+            new GraphQLOutputField(
+                'isUpcoming',
+                'Boolean',
+                'is_upcoming',
+                esc_html__('Whether the date is upcoming', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'length',
                 'Int',
-                'reserved',
-                esc_html__('Quantity of tickets reserved, but not yet fully purchased', 'event_espresso')
+                'length',
+                esc_html__('The length of the event (start to end time) in seconds', 'event_espresso')
+            ),
+            new GraphQLField(
+                'name',
+                'String',
+                'name',
+                esc_html__('Datetime Name', 'event_espresso')
             ),
             new GraphQLField(
                 'order',
                 'Int',
                 'order',
                 esc_html__('The order in which the Datetime is displayed', 'event_espresso')
-            ),
-            new GraphQLField(
-                'length',
-                'Int',
-                'length',
-                esc_html__('The length of the event (start to end time) in seconds', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'parent',
@@ -137,55 +177,29 @@ class Datetime extends TypeBase
                 esc_html__('The parent datetime ID', 'event_espresso')
             ),
             new GraphQLField(
-                'isPrimary',
-                'Boolean',
-                'is_primary',
-                esc_html__('Flag indicating datetime is primary one for event', 'event_espresso')
+                'reserved',
+                'Int',
+                'reserved',
+                esc_html__('Quantity of tickets reserved, but not yet fully purchased', 'event_espresso')
             ),
             new GraphQLField(
-                'isSoldOut',
-                'Boolean',
-                'sold_out',
-                esc_html__(
-                    'Flag indicating whether the tickets sold for this datetime, met or exceed the registration limit',
-                    'event_espresso'
-                )
+                'startDate',
+                'String',
+                'start_date_and_time',
+                esc_html__('Start date and time of the Event', 'event_espresso'),
+                [$this, 'formatDatetime']
             ),
-            new GraphQLOutputField(
-                'isUpcoming',
-                'Boolean',
-                'is_upcoming',
-                esc_html__('Whether the date is upcoming', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isActive',
-                'Boolean',
-                'is_active',
-                esc_html__('Flag indicating datetime is active', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isExpired',
-                'Boolean',
-                'is_expired',
-                esc_html__('Flag indicating datetime is expired or not', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'event',
-                $this->namespace . 'Event',
-                null,
-                esc_html__('Event of the datetime.', 'event_espresso')
-            ),
-            new GraphQLInputField(
-                'eventId',
+            new GraphQLField(
+                'sold',
                 'Int',
-                null,
-                esc_html__('Event ID of the datetime.', 'event_espresso')
+                'sold',
+                esc_html__('How many sales for this Datetime that have occurred', 'event_espresso')
             ),
-            new GraphQLInputField(
-                'event',
-                'ID',
-                null,
-                esc_html__('Globally unique event ID of the datetime.', 'event_espresso')
+            new GraphQLOutputField(
+                'status',
+                $this->namespace . 'DatetimeStatusEnum',
+                'get_active_status',
+                esc_html__('Datetime status', 'event_espresso')
             ),
             new GraphQLInputField(
                 'tickets',
@@ -196,20 +210,6 @@ class Datetime extends TypeBase
                     esc_html__('Globally unique IDs of the tickets related to the datetime.', 'event_espresso'),
                     esc_html__('Ignored if empty.', 'event_espresso')
                 )
-            ),
-            new GraphQLOutputField(
-                'status',
-                $this->namespace . 'DatetimeStatusEnum',
-                'get_active_status',
-                esc_html__('Datetime status', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isTrashed',
-                'Boolean',
-                null,
-                esc_html__('Flag indicating datetime has been trashed.', 'event_espresso'),
-                null,
-                [$this, 'getIsTrashed']
             ),
         ];
     }

--- a/core/domain/services/graphql/types/Price.php
+++ b/core/domain/services/graphql/types/Price.php
@@ -60,12 +60,6 @@ class Price extends TypeBase
                 esc_html__('Price ID', 'event_espresso')
             ),
             new GraphQLField(
-                'name',
-                'String',
-                'name',
-                esc_html__('Price Name', 'event_espresso')
-            ),
-            new GraphQLField(
                 'amount',
                 'Float',
                 'amount',
@@ -77,17 +71,59 @@ class Price extends TypeBase
                 'desc',
                 esc_html__('Price description', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'isBasePrice',
+                'Boolean',
+                'is_base_price',
+                esc_html__('Flag indicating price is a base price type.', 'event_espresso')
+            ),
             new GraphQLField(
-                'overrides',
-                'Int',
-                'overrides',
-                esc_html__('Price ID for a global Price that will be overridden by this Price.', 'event_espresso')
+                'isDefault',
+                'Boolean',
+                'is_default',
+                esc_html__('Flag indicating price is the default one.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isDiscount',
+                'Boolean',
+                'is_discount',
+                esc_html__('Flag indicating price is a discount.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isPercent',
+                'Boolean',
+                'is_percent',
+                esc_html__('Flag indicating price is a percentage.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isTax',
+                'Boolean',
+                'is_tax',
+                esc_html__('Flag indicating price is a tax.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isTrashed',
+                'Boolean',
+                'deleted',
+                esc_html__('Flag indicating price has been trashed.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'name',
+                'String',
+                'name',
+                esc_html__('Price Name', 'event_espresso')
             ),
             new GraphQLField(
                 'order',
                 'Int',
                 'order',
                 esc_html__('Order of Application of Price.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'overrides',
+                'Int',
+                'overrides',
+                esc_html__('Price ID for a global Price that will be overridden by this Price.', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'parent',
@@ -112,42 +148,6 @@ class Price extends TypeBase
                 'ID',
                 null,
                 esc_html__('The price type ID', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isTrashed',
-                'Boolean',
-                'deleted',
-                esc_html__('Flag indicating price has been trashed.', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isDefault',
-                'Boolean',
-                'is_default',
-                esc_html__('Flag indicating price is the default one.', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isPercent',
-                'Boolean',
-                'is_percent',
-                esc_html__('Flag indicating price is a percentage.', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isBasePrice',
-                'Boolean',
-                'is_base_price',
-                esc_html__('Flag indicating price is a base price type.', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isDiscount',
-                'Boolean',
-                'is_discount',
-                esc_html__('Flag indicating price is a discount.', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isTax',
-                'Boolean',
-                'is_tax',
-                esc_html__('Flag indicating price is a tax.', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'wpUser',

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -67,11 +67,15 @@ class Ticket extends TypeBase
                 'ID',
                 esc_html__('Ticket ID', 'event_espresso')
             ),
-            new GraphQLField(
-                'name',
-                'String',
-                'name',
-                esc_html__('Ticket Name', 'event_espresso')
+            new GraphQLInputField(
+                'datetimes',
+                ['list_of' => 'ID'],
+                null,
+                sprintf(
+                    '%1$s %2$s',
+                    esc_html__('Globally unique IDs of the datetimes related to the ticket.', 'event_espresso'),
+                    esc_html__('Ignored if empty.', 'event_espresso')
+                )
             ),
             new GraphQLField(
                 'description',
@@ -80,24 +84,61 @@ class Ticket extends TypeBase
                 esc_html__('Description of Ticket', 'event_espresso')
             ),
             new GraphQLField(
-                'startDate',
-                'String',
-                'start_date',
-                esc_html__('Start date and time of the Ticket', 'event_espresso'),
-                [$this, 'formatDatetime']
-            ),
-            new GraphQLField(
                 'endDate',
                 'String',
                 'end_date',
                 esc_html__('End date and time of the Ticket', 'event_espresso'),
                 [$this, 'formatDatetime']
             ),
+            new GraphQLOutputField(
+                'event',
+                $this->namespace . 'Event',
+                null,
+                esc_html__('Event of the ticket.', 'event_espresso')
+            ),
             new GraphQLField(
-                'min',
-                'Int',
-                'min',
-                esc_html__('Minimum quantity of this ticket that must be purchased', 'event_espresso')
+                'isDefault',
+                'Boolean',
+                'is_default',
+                esc_html__('Flag indicating that this ticket is a default ticket', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isFree',
+                'Boolean',
+                'is_free',
+                esc_html__('Flag indicating whether the ticket is free.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isRequired',
+                'Boolean',
+                'required',
+                esc_html__(
+                    'Flag indicating whether this ticket must be purchased with a transaction',
+                    'event_espresso'
+                )
+            ),
+            new GraphQLOutputField(
+                'isSoldOut',
+                'Boolean',
+                null,
+                esc_html__('Flag indicating whether the ticket is sold out', 'event_espresso'),
+                null,
+                [$this, 'getIsSoldOut']
+            ),
+            new GraphQLField(
+                'isTaxable',
+                'Boolean',
+                'taxable',
+                esc_html__(
+                    'Flag indicating whether there is tax applied on this ticket',
+                    'event_espresso'
+                )
+            ),
+            new GraphQLField(
+                'isTrashed',
+                'Boolean',
+                'deleted',
+                esc_html__('Flag indicating ticket has been trashed.', 'event_espresso')
             ),
             new GraphQLField(
                 'max',
@@ -110,16 +151,50 @@ class Ticket extends TypeBase
                 [$this, 'parseInfiniteValue']
             ),
             new GraphQLField(
+                'min',
+                'Int',
+                'min',
+                esc_html__('Minimum quantity of this ticket that must be purchased', 'event_espresso')
+            ),
+            new GraphQLField(
+                'name',
+                'String',
+                'name',
+                esc_html__('Ticket Name', 'event_espresso')
+            ),
+            new GraphQLField(
+                'order',
+                'Int',
+                'order',
+                esc_html__('The order in which the Datetime is displayed', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'parent',
+                $this->name(),
+                null,
+                esc_html__('The parent ticket of the current ticket', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'parent',
+                'ID',
+                null,
+                esc_html__('The parent ticket ID', 'event_espresso')
+            ),
+            new GraphQLField(
                 'price',
                 'Float',
                 'price',
                 esc_html__('Final calculated price for ticket', 'event_espresso')
             ),
-            new GraphQLField(
-                'sold',
-                'Int',
-                'sold',
-                esc_html__('Number of this ticket sold', 'event_espresso')
+            new GraphQLInputField(
+                'prices',
+                ['list_of' => 'ID'],
+                null,
+                sprintf(
+                    '%1$s %2$s',
+                    esc_html__('Globally unique IDs of the prices related to the ticket.', 'event_espresso'),
+                    esc_html__('Ignored if empty.', 'event_espresso')
+                )
             ),
             new GraphQLField(
                 'quantity',
@@ -138,53 +213,45 @@ class Ticket extends TypeBase
                 )
             ),
             new GraphQLField(
-                'uses',
-                'Int',
-                'uses',
-                esc_html__('Number of datetimes this ticket can be used at', 'event_espresso'),
-                [$this, 'parseInfiniteValue']
-            ),
-            new GraphQLField(
-                'isRequired',
+                'reverseCalculate',
                 'Boolean',
-                'required',
+                'reverse_calculate',
                 esc_html__(
-                    'Flag indicating whether this ticket must be purchased with a transaction',
+                    'Flag indicating whether ticket calculations should run in reverse and calculate the base ticket price from the provided ticket total.',
                     'event_espresso'
                 )
-            ),
-            new GraphQLField(
-                'isTaxable',
-                'Boolean',
-                'taxable',
-                esc_html__(
-                    'Flag indicating whether there is tax applied on this ticket',
-                    'event_espresso'
-                )
-            ),
-            new GraphQLField(
-                'isDefault',
-                'Boolean',
-                'is_default',
-                esc_html__('Flag indicating that this ticket is a default ticket', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isTrashed',
-                'Boolean',
-                'deleted',
-                esc_html__('Flag indicating ticket has been trashed.', 'event_espresso')
-            ),
-            new GraphQLField(
-                'order',
-                'Int',
-                'order',
-                esc_html__('The order in which the Datetime is displayed', 'event_espresso')
             ),
             new GraphQLField(
                 'row',
                 'Int',
                 'row',
                 esc_html__('How tickets are displayed in the ui', 'event_espresso')
+            ),
+            new GraphQLField(
+                'sold',
+                'Int',
+                'sold',
+                esc_html__('Number of this ticket sold', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'status',
+                $this->namespace . 'TicketStatusEnum',
+                'ticket_status',
+                esc_html__('Ticket status', 'event_espresso')
+            ),
+            new GraphQLField(
+                'startDate',
+                'String',
+                'start_date',
+                esc_html__('Start date and time of the Ticket', 'event_espresso'),
+                [$this, 'formatDatetime']
+            ),
+            new GraphQLField(
+                'uses',
+                'Int',
+                'uses',
+                esc_html__('Number of datetimes this ticket can be used at', 'event_espresso'),
+                [$this, 'parseInfiniteValue']
             ),
             new GraphQLOutputField(
                 'wpUser',
@@ -197,73 +264,6 @@ class Ticket extends TypeBase
                 'Int',
                 null,
                 esc_html__('Ticket Creator ID', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'parent',
-                $this->name(),
-                null,
-                esc_html__('The parent ticket of the current ticket', 'event_espresso')
-            ),
-            new GraphQLInputField(
-                'parent',
-                'ID',
-                null,
-                esc_html__('The parent ticket ID', 'event_espresso')
-            ),
-            new GraphQLField(
-                'reverseCalculate',
-                'Boolean',
-                'reverse_calculate',
-                esc_html__(
-                    'Flag indicating whether ticket calculations should run in reverse and calculate the base ticket price from the provided ticket total.',
-                    'event_espresso'
-                )
-            ),
-            new GraphQLField(
-                'isFree',
-                'Boolean',
-                'is_free',
-                esc_html__('Flag indicating whether the ticket is free.', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'event',
-                $this->namespace . 'Event',
-                null,
-                esc_html__('Event of the ticket.', 'event_espresso')
-            ),
-            new GraphQLInputField(
-                'datetimes',
-                ['list_of' => 'ID'],
-                null,
-                sprintf(
-                    '%1$s %2$s',
-                    esc_html__('Globally unique IDs of the datetimes related to the ticket.', 'event_espresso'),
-                    esc_html__('Ignored if empty.', 'event_espresso')
-                )
-            ),
-            new GraphQLInputField(
-                'prices',
-                ['list_of' => 'ID'],
-                null,
-                sprintf(
-                    '%1$s %2$s',
-                    esc_html__('Globally unique IDs of the prices related to the ticket.', 'event_espresso'),
-                    esc_html__('Ignored if empty.', 'event_espresso')
-                )
-            ),
-            new GraphQLOutputField(
-                'status',
-                $this->namespace . 'TicketStatusEnum',
-                'ticket_status',
-                esc_html__('Ticket status', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isSoldOut',
-                'Boolean',
-                null,
-                esc_html__('Flag indicating whether the ticket is sold out', 'event_espresso'),
-                null,
-                [$this, 'getIsSoldOut']
             ),
         ];
     }


### PR DESCRIPTION
This PR:
- Completes server-side GQL mutations for `Datetime`, `Ticket` and `Price`
- Sorts fields in types and mutations in alphabetical order.
- Removes calculated/computed fields from mutation input.
- Closes #2417