### PR TITLE
Switch to using a timestamp on the Event admin list month_range query.

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1783,7 +1783,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 new DateTimeZone('UTC')
             );
             $start = $DateTime->getTimestamp();
-            //Set the datetime to be the end of the month.
+            // set the datetime to be the end of the month
             $DateTime->setDate(
                 $year_r,
                 $month_r,

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1780,16 +1780,16 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         if (isset($this->_req_data['month_range']) && $this->_req_data['month_range'] != '') {
             $DateTime = new DateTime(
                 $year_r . '-' . $month_r . '-01 00:00:00',
-                new DateTimeZone(EEM_Datetime::instance()->get_timezone())
+                new DateTimeZone('UTC')
             );
-            $start = $DateTime->format(implode(' ', $start_formats));
-            $end = $DateTime->setDate(
+            $start = $DateTime->getTimestamp();
+            //Set the datetime to be the end of the month.
+            $DateTime->setDate(
                 $year_r,
                 $month_r,
-                $DateTime
-                    ->format('t')
-            )->setTime(23, 59, 59)
-                            ->format(implode(' ', $start_formats));
+                $DateTime->format('t')
+            )->setTime(23, 59, 59);
+            $end = $DateTime->getTimestamp();
             $where['Datetime.DTT_EVT_start'] = array('BETWEEN', array($start, $end));
         } elseif (isset($this->_req_data['status']) && $this->_req_data['status'] == 'today') {
             $DateTime = new DateTime('now', new DateTimeZone(EEM_Event::instance()->get_timezone()));
@@ -1852,6 +1852,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             ),
             $this->_req_data
         );
+                d($query_params);
+
         // let's first check if we have special requests coming in.
         if (isset($this->_req_data['active_status'])) {
             switch ($this->_req_data['active_status']) {

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1852,7 +1852,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             ),
             $this->_req_data
         );
-                d($query_params);
 
         // let's first check if we have special requests coming in.
         if (isset($this->_req_data['active_status'])) {


### PR DESCRIPTION
See: https://eventespresso.com/topic/event-espresso-events-filter-not-working-as-expected/

If you have your sites date format set to not include a year, the 'Select a Month/Year' dropdown breaks as it will only use the current year.

## How has this been tested
On master.

Set your site to use a date format without a year, `F j` for example.

Now on Event Espresso -> Events.

Select a month/year in the dropdown that is not within the current year and hit filter, you should see either no results or events for the current year returned and not earlier events.
(Selecting Jan 2019 will search for events in Jan 2020)

Switch to this branch and repeat, you should now get the expected events returned when you filter.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
