### PR TITLE
Add eventStatus schema

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -50,15 +50,14 @@ class EEH_Schema
         $template_args['event_end'] = $primary_datetime->end_date(DateTime::ATOM);
         unset($primary_datetime);
         switch ($event->status()) {
-            case 'cancelled':
+            case EEM_Event::cancelled:
                 $event_status = 'EventCancelled';
                 break;
-            case 'postponed':
+            case EEM_Event::postponed:
                 $event_status = 'EventPostponed';
                 break;
             default:
                 $event_status = 'EventScheduled';
-                break;
         }
         $template_args['event_status'] = $event_status;
         $template_args['currency'] = EE_Registry::instance()->CFG->currency->code;

--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -31,6 +31,7 @@ class EEH_Schema
             'event_description' => '',
             'event_start' => '',
             'event_end' => '',
+            'event_status' => '',
             'currency' => '',
             'event_tickets' => array(),
             'venue_name' => '',
@@ -48,6 +49,18 @@ class EEH_Schema
         $template_args['event_start'] = $primary_datetime->start_date(DateTime::ATOM);
         $template_args['event_end'] = $primary_datetime->end_date(DateTime::ATOM);
         unset($primary_datetime);
+        switch ($event->status()) {
+            case 'cancelled':
+                $event_status = 'EventCancelled';
+                break;
+            case 'postponed':
+                $event_status = 'EventPostponed';
+                break;
+            default:
+                $event_status = 'EventScheduled';
+                break;
+        }
+        $template_args['event_status'] = $event_status;
         $template_args['currency'] = EE_Registry::instance()->CFG->currency->code;
         foreach ($event->tickets() as $original_ticket) {
             // clone tickets so that date formats don't override those for the original ticket

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -5,6 +5,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
 /** @var string $event_description */
 /** @var string $event_start */
 /** @var string $event_end */
+/** @var string $event_status */
 /** @var string $currency */
 /** @var array $event_tickets */
 /** @var string $venue_name */
@@ -22,6 +23,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
   "endDate": "<?php echo $event_end; ?>",
   "description": <?php echo wp_json_encode($event_description); ?>,
   "url": "<?php echo $event_permalink; ?>",
+  "eventStatus": "https://schema.org/<?php echo $event_status; ?>",
   "offers": [
     <?php
     $i = 0;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This adds one new property to the event structured data: eventStatus. Event Espresso doesn't have an equivalent event status for every provided event status option, so only "postponed", "cancelled", and "scheduled" will be supported for now. 

Note: Existing filter hooks could be used to alter ld+json output to show eventStatus as "EventMovedOnline" or "EventRescheduled".

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Check the page source of a published event page, it should now include '"eventStatus": "https://schema.org/EventScheduled",' within the ld+json structured data
- [x] Set an event to Postponed, and check its page source, it should now include "eventStatus": "https://schema.org/EventPostponed",'
- [x] Set an event to Cancelled status, and check its page source, it should now include "eventStatus": "https://schema.org/EventCancelled",'
- [x] Test the ld+json with the Structured data testing tool available at https://search.google.com/structured-data/testing-tool/u/0/

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
