### PR TITLE
Add action hooks to Questions editor admin page template

### DIFF
--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 // PARAMS THAT MUST BE PASSED ARE:
 assert(isset($QST_ID));
 assert($question);
@@ -11,6 +12,8 @@ echo EEH_Form_Fields::hidden_input('QST_wp_user', $question->wp_user());
 echo EEH_Form_Fields::hidden_input('QST_deleted', $question->deleted());
 $QST_system = $question->system_ID();
 $fields = $question->get_model()->field_settings();
+
+do_action('AHEE__questions_main_meta_box__template__before_admin_page_content', $question);
 
 // does question have any answers? cause if it does then we have to disable type
 $has_answers = $question->has_answers();
@@ -32,9 +35,16 @@ if ($QST_system === 'country') {
 }
 ?>
 
+<?php
+    do_action('AHEE__questions_main_meta_box__template__inner_admin_page_content', $question);
+?>
+
 <div class="padding">
     <table class="form-table">
         <tbody>
+        <?php
+            do_action('AHEE__questions_main_meta_box__template__before_table_form_table', $question);
+        ?>
         <tr>
             <th>
                 <label for="QST_display_text"><?php echo $fields['QST_display_text']->get_nicename(); ?></label>
@@ -382,9 +392,15 @@ if ($QST_system === 'country') {
 
             </td>
         </tr>
-
+        <?php
+            do_action('AHEE__questions_main_meta_box__template__after_table_form_table', $question);
+        ?>
         </tbody>
     </table>
 
     <div class="clear"></div>
 </div>
+
+<?php
+    do_action('AHEE__questions_main_meta_box__template__after_admin_page_content', $question);
+?>

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -403,4 +403,4 @@ if ($QST_system === 'country') {
 
 <?php
     do_action('AHEE__questions_main_meta_box__template__after_admin_page_content', $question);
-?>
+


### PR DESCRIPTION
See #2549 

Cherry-picked the one commit for this.

No changes to test, this adds action hooks only.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
