### PR TITLE
Entity edit forms: Empty box for no limit | Closes #1699

### DIFF
--- a/assets/src/application/services/utilities/number/formatInfinity.ts
+++ b/assets/src/application/services/utilities/number/formatInfinity.ts
@@ -7,7 +7,7 @@ const formatInfinity: FormatInfinity = (value, defaultValue = '') => {
 	if (isInfinite(value)) {
 		return defaultValue;
 	}
-	return `${value}`;
+	return value.toString();
 };
 
 export default formatInfinity;

--- a/assets/src/application/services/utilities/number/formatInfinity.ts
+++ b/assets/src/application/services/utilities/number/formatInfinity.ts
@@ -1,0 +1,13 @@
+import isInfinite from './isInfinite';
+
+type FormatInfinity = (value: number, defaultValue?: string) => string;
+
+const formatInfinity: FormatInfinity = (value, defaultValue = '') => {
+	// If it is infinity
+	if (isInfinite(value)) {
+		return defaultValue;
+	}
+	return `${value}`;
+};
+
+export default formatInfinity;

--- a/assets/src/application/services/utilities/number/index.ts
+++ b/assets/src/application/services/utilities/number/index.ts
@@ -1,0 +1,5 @@
+export { default as formatInfinity } from './formatInfinity';
+
+export { default as parseInfinity } from './parseInfinity';
+
+export { default as isInfinite } from './isInfinite';

--- a/assets/src/application/ui/forms/espressoForm/fields/Field.tsx
+++ b/assets/src/application/ui/forms/espressoForm/fields/Field.tsx
@@ -14,8 +14,10 @@ const Field: React.FC<FieldProps> = ({ conditions, parseAsInfinity, ...rest }) =
 	const extraProps: RFFFieldProps = parseAsInfinity
 		? {
 				// `format` will convert infinite value from form (like -1) to empty string
+				// before it gets passed to the input
 				format: (value: number) => formatInfinity(value),
 				// `parse` will convert empty string from the field to infinite value (like -1)
+				// before it is added to form values object
 				parse: (value: any) => parseInfinity(value),
 		  }
 		: {};

--- a/assets/src/application/ui/forms/espressoForm/fields/Field.tsx
+++ b/assets/src/application/ui/forms/espressoForm/fields/Field.tsx
@@ -4,11 +4,23 @@ import { Field as RFFField } from 'react-final-form';
 import { FieldProps } from '../types';
 import FieldRenderer from '../renderers/FieldRenderer';
 import useShouldBeVisible from '../hooks/useShouldBeVisible';
+import { parseInfinity, formatInfinity } from '@appServices/utilities/number';
 
-const Field: React.FC<FieldProps> = ({ conditions, ...rest }) => {
+type RFFFieldProps = Partial<React.ComponentProps<typeof RFFField>>;
+
+const Field: React.FC<FieldProps> = ({ conditions, parseAsInfinity, ...rest }) => {
 	const visible = useShouldBeVisible(conditions, rest.name);
 
-	return visible && <RFFField render={FieldRenderer} {...rest} type={rest.fieldType} />;
+	const extraProps: RFFFieldProps = parseAsInfinity
+		? {
+				// `format` will convert infinite value from form (like -1) to empty string
+				format: (value: number) => formatInfinity(value),
+				// `parse` will convert empty string from the field to infinite value (like -1)
+				parse: (value: any) => parseInfinity(value),
+		  }
+		: {};
+
+	return visible && <RFFField render={FieldRenderer} {...extraProps} {...rest} type={rest.fieldType} />;
 };
 
 export default Field;

--- a/assets/src/application/ui/forms/espressoForm/types.ts
+++ b/assets/src/application/ui/forms/espressoForm/types.ts
@@ -61,6 +61,7 @@ export interface AdditionalFieldProps<FormValues = AnyObject> {
 	isRepeatable?: boolean;
 	conditions?: FieldConditions;
 	formItemProps?: FormItemProps;
+	parseAsInfinity?: boolean;
 	[key: string]: any;
 }
 

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -118,10 +118,11 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 						name: 'capacity',
 						label: __('Capacity'),
 						fieldType: 'number',
+						parseAsInfinity: true,
 						min: -1,
 						info: sprintf(
 							__(
-								'The maximum number of registrants that can attend the event at this particular date.%sSet to 0 to close registration or set to -1 for no limit.'
+								'The maximum number of registrants that can attend the event at this particular date.%sSet to 0 to close registration or leave blank for no limit.'
 							),
 							'\n'
 						),

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -157,11 +157,12 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'quantity',
 						label: __('Quantity For Sale'),
 						fieldType: 'number',
+						parseAsInfinity: true,
 						formItemProps: adjacentFormItemProps,
 						min: -1,
 						info: sprintf(
 							__(
-								'The maximum number of this ticket available for sale.%sSet to 0 stop sales or set to -1 for no limit.'
+								'The maximum number of this ticket available for sale.%sSet to 0 stop sales or leave blank for no limit.'
 							),
 							'\n'
 						),
@@ -170,6 +171,7 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'uses',
 						label: __('Number of Uses'),
 						fieldType: 'number',
+						parseAsInfinity: true,
 						formItemProps: adjacentFormItemProps,
 						min: 0,
 						info: sprintf(
@@ -196,11 +198,12 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'max',
 						label: __('Maximum Quantity'),
 						fieldType: 'number',
+						parseAsInfinity: true,
 						formItemProps: adjacentFormItemProps,
 						min: -1,
 						info: sprintf(
 							__(
-								'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sSet to -1 for no maximum.'
+								'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sLeave blank for no maximum.'
 							),
 							'\n'
 						),


### PR DESCRIPTION
This PR adds support for empty/blank field for no limit for the fields that can be infinity.
- Creates `formatInfinity` utility in `/application/services/utilities/number`
- Adds support for `parseAsInfinity` prop in `EspressoForm`
- Updates date and ticket form configs to use `parseAsInfinity`
- Closes #1699