### PR TITLE
Reset pagination when entity count changes | Closes #2492

### DIFF
--- a/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
+++ b/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
@@ -17,6 +17,7 @@ const useEntityPagination = <E extends Entity>({ entities }: EntityListComponent
 		if (previousCount.current !== total) {
 			// reset page number to 1
 			setPageNumber(1);
+			previousCount.current = total;
 		}
 	}, [total]);
 

--- a/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
+++ b/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
@@ -1,5 +1,5 @@
 import { slice } from 'ramda';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 
 import { Entity } from '@appServices/apollo/types';
 import { PaginationProps, onChangeFn, onShowSizeChangeFn } from './types';
@@ -10,6 +10,13 @@ const useEntityPagination = <E extends Entity>({ entities }: EntityListComponent
 	const [perPage, setPerPage] = useState(6);
 	const paginatedEntities = slice<E>(perPage * (pageNumber - 1), perPage * pageNumber, entities);
 	const total = entities.length;
+	const previousCount = useRef(total);
+
+	useEffect(() => {
+		if (previousCount.current !== total) {
+			setPageNumber(1);
+		}
+	}, [total]);
 
 	const onChange: onChangeFn = useCallback((newPageNumber) => setPageNumber(newPageNumber), []);
 

--- a/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
+++ b/assets/src/application/ui/layout/entityList/pagination/useEntityPagination.ts
@@ -13,7 +13,9 @@ const useEntityPagination = <E extends Entity>({ entities }: EntityListComponent
 	const previousCount = useRef(total);
 
 	useEffect(() => {
+		// if the entity count changes
 		if (previousCount.current !== total) {
+			// reset page number to 1
 			setPageNumber(1);
 		}
 	}, [total]);


### PR DESCRIPTION
This PR:
- Makes changes to `useEntityPagination` hook to make sure the pagination resets when entity count changes.
- Closes #2492