### PR TITLE
Fix TPC ticket update | Closes #2493

### DIFF
--- a/assets/src/domain/shared/entities/prices/predicates/priceFields.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/priceFields.ts
@@ -1,4 +1,6 @@
-export const PRICE_INPUT_FIELDS = [
+import { UpdatePriceInput } from '@edtrServices/apollo/mutations';
+
+export const PRICE_INPUT_FIELDS: Array<keyof UpdatePriceInput> = [
 	'amount',
 	'desc',
 	'isDefault',

--- a/assets/src/domain/shared/entities/tickets/predicates/ticketFields.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/ticketFields.ts
@@ -1,9 +1,10 @@
-export const TICKET_INPUT_FIELDS = [
+import { UpdateTicketInput } from '@edtrServices/apollo/mutations';
+
+export const TICKET_INPUT_FIELDS: Array<keyof UpdateTicketInput> = [
 	'datetimes',
 	'description',
 	'endDate',
 	'isDefault',
-	'isFree',
 	'isRequired',
 	'isTaxable',
 	'isTrashed',

--- a/assets/src/domain/shared/entities/tickets/predicates/ticketFields.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/ticketFields.ts
@@ -25,4 +25,4 @@ export const TICKET_INPUT_FIELDS: Array<keyof UpdateTicketInput> = [
 	'wpUser',
 ];
 
-export const TICKET_FIELDS = [...TICKET_INPUT_FIELDS, 'id', 'dbId', 'isSoldOut'];
+export const TICKET_FIELDS = [...TICKET_INPUT_FIELDS, 'id', 'dbId', 'isSoldOut', 'isFree'];


### PR DESCRIPTION
This PR
- Removes `isFree` field from ticket mutation input
- Tightens the type checks for TPC fields.
- Closes #2493