### PR TITLE
Destroy wp components | Closes #2454

### DIFF
--- a/assets/src/application/ui/input/BaseInput/BaseInput.tsx
+++ b/assets/src/application/ui/input/BaseInput/BaseInput.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import './style.scss';
+
+interface BaseInputProps {
+	id?: string;
+	label?: string;
+	className?: string;
+	children?: React.ReactNode;
+}
+
+const BaseInput: React.FC<BaseInputProps> = ({ id, label, className, children }) => {
+	return (
+		<div className={classnames('ee-base-input', className)}>
+			<div className='ee-base-input-field'>
+				{label && (
+					<label className='ee-base-input-label' htmlFor={id}>
+						{label}
+					</label>
+				)}
+				{children}
+			</div>
+		</div>
+	);
+};
+
+export default BaseInput;

--- a/assets/src/application/ui/input/BaseInput/index.ts
+++ b/assets/src/application/ui/input/BaseInput/index.ts
@@ -1,0 +1,1 @@
+export { default as BaseInput } from './BaseInput';

--- a/assets/src/application/ui/input/BaseInput/style.scss
+++ b/assets/src/application/ui/input/BaseInput/style.scss
@@ -1,0 +1,9 @@
+.ee-base-input {
+	.ee-base-input-label {
+		color: var(--ee-default-text-color);
+		display: block;
+		font-weight: bold;
+		margin: var(--ee-margin-micro) var(--ee-margin-micro) 0;
+		white-space: nowrap;
+	}
+}

--- a/assets/src/application/ui/input/SearchInput/index.tsx
+++ b/assets/src/application/ui/input/SearchInput/index.tsx
@@ -1,26 +1,29 @@
-import React, { useMemo } from 'react';
-import { TextControl } from '@wordpress/components';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
+import { Input } from 'antd';
+import { InputProps } from 'antd/lib/input';
 
-type voidFn = () => void;
+import { BaseInput } from '../BaseInput';
 
-interface SearchInputProps {
-	listId: string;
+interface SearchInputProps extends InputProps {
 	searchText: string;
-	setSearchText: voidFn;
+	setSearchText: (text?: string) => void;
 }
 
-const SearchInput: React.FC<SearchInputProps> = ({ listId, searchText, setSearchText }) =>
-	useMemo(() => {
-		return typeof setSearchText === 'function' ? (
-			<TextControl
-				id={`ee-search-text-${listId}`}
-				label={__('search')}
+const SearchInput: React.FC<SearchInputProps> = React.memo(({ id, searchText, setSearchText, className, ...rest }) => {
+	const htmlId = `ee-search-input-${id}`;
+	return typeof setSearchText === 'function' ? (
+		<BaseInput label={__('search')} id={htmlId} className={className}>
+			<Input
+				id={htmlId}
 				className='ee-entity-list-filter-bar-search'
 				value={searchText}
-				onChange={setSearchText}
+				onChange={(e) => setSearchText(e.target.value)}
+				size='middle'
+				{...rest}
 			/>
-		) : null;
-	}, [listId, searchText, setSearchText]);
+		</BaseInput>
+	) : null;
+});
 
 export default SearchInput;

--- a/assets/src/application/ui/input/SelectInput/SelectInput.tsx
+++ b/assets/src/application/ui/input/SelectInput/SelectInput.tsx
@@ -12,7 +12,7 @@ const SelectInput: React.FC<SelectInputProps> = React.memo(({ id, label, classNa
 	const htmlId = id ? `ee-select-input-${id}` : null;
 	return (
 		<BaseInput label={label} id={htmlId} className={className}>
-			<Select style={{ width: 'auto' }} id={htmlId} size='middle' dropdownMatchSelectWidth={true} {...rest} />
+			<Select id={htmlId} size='middle' dropdownMatchSelectWidth={true} {...rest} />
 		</BaseInput>
 	);
 });

--- a/assets/src/application/ui/input/SelectInput/SelectInput.tsx
+++ b/assets/src/application/ui/input/SelectInput/SelectInput.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { SelectProps, SelectValue } from 'antd/lib/select';
+import { Select } from 'antd';
+
+import { BaseInput } from '../BaseInput';
+
+interface SelectInputProps extends SelectProps<SelectValue> {
+	label: string;
+}
+
+const SelectInput: React.FC<SelectInputProps> = React.memo(({ id, label, className, ...rest }) => {
+	const htmlId = id ? `ee-select-input-${id}` : null;
+	return (
+		<BaseInput label={label} id={htmlId} className={className}>
+			<Select style={{ width: 'auto' }} id={htmlId} size='middle' dropdownMatchSelectWidth={true} {...rest} />
+		</BaseInput>
+	);
+});
+
+export default SelectInput;

--- a/assets/src/application/ui/input/SelectInput/index.ts
+++ b/assets/src/application/ui/input/SelectInput/index.ts
@@ -1,0 +1,1 @@
+export { default as SelectInput } from './SelectInput';

--- a/assets/src/application/ui/layout/entityList/filterBar/Collapsible.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/Collapsible.tsx
@@ -39,7 +39,7 @@ const Collapsible: React.FC<CollapsibleProps> = ({
 				{showEntityFilters && (
 					<>
 						{entityFilters}
-						<SearchInput listId={listId} searchText={searchText} setSearchText={setSearchText} />
+						<SearchInput id={listId} searchText={searchText} setSearchText={setSearchText} />
 					</>
 				)}
 			</div>

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DatesSortedControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DatesSortedControl.tsx
@@ -1,10 +1,7 @@
-/**
- * External imports
- */
-import React, { useMemo } from 'react';
-import { SelectControl } from '@wordpress/components';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { DatesSorted } from '@edtrInterfaces/datetimes/types';
+import { SelectInput } from '@appInputs/SelectInput';
 
 interface DatesSortedControlProps {
 	datesSortedBy: DatesSorted;
@@ -13,35 +10,34 @@ interface DatesSortedControlProps {
 /**
  * filter for controlling the sorting of a list of Event Dates
  */
-const DatesSortedControl: React.FC<DatesSortedControlProps> = ({ datesSortedBy, setDatesSortedBy }) => {
-	return useMemo(() => {
-		return (
-			<SelectControl
-				label={__('sort')}
-				className='espresso-date-list-filter-bar-order-select'
-				value={datesSortedBy}
-				options={[
-					{
-						value: DatesSorted.chronologically,
-						label: __('chronologically'),
-					},
-					{
-						value: DatesSorted.byName,
-						label: __('by date name'),
-					},
-					{
-						value: DatesSorted.byId,
-						label: __('by date ID'),
-					},
-					{
-						value: DatesSorted.byOrder,
-						label: __('by custom order'),
-					},
-				]}
-				onChange={setDatesSortedBy}
-			/>
-		);
-	}, [datesSortedBy, setDatesSortedBy]);
-};
+const DatesSortedControl: React.FC<DatesSortedControlProps> = React.memo(({ datesSortedBy, setDatesSortedBy }) => {
+	return (
+		<SelectInput
+			label={__('sort')}
+			className='espresso-date-list-filter-bar-order-select'
+			value={datesSortedBy}
+			options={[
+				{
+					value: DatesSorted.chronologically,
+					label: __('chronologically'),
+				},
+				{
+					value: DatesSorted.byName,
+					label: __('by date name'),
+				},
+				{
+					value: DatesSorted.byId,
+					label: __('by date ID'),
+				},
+				{
+					value: DatesSorted.byOrder,
+					label: __('by custom order'),
+				},
+			]}
+			onChange={setDatesSortedBy}
+			size='large'
+		/>
+	);
+});
 
 export default DatesSortedControl;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DisplayDatesControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/DisplayDatesControl.tsx
@@ -1,10 +1,7 @@
-/**
- * External imports
- */
-import React, { useMemo } from 'react';
-import { SelectControl } from '@wordpress/components';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { DisplayDates } from '@edtrInterfaces/datetimes/types';
+import { SelectInput } from '@appInputs/SelectInput';
 
 interface DisplayDatesControlProps {
 	displayDates: DisplayDates;
@@ -13,30 +10,30 @@ interface DisplayDatesControlProps {
 /**
  * filter for controlling which dates display in a list of Event Dates
  */
-const DisplayDatesControl: React.FC<DisplayDatesControlProps> = ({ displayDates, setDisplayDates }) =>
-	useMemo<JSX.Element>(() => {
-		return (
-			<SelectControl
-				label={__('display')}
-				className='espresso-date-list-filter-bar-display-select'
-				value={displayDates}
-				options={[
-					{
-						value: DisplayDates.start,
-						label: __('start dates only'),
-					},
-					{
-						value: DisplayDates.end,
-						label: __('end dates only'),
-					},
-					{
-						value: DisplayDates.both,
-						label: __('start and end dates'),
-					},
-				]}
-				onChange={setDisplayDates}
-			/>
-		);
-	}, [displayDates, setDisplayDates]);
+const DisplayDatesControl: React.FC<DisplayDatesControlProps> = React.memo(({ displayDates, setDisplayDates }) => {
+	return (
+		<SelectInput
+			label={__('display')}
+			className='espresso-date-list-filter-bar-display-select'
+			value={displayDates}
+			options={[
+				{
+					value: DisplayDates.start,
+					label: __('start dates only'),
+				},
+				{
+					value: DisplayDates.end,
+					label: __('end dates only'),
+				},
+				{
+					value: DisplayDates.both,
+					label: __('start and end dates'),
+				},
+			]}
+			onChange={setDisplayDates}
+			size='large'
+		/>
+	);
+});
 
 export default DisplayDatesControl;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/ShowDatesControl.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/filterBar/controls/ShowDatesControl.tsx
@@ -1,10 +1,7 @@
-/**
- * External imports
- */
-import React, { useMemo } from 'react';
-import { SelectControl } from '@wordpress/components';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { ShowDates } from '@edtrInterfaces/datetimes/types';
+import { SelectInput } from '@appInputs/SelectInput';
 
 interface ShowDatesControlProps {
 	showDates: ShowDates;
@@ -17,71 +14,70 @@ interface ShowDatesControlProps {
  * @param {Function} setShowDates
  * @return {Object} rendered control
  */
-const ShowDatesControl: React.FC<ShowDatesControlProps> = ({ showDates, setShowDates }) => {
-	return useMemo<JSX.Element>(() => {
-		return (
-			<SelectControl
-				label={__('show')}
-				className='espresso-date-list-filter-bar-show-select'
-				value={showDates}
-				options={[
-					{
-						value: ShowDates.all,
-						label: __('all dates'),
-					},
-					{
-						value: ShowDates.activeUpcoming,
-						label: __('all active and upcoming'),
-					},
-					{
-						value: ShowDates.activeOnly,
-						label: __('active dates only'),
-					},
-					{
-						value: ShowDates.upcomingOnly,
-						label: __('upcoming dates only'),
-					},
-					{
-						value: ShowDates.nextActiveUpcomingOnly,
-						label: __('next active or upcoming only'),
-					},
-					{
-						value: ShowDates.soldOutOnly,
-						label: __('sold out dates only'),
-					},
-					{
-						value: ShowDates.above90Capacity,
-						label: __('dates above 90% capacity'),
-					},
-					{
-						value: ShowDates.above75Capacity,
-						label: __('dates above 75% capacity'),
-					},
-					{
-						value: ShowDates.above50Capacity,
-						label: __('dates above 50% capacity'),
-					},
-					{
-						value: ShowDates.below50Capacity,
-						label: __('dates below 50% capacity'),
-					},
-					{
-						value: ShowDates.recentlyExpiredOnly,
-						label: __('recently expired dates'),
-					},
-					{
-						value: ShowDates.expiredOnly,
-						label: __('all expired dates'),
-					},
-					{
-						value: ShowDates.trashedOnly,
-						label: __('trashed dates only'),
-					},
-				]}
-				onChange={setShowDates}
-			/>
-		);
-	}, [showDates, setShowDates]);
-};
+const ShowDatesControl: React.FC<ShowDatesControlProps> = React.memo(({ showDates, setShowDates }) => {
+	return (
+		<SelectInput
+			label={__('show')}
+			className='espresso-date-list-filter-bar-show-select'
+			value={showDates}
+			options={[
+				{
+					value: ShowDates.all,
+					label: __('all dates'),
+				},
+				{
+					value: ShowDates.activeUpcoming,
+					label: __('all active and upcoming'),
+				},
+				{
+					value: ShowDates.activeOnly,
+					label: __('active dates only'),
+				},
+				{
+					value: ShowDates.upcomingOnly,
+					label: __('upcoming dates only'),
+				},
+				{
+					value: ShowDates.nextActiveUpcomingOnly,
+					label: __('next active or upcoming only'),
+				},
+				{
+					value: ShowDates.soldOutOnly,
+					label: __('sold out dates only'),
+				},
+				{
+					value: ShowDates.above90Capacity,
+					label: __('dates above 90% capacity'),
+				},
+				{
+					value: ShowDates.above75Capacity,
+					label: __('dates above 75% capacity'),
+				},
+				{
+					value: ShowDates.above50Capacity,
+					label: __('dates above 50% capacity'),
+				},
+				{
+					value: ShowDates.below50Capacity,
+					label: __('dates below 50% capacity'),
+				},
+				{
+					value: ShowDates.recentlyExpiredOnly,
+					label: __('recently expired dates'),
+				},
+				{
+					value: ShowDates.expiredOnly,
+					label: __('all expired dates'),
+				},
+				{
+					value: ShowDates.trashedOnly,
+					label: __('trashed dates only'),
+				},
+			]}
+			onChange={setShowDates}
+			size='large'
+		/>
+	);
+});
 
 export default ShowDatesControl;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/DisplayTicketsControl.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/DisplayTicketsControl.tsx
@@ -2,8 +2,8 @@
  * External imports
  */
 import React from 'react';
-import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { SelectInput } from '@appInputs/SelectInput';
 
 /**
  * Internal imports
@@ -22,10 +22,10 @@ interface DisplayTicketsControlProps {
  * @param {Function} setDisplayTicketDate
  * @return {Object} rendered control
  */
-const DisplayTicketsControl: React.FC<DisplayTicketsControlProps> = ({ displayTicketDate, setDisplayTicketDate }) => {
-	return React.useMemo(() => {
+const DisplayTicketsControl: React.FC<DisplayTicketsControlProps> = React.memo(
+	({ displayTicketDate, setDisplayTicketDate }) => {
 		return (
-			<SelectControl
+			<SelectInput
 				label={__('display')}
 				className='ee-ticket-list-filter-bar-display-select'
 				value={displayTicketDate}
@@ -44,9 +44,10 @@ const DisplayTicketsControl: React.FC<DisplayTicketsControlProps> = ({ displayTi
 					},
 				]}
 				onChange={setDisplayTicketDate}
+				size='large'
 			/>
 		);
-	}, [displayTicketDate, setDisplayTicketDate]);
-};
+	}
+);
 
 export default DisplayTicketsControl;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/ShowTicketsControl.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/ShowTicketsControl.tsx
@@ -2,8 +2,8 @@
  * External imports
  */
 import React from 'react';
-import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { SelectInput } from '@appInputs/SelectInput';
 
 /**
  * Internal imports
@@ -24,69 +24,68 @@ interface ShowDatesControlProps {
  * @param {Function} setShowTickets
  * @return {Object} rendered control
  */
-const ShowTicketsControl: React.FC<ShowDatesControlProps> = ({ isChained, setShowTickets, showTickets }) => {
-	return React.useMemo(() => {
-		return (
-			<SelectControl
-				label={__('show')}
-				className='ee-ticket-list-filter-bar-show-select'
-				value={showTickets}
-				options={[
-					{
-						value: ShowTickets.above50Sold,
-						label: __('tickets with 50% or more sold'),
-					},
-					{
-						value: ShowTickets.above75Sold,
-						label: __('tickets with 75% or more sold'),
-					},
-					{
-						value: ShowTickets.above90Sold,
-						label: __('tickets with 90% or more sold'),
-					},
-					{
-						value: ShowTickets.all,
-						label: isChained ? __('all tickets for above dates') : __('all tickets for all dates'),
-					},
-					{
-						value: ShowTickets.trashedOnly,
-						label: __('trashed tickets only'),
-					},
-					{
-						value: ShowTickets.below50Sold,
-						label: __('tickets with less than 50% sold'),
-					},
+const ShowTicketsControl: React.FC<ShowDatesControlProps> = React.memo(({ isChained, setShowTickets, showTickets }) => {
+	return (
+		<SelectInput
+			label={__('show')}
+			className='ee-ticket-list-filter-bar-show-select'
+			value={showTickets}
+			options={[
+				{
+					value: ShowTickets.above50Sold,
+					label: __('tickets with 50% or more sold'),
+				},
+				{
+					value: ShowTickets.above75Sold,
+					label: __('tickets with 75% or more sold'),
+				},
+				{
+					value: ShowTickets.above90Sold,
+					label: __('tickets with 90% or more sold'),
+				},
+				{
+					value: ShowTickets.all,
+					label: isChained ? __('all tickets for above dates') : __('all tickets for all dates'),
+				},
+				{
+					value: ShowTickets.trashedOnly,
+					label: __('trashed tickets only'),
+				},
+				{
+					value: ShowTickets.below50Sold,
+					label: __('tickets with less than 50% sold'),
+				},
 
-					{
-						value: ShowTickets.expiredOnly,
-						label: __('expired tickets only'),
-					},
-					{
-						value: ShowTickets.nextOnSaleOrPendingOnly,
-						label: __('next on sale or sale pending only'),
-					},
-					{
-						value: ShowTickets.onSaleAndPending,
-						label: __('all on sale and sale pending'),
-					},
-					{
-						value: ShowTickets.onSaleOnly,
-						label: __('on sale tickets only'),
-					},
-					{
-						value: ShowTickets.pendingOnly,
-						label: __('sale pending tickets only'),
-					},
+				{
+					value: ShowTickets.expiredOnly,
+					label: __('expired tickets only'),
+				},
+				{
+					value: ShowTickets.nextOnSaleOrPendingOnly,
+					label: __('next on sale or sale pending only'),
+				},
+				{
+					value: ShowTickets.onSaleAndPending,
+					label: __('all on sale and sale pending'),
+				},
+				{
+					value: ShowTickets.onSaleOnly,
+					label: __('on sale tickets only'),
+				},
+				{
+					value: ShowTickets.pendingOnly,
+					label: __('sale pending tickets only'),
+				},
 
-					{
-						value: ShowTickets.soldOutOnly,
-						label: __('sold out tickets only'),
-					},
-				]}
-				onChange={setShowTickets}
-			/>
-		);
-	}, [isChained, showTickets, setShowTickets]);
-};
+				{
+					value: ShowTickets.soldOutOnly,
+					label: __('sold out tickets only'),
+				},
+			]}
+			onChange={setShowTickets}
+			size='large'
+		/>
+	);
+});
 
 export default ShowTicketsControl;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
@@ -2,7 +2,6 @@
  * External imports
  */
 import React from 'react';
-import { LinkOutlined } from '@ant-design/icons';
 import { EspressoButton, EspressoButtonType, Icon } from '@application/ui/input/EspressoButton';
 import { __ } from '@wordpress/i18n';
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsSortedByControl.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsSortedByControl.tsx
@@ -2,8 +2,8 @@
  * External imports
  */
 import React from 'react';
-import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { SelectInput } from '@appInputs/SelectInput';
 
 /**
  * Internal imports
@@ -22,10 +22,10 @@ interface TicketsSortedByControlProps {
  * @param {string} sortTicketsBy
  * @return {Object} rendered control
  */
-const TicketsSortedByControl: React.FC<TicketsSortedByControlProps> = ({ setSortTicketsBy, sortTicketsBy }) => {
-	return React.useMemo(() => {
+const TicketsSortedByControl: React.FC<TicketsSortedByControlProps> = React.memo(
+	({ setSortTicketsBy, sortTicketsBy }) => {
 		return (
-			<SelectControl
+			<SelectInput
 				label={__('sort')}
 				className='ee-ticket-list-filter-bar-order-select'
 				value={sortTicketsBy}
@@ -48,9 +48,10 @@ const TicketsSortedByControl: React.FC<TicketsSortedByControlProps> = ({ setSort
 					},
 				]}
 				onChange={setSortTicketsBy}
+				size='large'
 			/>
 		);
-	}, [sortTicketsBy, setSortTicketsBy]);
-};
+	}
+);
 
 export default TicketsSortedByControl;


### PR DESCRIPTION
This PR:
- Creates inputs in `/application/ui/input`
- Updates filterbar controls to use new inputs
- Closes #2454