### PR TITLE
Make the Event Check-in tab contextual

### DIFF
--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -49,6 +49,9 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
         $reg_id = ! empty($this->_req_data['_REG_ID']) && ! is_array($this->_req_data['_REG_ID'])
             ? $this->_req_data['_REG_ID']
             : 0;
+        $EVT_ID = ! empty($this->_req_data['event_id']) && ! is_array($this->_req_data['event_id'])
+            ? $this->_req_data['event_id']
+            : 0;
         $new_page_routes = array(
             'reports'                      => array(
                 'func'       => '_registration_reports',

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -119,7 +119,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
                     'label'      => esc_html__('Event Check-In', 'event_espresso'),
                     'order'      => 10,
                     'persistent' => true,
-                    'url'        => !empty($EVT_ID)
+                    'url'        => !empty($EVT_ID) && $this->get_current_view() !== 'event_registrations'
                         ? self::add_query_args_and_nonce(array('action' => 'event_registrations', 'event_id' => $EVT_ID), $this->_admin_base_url)
                         : null,
                 ),

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -119,6 +119,9 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
                     'label'      => esc_html__('Event Check-In', 'event_espresso'),
                     'order'      => 10,
                     'persistent' => true,
+                    'url'        => !empty($EVT_ID)
+                        ? self::add_query_args_and_nonce(array('action' => 'event_registrations', 'event_id' => $EVT_ID), $this->_admin_base_url)
+                        : null,
                 ),
                 'help_tabs'     => array(
                     'registrations_event_checkin_help_tab'                       => array(

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -50,7 +50,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             ? $this->_req_data['_REG_ID']
             : 0;
         $EVT_ID = ! empty($this->_req_data['event_id']) && ! is_array($this->_req_data['event_id'])
-            ? $this->_req_data['event_id']
+            ? absint($this->_req_data['event_id'])
             : 0;
         $new_page_routes = array(
             'reports'                      => array(


### PR DESCRIPTION
See: #1021

This makes the 'Event Check-in' tab contextual, meaning if you are viewing registrations for a specific event and you click on that tab, it opens checks for the event in question.

The nav URL value has a hardcoded 'action' because I don't think we can pull it any other way as its set right in that section, if no EVT_ID it uses null, which then defaults to the 'normal' link for all check-ins.

Would it be worth altering how the page config [nav url's are generated](https://github.com/eventespresso/event-espresso-core/blob/master/core/admin/EE_Admin_Page.core.php#L1478-L1483) here so we can pass values to them? I've seen `'extra_request'` passed around in a few places, something similar here that can be passed into the query_args?

## How has this been tested
Go to Event Espresso -> Registrations.

Confirm that the 'Event Check-in' tab works as expected and show all check-ins.

Back to the registration list, open up a specific events registrations list.

Now confirm that clicking on the Event Check-in link lists the checkings for the specific event you were viewing.

Now, on the check-in list, click on the 'Event Check-in' tab again, this time it should load all check-ins for all events again.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
