### PR TITLE
Fix submit on enter for search input | Closes #2522

### DIFF
--- a/assets/src/application/ui/input/SearchInput/index.tsx
+++ b/assets/src/application/ui/input/SearchInput/index.tsx
@@ -19,7 +19,7 @@ const SearchInput: React.FC<SearchInputProps> = React.memo(({ id, searchText, se
 				className='ee-entity-list-filter-bar-search'
 				value={searchText}
 				onChange={(e) => setSearchText(e.target.value)}
-				size='middle'
+				onPressEnter={(e) => e.preventDefault()}
 				{...rest}
 			/>
 		</BaseInput>


### PR DESCRIPTION
This PR:
- Prevents the default `onPressEnter` behavior for search input
- Closes #2522