### PR TITLE
TAM - fix errors | Closes #2555

### DIFF
--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/TicketAssignmentsManager.tsx
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/TicketAssignmentsManager.tsx
@@ -13,15 +13,17 @@ const TicketAssignmentsManager: React.FC<TAMProps> = ({ assignmentType, entityId
 	const relations = useRelations();
 	const { initialize, isInitialized } = useTAMState();
 
+	const initialized = isInitialized();
+
 	useEffect(() => {
-		if (!isInitialized()) {
+		if (!initialized) {
 			// If TAM is only for a single datetime
 			// limit relations to that datetime
 			const forDate = assignmentType === 'forDate' ? entityId : null;
 			// initialize with existing data
 			initialize(relations.getData(), forDate);
 		}
-	}, [isInitialized()]);
+	}, [initialized]);
 
 	return (
 		<>

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/TicketAssignmentsManager.tsx
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/TicketAssignmentsManager.tsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import ErrorMessage from './ErrorMessage';
 import { Table } from './table';
 import { TAMProps } from './types';
 import useTAMDatesAndTickets from './useTAMDatesAndTickets';
+import useTAMState from './useTAMState';
+import { useRelations } from '@appServices/apollo/relations';
 
 const TicketAssignmentsManager: React.FC<TAMProps> = ({ assignmentType, entityId }) => {
 	const datesAndTickets = useTAMDatesAndTickets({ assignmentType, entityId });
+
+	const relations = useRelations();
+	const { initialize, isInitialized } = useTAMState();
+
+	useEffect(() => {
+		if (!isInitialized()) {
+			// If TAM is only for a single datetime
+			// limit relations to that datetime
+			const forDate = assignmentType === 'forDate' ? entityId : null;
+			// initialize with existing data
+			initialize(relations.getData(), forDate);
+		}
+	}, [isInitialized()]);
 
 	return (
 		<>

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/types.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/types.ts
@@ -35,12 +35,13 @@ export interface AssignmentManager {
 	getAssignedDates: (args: Pick<AssignmentFnArgs, 'ticketId'>) => EntityId[];
 	getAssignedTickets: (args: Pick<AssignmentFnArgs, 'datetimeId'>) => EntityId[];
 	getData: RelationsManager['getData'];
-	initialize: RelationsManager['initialize'];
+	initialize: (data: TAMRelationalData, forDate: EntityId) => void;
+	isInitialized: RelationsManager['isInitialized'];
 	removeAssignment: (args: SetAssignmentFnArgs) => void;
 	toggleAssignment: (args: AssignmentFnArgs) => void;
 }
 
-export interface TAMStateManager extends Omit<AssignmentManager, 'initialize'> {
+export interface TAMStateManager extends AssignmentManager {
 	getAssignmentStatus: (args: AssignmentFnArgs) => AssignmentStatus;
 	hasNoAssignedDates: (options: Pick<AssignmentFnArgs, 'ticketId'>) => boolean;
 	hasNoAssignedTickets: (options: Pick<AssignmentFnArgs, 'datetimeId'>) => boolean;

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useAssignmentManager.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useAssignmentManager.ts
@@ -94,8 +94,6 @@ const useAssignmentManager = (): AM => {
 			}, relationalEntityToUse);
 		}, newData);
 
-		console.log('newData', newData);
-
 		initializeRelations(newData);
 	};
 

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useTAMDatesAndTickets.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useTAMDatesAndTickets.ts
@@ -20,8 +20,8 @@ const useTAMDatesAndTickets = ({ assignmentType, entityId }: TAMProps): DatesAnd
 			};
 		case 'forTicket':
 			return {
-				tickets: [singleTicket],
 				datetimes: allDatetimes,
+				tickets: [singleTicket],
 			};
 	}
 };

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useTAMStateManager.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useTAMStateManager.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { EntityId } from '@appServices/apollo/types';
 import { useRelations } from '@appServices/apollo/relations';
 import useAssignmentManager from './useAssignmentManager';
@@ -7,17 +5,12 @@ import useValidateTAMData from './useValidateTAMData';
 import { TAMStateManager, AssignmentStatus } from './types';
 
 const useTAMStateManager = (): TAMStateManager => {
-	const { initialize, ...assignmentManager } = useAssignmentManager();
+	const assignmentManager = useAssignmentManager();
 
 	// The existing relations to be used to create initial data
 	// and to calculate difference between new and old data
 	const relations = useRelations();
 	const orphanEntities = useValidateTAMData(assignmentManager);
-
-	useEffect(() => {
-		// initialize with existing data
-		initialize(relations.getData());
-	}, []);
 
 	const hasNoAssignedDates = ({ ticketId }) => orphanEntities.tickets.includes(ticketId);
 

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useValidateTAMData.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/useValidateTAMData.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
 import { mapObjIndexed, pickBy, pathOr, isEmpty } from 'ramda';
 
-import { TAMPossibleRelation, TAMRelationalEntity, TAMRelationalData } from './types';
+import { TAMPossibleRelation, TAMRelationalEntity, TAMRelationalData, AssignmentManager } from './types';
 
 const DEFAULT_VALIDATION_DATA: TAMPossibleRelation = {
 	datetimes: [],
 	tickets: [],
 };
 
-const useValidateTAMData = (assignmentManager) => {
+const useValidateTAMData = (assignmentManager: AssignmentManager): TAMPossibleRelation => {
 	const [validationData, setValidationData] = useState(DEFAULT_VALIDATION_DATA);
 	const TAMData: TAMRelationalData = assignmentManager.getData();
 

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/utils.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/utils.ts
@@ -1,7 +1,7 @@
 import { pathOr, filter, equals } from 'ramda';
 
 import { EntityId } from '@appServices/apollo/types';
-import { TAMPossibleRelation, TAMRelationalEntity, TAMRelationalData, TAMRelationEntity } from './types';
+import { TAMPossibleRelation, TAMRelationEntity, TAMRelationalData, TAMRelationalEntity } from './types';
 
 type EntitiesToUpdate = Array<[EntityId, TAMPossibleRelation]>;
 


### PR DESCRIPTION
This PR:
- Updates `useAssignmentManager` and `useTAMStateManager` to expose `initialize()`
- Initializes data conditionally to use relations only for dates used in TAM
- Closes #2555