### PR TITLE
Fix WP GraphQL v0.6.0 fatal error | Closes #2562

### DIFF
--- a/assets/src/application/ui/input/InlineEditInput/Editable.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/Editable.tsx
@@ -15,7 +15,7 @@ const EditableTypes = {
 };
 // Leave `ellipsis` unused to avoid TS conflict
 /* eslint-disable no-unused-vars */
-const Editable: React.FC<EditableProps> = ({ inputType, ellipsis, onChange, className, ...rest }) => {
+const Editable: React.FC<EditableProps> = ({ inputType, onChange, className, ...rest }) => {
 	const Component = EditableTypes[inputType];
 
 	const htmlClasses = classNames('ee-inline-edit', `ee-inline-edit-${inputType}`, className);

--- a/assets/src/application/ui/input/InlineEditInput/Editable.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/Editable.tsx
@@ -20,7 +20,7 @@ const Editable: React.FC<EditableProps> = ({ inputType, ellipsis, onChange, clas
 
 	const htmlClasses = classNames('ee-inline-edit', `ee-inline-edit-${inputType}`, className);
 
-	return <Component className={htmlClasses} editable={{ onChange }} ellipsis={ellipsis} tabIndex={0} {...rest} />;
+	return <Component className={htmlClasses} editable={{ onChange }} tabIndex={0} {...rest} />;
 };
 
 export default Editable;

--- a/assets/src/application/ui/input/InlineEditInput/Editable.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/Editable.tsx
@@ -13,14 +13,21 @@ const EditableTypes = {
 	heading: Title,
 	textarea: Paragraph,
 };
-// Leave `ellipsis` unused to avoid TS conflict
-/* eslint-disable no-unused-vars */
-const Editable: React.FC<EditableProps> = ({ inputType, onChange, className, ...rest }) => {
+const Editable: React.FC<EditableProps> = ({ inputType, ellipsis, onChange, className, ...rest }) => {
 	const Component = EditableTypes[inputType];
 
 	const htmlClasses = classNames('ee-inline-edit', `ee-inline-edit-${inputType}`, className);
 
-	return <Component className={htmlClasses} editable={{ onChange }} tabIndex={0} {...rest} />;
+	return (
+		<Component
+			className={htmlClasses}
+			editable={{ onChange }}
+			// TS treats ellipsis as a prop for Typography.Text
+			ellipsis={ellipsis as boolean}
+			tabIndex={0}
+			{...rest}
+		/>
+	);
 };
 
 export default Editable;

--- a/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\domain\services\graphql\connection_resolvers;
 
+use EE_Base_Class;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver as WPGraphQLConnectionResolver;
 use GraphQLRelay\Relay;
 
@@ -32,6 +33,25 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
         );
         $limit++;
         return $limit;
+    }
+
+    /**
+     * Determine whether or not the the offset is valid, i.e the entity corresponding to the
+     * offset exists. Offset is equivalent to entity ID. So this function is equivalent to
+     * checking if the entity with the given ID exists.
+     *
+     * @access public
+     *
+     * @param int $offset The ID of the node used for the cursor offset
+     *
+     * @return bool
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function is_valid_offset($offset)
+    {
+        $entity = $this->get_query()->get_one_by_ID($offset);
+        
+        return $entity instanceof EE_Base_Class;
     }
 
 


### PR DESCRIPTION
This PR fixes the fatal error caused after WP GraphQL v0.6.0, due to a new abstract method `is_valid_offset` in `WPGraphQL\Data\Connection\AbstractConnectionResolver`.

**Changes:**
- Added `is_valid_offset` method to `AbstractConnectionResolver` to cater for all the connection resolvers that extend it.

Closes #2562