### PR TITLE
Fixed issue of wait list button when Google recaptcha is enabled

### DIFF
--- a/caffeinated/modules/recaptcha_invisible/assets/espresso_invisible_recaptcha.js
+++ b/caffeinated/modules/recaptcha_invisible/assets/espresso_invisible_recaptcha.js
@@ -99,7 +99,8 @@ function espressoLoadRecaptcha() {
                             setTimeout(
                                 function() {
                                     $submit.click();
-                                    if (eeRecaptcha.disable_submit !== true) {
+
+                                    if ($submit.data('ee-disable-after-recaptcha') === true && eeRecaptcha.disable_submit !== true) {
                                         $submit.prop('disabled', true).addClass('disabled ee-button-disabled');
                                     }
                                 },

--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -655,7 +655,7 @@ class DisplayTicketSelector
         $html .= '<input id="ticket-selector-submit-' . $this->event->ID() . '-btn"';
         $html .= ' class="ticket-selector-submit-btn ';
         $html .= empty($external_url) ? 'ticket-selector-submit-ajax"' : '"';
-        $html .= ' type="submit" value="' . $btn_text . '" />';
+        $html .= ' type="submit" value="' . $btn_text . '" data-ee-disable-after-recaptcha="true" />';
         $html .= EEH_HTML::divx() . '<!-- .ticket-selector-submit-btn-wrap -->';
         $html .= apply_filters(
             'FHEE__EE_Ticket_Selector__after_ticket_selector_submit',


### PR DESCRIPTION
This fix is related to https://github.com/eventespresso/eea-wait-lists/issues/21 issue. I checked the JS code of Google Recaptcha and found that it is disabling the submit button after validating the token.

I didn't removed the code completely but I added a new data parameter to be able to handle when the button should be disabled and when shouldn't.  Then I added this feature for ticket selection form and turned it off for the wait-list form. Now the submit button on wait-list form won't disable after Google recaptcha validation.