### PR TITLE
Add Confirmation Popup to Delete Buttons | Closes #2494

### DIFF
--- a/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
+++ b/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
@@ -40,7 +40,7 @@ const EspressoButton = React.forwardRef<Button, EspressoButtonProps>((props, ref
 		'ant-btn-icon-only': !buttonText,
 		'ee-noIcon': !icon,
 	});
-	let eeButton: React.ReactNode;
+	let eeButton: JSX.Element;
 	// check if icon prop is just an icon name (like "calendar") and if not, assume it is JSX
 	if (isEspressoIcon(icon)) {
 		// custom EE icon

--- a/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
+++ b/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
@@ -8,20 +8,25 @@ import { EspressoIcon, isEspressoIcon } from '../../display';
 
 /**
  * Button wrapper for adding styles
+ *
+ * forwardRef to be able to accept
+ * onMouseEnter, onMouseLeave, onFocus, onClick events from parent
  */
-const EspressoButton: React.FC<EspressoButtonProps> = ({
-	icon,
-	onClick,
-	buttonText,
-	buttonSize = EspressoButtonSize.DEFAULT,
-	buttonType = EspressoButtonType.DEFAULT,
-	className,
-	tooltip,
-	tooltipProps = {},
-	...buttonProps
-}) => {
-	className = classNames({
-		[className]: className,
+const EspressoButton = React.forwardRef<Button, EspressoButtonProps>((props, ref) => {
+	const {
+		icon,
+		onClick,
+		buttonText,
+		buttonSize = EspressoButtonSize.DEFAULT,
+		buttonType = EspressoButtonType.DEFAULT,
+		className: htmlClass,
+		tooltip,
+		tooltipProps = {},
+		...buttonProps
+	} = props;
+
+	const className = classNames({
+		[htmlClass]: htmlClass,
 		'esprs-button': true,
 		'esprs-btn-accent': buttonType === EspressoButtonType.ACCENT,
 		'esprs-btn-default': buttonType === EspressoButtonType.DEFAULT,
@@ -35,7 +40,7 @@ const EspressoButton: React.FC<EspressoButtonProps> = ({
 		'ant-btn-icon-only': !buttonText,
 		'ee-noIcon': !icon,
 	});
-	let eeButton: JSX.Element;
+	let eeButton: React.ReactNode;
 	// check if icon prop is just an icon name (like "calendar") and if not, assume it is JSX
 	if (isEspressoIcon(icon)) {
 		// custom EE icon
@@ -49,6 +54,7 @@ const EspressoButton: React.FC<EspressoButtonProps> = ({
 					icon={<AntIcon component={svgIcon} />}
 					onClick={onClick}
 					tabIndex={0}
+					ref={ref}
 				>
 					{buttonText && buttonText}
 				</Button>
@@ -57,7 +63,7 @@ const EspressoButton: React.FC<EspressoButtonProps> = ({
 	} else {
 		// AntD or JSX element icon
 		eeButton = (
-			<Button {...buttonProps} className={className} icon={icon} onClick={onClick} tabIndex={0}>
+			<Button {...buttonProps} className={className} icon={icon} onClick={onClick} tabIndex={0} ref={ref}>
 				{buttonText && buttonText}
 			</Button>
 		);
@@ -69,6 +75,6 @@ const EspressoButton: React.FC<EspressoButtonProps> = ({
 	) : (
 		eeButton
 	);
-};
+});
 
 export default EspressoButton;

--- a/assets/src/application/ui/input/EspressoButton/types.ts
+++ b/assets/src/application/ui/input/EspressoButton/types.ts
@@ -28,7 +28,7 @@ export interface EspressoButtonProps extends Partial<NativeButtonProps> {
 	buttonType?: EspressoButtonType;
 	className?: string;
 	disabled?: boolean;
-	onClick: ClickHandler;
+	onClick?: ClickHandler;
 	tooltip?: string;
 	tooltipProps?: Partial<TooltipPropsWithTitle>;
 	icon?: EspressoIcon | React.ReactNode;

--- a/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
+++ b/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
@@ -4,7 +4,7 @@ import { PopconfirmProps } from 'antd/lib/popconfirm';
 import { __ } from '@wordpress/i18n';
 
 interface ConfirmDeleteProps extends Omit<PopconfirmProps, 'title'> {
-	message: string;
+	message?: string;
 }
 
 const ConfirmDelete: React.FC<ConfirmDeleteProps> = ({ children, message, ...props }) => {

--- a/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
+++ b/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Popconfirm } from 'antd';
+import { PopconfirmProps } from 'antd/lib/popconfirm';
+import { __ } from '@wordpress/i18n';
+
+const ConfirmDelete: React.FC<Partial<PopconfirmProps>> = ({ children, ...props }) => {
+	return (
+		<Popconfirm title={__('Are you sure delete it?')} okText={__('Yes')} cancelText={__('No')} {...props}>
+			{children}
+		</Popconfirm>
+	);
+};
+
+export default ConfirmDelete;

--- a/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
+++ b/assets/src/application/ui/layout/confirmDelete/ConfirmDelete.tsx
@@ -3,9 +3,14 @@ import { Popconfirm } from 'antd';
 import { PopconfirmProps } from 'antd/lib/popconfirm';
 import { __ } from '@wordpress/i18n';
 
-const ConfirmDelete: React.FC<Partial<PopconfirmProps>> = ({ children, ...props }) => {
+interface ConfirmDeleteProps extends Omit<PopconfirmProps, 'title'> {
+	message: string;
+}
+
+const ConfirmDelete: React.FC<ConfirmDeleteProps> = ({ children, message, ...props }) => {
+	const title = message || __('Are you sure you want to delete this?');
 	return (
-		<Popconfirm title={__('Are you sure delete it?')} okText={__('Yes')} cancelText={__('No')} {...props}>
+		<Popconfirm title={title} okText={__('Yes')} cancelText={__('No')} {...props}>
 			{children}
 		</Popconfirm>
 	);

--- a/assets/src/application/ui/layout/confirmDelete/index.ts
+++ b/assets/src/application/ui/layout/confirmDelete/index.ts
@@ -1,0 +1,1 @@
+export { default as ConfirmDelete } from './ConfirmDelete';

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/DeleteDateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/DeleteDateButton.tsx
@@ -2,21 +2,22 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { EspressoButton, Icon } from '@application/ui/input';
-import { MutationResult } from '@appServices/apollo/mutations';
 import { ListItemProps } from '@edtrInterfaces/types';
 import { useDatetimeMutator } from '@edtrServices/apollo/mutations';
+import { ConfirmDelete } from '@appLayout/confirmDelete';
 
 const DeleteDateButton: React.FC<ListItemProps> = ({ id, ...rest }) => {
 	const { deleteEntity } = useDatetimeMutator(id);
 
 	return (
-		<EspressoButton
-			icon={Icon.TRASH}
-			tooltip={__('delete datetime')}
-			tooltipProps={{ placement: 'right' }}
-			onClick={(): MutationResult => deleteEntity({ id })}
-			{...rest}
-		/>
+		<ConfirmDelete onConfirm={() => deleteEntity({ id })}>
+			<EspressoButton
+				icon={Icon.TRASH}
+				tooltip={__('delete datetime')}
+				tooltipProps={{ placement: 'right' }}
+				{...rest}
+			/>
+		</ConfirmDelete>
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/DeleteTicketButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/DeleteTicketButton.tsx
@@ -4,18 +4,20 @@ import { __ } from '@wordpress/i18n';
 
 import useDeleteTicketHandler from '../../hooks/useDeleteTicketHandler';
 import { ListItemProps } from '@edtrInterfaces/types';
+import { ConfirmDelete } from '@appLayout/confirmDelete';
 
 const DeleteTicketButton: React.FC<ListItemProps> = ({ id, ...rest }) => {
 	const handleDeleteTicket = useDeleteTicketHandler({ id });
 
 	return (
-		<EspressoButton
-			icon={Icon.TRASH}
-			onClick={handleDeleteTicket}
-			tooltip={__('delete ticket')}
-			tooltipProps={{ placement: 'left' }}
-			{...rest}
-		/>
+		<ConfirmDelete onConfirm={handleDeleteTicket}>
+			<EspressoButton
+				icon={Icon.TRASH}
+				tooltip={__('delete ticket')}
+				tooltipProps={{ placement: 'left' }}
+				{...rest}
+			/>
+		</ConfirmDelete>
 	);
 };
 


### PR DESCRIPTION
This PR:
- Improves `EspressoButton` to accept mouse events from parent
- Creates `ConfirmDelete` component inside `/application/ui/layout/confirmDelete`
- Adds delete confirmation to date and ticket deletion
- Closes #2494