### PR TITLE
Move related entities to badge | Closes #2526

### DIFF
--- a/assets/src/application/services/apollo/relations/reducer.ts
+++ b/assets/src/application/services/apollo/relations/reducer.ts
@@ -1,0 +1,78 @@
+import { pathOr, assocPath, dissocPath, clone } from 'ramda';
+import { RelationsReducer, RelationalData } from './types';
+
+const reducer: RelationsReducer = (state, action) => {
+	const { entity, entityId, relation, relationId, relationIds } = action;
+	let newState: RelationalData, relations: string[];
+	switch (action.type) {
+		case 'INITIALIZE':
+			return action.data;
+
+		case 'ADD_RELATION':
+			relations = pathOr([], [entity, entityId, relation], state);
+			// If the relation already exists
+			if (relations.includes(relationId)) {
+				return state;
+			}
+			newState = assocPath([entity, entityId, relation], [...relations, relationId], state);
+			return newState;
+
+		case 'REMOVE_RELATION':
+			newState = clone(state);
+			// existing relation list.
+			relations = pathOr([], [entity, entityId, relation], newState);
+			// if relationId is given remove it from the list.
+			if (relationId) {
+				return assocPath(
+					[entity, entityId, relation],
+					relations.filter((id) => id !== relationId),
+					newState
+				);
+			}
+
+			if (relations.length) {
+				/**
+				 * If we are here, it means that we have values for `entityId` in `relation`
+				 * i.e. if we are trying to remove a datetime (`entityId`) from all the tickets
+				 * we luckily have `state.datetimes[entityId].tickets` list, which means we know
+				 * from where to remove `entityId`.
+				 */
+				relations.forEach((id) => {
+					newState = assocPath(
+						[relation, id, entity],
+						pathOr([], [relation, id, entity], newState).filter((_id: string) => _id !== entityId),
+						newState
+					);
+				});
+				return newState;
+			}
+			/**
+			 * If we are here it means that we don't have the values for `entityId` in `relation`
+			 * which means we will have to loop through all the entries in `state[relation]`
+			 * to remove `entityId` from them.
+			 * For example if we are trying to remove a datetime (`entityId`) from all the tickets,
+			 * We will loop through `state.tickets` to delete `entityId` from `state.tickets[ticketId].datetimes`
+			 */
+			for (const id in newState[relation]) {
+				newState = assocPath(
+					[relation, id, entity],
+					pathOr([], [relation, id, entity], newState).filter((_id: string) => _id !== entityId),
+					newState
+				);
+			}
+			return newState;
+
+		case 'UPDATE_RELATIONS':
+			newState = assocPath([entity, entityId, relation], relationIds, state);
+			return newState;
+
+		case 'DROP_RELATIONS':
+			newState = dissocPath([entity, entityId], state);
+			return newState;
+
+		default:
+			throw new Error();
+	}
+};
+
+export default reducer;

--- a/assets/src/application/services/apollo/relations/test/useRelationsManager/addRelation.test.ts
+++ b/assets/src/application/services/apollo/relations/test/useRelationsManager/addRelation.test.ts
@@ -13,7 +13,7 @@ describe('RelationsManager.addRelation()', () => {
 	it('makes no difference when trying to add an already existing relation', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',
@@ -43,7 +43,7 @@ describe('RelationsManager.addRelation()', () => {
 	it('returns an updated array of related entity ids after using addRelation', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',

--- a/assets/src/application/services/apollo/relations/test/useRelationsManager/dropRelations.test.ts
+++ b/assets/src/application/services/apollo/relations/test/useRelationsManager/dropRelations.test.ts
@@ -11,7 +11,7 @@ describe('RelationsManager.dropRelations()', () => {
 	it('returns an empty array for related entity ids after using dropRelations', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',

--- a/assets/src/application/services/apollo/relations/test/useRelationsManager/removeRelation.test.ts
+++ b/assets/src/application/services/apollo/relations/test/useRelationsManager/removeRelation.test.ts
@@ -13,7 +13,7 @@ describe('RelationsManager.removeRelation()', () => {
 	it('makes no difference when trying to remove a non-existant relation', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',
@@ -43,7 +43,7 @@ describe('RelationsManager.removeRelation()', () => {
 	it('returns an updated array of related entity ids after using removeRelation WITH `relationId`', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',
@@ -75,7 +75,7 @@ describe('RelationsManager.removeRelation()', () => {
 	it('removes entityId from all `relation` lists after using removeRelation WITHOUT `relationId`', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',

--- a/assets/src/application/services/apollo/relations/test/useRelationsManager/updateRelations.test.ts
+++ b/assets/src/application/services/apollo/relations/test/useRelationsManager/updateRelations.test.ts
@@ -11,7 +11,7 @@ describe('RelationsManager.updateRelations()', () => {
 	it('returns an updated array of related entity ids after using updateRelations', () => {
 		const { result } = renderHook(() => useRelationsManager(relationalData));
 
-		const options: RelationFunctionProps = {
+		const options: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: existingRelationalEntityId,
 			relation: 'tickets',

--- a/assets/src/application/services/apollo/relations/types.ts
+++ b/assets/src/application/services/apollo/relations/types.ts
@@ -1,38 +1,32 @@
 import { EntityId } from '@appServices/apollo/types';
 
-type RelationEntity = 'datetimes' | 'tickets' | 'prices' | 'priceTypes';
+export type RelationEntity = 'datetimes' | 'tickets' | 'prices' | 'priceTypes';
 
-interface CommonProps {
-	relation?: RelationEntity;
+interface CommonProps<Entity extends RelationEntity> {
+	relation?: Exclude<RelationEntity, Entity>;
 	relationId?: EntityId;
 	relationIds?: EntityId[];
 }
 
-export type PossibleRelation = {
-	datetimes?: EntityId[];
-	tickets?: EntityId[];
-	prices?: EntityId[];
-	priceTypes?: EntityId[];
+export type PossibleRelation<ForEntity extends RelationEntity> = {
+	[key in Exclude<RelationEntity, ForEntity>]?: EntityId[];
 };
 
-export type RelationalEntity = {
-	[key: string]: PossibleRelation;
+export type RelationalEntity<Entity extends RelationEntity> = {
+	[key: string]: PossibleRelation<Entity>;
 };
 
 export type RelationalData = {
-	datetimes?: RelationalEntity;
-	tickets?: RelationalEntity;
-	prices?: RelationalEntity;
-	priceTypes?: RelationalEntity;
+	[key in RelationEntity]?: RelationalEntity<null>;
 };
 
-export interface RelationFunctionProps extends CommonProps {
-	entity: RelationEntity;
+export interface RelationFunctionProps<Entity extends RelationEntity> extends CommonProps<Entity> {
+	entity: Entity;
 	entityId: EntityId;
 }
 
-export interface RelationAction extends CommonProps {
-	type: 'SET_DATA' | 'ADD_RELATION' | 'REMOVE_RELATION' | 'UPDATE_RELATIONS' | 'DROP_RELATIONS';
+export interface RelationAction extends CommonProps<null> {
+	type: 'INITIALIZE' | 'ADD_RELATION' | 'REMOVE_RELATION' | 'UPDATE_RELATIONS' | 'DROP_RELATIONS';
 	entity?: RelationEntity;
 	entityId?: EntityId;
 	data?: RelationalData;
@@ -42,9 +36,11 @@ export interface RelationsManager {
 	initialize: (data: RelationalData) => void;
 	isInitialized: () => boolean;
 	getData: () => RelationalData;
-	getRelations: (options: RelationFunctionProps) => EntityId[];
-	addRelation: (options: RelationFunctionProps) => void;
-	updateRelations: (options: RelationFunctionProps) => void;
-	removeRelation: (options: RelationFunctionProps) => void;
-	dropRelations: (options: RelationFunctionProps) => void;
+	getRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => EntityId[];
+	addRelation: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	updateRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	removeRelation: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
+	dropRelations: <ForEntity extends RelationEntity>(options: RelationFunctionProps<ForEntity>) => void;
 }
+
+export type RelationsReducer = (state: RelationalData, action: RelationAction) => RelationalData;

--- a/assets/src/application/ui/display/ItemCount/index.tsx
+++ b/assets/src/application/ui/display/ItemCount/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge } from 'antd';
+import { Badge, Tooltip } from 'antd';
 import { BadgeProps } from 'antd/lib/badge';
 import classNames from 'classnames';
 
@@ -10,15 +10,18 @@ interface ItemCountProps extends BadgeProps {
 	showClock?: boolean;
 }
 
-const ItemCount: React.FC<ItemCountProps> = ({ children, count, ...props }) => {
+const ItemCount: React.FC<ItemCountProps> = ({ children, title, count, ...props }) => {
 	const className = classNames(props.className, 'ee-item-count', {
 		'ee-item-count--has-items': count > 0,
 		'ee-item-count--no-items': count === 0,
 	});
 	const offset = props.offset || [-5, 5];
 
+	const countBadge = <span className='ant-badge-count'>{count}</span>;
+	const countNode = title ? <Tooltip title={title}>{countBadge}</Tooltip> : countBadge;
+
 	return (
-		<Badge {...props} className={className} count={count} offset={offset} showZero>
+		<Badge {...props} className={className} count={countNode} offset={offset} showZero>
 			{children}
 		</Badge>
 	);

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/index.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/index.ts
@@ -1,11 +1,13 @@
 export * from './queries';
 
-export { default as useDatetimes } from './useDatetimes';
-
 export { default as useDatetimeIds } from './useDatetimeIds';
 
 export { default as useDatetimeItem } from './useDatetimeItem';
 
 export { default as useDatetimeQueryOptions } from './useDatetimeQueryOptions';
 
+export { default as useDatetimes } from './useDatetimes';
+
 export { default as useFetchDatetimes } from './useFetchDatetimes';
+
+export { default as useRelatedDatetimes } from './useRelatedDatetimes';

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useDatetimeItem.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useDatetimeItem.test.ts
@@ -18,7 +18,7 @@ describe('useDatetimeItem', () => {
 		});
 		waitForValueToChange(() => result.current);
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for non existent datetime when the cache is NOT empty', () => {
@@ -31,7 +31,7 @@ describe('useDatetimeItem', () => {
 		);
 		waitForValueToChange(() => result.current);
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for an existent datetime', () => {

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useDatetimeItem.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useDatetimeItem.ts
@@ -1,4 +1,3 @@
-import { pathOr } from 'ramda';
 import { GET_DATETIME } from '../datetimes';
 import { Datetime, DatetimeItem } from '../../types';
 import { EntityItemProps, ReadQueryOptions } from '../types';
@@ -13,7 +12,7 @@ const useDatetimeItem = ({ id }: EntityItemProps): Datetime => {
 	};
 	const { data } = useCacheQuery<DatetimeItem>(options);
 
-	return pathOr<Datetime>(null, ['datetime'], data);
+	return data?.datetime;
 };
 
 export default useDatetimeItem;

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useDatetimes.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useDatetimes.ts
@@ -1,5 +1,3 @@
-import { pathOr } from 'ramda';
-
 import useDatetimeQueryOptions from './useDatetimeQueryOptions';
 import { Datetime, DatetimesList } from '../../types';
 import useCacheQuery from '../useCacheQuery';
@@ -8,7 +6,7 @@ const useDatetimes = (): Array<Datetime> => {
 	const options = useDatetimeQueryOptions();
 	const { data } = useCacheQuery<DatetimesList>(options);
 
-	return pathOr<Array<Datetime>>([], ['espressoDatetimes', 'nodes'], data);
+	return data?.espressoDatetimes?.nodes || [];
 };
 
 export default useDatetimes;

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useRelatedDatetimes.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/useRelatedDatetimes.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useRelations, RelationEntity } from '@appServices/apollo/relations';
+import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
+import useDatetimes from './useDatetimes';
+import { Datetime } from '../../types';
+import { EntityId } from '@appServices/apollo/types';
+
+interface RelatedDatetimesProps {
+	entity: Exclude<RelationEntity, 'datetimes'>;
+	entityId: EntityId;
+}
+
+const useRelatedDatetimes = ({ entity, entityId }: RelatedDatetimesProps): Array<Datetime> => {
+	const datetimes = useDatetimes();
+	const { getRelations } = useRelations();
+	const relatedDatetimeIds = getRelations({
+		entity,
+		entityId,
+		relation: 'datetimes',
+	});
+
+	return useMemo(() => {
+		return relatedDatetimeIds.length ? entitiesWithGuIdInArray(datetimes, relatedDatetimeIds) : [];
+	}, [relatedDatetimeIds.length, datetimes]);
+};
+
+export default useRelatedDatetimes;

--- a/assets/src/domain/eventEditor/services/apollo/queries/events/useEvent.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/events/useEvent.ts
@@ -1,4 +1,3 @@
-import { pathOr } from 'ramda';
 import { GET_EVENT } from './';
 import { Event, EventData } from '../../types';
 import { ReadQueryOptions } from '../types';
@@ -15,7 +14,7 @@ const useEvent = (): Event => {
 	};
 	const { data } = useCacheQuery<EventData>({ ...options, fetchPolicy: 'cache-first' });
 
-	return pathOr<Event>(null, ['espressoEventBy'], data);
+	return data?.espressoEventBy;
 };
 
 export default useEvent;

--- a/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/usePriceTypes.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/priceTypes/usePriceTypes.ts
@@ -1,8 +1,5 @@
-import { pathOr } from 'ramda';
-
 import usePriceTypeQueryOptions from './usePriceTypeQueryOptions';
-import { entitiesWithGuIdInArray } from '../../../../../shared/services/predicates';
-import { useStatus, TypeName } from '../../../../../../application/services/apollo/status';
+import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
 import { EntityId } from '@appServices/apollo/types';
 import { PriceType, PriceTypesList } from '../../types';
 import useCacheQuery from '../useCacheQuery';
@@ -14,13 +11,9 @@ import useCacheQuery from '../useCacheQuery';
  */
 const usePriceTypes = (include: EntityId[] = []): PriceType[] => {
 	const options = usePriceTypeQueryOptions();
-	const { isLoaded } = useStatus();
 	const { data } = useCacheQuery<PriceTypesList>(options);
 
-	if (!isLoaded(TypeName.priceTypes)) {
-		return [];
-	}
-	const priceTypes = pathOr<PriceType[]>([], ['espressoPriceTypes', 'nodes'], data);
+	const priceTypes = data?.espressoPriceTypes?.nodes || [];
 
 	return include.length ? entitiesWithGuIdInArray(priceTypes, include) : priceTypes;
 };

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/index.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/index.ts
@@ -1,7 +1,9 @@
 export * from './queries';
 
-export { default as usePrices } from './usePrices';
+export { default as useFetchPrices } from './useFetchPrices';
 
 export { default as usePriceQueryOptions } from './usePriceQueryOptions';
 
-export { default as useFetchPrices } from './useFetchPrices';
+export { default as usePrices } from './usePrices';
+
+export { default as useRelatedPrices } from './useRelatedPrices';

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/test/usePrices.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/test/usePrices.test.ts
@@ -36,30 +36,4 @@ describe('usePrices()', () => {
 
 		expect(cachedPrices[0].name).toEqual(nodes[0].name);
 	});
-
-	it('returns the prices limitted to the supplied ids', async () => {
-		const filteredPriceIds = [nodes[1].id, nodes[2].id];
-		const filteredPrices = nodes.filter(({ id }) => filteredPriceIds.includes(id));
-		const { result, waitForNextUpdate } = renderHook(
-			() => {
-				useInitPriceTestCache();
-				return usePrices(filteredPriceIds);
-			},
-			{ wrapper }
-		);
-
-		await waitForNextUpdate({ timeout });
-
-		const { current: cachedPrices } = result;
-
-		expect(cachedPrices).toEqual(filteredPrices);
-
-		expect(cachedPrices.length).toEqual(filteredPrices.length);
-
-		expect(cachedPrices.length).toBeLessThanOrEqual(nodes.length);
-
-		expect(cachedPrices[0].id).toEqual(filteredPrices[0].id);
-
-		expect(cachedPrices[0].name).toEqual(filteredPrices[0].name);
-	});
 });

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/usePrices.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/usePrices.ts
@@ -1,7 +1,4 @@
-import { pathOr } from 'ramda';
-
-import { entitiesWithGuIdInArray } from '../../../../../shared/services/predicates';
-import { useStatus, TypeName } from '../../../../../../application/services/apollo/status';
+import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
 import usePriceQueryOptions from './usePriceQueryOptions';
 import { EntityId } from '@appServices/apollo/types';
 import { Price, PricesList } from '../../types';
@@ -14,14 +11,9 @@ import useCacheQuery from '../useCacheQuery';
  */
 const usePrices = (include: EntityId[] = []): Price[] => {
 	const options = usePriceQueryOptions();
-	const { isLoaded } = useStatus();
 	const { data } = useCacheQuery<PricesList>(options);
 
-	if (!isLoaded(TypeName.prices)) {
-		return [];
-	}
-
-	const prices = pathOr<Price[]>([], ['espressoPrices', 'nodes'], data);
+	const prices = data?.espressoPrices?.nodes || [];
 
 	return include.length ? entitiesWithGuIdInArray(prices, include) : prices;
 };

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/usePrices.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/usePrices.ts
@@ -1,21 +1,15 @@
-import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
 import usePriceQueryOptions from './usePriceQueryOptions';
-import { EntityId } from '@appServices/apollo/types';
 import { Price, PricesList } from '../../types';
 import useCacheQuery from '../useCacheQuery';
 /**
  * A custom react hook for retrieving all the prices from cache
  * limited to the ids passed in `include`
- *
- * @param {array} include Array of price ids to include.
  */
-const usePrices = (include: EntityId[] = []): Price[] => {
+const usePrices = (): Price[] => {
 	const options = usePriceQueryOptions();
 	const { data } = useCacheQuery<PricesList>(options);
 
-	const prices = data?.espressoPrices?.nodes || [];
-
-	return include.length ? entitiesWithGuIdInArray(prices, include) : prices;
+	return data?.espressoPrices?.nodes || [];
 };
 
 export default usePrices;

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/useRelatedPrices.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/useRelatedPrices.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useRelations, RelationEntity } from '@appServices/apollo/relations';
+import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
+import usePrices from './usePrices';
+import { Price } from '../../types';
+import { EntityId } from '@appServices/apollo/types';
+
+interface RelatedPricesProps {
+	entity: Exclude<RelationEntity, 'prices'>;
+	entityId: EntityId;
+}
+
+const useRelatedPrices = ({ entity, entityId }: RelatedPricesProps): Array<Price> => {
+	const prices = usePrices();
+	const { getRelations } = useRelations();
+	const relatedPriceIds = getRelations({
+		entity,
+		entityId,
+		relation: 'prices',
+	});
+
+	return useMemo(() => {
+		return relatedPriceIds.length ? entitiesWithGuIdInArray(prices, relatedPriceIds) : [];
+	}, [relatedPriceIds.length, prices]);
+};
+
+export default useRelatedPrices;

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/index.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/index.ts
@@ -1,6 +1,8 @@
 export * from './queries';
 
-export { default as useTickets } from './useTickets';
+export { default as useFetchTickets } from './useFetchTickets';
+
+export { default as useRelatedTickets } from './useRelatedTickets';
 
 export { default as useTicketIds } from './useTicketIds';
 
@@ -8,4 +10,4 @@ export { default as useTicketItem } from './useTicketItem';
 
 export { default as useTicketQueryOptions } from './useTicketQueryOptions';
 
-export { default as useFetchTickets } from './useFetchTickets';
+export { default as useTickets } from './useTickets';

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketItem.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketItem.test.ts
@@ -14,7 +14,7 @@ describe('useTicketItem', () => {
 		});
 		waitForValueToChange(() => result.current);
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for non existent ticket when the cache is NOT empty', () => {
@@ -27,7 +27,7 @@ describe('useTicketItem', () => {
 		);
 		waitForValueToChange(() => result.current);
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for an existent ticket', () => {

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketPrices.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketPrices.test.ts
@@ -73,7 +73,7 @@ describe('useTicketPrices', () => {
 			relation: 'prices',
 		});
 
-		const { result, waitForValueToChange } = renderHook(
+		const { result, waitForNextUpdate } = renderHook(
 			() => {
 				useInitTicketTestCache();
 				useInitPriceTestCache();
@@ -81,7 +81,7 @@ describe('useTicketPrices', () => {
 			},
 			{ wrapper }
 		);
-		await waitForValueToChange(() => result.current, { timeout });
+		await waitForNextUpdate({ timeout });
 
 		const { current: cachedTicketPrices } = result;
 

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/useRelatedTickets.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/useRelatedTickets.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useRelations, RelationEntity } from '@appServices/apollo/relations';
+import { entitiesWithGuIdInArray } from '@sharedServices/predicates';
+import useTickets from './useTickets';
+import { Ticket } from '../../types';
+import { EntityId } from '@appServices/apollo/types';
+
+interface RelatedTicketsProps {
+	entity: Exclude<RelationEntity, 'tickets'>;
+	entityId: EntityId;
+}
+
+const useRelatedTickets = ({ entity, entityId }: RelatedTicketsProps): Array<Ticket> => {
+	const tickets = useTickets();
+	const { getRelations } = useRelations();
+	const relatedTicketIds = getRelations({
+		entity,
+		entityId,
+		relation: 'tickets',
+	});
+
+	return useMemo(() => {
+		return relatedTicketIds.length ? entitiesWithGuIdInArray(tickets, relatedTicketIds) : [];
+	}, [relatedTicketIds.length, tickets]);
+};
+
+export default useRelatedTickets;

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTicketItem.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTicketItem.ts
@@ -1,4 +1,3 @@
-import { pathOr } from 'ramda';
 import { GET_TICKET } from '../tickets';
 import { Ticket, TicketItem } from '../../types';
 import { EntityItemProps, ReadQueryOptions } from '../types';
@@ -13,7 +12,7 @@ const useTicketItem = ({ id }: EntityItemProps): Ticket => {
 	};
 	const { data } = useCacheQuery<TicketItem>(options);
 
-	return pathOr<Ticket>(null, ['ticket'], data);
+	return data?.ticket;
 };
 
 export default useTicketItem;

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTicketPrices.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTicketPrices.ts
@@ -1,7 +1,6 @@
-import useRelations from '../../../../../../application/services/apollo/relations/useRelations';
-import usePrices from '../prices/usePrices';
 import { EntityId } from '@appServices/apollo/types';
 import { Price } from '../../types';
+import { useRelatedPrices } from '../prices';
 /**
  * A custom react hook for retrieving the related prices
  * for the given `ticket` identified by `ticket.id`
@@ -9,18 +8,13 @@ import { Price } from '../../types';
  * @param {string}  ticketId ticket.id
  */
 const useTicketPrices = (ticketId: EntityId): Price[] => {
-	const { getRelations } = useRelations();
-	// get related price Ids for this ticket
-	const relatedPriceIds = getRelations({
+	// get price objects.
+	const relatedPrices = useRelatedPrices({
 		entity: 'tickets',
 		entityId: ticketId,
-		relation: 'prices',
 	});
 
-	// get price objects.
-	const relatedPrices = usePrices(relatedPriceIds);
-
-	return relatedPriceIds.length ? relatedPrices : [];
+	return relatedPrices;
 };
 
 export default useTicketPrices;

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTickets.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/useTickets.ts
@@ -1,20 +1,12 @@
-import { pathOr } from 'ramda';
-
-import { useStatus, TypeName } from '../../../../../../application/services/apollo/status';
 import useTicketQueryOptions from './useTicketQueryOptions';
 import { Ticket, TicketsList } from '../../types';
 import useCacheQuery from '../useCacheQuery';
 
 const useTickets = (): Array<Ticket> => {
 	const options = useTicketQueryOptions();
-	const { isLoaded } = useStatus();
 	const { data } = useCacheQuery<TicketsList>(options);
 
-	if (!isLoaded(TypeName.tickets)) {
-		return [];
-	}
-
-	return pathOr<Array<Ticket>>([], ['espressoTickets', 'nodes'], data);
+	return data?.espressoTickets?.nodes || [];
 };
 
 export default useTickets;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -4,24 +4,28 @@ import { __ } from '@wordpress/i18n';
 import { EspressoButton, Icon } from '@application/ui/input';
 import { EditItemModalProps } from '@edtrInterfaces/types';
 import ItemCount from '@appDisplay/ItemCount';
-import useRelations from '@appServices/apollo/relations/useRelations';
+import { useRelatedTickets } from '@edtrServices/apollo/queries';
 import useTicketAssignmentsManager from '@edtrUI/ticketAssignmentsManager/useTicketAssignmentsManager';
 
 const AssignTicketsButton: React.FC<EditItemModalProps> = ({ id, ...rest }) => {
 	const { assignTicketsToDate } = useTicketAssignmentsManager();
-	const { getRelations } = useRelations();
-	const relatedTicketIds = getRelations({
+
+	const relatedTickets = useRelatedTickets({
 		entity: 'datetimes',
 		entityId: id,
-		relation: 'tickets',
 	});
-	const count = relatedTicketIds.length;
+	const count = relatedTickets.length;
+
+	const relatedTicketDbIds = relatedTickets.map(({ dbId }) => dbId);
+
+	const title = count ? `${__('Related Tickets:')} ${relatedTicketDbIds.join(', ')}` : '';
+
 	const onClick = (): void => {
 		assignTicketsToDate({ datetimeId: id });
 	};
 
 	return (
-		<ItemCount count={count}>
+		<ItemCount count={count} title={title}>
 			<EspressoButton
 				icon={Icon.TICKET}
 				tooltip={__('assign tickets')}

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { parseISO } from 'date-fns';
 import { __ } from '@wordpress/i18n';
 
-import { CalendarDateRange } from '@appCalendars';
+import { CalendarDateRange } from '@appCalendars/dateDisplay';
 import DateDetails from './DateDetails';
 import DateActionsMenu from '../actionsMenu/DateActionsMenu';
 

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import React, { useState } from 'react';
+import React from 'react';
 import { parseISO } from 'date-fns';
 import { __ } from '@wordpress/i18n';
 
@@ -9,48 +8,24 @@ import DateActionsMenu from '../actionsMenu/DateActionsMenu';
 
 import { DatetimeProvider } from '@edtrServices/context/DatetimeContext';
 import useDatetimeItem from '@edtrServices/apollo/queries/datetimes/useDatetimeItem';
-import TicketIdTag from '../../../tickets/TicketIdTag';
-
 import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@sharedConstants/defaultDates';
 import statusBgColorClassName from '@sharedEntities/datetimes/helpers/statusBgColorClassName';
 
-import useRelations from '@appServices/apollo/relations/useRelations';
-import { useStatus, TypeName } from '@appServices/apollo/status';
 import EntityCard from '@appLayout/EntityCard';
-import { ListItemProps } from '@edtrInterfaces';
+import { ListItemProps } from '@edtrInterfaces/types';
 import { useDatetimeMutator } from '@edtrServices/apollo/mutations';
 import { InlineEditHeading, InlineEditTextArea } from '@appInputs/InlineEditInput';
 
 const DateCard: React.FC<ListItemProps> = ({ id }) => {
 	const date = useDatetimeItem({ id });
-	const { isLoaded } = useStatus();
 	const { updateEntity } = useDatetimeMutator(id);
-	const { getRelations } = useRelations();
 
 	const startDate = parseISO(date.startDate) || PLUS_ONE_MONTH;
 	const endDate = parseISO(date.endDate) || PLUS_TWO_MONTHS;
-	const defaultRangeValues: [Date, Date] = [startDate, endDate];
-	const [range, setRange] = useState<[Date, Date]>(defaultRangeValues);
 
 	if (!date) {
 		return null;
 	}
-
-	const ticketsLoaded = isLoaded(TypeName.tickets);
-
-	// get related ticket IDs for this datetime
-	const relatedTicketIds =
-		ticketsLoaded &&
-		getRelations({
-			entity: 'datetimes',
-			entityId: id,
-			relation: 'tickets',
-		});
-
-	let relatedTicketTags =
-		ticketsLoaded &&
-		relatedTicketIds.filter(Boolean).map((ticketId) => <TicketIdTag key={ticketId} id={ticketId} />);
-	relatedTicketTags = relatedTicketTags ? relatedTicketTags : __('none');
 
 	const bgClassName = statusBgColorClassName(date);
 
@@ -63,8 +38,8 @@ const DateCard: React.FC<ListItemProps> = ({ id }) => {
 					<CalendarDateRange
 						headerText={__('starts')}
 						className={bgClassName}
-						startDate={range[0]}
-						endDate={range[1]}
+						startDate={startDate}
+						endDate={endDate}
 					/>
 				}
 				details={
@@ -90,11 +65,6 @@ const DateCard: React.FC<ListItemProps> = ({ id }) => {
 						>
 							{date.description ? date.description : __('Edit description...')}
 						</InlineEditTextArea>
-						{/* the following will be replaced by the entity details panel */}
-						<div style={{ margin: '0 0 .5rem' }}>
-							{__('Related Tickets:') + ' '}
-							{relatedTicketTags}
-						</div>
 						<DateDetails datetime={date} updateDatetime={updateEntity} />
 					</>
 				}

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/types.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/types.ts
@@ -1,7 +1,17 @@
 import { EntityId } from '@appServices/apollo/types';
-import { RelationsManager } from '@appServices/apollo/relations';
+import { RelationsManager, RelationalData, PossibleRelation } from '@appServices/apollo/relations';
 import { Datetime, Ticket } from '@edtrServices/apollo/types';
 import { ColumnTitleProps } from 'antd/lib/table/interface';
+
+export type TAMRelationEntity = 'datetimes' | 'tickets';
+
+export type TAMPossibleRelation = Pick<PossibleRelation<null>, TAMRelationEntity>;
+
+export type TAMRelationalEntity = {
+	[key: string]: TAMPossibleRelation;
+};
+
+export type TAMRelationalData = Pick<RelationalData, TAMRelationEntity>;
 
 export type AssignmentType = 'forDate' | 'forTicket' | 'forAll';
 

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useAssignmentManager.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useAssignmentManager.ts
@@ -1,7 +1,7 @@
 import { pick, map } from 'ramda';
 
-import { useRelationsManager, RelationFunctionProps, RelationalData } from '@appServices/apollo/relations';
-import { AssignmentManager } from './types';
+import { useRelationsManager, RelationFunctionProps } from '@appServices/apollo/relations';
+import { AssignmentManager, TAMRelationalData } from './types';
 
 type AM = AssignmentManager;
 /**
@@ -52,14 +52,14 @@ const useAssignmentManager = (): AM => {
 	// args are same
 	const updateAssignment: AM['removeAssignment'] = ({ datetimeId, ticketId, remove = false }) => {
 		// relation from datetimes towards tickets
-		const datetimeToTickets: RelationFunctionProps = {
+		const datetimeToTickets: RelationFunctionProps<'datetimes'> = {
 			entity: 'datetimes',
 			entityId: datetimeId,
 			relation: 'tickets',
 			relationId: ticketId,
 		};
 		// relation from tickets towards datetimes
-		const ticketsToDatetimes: RelationFunctionProps = {
+		const ticketsToDatetimes: RelationFunctionProps<'tickets'> = {
 			entity: 'tickets',
 			entityId: ticketId,
 			relation: 'datetimes',
@@ -76,8 +76,8 @@ const useAssignmentManager = (): AM => {
 		}
 	};
 
-	const initialize: AM['initialize'] = (data: RelationalData) => {
-		const relationsToPick: Array<keyof Pick<RelationalData, 'datetimes' | 'tickets'>> = ['datetimes', 'tickets'];
+	const initialize: AM['initialize'] = (data: TAMRelationalData) => {
+		const relationsToPick: Array<keyof TAMRelationalData> = ['datetimes', 'tickets'];
 		// pick only datetimes and tickets from relational data
 		let newData = pick(relationsToPick, data);
 

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useOnSubmitAssignments.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useOnSubmitAssignments.ts
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 import { pathOr } from 'ramda';
 
-import { useRelations, RelationalData } from '@appServices/apollo/relations';
+import { useRelations } from '@appServices/apollo/relations';
 import { EntityId } from '@appServices/apollo/types';
 import { useDatetimeMutator, useTicketMutator } from '@edtrServices/apollo/mutations';
 import { prepareEntitiesForUpdate } from './utils';
+import { TAMRelationalData } from './types';
 
 const useOnSubmitAssignments = () => {
 	const { getData: getExistingData } = useRelations();
@@ -12,7 +13,7 @@ const useOnSubmitAssignments = () => {
 	const { updateEntity: updateTicket } = useTicketMutator();
 
 	return useCallback(
-		async (data: RelationalData): Promise<void> => {
+		async (data: TAMRelationalData): Promise<void> => {
 			const existingData = getExistingData();
 
 			/**

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useValidateTAMData.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useValidateTAMData.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react';
 import { mapObjIndexed, pickBy, pathOr, isEmpty } from 'ramda';
 
-import { RelationalData, RelationalEntity, PossibleRelation } from '@appServices/apollo/relations';
+import { TAMPossibleRelation, TAMRelationalEntity, TAMRelationalData } from './types';
 
-const DEFAULT_VALIDATION_DATA: PossibleRelation = {
+const DEFAULT_VALIDATION_DATA: TAMPossibleRelation = {
 	datetimes: [],
 	tickets: [],
 };
 
 const useValidateTAMData = (assignmentManager) => {
 	const [validationData, setValidationData] = useState(DEFAULT_VALIDATION_DATA);
-	const TAMData: RelationalData = assignmentManager.getData();
+	const TAMData: TAMRelationalData = assignmentManager.getData();
 
 	useEffect(() => {
 		// may be the data is not initialized yet
@@ -18,11 +18,11 @@ const useValidateTAMData = (assignmentManager) => {
 			return;
 		}
 		// loop through TAM data to find entities with no relations
-		// See the data shape, please check the shape of RelationalData
-		const newTAMData: PossibleRelation = mapObjIndexed((relationalEntity, entity) => {
-			const relation: keyof PossibleRelation = entity === 'datetimes' ? 'tickets' : 'datetimes';
-			const emptyRelationalEntities = pickBy<RelationalEntity, RelationalEntity>(
-				(relations: PossibleRelation) => {
+		// See the data shape, please check the shape of TAMRelationalData
+		const newTAMData: TAMPossibleRelation = mapObjIndexed((relationalEntity, entity) => {
+			const relation: keyof TAMPossibleRelation = entity === 'datetimes' ? 'tickets' : 'datetimes';
+			const emptyRelationalEntities = pickBy<TAMRelationalEntity, TAMRelationalEntity>(
+				(relations: TAMPossibleRelation) => {
 					const relatedIds = pathOr<Array<string>>([], [relation], relations);
 					return relatedIds.length === 0;
 				},

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/utils.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/utils.ts
@@ -1,25 +1,25 @@
 import { pathOr, filter, equals } from 'ramda';
 
 import { EntityId } from '@appServices/apollo/types';
-import { RelationalEntity, PossibleRelation, RelationalData } from '@appServices/apollo/relations';
+import { TAMPossibleRelation, TAMRelationalEntity, TAMRelationalData, TAMRelationEntity } from './types';
 
-type EntitiesToUpdate = Array<[EntityId, PossibleRelation]>;
+type EntitiesToUpdate = Array<[EntityId, TAMPossibleRelation]>;
 
-interface EntitiesForUpdateOptions {
-	entity: 'datetimes' | 'tickets';
-	existingData: RelationalData;
-	newData: RelationalData;
-	relation: 'datetimes' | 'tickets';
+interface EntitiesForUpdateOptions<Entity extends TAMRelationEntity> {
+	entity: Entity;
+	existingData: TAMRelationalData;
+	newData: TAMRelationalData;
+	relation: Exclude<TAMRelationEntity, Entity>;
 }
 
-export const prepareEntitiesForUpdate = ({
+export const prepareEntitiesForUpdate = <Entity extends TAMRelationEntity>({
 	entity,
 	existingData,
 	newData,
 	relation,
-}: EntitiesForUpdateOptions): EntitiesToUpdate => {
-	const existingEntities = pathOr<RelationalEntity>({}, [entity], existingData);
-	const newEntities = pathOr<RelationalEntity>({}, [entity], newData);
+}: EntitiesForUpdateOptions<Entity>): EntitiesToUpdate => {
+	const existingEntities = pathOr<TAMRelationalEntity>({}, [entity], existingData);
+	const newEntities = pathOr<TAMRelationalEntity>({}, [entity], newData);
 
 	return filter<EntitiesToUpdate[0]>(([entityId, possibleRelation]) => {
 		const newRelatedEntities = pathOr<EntityId[]>([], [relation], possibleRelation);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
@@ -4,24 +4,28 @@ import { __ } from '@wordpress/i18n';
 import { EspressoButton, Icon } from '@application/ui/input';
 import { EditItemModalProps } from '@edtrInterfaces/types';
 import ItemCount from '@appDisplay/ItemCount';
-import useRelations from '@appServices/apollo/relations/useRelations';
+import { useRelatedDatetimes } from '@edtrServices/apollo/queries';
 import useTicketAssignmentsManager from '@edtrUI/ticketAssignmentsManager/useTicketAssignmentsManager';
 
 const AssignDatesButton: React.FC<EditItemModalProps> = ({ id, ...rest }) => {
 	const { assignDatesToTicket } = useTicketAssignmentsManager();
-	const { getRelations } = useRelations();
-	const relatedDatetimeIds = getRelations({
+
+	const relatedDatetimes = useRelatedDatetimes({
 		entity: 'tickets',
 		entityId: id,
-		relation: 'datetimes',
 	});
-	const count = relatedDatetimeIds.length;
+	const count = relatedDatetimes.length;
+
+	const relatedDatetimeDbIds = relatedDatetimes.map(({ dbId }) => dbId);
+
+	const title = count ? `${__('Related Dates:')} ${relatedDatetimeDbIds.join(', ')}` : '';
+
 	const onClick = (): void => {
 		assignDatesToTicket({ ticketId: id });
 	};
 
 	return (
-		<ItemCount count={count}>
+		<ItemCount count={count} title={title}>
 			<EspressoButton
 				icon={Icon.CALENDAR}
 				tooltip={__('assign dates')}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCard.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCard.tsx
@@ -7,9 +7,7 @@ import TicketDetails from './TicketDetails';
 import useTicketItem from '@edtrServices/apollo/queries/tickets/useTicketItem';
 import TicketProvider from '@edtrServices/context/TicketContext';
 import CurrencyInput from '@appInputs/CurrencyInput';
-import useRelations from '@appServices/apollo/relations/useRelations';
 import EntityCard from '@appLayout/EntityCard';
-import DatetimeIdTag from '../../../datetimes/DatetimeIdTag';
 import { ListItemProps } from '@edtrInterfaces/types';
 import { useTicketMutator } from '@edtrServices/apollo/mutations';
 import { InlineEditHeading, InlineEditTextArea } from '@appInputs/InlineEditInput';
@@ -18,13 +16,6 @@ import statusBgColorClassName from '@sharedEntities/tickets/helpers/statusBgColo
 const TicketCard: React.FC<ListItemProps> = ({ id }) => {
 	const ticket = useTicketItem({ id });
 	const { updateEntity } = useTicketMutator(id);
-	const { getRelations } = useRelations();
-	// get related datetimes for this datetime
-	const relatedDates = getRelations({
-		entity: 'tickets',
-		entityId: id,
-		relation: 'datetimes',
-	});
 
 	const bgClassName = statusBgColorClassName(ticket);
 
@@ -79,12 +70,6 @@ const TicketCard: React.FC<ListItemProps> = ({ id }) => {
 							}}
 							tag={'h3'}
 						/>
-						<div style={{ margin: '0 0 .5rem' }}>
-							{__('Related Dates:')}{' '}
-							{relatedDates.filter(Boolean).map((datetimeId) => (
-								<DatetimeIdTag key={datetimeId} id={datetimeId} />
-							))}
-						</div>
 						<TicketDetails ticket={ticket} updateTicket={updateEntity} />
 					</>
 				}

--- a/assets/src/domain/shared/services/apollo/queries/currentUser/test/useCurrentUser.test.ts
+++ b/assets/src/domain/shared/services/apollo/queries/currentUser/test/useCurrentUser.test.ts
@@ -11,7 +11,7 @@ describe('useCurrentUser', () => {
 	it('checks for the current user when the cache is empty', async () => {
 		const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for the current user when the cache is NOT empty', async () => {

--- a/assets/src/domain/shared/services/apollo/queries/currentUser/useCurrentUser.ts
+++ b/assets/src/domain/shared/services/apollo/queries/currentUser/useCurrentUser.ts
@@ -1,8 +1,6 @@
-import pathOr from 'ramda/src/pathOr';
-
 import { GET_CURRENT_USER } from './';
-import { ReadQueryOptions, useCacheQuery } from '../../../../../eventEditor/services/apollo/queries';
-import { CurrentUserProps, Viewer } from '../../../../../../application/valueObjects/config/types';
+import { ReadQueryOptions, useCacheQuery } from '@edtrServices/apollo/queries';
+import { CurrentUserProps, Viewer } from '@application/valueObjects/config/types';
 
 /**
  * A custom react hook for retrieving CurrentUser
@@ -13,7 +11,7 @@ const useCurrentUser = (): CurrentUserProps => {
 	};
 	const { data } = useCacheQuery<Viewer>(options);
 
-	return pathOr<CurrentUserProps>(null, ['viewer'], data);
+	return data?.viewer;
 };
 
 export default useCurrentUser;

--- a/assets/src/domain/shared/services/apollo/queries/generalSettings/test/useGeneralSettings.test.ts
+++ b/assets/src/domain/shared/services/apollo/queries/generalSettings/test/useGeneralSettings.test.ts
@@ -11,7 +11,7 @@ describe('useGeneralSettings', () => {
 	it('checks for the current user when the cache is empty', () => {
 		const { result } = renderHook(() => useGeneralSettings(), { wrapper });
 
-		expect(result.current).toBe(null);
+		expect(result.current).toBe(undefined);
 	});
 
 	it('checks for the current user when the cache is NOT empty', async () => {

--- a/assets/src/domain/shared/services/apollo/queries/generalSettings/useGeneralSettings.ts
+++ b/assets/src/domain/shared/services/apollo/queries/generalSettings/useGeneralSettings.ts
@@ -1,8 +1,6 @@
-import pathOr from 'ramda/src/pathOr';
-
 import { GET_GENERAL_SETTINGS } from './';
-import { ReadQueryOptions, useCacheQuery } from '../../../../../eventEditor/services/apollo/queries';
-import { GeneralSettings, GeneralSettingsData } from '../../../../../../application/valueObjects/config/types';
+import { ReadQueryOptions, useCacheQuery } from '@edtrServices/apollo/queries';
+import { GeneralSettings, GeneralSettingsData } from '@application/valueObjects/config/types';
 /**
  * A custom react hook for retrieving GeneralSettings
  */
@@ -12,7 +10,7 @@ const useGeneralSettings = (): GeneralSettings => {
 	};
 	const { data } = useCacheQuery<GeneralSettingsData>(options);
 
-	return pathOr<GeneralSettings>(null, ['generalSettings'], data);
+	return data?.generalSettings;
 };
 
 export default useGeneralSettings;

--- a/assets/src/domain/shared/services/apollo/queries/types.ts
+++ b/assets/src/domain/shared/services/apollo/queries/types.ts
@@ -1,3 +1,3 @@
-import { WriteQueryOptions } from '../../../../eventEditor/services/apollo/queries/types';
+import { WriteQueryOptions } from '@edtrServices/apollo/queries/types';
 
 export type CacheUpdaterFn<TData = any> = (writeOptions?: WriteQueryOptions<TData>) => void;

--- a/assets/src/domain/shared/services/apollo/queries/useUpdateCache.ts
+++ b/assets/src/domain/shared/services/apollo/queries/useUpdateCache.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useApolloClient } from '@apollo/react-hooks';
 
-import { WriteQueryOptions } from '../../../../eventEditor/services/apollo/queries/types';
+import { WriteQueryOptions } from '@edtrServices/apollo/queries/types';
 import { CacheUpdaterFn } from './types';
 
 const useUpdateCache = <Data = any>(writeQueryOptions: WriteQueryOptions<Data>): CacheUpdaterFn<Data> => {


### PR DESCRIPTION
This PR:
- Improves types and extracts reducer for relations manager
- Updates `<ItemCount />` to add support for `title`
- Improves and simplifies query hooks
- Adds and improves query hooks for relations. Newly created hooks include `useRelatedDatetimes()`, `useRelatedTickets` and `useRelatedPrices`.
- Moves related Dates and Tickets to related badge tooltip
- Removes related entities from cards
- Closes #2526

Here is the demo of how it looks
![image](https://user-images.githubusercontent.com/18226415/76311337-bff1e780-62f6-11ea-8600-3bf405c12f22.png)
