### PR TITLE
Move Usage of withIsLoaded HOC into action Components | Closes #2544

### DIFF
--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -6,6 +6,8 @@ import { EntityListItemProps } from '@appLayout/entityList';
 import ItemCount from '@appDisplay/ItemCount';
 import { useRelatedTickets } from '@edtrServices/apollo/queries';
 import useTicketAssignmentsManager from '@edtrUI/ticketAssignmentsManager/useTicketAssignmentsManager';
+import { TypeName } from '@appServices/apollo/status';
+import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
 const AssignTicketsButton: React.FC<EntityListItemProps> = ({ id }) => {
 	const { assignTicketsToDate } = useTicketAssignmentsManager();
@@ -38,4 +40,8 @@ const AssignTicketsButton: React.FC<EntityListItemProps> = ({ id }) => {
 	);
 };
 
-export default AssignTicketsButton;
+
+export default withIsLoaded<EntityListItemProps>(TypeName.tickets, ({ loaded, id }) => {
+	/* Hide TAM unless tickets are loaded */
+	return loaded && <AssignTicketsButton id={id} />;
+});;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/DeleteDateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/DeleteDateButton.tsx
@@ -5,20 +5,22 @@ import { EspressoButton, Icon } from '@application/ui/input';
 import { EntityListItemProps } from '@appLayout/entityList';
 import { useDatetimeMutator } from '@edtrServices/apollo/mutations';
 import { ConfirmDelete } from '@appLayout/confirmDelete';
+import { TypeName } from '@appServices/apollo/status';
+import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
-const DeleteDateButton: React.FC<EntityListItemProps> = ({ id, ...rest }) => {
+const DeleteDateButton: React.FC<EntityListItemProps> = ({ id }) => {
 	const { deleteEntity } = useDatetimeMutator(id);
+
+	const tooltipProps = { placement: 'right' };
 
 	return (
 		<ConfirmDelete onConfirm={() => deleteEntity({ id })}>
-			<EspressoButton
-				icon={Icon.TRASH}
-				tooltip={__('delete datetime')}
-				tooltipProps={{ placement: 'right' }}
-				{...rest}
-			/>
+			<EspressoButton icon={Icon.TRASH} tooltip={__('delete datetime')} tooltipProps={tooltipProps} />
 		</ConfirmDelete>
 	);
 };
 
-export default DeleteDateButton;
+export default withIsLoaded<EntityListItemProps>(TypeName.tickets, ({ loaded, id }) => {
+	/* Delete button should be hidden to avoid relational inconsistencies */
+	return loaded && <DeleteDateButton id={id} />;
+});

--- a/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesActionMenuHandler.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesActionMenuHandler.tsx
@@ -6,8 +6,6 @@ import DeleteDateButton from '../datesList/actionsMenu/DeleteDateButton';
 import AssignTicketsButton from '../datesList/actionsMenu/AssignTicketsButton';
 import { Datetime } from '@edtrServices/apollo/types';
 import { EntityActionsSubscriptionCb } from '@appLayout/entityActionsMenu';
-import { TypeName } from '@appServices/apollo/status';
-import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
 type DatesSubscriptionCallback = EntityActionsSubscriptionCb<Datetime, 'datetime'>;
 
@@ -19,25 +17,12 @@ const useDatesActionMenuHandler = (): DatesSubscriptionCallback => {
 		}
 
 		const { registerElement: registerMenuItem } = registry;
-		const withTicketsLoaded = withIsLoaded(TypeName.tickets);
 
 		registerMenuItem('editDate', () => <EditDateButton />);
 
-		registerMenuItem(
-			'assignTickets',
-			withTicketsLoaded(({ loaded }) => {
-				/* Hide TAM unless tickets are loaded */
-				return loaded && <AssignTicketsButton id={date.id} />;
-			})
-		);
+		registerMenuItem('assignTickets', () => <AssignTicketsButton id={date.id} />);
 
-		registerMenuItem(
-			'deleteTicket',
-			withTicketsLoaded(({ loaded }) => {
-				/* Delete button should be hidden to avoid relational inconsistencies */
-				return loaded && <DeleteDateButton id={date.id} />;
-			})
-		);
+		registerMenuItem('deleteTicket', () => <DeleteDateButton id={date.id} />);
 	}, []);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsActionMenuHandler.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsActionMenuHandler.tsx
@@ -7,45 +7,20 @@ import AssignDatesButton from '../ticketsList/actionsMenu/AssignDatesButton';
 import TicketPriceCalculatorButton from '../ticketPriceCalculator/buttons/TicketPriceCalculatorButton';
 import { EntityActionsSubscriptionCb } from '@appLayout/entityActionsMenu';
 import { Ticket } from '@edtrServices/apollo/types';
-import { TypeName } from '@appServices/apollo/status';
-import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
 type TicketsSubscriptionCallback = EntityActionsSubscriptionCb<Ticket, 'ticket'>;
 
 const useTicketsActionMenuHandler = (): TicketsSubscriptionCallback => {
 	return useCallback<TicketsSubscriptionCallback>(({ entity: ticket, registry }) => {
-		const withPricesLoaded = withIsLoaded(TypeName.prices);
-		const withDatesLoaded = withIsLoaded(TypeName.datetimes);
-
 		const { registerElement: registerMenuItem } = registry;
 
 		registerMenuItem('editTicket', () => <EditTicketButton />);
 
-		registerMenuItem(
-			'assignDates',
-			withDatesLoaded(({ loaded }) => {
-				/* Hide TAM unless dates are loaded */
-				return loaded && <AssignDatesButton id={ticket.id} />;
-			})
-		);
+		registerMenuItem('assignDates', () => <AssignDatesButton id={ticket.id} />);
 
-		registerMenuItem(
-			'ticketPriceCalculator',
-			withPricesLoaded(({ loaded }) => {
-				/* Hide price calculator unless prices are loaded */
-				return loaded && <TicketPriceCalculatorButton ticketId={ticket.id} />;
-			})
-		);
+		registerMenuItem('ticketPriceCalculator', () => <TicketPriceCalculatorButton ticketId={ticket.id} />);
 
-		registerMenuItem(
-			'deleteTicket',
-			withDatesLoaded(
-				withPricesLoaded(({ loaded }) => {
-					/* Delete button should be hidden to avoid relational inconsistencies */
-					return loaded && <DeleteTicketButton id={ticket.id} />;
-				})
-			)
-		);
+		registerMenuItem('deleteTicket', () => <DeleteTicketButton id={ticket.id} />);
 	}, []);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/TicketPriceCalculatorButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/TicketPriceCalculatorButton.tsx
@@ -4,6 +4,8 @@ import { __ } from '@wordpress/i18n';
 
 import { TpcButtonDataProps } from '../types';
 import { useFormModal } from '@appLayout/formModal';
+import { TypeName } from '@appServices/apollo/status';
+import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
 const TicketPriceCalculatorButton: React.FC<TpcButtonDataProps> = ({ ticketId, ...buttonProps }) => {
 	const { openEditor } = useFormModal();
@@ -25,4 +27,7 @@ const TicketPriceCalculatorButton: React.FC<TpcButtonDataProps> = ({ ticketId, .
 	);
 };
 
-export default TicketPriceCalculatorButton;
+export default withIsLoaded<TpcButtonDataProps>(TypeName.prices, ({ loaded, id }) => {
+	/* Hide price calculator unless prices are loaded */
+	return loaded && <TicketPriceCalculatorButton ticketId={id} />;
+});;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
@@ -6,8 +6,10 @@ import { EntityListItemProps } from '@appLayout/entityList';
 import ItemCount from '@appDisplay/ItemCount';
 import { useRelatedDatetimes } from '@edtrServices/apollo/queries';
 import useTicketAssignmentsManager from '@edtrUI/ticketAssignmentsManager/useTicketAssignmentsManager';
+import { TypeName } from '@appServices/apollo/status';
+import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
-const AssignDatesButton: React.FC<EntityListItemProps> = ({ id, ...rest }) => {
+const AssignDatesButton: React.FC<EntityListItemProps> = ({ id }) => {
 	const { assignDatesToTicket } = useTicketAssignmentsManager();
 
 	const relatedDatetimes = useRelatedDatetimes({
@@ -28,17 +30,21 @@ const AssignDatesButton: React.FC<EntityListItemProps> = ({ id, ...rest }) => {
 		assignDatesToTicket({ ticketId: id });
 	};
 
+	const tooltipProps = { placement: 'right' };
+
 	return (
 		<ItemCount count={count} title={title}>
 			<EspressoButton
 				icon={Icon.CALENDAR}
 				tooltip={__('assign dates')}
-				tooltipProps={{ placement: 'right' }}
+				tooltipProps={tooltipProps}
 				onClick={onClick}
-				{...rest}
 			/>
 		</ItemCount>
 	);
 };
 
-export default AssignDatesButton;
+export default withIsLoaded<EntityListItemProps>(TypeName.datetimes, ({ loaded, id }) => {
+	/* Hide TAM unless dates are loaded */
+	return loaded && <AssignDatesButton id={id} />;
+});

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/DeleteTicketButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/DeleteTicketButton.tsx
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import useDeleteTicketHandler from '../../hooks/useDeleteTicketHandler';
 import { EntityListItemProps } from '@appLayout/entityList';
 import { ConfirmDelete } from '@appLayout/confirmDelete';
+import { TypeName } from '@appServices/apollo/status';
+import withIsLoaded from '@sharedUI/hoc/withIsLoaded';
 
 const DeleteTicketButton: React.FC<EntityListItemProps> = ({ id, ...rest }) => {
 	const handleDeleteTicket = useDeleteTicketHandler({ id });
@@ -21,4 +23,10 @@ const DeleteTicketButton: React.FC<EntityListItemProps> = ({ id, ...rest }) => {
 	);
 };
 
-export default DeleteTicketButton;
+export default withIsLoaded(
+	TypeName.datetimes,
+	withIsLoaded<EntityListItemProps>(TypeName.prices, ({ loaded, id }) => {
+		/* Delete button should be hidden to avoid relational inconsistencies */
+		return loaded && <DeleteTicketButton id={id} />;
+	})
+);


### PR DESCRIPTION
This PR:
- Refactor `withIsLoaded` HOC
- Removes `withIsLoaded` usage from ActionMenu handlers
- Adds `withIsLoaded` use to action components
- Closes #2544