### PR TITLE
Extract the logic for recalculating line items into the EE_Transaction class

### DIFF
--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -2553,11 +2553,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
         /** @var EE_Transaction $transaction */
         $transaction = EEM_Transaction::instance()->get_one_by_ID($TXN_ID);
         $total_line_item = $transaction->total_line_item(false);
-        $success = false;
-        if ($total_line_item instanceof EE_Line_Item) {
-            EEH_Line_Item::resetIsTaxableForTickets($total_line_item);
-            $success = EEH_Line_Item::apply_taxes($total_line_item, true);
-        }
+        $success = $transaction->recalculateLineItems();
         $this->_redirect_after_action(
             (bool) $success,
             esc_html__('Transaction taxes and totals', 'event_espresso'),

--- a/core/db_classes/EE_Transaction.class.php
+++ b/core/db_classes/EE_Transaction.class.php
@@ -1691,4 +1691,25 @@ class EE_Transaction extends EE_Base_Class implements EEI_Transaction
             }
         }
     }
+
+
+    /**
+     * @since $VID:$
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     * @throws RuntimeException
+     */
+    public function recalculateLineItems()
+    {
+        $total_line_item = $this->total_line_item(false);
+        $success = false;
+        if ($total_line_item instanceof EE_Line_Item) {
+            EEH_Line_Item::resetIsTaxableForTickets($total_line_item);
+            $success = EEH_Line_Item::apply_taxes($total_line_item, true);
+        }
+        return $success;
+    }
 }

--- a/core/db_classes/EE_Transaction.class.php
+++ b/core/db_classes/EE_Transaction.class.php
@@ -1705,11 +1705,10 @@ class EE_Transaction extends EE_Base_Class implements EEI_Transaction
     public function recalculateLineItems()
     {
         $total_line_item = $this->total_line_item(false);
-        $success = false;
         if ($total_line_item instanceof EE_Line_Item) {
             EEH_Line_Item::resetIsTaxableForTickets($total_line_item);
-            $success = EEH_Line_Item::apply_taxes($total_line_item, true);
+            return EEH_Line_Item::apply_taxes($total_line_item, true);
         }
-        return $success;
+        return false;
     }
 }


### PR DESCRIPTION
Required for: https://github.com/eventespresso/EE4-Promotions/pull/24

This branch pulls the logic for recalculating line items into its own method on the EE_Transaction class so it is available to use.

## How has this been tested
The testing notes for this are the same as: https://github.com/eventespresso/event-espresso-core/pull/864

In short, create a paid ticket that is not taxable.
Add registrations to said ticket and pay.
Edit the ticket and mark it taxable.
Edit the transaction(s) for the registration(s) you ceated and click the Recalculate Taxes and Total button.

Confirm the transaction shows the new taxable amount and switches to the correct status etc.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
