### PR TITLE
Add eventAttendanceMode schema property

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -97,7 +97,7 @@ class EEH_Schema
             $template_args['venue_locality'] = $venue->city();
             $template_args['venue_region'] = $venue->state_name();
             $template_args['venue_address'] = $venue->address();
-            if ($venue->virtual_url() != '') {
+            if ($venue->virtual_url() !== '') {
                 $template_args['event_attendance_mode'] = 'OnlineEventAttendanceMode';
             }
             if ($venue->virtual_url() != '' && $venue->address() != '') {

--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -31,6 +31,7 @@ class EEH_Schema
             'event_description' => '',
             'event_start' => '',
             'event_end' => '',
+            'event_attendance_mode' => '',
             'event_status' => '',
             'currency' => '',
             'event_tickets' => array(),
@@ -59,6 +60,7 @@ class EEH_Schema
             default:
                 $event_status = 'EventScheduled';
         }
+        $template_args['event_attendance_mode'] = 'OfflineEventAttendanceMode';
         $template_args['event_status'] = $event_status;
         $template_args['currency'] = EE_Registry::instance()->CFG->currency->code;
         foreach ($event->tickets() as $original_ticket) {
@@ -95,6 +97,12 @@ class EEH_Schema
             $template_args['venue_locality'] = $venue->city();
             $template_args['venue_region'] = $venue->state_name();
             $template_args['venue_address'] = $venue->address();
+            if ($venue->virtual_url() != '') {
+                $template_args['event_attendance_mode'] = 'OnlineEventAttendanceMode';
+            }
+            if ($venue->virtual_url() != '' && $venue->address() != '') {
+                $template_args['event_attendance_mode'] = 'MixedEventAttendanceMode';
+            }
         }
         $template_args['event_image'] = $event->feature_image_url();
         $template_args = apply_filters(

--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -100,7 +100,7 @@ class EEH_Schema
             if ($venue->virtual_url() !== '') {
                 $template_args['event_attendance_mode'] = 'OnlineEventAttendanceMode';
             }
-            if ($venue->virtual_url() != '' && $venue->address() != '') {
+            if ($venue->virtual_url() !== '' && $venue->address() !== '') {
                 $template_args['event_attendance_mode'] = 'MixedEventAttendanceMode';
             }
         }

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -5,6 +5,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
 /** @var string $event_description */
 /** @var string $event_start */
 /** @var string $event_end */
+/** @var string $event_attendance_mode */
 /** @var string $event_status */
 /** @var string $currency */
 /** @var array $event_tickets */
@@ -23,6 +24,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
   "endDate": "<?php echo $event_end; ?>",
   "description": <?php echo wp_json_encode($event_description); ?>,
   "url": "<?php echo $event_permalink; ?>",
+  "eventAttendanceMode": "https://schema.org/<?php echo $event_attendance_mode; ?>",
   "eventStatus": "https://schema.org/<?php echo $event_status; ?>",
   "offers": [
     <?php


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
See http://p2.eventespresso.com/2020/03/23/this-week-in-event-espresso-march-22-march-28/#comment-20558
and also:
https://eventespresso.com/topic/google-schema-support/
https://eventespresso.com/topic/eventattendancemode-tags-for-schema-org-possible/
https://eventespresso.com/topic/eventattendancemode-tags-for-schema/

## How has this been tested
- [x] Check the page source of a published event page, with no venue assigned, it should now include '"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",' within the ld+json structured data
- [x] Check the page source of a published event page, with an venue assigned and no virtual URL set, it should include '"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",' within the ld+json structured data
- [x] Set an event to have a venue with **no** address **and** with a virtual URL, and check its page source, it should now include '"eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",'
- [x] Set an event to have a venue with an address **and** with a virtual URL, and check its page source, it should now include '"eventAttendanceMode": "https://schema.org/MixedEventAttendanceMode",'
- [x] Test the ld+json with the Structured data testing tool available at https://search.google.com/structured-data/testing-tool/u/0/

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
