### PR TITLE
ADD: Format for thousands add spacing into inputs value to help display in other format

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -785,7 +785,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                         'id'   => ',',
                         'text' => __(', (comma)', 'event_espresso'),
                     ),
-                    array('id' => '.', 'text' => __('. (decimal)', 'event_espresso')),
+                    array(
+                        'id' => '.',
+                        'text' => __('. (decimal)', 'event_espresso')
+                    ),
+                    array(
+                        'id' => '&nbsp;',
+                        'text' => __('(space)', 'event_espresso')
+                    )
                 ),
                 'use_desc_4_label' => true,
                 'disabled'         => $CNT_cur_disabled,

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 // PARAMS THAT MUST BE PASSED ARE:
 assert(isset($QST_ID));
 assert($question);
@@ -11,6 +12,8 @@ echo EEH_Form_Fields::hidden_input('QST_wp_user', $question->wp_user());
 echo EEH_Form_Fields::hidden_input('QST_deleted', $question->deleted());
 $QST_system = $question->system_ID();
 $fields = $question->get_model()->field_settings();
+
+do_action('AHEE__questions_main_meta_box__template__before_admin_page_content', $question);
 
 // does question have any answers? cause if it does then we have to disable type
 $has_answers = $question->has_answers();
@@ -32,9 +35,16 @@ if ($QST_system === 'country') {
 }
 ?>
 
+<?php
+    do_action('AHEE__questions_main_meta_box__template__inner_admin_page_content', $question);
+?>
+
 <div class="padding">
     <table class="form-table">
         <tbody>
+        <?php
+            do_action('AHEE__questions_main_meta_box__template__before_table_form_table', $question);
+        ?>
         <tr>
             <th>
                 <label for="QST_display_text"><?php echo $fields['QST_display_text']->get_nicename(); ?></label>
@@ -382,9 +392,15 @@ if ($QST_system === 'country') {
 
             </td>
         </tr>
-
+        <?php
+            do_action('AHEE__questions_main_meta_box__template__after_table_form_table', $question);
+        ?>
         </tbody>
     </table>
 
     <div class="clear"></div>
 </div>
+
+<?php
+    do_action('AHEE__questions_main_meta_box__template__after_admin_page_content', $question);
+?>

--- a/core/libraries/line_item_display/EE_Admin_Table_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_Admin_Table_Line_Item_Display_Strategy.strategy.php
@@ -199,6 +199,14 @@ class EE_Admin_Table_Line_Item_Display_Strategy implements EEI_Line_Item_Display
             $parent_related_object_link ? '<a href="' . $parent_related_object_link . '">' . $parent_related_object_name . '</a>' : $parent_related_object_name,
             '</span>'
         );
+
+        $name_html = apply_filters(
+            'FHEE__EE_Admin_Table_Line_Item_Display_Strategy___item_row__name_html',
+            $name_html,
+            $line_item,
+            $options
+        );
+
         $html .= EEH_HTML::td($name_html, '', 'jst-left');
         // Type Column
         $type_html = $line_item->OBJ_type() ? $line_item->OBJ_type_i18n() : '';

--- a/core/libraries/line_item_display/EE_Admin_Table_Registration_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_Admin_Table_Registration_Line_Item_Display_Strategy.strategy.php
@@ -90,6 +90,14 @@ class EE_Admin_Table_Registration_Line_Item_Display_Strategy extends EE_Admin_Ta
                 : $parent_related_object_name,
             '</span>'
         );
+
+        $name_html = apply_filters(
+            'FHEE__EE_Admin_Table_Registration_Line_Item_Display_Strategy___item_row__name_html',
+            $name_html,
+            $line_item,
+            $options
+        );
+        
         $html .= EEH_HTML::td($name_html, '', 'jst-left');
         // Type Column
         $type_html = $line_item->OBJ_type() ? $line_item->OBJ_type_i18n() : '';

--- a/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
@@ -267,6 +267,13 @@ class EE_SPCO_Line_Item_Display_Strategy implements EEI_Line_Item_Display
             $options
         );
         $name_and_desc .= $line_item->is_taxable() ? ' * ' : '';
+        $name_and_desc = apply_filters(
+            'FHEE__EE_SPCO_Line_Item_Display_Strategy___ticket_row__name_and_desc',
+            $name_and_desc,
+            $line_item,
+            $options
+        );
+
         // name td
         $html .= EEH_HTML::td( /*__FUNCTION__ .*/
             $name_and_desc,
@@ -334,6 +341,13 @@ class EE_SPCO_Line_Item_Display_Strategy implements EEI_Line_Item_Display
             $options
         );
         $name_and_desc .= $line_item->is_taxable() ? ' * ' : '';
+        $name_and_desc = apply_filters(
+            'FHEE__EE_SPCO_Line_Item_Display_Strategy__item_row__name_and_desc',
+            $name_and_desc,
+            $line_item,
+            $options
+        );
+
         // name td
         $html .= EEH_HTML::td($name_and_desc, '', 'item_l');
         // price td

--- a/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
+++ b/core/libraries/line_item_display/EE_SPCO_Line_Item_Display_Strategy.strategy.php
@@ -342,7 +342,7 @@ class EE_SPCO_Line_Item_Display_Strategy implements EEI_Line_Item_Display
         );
         $name_and_desc .= $line_item->is_taxable() ? ' * ' : '';
         $name_and_desc = apply_filters(
-            'FHEE__EE_SPCO_Line_Item_Display_Strategy__item_row__name_and_desc',
+            'FHEE__EE_SPCO_Line_Item_Display_Strategy___item_row__name_and_desc',
             $name_and_desc,
             $line_item,
             $options


### PR DESCRIPTION
## Problem this Pull Request solves
ADD: Format for thousands add spacing into inputs value to help display in other format (french)
CHG: Change the Input value display in PHP code to be aligned with the format of the code

## How has this been tested
I tested directly online with the real payment option for the page.
