### PR TITLE
Move Venue virtual URL field textarea contents into one line to avoid line breaks

### DIFF
--- a/admin_pages/venues/templates/venue_virtual_location_metabox_content.template.php
+++ b/admin_pages/venues/templates/venue_virtual_location_metabox_content.template.php
@@ -4,16 +4,16 @@
             <fieldset>
                 <p>
                     <label for="url-event" style="display:inline-block; width:100px; vertical-align:top;">
-                        <?php _e('URL of Event:', 'event_espresso'); ?>
+                        <?php esc_html_e('URL of Event:', 'event_espresso'); ?>
                     </label>
-                    <textarea id="url-event" cols="30" rows="4" tabindex="112" name="vnu_virtual_url">
-                        <?php $_venue->f(
-                            'VNU_virtual_url'
-                        ); ?></textarea>
+                    <?php //phpcs:disable Generic.Files.LineLength.TooLong
+                    // no new lines within <textarea> here because they'll output whitespace ?>
+                    <textarea id="url-event" cols="30" rows="4" tabindex="112" name="vnu_virtual_url"><?php $_venue->f('VNU_virtual_url'); ?></textarea>
+                    <?php //phpcs:enable ?>
                 </p>
                 <p>
                     <label for="call-in-num" style="display:inline-block; width:100px;">
-                        <?php _e('Call in Number:', 'event_espresso'); ?>
+                        <?php esc_html_e('Call in Number:', 'event_espresso'); ?>
                     </label>
                     <input id="call-in-num" class="all-options" tabindex="113" type="text"
                            value="<?php $_venue->f('VNU_virtual_phone'); ?>" name="vnu_virtual_phone"/>


### PR DESCRIPTION
also escape i18n-ready strings

There was some unexpected extra spaces within the textarea field for the Venue 
![image (2)](https://user-images.githubusercontent.com/891156/77184895-dd694300-6aa6-11ea-828b-4da118c5e71b.png)

## How has this been tested
Load up an "add new venue" page and check the Venue Location - URL of Event field, there should be no extra spaces within the textarea.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)