### PR TITLE
Fet/live event msg preview

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -2139,6 +2139,11 @@ class Messages_Admin_Page extends EE_Admin_Page
         }
 
         EE_Registry::instance()->REQ->set('GRP_ID', $this->_req_data['GRP_ID']);
+        
+        // if we have an evt_id set on the request, use it.
+        $EVT_ID = isset($this->_req_data['evt_id']) && ! empty($this->_req_data['evt_id'])
+        ? absint($this->_req_data['evt_id'])
+        : false;
 
 
         // get the preview!
@@ -2156,7 +2161,7 @@ class Messages_Admin_Page extends EE_Admin_Page
         // let's add a button to go back to the edit view
         $query_args = array(
             'id'      => $this->_req_data['GRP_ID'],
-            'evt_id'  => $this->_req_data['evt_id'],
+            'evt_id'  => $EVT_ID,
             'context' => $this->_req_data['context'],
             'action'  => 'edit_message_template',
         );

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -1308,6 +1308,10 @@ class Messages_Admin_Page extends EE_Admin_Page
             ? absint($this->_req_data['id'])
             : false;
 
+        $EVT_ID = isset($this->_req_data['evt_id']) && ! empty($this->_req_data['evt_id'])
+        ? absint($this->_req_data['evt_id'])
+        : false;
+
         $this->_set_shortcodes(); // this also sets the _message_template property.
         $message_template_group = $this->_message_template_group;
         $c_label = $message_template_group->context_label();

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -1738,6 +1738,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                 'messenger'    => $message_template_group->messenger(),
                 'context'      => $context,
                 'GRP_ID'       => $GRP_ID,
+                'evt_id'       => $EVT_ID,
                 'action'       => 'preview_message',
             ),
             $this->_admin_base_url
@@ -1752,6 +1753,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'page'    => 'espresso_messages',
             'action'  => 'edit_message_template',
             'id'      => $GRP_ID,
+            'evt_id'  => $EVT_ID,
             'context' => $context,
             'extra'   => $preview_button,
         );
@@ -2154,6 +2156,7 @@ class Messages_Admin_Page extends EE_Admin_Page
         // let's add a button to go back to the edit view
         $query_args = array(
             'id'      => $this->_req_data['GRP_ID'],
+            'evt_id'  => $this->_req_data['evt_id'],
             'context' => $this->_req_data['context'],
             'action'  => 'edit_message_template',
         );

--- a/core/libraries/messages/EE_messenger.lib.php
+++ b/core/libraries/messages/EE_messenger.lib.php
@@ -556,7 +556,7 @@ abstract class EE_messenger extends EE_Messages_Base
                 }
                 // if there is no $default_value then we set it as the global
                 $default_value = empty($default_value) ? $mtpgID : $default_value;
-                $edit_url = EEH_URL::add_query_args_and_nonce(array( 'page' => 'espresso_messages', 'action' => 'edit_message_template', 'id' => $default_value ), admin_url('admin.php'));
+                $edit_url = EEH_URL::add_query_args_and_nonce(array( 'page' => 'espresso_messages', 'action' => 'edit_message_template', 'id' => $default_value, 'evt_id' => $event_id ), admin_url('admin.php'));
                 $create_url = EEH_URL::add_query_args_and_nonce(array( 'page' => 'espresso_messages', 'action' => 'add_new_message_template', 'GRP_ID' => $default_value ), admin_url('admin.php'));
                 $st_args['mt_name'] = ucwords($mtp_obj->label['singular']);
                 $st_args['mt_slug'] = $mtpg->message_type();

--- a/core/libraries/messages/EE_messenger.lib.php
+++ b/core/libraries/messages/EE_messenger.lib.php
@@ -556,8 +556,19 @@ abstract class EE_messenger extends EE_Messages_Base
                 }
                 // if there is no $default_value then we set it as the global
                 $default_value = empty($default_value) ? $mtpgID : $default_value;
-                $edit_url = EEH_URL::add_query_args_and_nonce(array( 'page' => 'espresso_messages', 'action' => 'edit_message_template', 'id' => $default_value, 'evt_id' => $event_id ), admin_url('admin.php'));
-                $create_url = EEH_URL::add_query_args_and_nonce(array( 'page' => 'espresso_messages', 'action' => 'add_new_message_template', 'GRP_ID' => $default_value ), admin_url('admin.php'));
+                $edit_url_query_args = [
+                    'page' => 'espresso_messages',
+                    'action' => 'edit_message_template',
+                    'id' => $default_value,
+                    'evt_id' => $event_id
+                ];
+                $edit_url = EEH_URL::add_query_args_and_nonce($edit_url_query_args, admin_url('admin.php'));
+                $create_url_query_args = [
+                    'page' => 'espresso_messages',
+                    'action' => 'add_new_message_template',
+                    'GRP_ID' => $default_value
+                ];
+                $create_url = EEH_URL::add_query_args_and_nonce($create_url_query_args, admin_url('admin.php'));
                 $st_args['mt_name'] = ucwords($mtp_obj->label['singular']);
                 $st_args['mt_slug'] = $mtpg->message_type();
                 $st_args['messenger_slug'] = $this->name;


### PR DESCRIPTION
See #1447 

The message system already checks for an event id set on the request for it to use for data so this just adds the that to the evt_id query var it uses.

## How has this been tested
(Make sure the event you are editing is not the 'first' event you created, meaning you can't test this on a 'fresh' install as you won't know if you're getting the correct event data)

Edit an event (make a note of the event id) and click on the edit link for a message type, then preview that message type.

Check that the preview now relates to the event in question.
Confirm the shortcodes do actually relate to the current event.

You'll know pretty quick if this isn't working, it'll error or you'll get the preview data and not your current event.

Click the link to go back to the message editor and confirm the evt_id query var is still set and this it is the correct ID. 

Switch recipients and confirm the above is still set and its the correct ID.

Repeat the above a draft event.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
