### PR TITLE
Fix TAM relations | Closes #2601

### DIFF
--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOptimisticResponse.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOptimisticResponse.ts
@@ -10,7 +10,7 @@ import { removeNullAndUndefined } from '@appServices/utilities/predicates';
 import { ucFirst } from '@appServices/utilities/text';
 
 export const DATETIME_DEFAULTS: Datetime = {
-	id: 'NEW',
+	id: '',
 	dbId: 0,
 	capacity: -1,
 	description: '',

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOptimisticResponse.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOptimisticResponse.ts
@@ -10,7 +10,7 @@ import { removeNullAndUndefined } from '@appServices/utilities/predicates';
 import { ucFirst } from '@appServices/utilities/text';
 
 export const TICKET_DEFAULTS: Ticket = {
-	id: 'NEW',
+	id: '',
 	dbId: 0,
 	description: '',
 	endDate: PLUS_TWO_MONTHS.toISOString(),


### PR DESCRIPTION
This PR sets the `id` for optimistic responses to be empty to avoid them being added to relations, which creates problems for Ticket Assignment Manager because it checks for the relations strictly.
Closes #2601