### PR TITLE
Remove link to event's checkins when context is already viewing event's checkins

### DIFF
--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -70,10 +70,6 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         );
         $columns = array();
         // $columns['_Reg_Status'] = '';
-        if (! empty($evt_id)) {
-            $columns['cb'] = '<input type="checkbox" />'; // Render a checkbox instead of text
-            $this->_has_checkbox_column = true;
-        }
         $this->_columns = array(
             '_REG_att_checked_in' => '<span class="dashicons dashicons-yes ee-icon-size-18"></span>',
             'ATT_name'            => __('Registrant', 'event_espresso'),
@@ -84,6 +80,14 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             'TXN_paid'            => __('Paid', 'event_espresso'),
             'TXN_total'           => __('Total', 'event_espresso'),
         );
+        // Add/remove columns when an event has been selected
+        if (! empty($evt_id)) {
+            // Render a checkbox column
+            $columns['cb'] = '<input type="checkbox" />';
+            $this->_has_checkbox_column = true;
+            // Remove the 'Event' column
+            unset($this->_columns['Event']);
+        }
         $this->_columns = array_merge($columns, $this->_columns);
         $this->_primary_column = '_REG_att_checked_in';
         if (! empty($evt_id)


### PR DESCRIPTION
See: https://github.com/eventespresso/event-espresso-core/issues/1022

Rather than jumping in checking for an evt_id in various places, I moved the current check for adding the checkbox column, below the default columns array and then removed the 'Event' column from within that conditional.

## Problem this Pull Request solves
See #1022 

## How has this been tested
Go to Event Espresso -> Registrations -> Event Check-in

You should see an 'event' column shown on that page.

Click on the event name to view check-ins for that event, on that page, you should not see the event link/column

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
