### PR TITLE
Remove the Codebase redirect URL.

### DIFF
--- a/core/admin/templates/espresso_ratings_request_content.template.php
+++ b/core/admin/templates/espresso_ratings_request_content.template.php
@@ -11,7 +11,7 @@
         class="ee-wp-blue dashicons dashicons-star-filled"></span><span
         class="ee-wp-blue dashicons dashicons-star-filled"></span>
     <p><a class="button button-primary"
-          href="https://events.codebasehq.com/redirect?https://login.wordpress.org/?redirect_to=https%3A%2F%2Fwordpress.org%2Fsupport%2Fview%2Fplugin-reviews%2Fevent-espresso-decaf%3Frate%3D5%23postform"><?php
+          href="https://login.wordpress.org/?redirect_to=https%3A%2F%2Fwordpress.org%2Fsupport%2Fview%2Fplugin-reviews%2Fevent-espresso-decaf%3Frate%3D5%23postform"><?php
             _e(
                 'Rate It!',
                 'event_espresso'


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Garth found that if you have decaf installed and go to the Payment Methods settings page, then click the “Rate It!” button, the button URL is wrong:
![image (9)](https://user-images.githubusercontent.com/235315/75365375-5abfe000-587a-11ea-9d64-75c83e2618d5.png)

The URL is wrong because it’s redirecting through CodebaseHQ: https://events.codebasehq.com/redirect?https://login.wordpress.org/?redirect_to=https%3A%2F%2Fwordpress.org%2Fsupport%2Fview%2Fplugin-reviews%2Fevent-espresso-decaf%3Frate%3D5%23postform

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Intall EE4 Decaf, then visit the Payment Methods settings page, then click the "Rate It!" button in the sidebar. You should be taken to the WordPress.org login page.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
