### PR TITLE
Fix Filter Bar Filter Markup and CSS Classes; closes #2592.

### DIFF
--- a/assets/src/application/services/utilities/string/index.ts
+++ b/assets/src/application/services/utilities/string/index.ts
@@ -1,0 +1,1 @@
+export { default as isEmpty } from './isEmpty';

--- a/assets/src/application/services/utilities/string/isEmpty.ts
+++ b/assets/src/application/services/utilities/string/isEmpty.ts
@@ -1,0 +1,12 @@
+import { is, isNil } from 'ramda';
+
+const isEmpty = (str: string): boolean => {
+	// treat undefined as empty
+	if (isNil(str)) {
+		return true;
+	}
+
+	return is(String, str) && str.length === 0;
+};
+
+export default isEmpty;

--- a/assets/src/application/services/utilities/text/changeCase/index.ts
+++ b/assets/src/application/services/utilities/text/changeCase/index.ts
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { is } from 'ramda';
 
 export const lcFirst = (str: string): string => {

--- a/assets/src/application/ui/input/BaseInput/BaseInput.tsx
+++ b/assets/src/application/ui/input/BaseInput/BaseInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
+import classNames from 'classnames';
 
 import './style.scss';
 
@@ -12,7 +12,7 @@ interface BaseInputProps {
 
 const BaseInput: React.FC<BaseInputProps> = ({ children, className, id, label }) => {
 	return (
-		<div className={classnames('ee-base-input', className)}>
+		<div className={classNames('ee-base-input', className)}>
 			{label && (
 				<label className='ee-base-input-label' htmlFor={id}>
 					{label}

--- a/assets/src/application/ui/input/BaseInput/BaseInput.tsx
+++ b/assets/src/application/ui/input/BaseInput/BaseInput.tsx
@@ -10,7 +10,7 @@ interface BaseInputProps {
 	children?: React.ReactNode;
 }
 
-const BaseInput: React.FC<BaseInputProps> = ({ id, label, className, children }) => {
+const BaseInput: React.FC<BaseInputProps> = ({ children, className, id, label }) => {
 	return (
 		<div className={classnames('ee-base-input', className)}>
 			{label && (

--- a/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
+++ b/assets/src/application/ui/input/EspressoButton/EspressoButton.tsx
@@ -5,6 +5,7 @@ import AntIcon from '@ant-design/icons';
 
 import { EspressoButtonProps, EspressoButtonSize, EspressoButtonType, Icon } from './types';
 import { EspressoIcon, isEspressoIcon } from '../../display';
+import { isEmpty } from '@appServices/utilities/string';
 
 /**
  * Button wrapper for adding styles
@@ -12,70 +13,77 @@ import { EspressoIcon, isEspressoIcon } from '../../display';
  * forwardRef to be able to accept
  * onMouseEnter, onMouseLeave, onFocus, onClick events from parent
  */
-const EspressoButton = React.forwardRef<Button, EspressoButtonProps>((props, ref) => {
-	const {
-		icon,
-		onClick,
-		buttonText,
-		buttonSize = EspressoButtonSize.DEFAULT,
-		buttonType = EspressoButtonType.DEFAULT,
-		className: htmlClass,
-		tooltip,
-		tooltipProps = {},
-		...buttonProps
-	} = props;
+const EspressoButton = React.forwardRef<Button, EspressoButtonProps>(
+	(
+		{
+			icon,
+			onClick,
+			buttonText,
+			buttonSize = EspressoButtonSize.DEFAULT,
+			buttonType = EspressoButtonType.DEFAULT,
+			className: htmlClass,
+			tooltip,
+			tooltipProps = {},
+			...props
+		},
+		ref
+	) => {
+		const ariaLabel = isEmpty(buttonText) && !isEmpty(tooltip) ? tooltip : null;
+		const buttonProps = { ...props, 'aria-label': ariaLabel };
+		const className = classNames({
+			[htmlClass]: htmlClass,
+			'esprs-button': true,
+			'esprs-btn-accent': buttonType === EspressoButtonType.ACCENT,
+			'esprs-btn-default': buttonType === EspressoButtonType.DEFAULT,
+			'esprs-btn-primary': buttonType === EspressoButtonType.PRIMARY,
+			'esprs-btn-minimal': buttonType === EspressoButtonType.MINIMAL,
+			'esprs-btn-secondary': buttonType === EspressoButtonType.SECONDARY,
+			'esprs-btn-tiny': buttonSize === EspressoButtonSize.TINY,
+			'esprs-btn-small': buttonSize === EspressoButtonSize.SMALL,
+			'esprs-btn-big': buttonSize === EspressoButtonSize.BIG,
+			'esprs-btn-huge': buttonSize === EspressoButtonSize.HUGE,
+			'ant-btn-icon-only': !buttonText,
+			'ee-noIcon': !icon,
+		});
 
-	const className = classNames({
-		[htmlClass]: htmlClass,
-		'esprs-button': true,
-		'esprs-btn-accent': buttonType === EspressoButtonType.ACCENT,
-		'esprs-btn-default': buttonType === EspressoButtonType.DEFAULT,
-		'esprs-btn-primary': buttonType === EspressoButtonType.PRIMARY,
-		'esprs-btn-minimal': buttonType === EspressoButtonType.MINIMAL,
-		'esprs-btn-secondary': buttonType === EspressoButtonType.SECONDARY,
-		'esprs-btn-tiny': buttonSize === EspressoButtonSize.TINY,
-		'esprs-btn-small': buttonSize === EspressoButtonSize.SMALL,
-		'esprs-btn-big': buttonSize === EspressoButtonSize.BIG,
-		'esprs-btn-huge': buttonSize === EspressoButtonSize.HUGE,
-		'ant-btn-icon-only': !buttonText,
-		'ee-noIcon': !icon,
-	});
-	let eeButton: JSX.Element;
-	// check if icon prop is just an icon name (like "calendar") and if not, assume it is JSX
-	if (isEspressoIcon(icon)) {
-		// custom EE icon
-		const svgSize = buttonText ? buttonSize : 20;
-		const svgIcon = () => <EspressoIcon icon={icon as Icon} svgSize={svgSize} />;
-		if (svgIcon) {
+		let eeButton: JSX.Element;
+
+		// check if icon prop is just an icon name (like "calendar") and if not, assume it is JSX
+		if (isEspressoIcon(icon)) {
+			// custom EE icon
+			const svgSize = buttonText ? buttonSize : 20;
+			const svgIcon = () => <EspressoIcon icon={icon as Icon} svgSize={svgSize} />;
+			if (svgIcon) {
+				eeButton = (
+					<Button
+						{...buttonProps}
+						className={className}
+						icon={<AntIcon component={svgIcon} />}
+						onClick={onClick}
+						tabIndex={0}
+						ref={ref}
+					>
+						{buttonText && buttonText}
+					</Button>
+				);
+			}
+		} else {
+			// AntD or JSX element icon
 			eeButton = (
-				<Button
-					{...buttonProps}
-					className={className}
-					icon={<AntIcon component={svgIcon} />}
-					onClick={onClick}
-					tabIndex={0}
-					ref={ref}
-				>
+				<Button {...buttonProps} className={className} icon={icon} onClick={onClick} tabIndex={0} ref={ref}>
 					{buttonText && buttonText}
 				</Button>
 			);
 		}
-	} else {
-		// AntD or JSX element icon
-		eeButton = (
-			<Button {...buttonProps} className={className} icon={icon} onClick={onClick} tabIndex={0} ref={ref}>
-				{buttonText && buttonText}
-			</Button>
+
+		return tooltip ? (
+			<Tooltip title={tooltip} {...tooltipProps}>
+				{eeButton}
+			</Tooltip>
+		) : (
+			eeButton
 		);
 	}
-
-	return tooltip ? (
-		<Tooltip title={tooltip} {...tooltipProps}>
-			{eeButton}
-		</Tooltip>
-	) : (
-		eeButton
-	);
-});
+);
 
 export default EspressoButton;

--- a/assets/src/application/ui/input/SearchInput/index.tsx
+++ b/assets/src/application/ui/input/SearchInput/index.tsx
@@ -10,18 +10,18 @@ interface SearchInputProps extends InputProps {
 	setSearchText: (text?: string) => void;
 }
 
-const SearchInput: React.FC<SearchInputProps> = React.memo(({ id, searchText, setSearchText, className, ...rest }) => {
-	const htmlId = `ee-search-input-${id}`;
+const SearchInput: React.FC<SearchInputProps> = React.memo(({ className, searchText, setSearchText, ...props }) => {
+	const id = `ee-search-input-${props.id}`;
 
 	return typeof setSearchText === 'function' ? (
-		<BaseInput label={__('search')} id={htmlId} className={className}>
+		<BaseInput label={__('search')} id={id} className={className}>
 			<Input
-				id={htmlId}
+				{...props}
+				id={id}
 				className='ee-entity-list-filter-bar-search'
 				value={searchText}
 				onChange={(e) => setSearchText(e.target.value)}
 				onPressEnter={(e) => e.preventDefault()}
-				{...rest}
 			/>
 		</BaseInput>
 	) : null;

--- a/assets/src/application/ui/layout/entityList/filterBar/EntityListFilterBar.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/EntityListFilterBar.tsx
@@ -52,12 +52,9 @@ const EntityListFilterBar = <FS extends ELFSM>({
 
 			<Collapsible show={showEntityFilters}>
 				{filerBarItems}
-				<SearchInput
-					className={'ee-filter-bar__filter'}
-					id={listId}
-					searchText={searchText}
-					setSearchText={setSearchText}
-				/>
+				<div className='ee-filter-bar__filter'>
+					<SearchInput id={listId} searchText={searchText} setSearchText={setSearchText} />
+				</div>
 			</Collapsible>
 
 			<Collapsible show={showLegend}>

--- a/assets/src/application/ui/layout/entityList/filterBar/style.scss
+++ b/assets/src/application/ui/layout/entityList/filterBar/style.scss
@@ -73,9 +73,10 @@ $filter-btn: '.esprs-button.ant-btn.ee-filter-bar__btn';
 		}
 	}
 
-	&__filter,
-	&__select {
-		margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;
+	&__chain {
+		button.esprs-button.ant-btn {
+			margin-bottom: 0;
+		}
 	}
 
 	&__filter {
@@ -84,6 +85,7 @@ $filter-btn: '.esprs-button.ant-btn.ee-filter-bar__btn';
 		flex-flow: column nowrap;
 		height: auto;
 		justify-content: flex-end;
+		margin: 0 var(--ee-margin-small) var(--ee-margin-smaller) 0;
 		max-width: 100%;
 		min-width: calc(var(--ee-font-size-default) * 12);
 		white-space: pre;

--- a/assets/src/application/ui/layout/entityList/filterBar/style.scss
+++ b/assets/src/application/ui/layout/entityList/filterBar/style.scss
@@ -73,12 +73,6 @@ $filter-btn: '.esprs-button.ant-btn.ee-filter-bar__btn';
 		}
 	}
 
-	&__chain {
-		button.esprs-button.ant-btn {
-			margin-bottom: 0;
-		}
-	}
-
 	&__filter {
 		align-items: flex-start;
 		display: flex;

--- a/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesListFilterBar.tsx
@@ -23,7 +23,7 @@ const useDatesListFilterBar = (): DatesListFilterBarCallback => {
 		registerFilterBarItem('status', ({ filterState }) => {
 			const { status, setStatus } = filterState;
 			return (
-				<div className='ee-filter-bar__filter ee-dates-datetimes-to-show-filter'>
+				<div className='ee-filter-bar__filter'>
 					<StatusControl setStatus={setStatus} status={status} />
 				</div>
 			);
@@ -32,7 +32,7 @@ const useDatesListFilterBar = (): DatesListFilterBarCallback => {
 		registerFilterBarItem('sales', ({ filterState }) => {
 			const { sales, setSales } = filterState;
 			return (
-				<div className='ee-filter-bar__filter ee-dates-datetimes-to-show-filter'>
+				<div className='ee-filter-bar__filter'>
 					<SalesControl sales={sales} setSales={setSales} />
 				</div>
 			);

--- a/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/hooks/useDatesListFilterBar.tsx
@@ -41,7 +41,7 @@ const useDatesListFilterBar = (): DatesListFilterBarCallback => {
 		registerFilterBarItem('displayStartOrEndDate', ({ filterState }) => {
 			const { displayStartOrEndDate, setDisplayStartOrEndDate } = filterState;
 			return (
-				<div className='ee-filter-bar__select'>
+				<div className='ee-filter-bar__filter'>
 					<DisplayStartOrEndDateControl
 						displayStartOrEndDate={displayStartOrEndDate}
 						setDisplayStartOrEndDate={setDisplayStartOrEndDate}
@@ -53,7 +53,7 @@ const useDatesListFilterBar = (): DatesListFilterBarCallback => {
 		registerFilterBarItem('sortBy', ({ filterState }) => {
 			const { sortBy, setSortBy } = filterState;
 			return (
-				<div className='ee-filter-bar__select'>
+				<div className='ee-filter-bar__filter'>
 					<SortByControl sortBy={sortBy} setSortBy={setSortBy} />
 				</div>
 			);

--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsListFilterBar.tsx
@@ -24,7 +24,7 @@ const useTicketsListFilterBar = (): TicketsListFilterBarCallback => {
 		registerFilterBarItem('status', ({ filterState }) => {
 			const { status, setStatus } = filterState;
 			return (
-				<div className='ee-filter-bar__filter ee-dates-datetimes-to-show-filter'>
+				<div className='ee-filter-bar__filter'>
 					<StatusControl setStatus={setStatus} status={status} />
 				</div>
 			);
@@ -42,7 +42,7 @@ const useTicketsListFilterBar = (): TicketsListFilterBarCallback => {
 		registerFilterBarItem('sales', ({ filterState }) => {
 			const { sales, setSales } = filterState;
 			return (
-				<div className='ee-filter-bar__filter ee-dates-datetimes-to-show-filter'>
+				<div className='ee-filter-bar__filter'>
 					<SalesControl sales={sales} setSales={setSales} />
 				</div>
 			);

--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsListFilterBar.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useTicketsListFilterBar.tsx
@@ -33,7 +33,7 @@ const useTicketsListFilterBar = (): TicketsListFilterBarCallback => {
 		registerFilterBarItem('isChained', ({ filterState }) => {
 			const { isChained, toggleIsChained } = filterState;
 			return (
-				<div className='ee-ticket-dates-chained-filter ee-filter-bar__filter ee-filter-bar-filter--micro'>
+				<div className='ee-filter-bar__chain ee-filter-bar__filter ee-filter-bar__filter--micro'>
 					<TicketsChainedButton isChained={isChained} toggleIsChained={toggleIsChained} />
 				</div>
 			);
@@ -51,7 +51,7 @@ const useTicketsListFilterBar = (): TicketsListFilterBarCallback => {
 		registerFilterBarItem('displayStartOrEndDate', ({ filterState }) => {
 			const { displayStartOrEndDate, setDisplayStartOrEndDate } = filterState;
 			return (
-				<div className='ee-tickets-display-start-or-end-ticket-filter ee-filter-bar-filter'>
+				<div className='ee-filter-bar__filter'>
 					<DisplayStartOrEndDateControl
 						displayStartOrEndDate={displayStartOrEndDate}
 						setDisplayStartOrEndDate={setDisplayStartOrEndDate}
@@ -63,7 +63,7 @@ const useTicketsListFilterBar = (): TicketsListFilterBarCallback => {
 		registerFilterBarItem('sortBy', ({ filterState }) => {
 			const { sortBy, setSortBy } = filterState;
 			return (
-				<div className='ee-tickets-sort-by-filter ee-filter-bar-filter'>
+				<div className='ee-filter-bar__filter'>
 					<SortByControl sortBy={sortBy} setSortBy={setSortBy} />
 				</div>
 			);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
@@ -23,11 +23,10 @@ const TicketsChainedButton: React.FC<TicketsChainedButtonProps> = ({ isChained, 
 		? 'ee-filter-bar-filter-btn ee-active-filters ee-ticket-list-is-chained'
 		: 'ee-filter-bar-filter-btn ee-ticket-list-not-chained';
 	const icon = isChained ? Icon.LINK : Icon.UNLINK;
+
 	return (
 		<>
-			<label className='esprs-button-label screen-reader-text' htmlFor={'ee-ticket-list-filter-bar-is-chained'}>
-				{__('Only Show Tickets for Dates Above')}
-			</label>
+			<label className='esprs-button-label screen-reader-text'>{__('Only Show Tickets for Dates Above')}</label>
 			<EspressoButton
 				buttonType={EspressoButtonType.MINIMAL}
 				className={className}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/filterBar/controls/TicketsChainedButton.tsx
@@ -1,9 +1,8 @@
-/**
- * External imports
- */
 import React from 'react';
-import { EspressoButton, EspressoButtonType, Icon } from '@application/ui/input/EspressoButton';
+import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
+
+import { EspressoButton, EspressoButtonType, Icon } from '@application/ui/input/EspressoButton';
 
 interface TicketsChainedButtonProps {
 	isChained?: boolean;
@@ -16,13 +15,14 @@ interface TicketsChainedButtonProps {
  * will appear, otherwise ALL tickets will appear (subject to other filters)
  */
 const TicketsChainedButton: React.FC<TicketsChainedButtonProps> = ({ isChained, toggleIsChained }) => {
+	const className = classNames('ee-filter-bar__btn', {
+		'ee-filter-bar__btn--active': isChained,
+	});
+
+	const icon = isChained ? Icon.LINK : Icon.UNLINK;
 	const tooltip = isChained
 		? __('tickets list is linked to dates list and is showing tickets for above dates only')
 		: __('tickets list is unlinked and is showing tickets for all event dates');
-	const className = isChained
-		? 'ee-filter-bar-filter-btn ee-active-filters ee-ticket-list-is-chained'
-		: 'ee-filter-bar-filter-btn ee-ticket-list-not-chained';
-	const icon = isChained ? Icon.LINK : Icon.UNLINK;
 
 	return (
 		<>


### PR DESCRIPTION

## Problem this Pull Request solves
- there's **four** elements using the `ee-dates-datetimes-to-show-filter` class ?!?!?! :laughing:

- classes for the input wrapper divs is inconsistent, with `ee-filter-bar__filter`, `ee-filter-bar__select`, and `ee-filter-bar-filter`. They should all use the same class block and element name

- the outer divs for the "search" filters use the `ee-base-input` class, whereas all other filters use that on an inner div. The structural markup should be consistent for all filters.

- the "search" filter labels (and hidden isChained  label) are the only ones that implement the `for` attribute, which is important for a11y. IDs should be added for all inputs and `for` attributes added to each label using the corresponding ID accordingly.

- the CSS that was previously applied to the isChained button is missing. I'm guessing it's a result of the recent sass changes in that file. The nesting is likely off in the sass file but should be corrected.

- Closes: Fix Filter Bar Filter Markup and CSS Classes #2592
