### PR TITLE
Fix guid length in shortenGuid | Closes #2474

### DIFF
--- a/assets/src/application/services/utilities/text/shortenGuid/index.test.ts
+++ b/assets/src/application/services/utilities/text/shortenGuid/index.test.ts
@@ -1,0 +1,41 @@
+import shortenGuid from './';
+
+const testCases = [
+	{
+		desc: 'returns last 6 characters if the string is of more than 6 characters',
+		guid: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+		result: 'UVWXYZ',
+	},
+	{
+		desc: 'returns the actual string if it is of exactly 6 characters',
+		guid: 'ABCD==',
+		result: 'ABCD==',
+	},
+	{
+		desc: 'returns the actual string if it is of less than 6 characters',
+		guid: 'ABCD',
+		result: 'ABCD',
+	},
+	{
+		desc: 'returns empty string if it is empty',
+		guid: '',
+		result: '',
+	},
+];
+
+describe('shortenGuid', () => {
+	testCases.forEach((testCase) => {
+		it(testCase.desc, () => {
+			const expectedResult = shortenGuid(testCase.guid);
+
+			expect(testCase.result).toBe(expectedResult);
+		});
+	});
+
+	it('throws TypeError if null or undefined is passed', () => {
+		[null, undefined].forEach((guid) => {
+			const getShortenedGuid = (): string => shortenGuid(guid);
+			expect(getShortenedGuid).toThrow(TypeError);
+		});
+	});
+});

--- a/assets/src/application/services/utilities/text/shortenGuid/index.ts
+++ b/assets/src/application/services/utilities/text/shortenGuid/index.ts
@@ -1,14 +1,11 @@
-import { EntityId, EntityDbId } from '@appServices/apollo/types';
+import { EntityId } from '@appServices/apollo/types';
 
 /**
- * converts a GUID like "RGF0ZXRpbWU6NQ==" into "WU6NQ=="
+ * converts a GUID like "RGF0ZXRpbWU6NQ==" into "U6NQ=="
  */
-const shortenGuid = (guid: EntityId | EntityDbId, start = 9, end = 16): string | EntityDbId => {
-	if (typeof guid === 'string' && guid.length > start) {
-		// use a smaller more unique portion of the CUID
-		return guid.substring(start, end);
-	}
-	return guid;
+const shortenGuid = <T extends EntityId>(guid: T): string => {
+	// Return last 6 characters
+	return guid.slice(-6);
 };
 
 export default shortenGuid;


### PR DESCRIPTION
This PR:
- Removes `start` and `end` args from `shortenGuid`.
- Changes `shortenGuid` to just return the last 6 characters of the passed GUID
- Adds tests for `shortenGuid`
- Closes #2474