### PR TITLE
Fix no prices after creating a ticket | Closes #2632 

### DIFF
--- a/assets/src/domain/eventEditor/hooks/entityListCacheUpdates/test/useUpdatePriceTypeList.test.ts
+++ b/assets/src/domain/eventEditor/hooks/entityListCacheUpdates/test/useUpdatePriceTypeList.test.ts
@@ -5,6 +5,7 @@ import { useCacheRehydration } from '@edtrServices/apollo/initialization';
 import useUpdatePriceTypeList from '../useUpdatePriceTypeList';
 import { usePriceTypeQueryOptions, usePriceTypes } from '@edtrServices/apollo/queries';
 import { ApolloMockedProvider } from '@edtrServices/context/TestContext';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useUpdatePriceTypeList', () => {
@@ -59,7 +60,7 @@ describe('useUpdatePriceTypeList', () => {
 		);
 		await waitForUpdate({ timeout });
 
-		const cachedPriceTypeIds = cacheResult.current.map(({ id }) => id);
+		const cachedPriceTypeIds = getGuids(cacheResult.current);
 
 		expect(cachedPriceTypeIds.length).toBe(priceTypelist.length + 1);
 

--- a/assets/src/domain/eventEditor/hooks/entityListCacheUpdates/test/useUpdatePricetList.test.ts
+++ b/assets/src/domain/eventEditor/hooks/entityListCacheUpdates/test/useUpdatePricetList.test.ts
@@ -5,6 +5,7 @@ import { useCacheRehydration } from '@edtrServices/apollo/initialization';
 import useUpdatePriceList from '../useUpdatePriceList';
 import { usePriceQueryOptions, usePrices } from '@edtrServices/apollo/queries';
 import { ApolloMockedProvider } from '@edtrServices/context/TestContext';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useUpdatePriceList', () => {
@@ -59,7 +60,7 @@ describe('useUpdatePriceList', () => {
 		);
 		await waitForUpdate({ timeout });
 
-		const cachedPriceIds = cacheResult.current.map(({ id }) => id);
+		const cachedPriceIds = getGuids(cacheResult.current);
 
 		expect(cachedPriceIds.length).toBe(pricelist.length + 1);
 

--- a/assets/src/domain/eventEditor/services/apollo/initialization/useCacheRehydration.ts
+++ b/assets/src/domain/eventEditor/services/apollo/initialization/useCacheRehydration.ts
@@ -23,6 +23,7 @@ import {
 	useGeneralSettingsQueryOptions,
 	useUpdateGeneralSettingsCache,
 } from '@sharedServices/apollo/queries/generalSettings';
+import { getGuids } from '@sharedServices/predicates';
 
 const useCacheRehydration = (): void => {
 	const { initialize: initializeRelations, isInitialized: relationsInitialized } = useRelations();
@@ -39,8 +40,8 @@ const useCacheRehydration = (): void => {
 	} = useCacheRehydrationData();
 	const { isLoaded } = useStatus();
 
-	const datetimeIn = pathOr<Datetime[]>([], ['nodes'], espressoDatetimes).map(({ id }) => id);
-	const ticketIn = pathOr<Ticket[]>([], ['nodes'], espressoTickets).map(({ id }) => id);
+	const datetimeIn = getGuids(pathOr<Datetime[]>([], ['nodes'], espressoDatetimes));
+	const ticketIn = getGuids(pathOr<Ticket[]>([], ['nodes'], espressoTickets));
 
 	const priceTypeQueryOptions = usePriceTypeQueryOptions();
 	const updatePriceTypeList = useUpdatePriceTypeList();

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/createDatetime.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/createDatetime.test.ts
@@ -14,6 +14,7 @@ import useDatetimeIds from '../../../queries/datetimes/useDatetimeIds';
 import useInitTicketTestCache from '../../../queries/tickets/test/useInitTicketTestCache';
 import useTickets from '../../../queries/tickets/useTickets';
 import useTicketQueryOptions from '../../../queries/tickets/useTicketQueryOptions';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 
@@ -21,7 +22,7 @@ describe('createDatetime', () => {
 	let testInput: MutationInput = { name: 'New Test Date', description: 'New Test Desc' };
 	const mockedDatetime = mockedDatetimes.CREATE;
 
-	const ticketIds = tickets.map(({ id }) => id);
+	const ticketIds = getGuids(tickets);
 
 	let mutationMocks = getMutationMocks(testInput, MutationType.Create);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/deleteDatetime.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/deleteDatetime.test.ts
@@ -7,13 +7,14 @@ import { ApolloMockedProvider } from '../../../../context/TestContext';
 import { getMutationMocks, mockedDatetimes } from './data';
 import { nodes as tickets } from '../../../queries/tickets/test/data';
 import { useDatetimeMutator } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 
 describe('deleteDatetime', () => {
 	const mockedDatetime = mockedDatetimes.DELETE;
 
-	const ticketIds = tickets.map(({ id }) => id);
+	const ticketIds = getGuids(tickets);
 
 	let mutationMocks = getMutationMocks({}, MutationType.Delete);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/updateDatetime.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/updateDatetime.test.ts
@@ -8,13 +8,14 @@ import { getMutationMocks, mockedDatetimes } from './data';
 import { nodes as tickets } from '../../../queries/tickets/test/data';
 import useInitDatetimeTestCache from '../../../queries/datetimes/test/useInitDatetimeTestCache';
 import { useDatetimeMutator, UpdateDatetimeInput } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('updateDatetime', () => {
 	const mockedDatetime = mockedDatetimes.UPDATE;
 	let testInput: UpdateDatetimeInput = { ...mockedDatetime, name: 'New Test Date', description: 'New Test Desc' };
 
-	const ticketIds = tickets.map(({ id }) => id);
+	const ticketIds = getGuids(tickets);
 
 	let mutationMocks = getMutationMocks({ ...testInput, id: mockedDatetime.id }, MutationType.Update);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnCreateDatetime.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnCreateDatetime.ts
@@ -1,8 +1,8 @@
 import updateTicketCache from './updateTicketCache';
 import useUpdateDatetimeCache from './useUpdateDatetimeCache';
-import { Datetime } from '@edtrServices/apollo/types';
 import { DatetimeMutationCallbackFn, DatetimeMutationCallbackFnArgs } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@sharedServices/predicates';
 
 const useOnCreateDatetime = (): DatetimeMutationCallbackFn => {
 	const { updateRelations, addRelation } = useRelations();
@@ -12,7 +12,7 @@ const useOnCreateDatetime = (): DatetimeMutationCallbackFn => {
 	const onCreateDatetime = ({ proxy, datetimes, datetime, tickets }: DatetimeMutationCallbackFnArgs): void => {
 		if (datetime.id) {
 			const { nodes = [] } = datetimes;
-			const datetimeIn = nodes.map(({ id }: Datetime) => id);
+			const datetimeIn = getGuids(nodes).sort();
 			const { id: datetimeId } = datetime;
 
 			// Update tickets cache for the changed datetimes,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnDeleteDatetime.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnDeleteDatetime.ts
@@ -2,6 +2,7 @@ import updateTicketCache from './updateTicketCache';
 import useUpdateDatetimeCache from './useUpdateDatetimeCache';
 import { DatetimeMutationCallbackFn, DatetimeMutationCallbackFnArgs, CacheUpdaterFn } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@sharedServices/predicates';
 
 const useOnDeleteDatetime = (): DatetimeMutationCallbackFn => {
 	const { dropRelations, removeRelation } = useRelations();
@@ -11,7 +12,7 @@ const useOnDeleteDatetime = (): DatetimeMutationCallbackFn => {
 	const onDeleteDatetime = ({ proxy, datetimes, datetime }: DatetimeMutationCallbackFnArgs): void => {
 		if (datetime.id) {
 			const { nodes = [] } = datetimes;
-			const datetimeIn = nodes.map(({ id }) => id);
+			const datetimeIn = getGuids(nodes).sort();
 			const { id: datetimeId } = datetime;
 
 			// Update tickets cache for the changed datetimes,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/createPrice.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/createPrice.test.ts
@@ -10,6 +10,7 @@ import usePrices from '../../../queries/prices/usePrices';
 import { nodes as tickets } from '../../../queries/tickets/test/data';
 import { nodes as priceTypes } from '../../../queries/priceTypes/test/data';
 import { usePriceMutator, CreatePriceInput } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('createPrice', () => {
@@ -90,7 +91,7 @@ describe('createPrice', () => {
 		// wait for mutation promise to resolve
 		await waitForUpdate({ timeout });
 
-		const cachedPriceIds = cacheResult.current.map(({ id }) => id);
+		const cachedPriceIds = getGuids(cacheResult.current);
 
 		expect(cachedPriceIds).toContain(mockedPrice.id);
 	});

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/deletePrice.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/deletePrice.test.ts
@@ -7,12 +7,13 @@ import { ApolloMockedProvider } from '../../../../context/TestContext';
 import { getMutationMocks, mockedPrices } from './data';
 import { nodes as tickets } from '../../../queries/tickets/test/data';
 import { usePriceMutator } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('deletePrice', () => {
 	const mockedPrice = mockedPrices.DELETE;
 
-	const ticketIds = tickets.map(({ id }) => id);
+	const ticketIds = getGuids(tickets);
 
 	let mutationMocks = getMutationMocks({}, MutationType.Delete);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/createTicket.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/createTicket.test.ts
@@ -12,14 +12,15 @@ import { MutationInput } from '../../../../../../../application/services/apollo/
 import useTicketItem from '../../../queries/tickets/useTicketItem';
 import useTicketIds from '../../../queries/tickets/useTicketIds';
 import { useTicketMutator } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('createTicket', () => {
 	let testInput: MutationInput = { name: 'New Test Ticket', description: 'New Test Desc' };
 	const mockedTicket = mockedTickets.CREATE;
 
-	const datetimeIds = datetimes.map(({ id }) => id);
-	const priceIds = prices.map(({ id }) => id);
+	const datetimeIds = getGuids(datetimes);
+	const priceIds = getGuids(prices);
 
 	let mutationMocks = getMutationMocks(testInput, MutationType.Create);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/deleteTicket.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/deleteTicket.test.ts
@@ -8,13 +8,14 @@ import { getMutationMocks, mockedTickets } from './data';
 import { nodes as datetimes } from '../../../queries/datetimes/test/data';
 import { nodes as prices } from '../../../queries/prices/test/data';
 import { useTicketMutator } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('deleteTicket', () => {
 	const mockedTicket = mockedTickets.DELETE;
 
-	const datetimeIds = datetimes.map(({ id }) => id);
-	const priceIds = prices.map(({ id }) => id);
+	const datetimeIds = getGuids(datetimes);
+	const priceIds = getGuids(prices);
 
 	let mutationMocks = getMutationMocks({}, MutationType.Delete);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/updateTicket.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/updateTicket.test.ts
@@ -10,14 +10,15 @@ import { nodes as prices } from '../../../queries/prices/test/data';
 import { MutationInput } from '../../../../../../../application/services/apollo/mutations/types';
 import useInitTicketTestCache from '../../../queries/tickets/test/useInitTicketTestCache';
 import { useTicketMutator } from '../';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('updateTicket', () => {
 	const mockedTicket = mockedTickets.UPDATE;
 	let testInput: MutationInput = { ...mockedTicket, name: 'New Test Ticket', description: 'New Test Desc' };
 
-	const datetimeIds = datetimes.map(({ id }) => id);
-	const priceIds = prices.map(({ id }) => id);
+	const datetimeIds = getGuids(datetimes);
+	const priceIds = getGuids(prices);
 
 	let mutationMocks = getMutationMocks({ ...testInput, id: mockedTicket.id }, MutationType.Update);
 

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
@@ -2,9 +2,10 @@ import { pathOr } from 'ramda';
 
 import updatePriceCache from './updatePriceCache';
 import useUpdateTicketCache from './useUpdateTicketCache';
-import { Ticket, Price } from '@edtrServices/apollo/types';
+import { Price } from '@edtrServices/apollo/types';
 import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@sharedServices/predicates';
 
 const useOnCreateTicket = (): TicketMutationCallbackFn => {
 	const { updateRelations, addRelation } = useRelations();
@@ -14,7 +15,7 @@ const useOnCreateTicket = (): TicketMutationCallbackFn => {
 	const onCreateTicket = ({ proxy, datetimeIds, ticket, tickets, prices }: TicketMutationCallbackFnArgs): void => {
 		if (ticket.id) {
 			const { nodes = [] } = tickets;
-			const ticketIn = nodes.map(({ id }: Ticket) => id);
+			const ticketIn = getGuids(nodes).sort();
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,
@@ -38,7 +39,7 @@ const useOnCreateTicket = (): TicketMutationCallbackFn => {
 			});
 
 			// Set relations with prices
-			const priceIds = pathOr<Price[]>([], ['nodes'], prices).map(({ id }: Price) => id);
+			const priceIds = getGuids(pathOr<Price[]>([], ['nodes'], prices));
 			updateRelations({
 				entity: 'tickets',
 				entityId: ticketId,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
@@ -1,8 +1,8 @@
 import updatePriceCache from './updatePriceCache';
 import useUpdateTicketCache from './useUpdateTicketCache';
-import { Ticket } from '@edtrServices/apollo/types';
 import { TicketMutationCallbackFn, TicketMutationCallbackFnArgs } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@sharedServices/predicates';
 
 const useOnDeleteTicket = (): TicketMutationCallbackFn => {
 	const { dropRelations, removeRelation } = useRelations();
@@ -12,7 +12,7 @@ const useOnDeleteTicket = (): TicketMutationCallbackFn => {
 	const onDeleteTicket = ({ proxy, tickets, ticket }: TicketMutationCallbackFnArgs): void => {
 		if (ticket.id) {
 			const { nodes = [] } = tickets;
-			const ticketIn = nodes.map(({ id }: Ticket) => id);
+			const ticketIn = getGuids(nodes).sort();
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,

--- a/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useDatetimeIds.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/datetimes/test/useDatetimeIds.test.ts
@@ -4,6 +4,7 @@ import useDatetimeIds from '../useDatetimeIds';
 import { ApolloMockedProvider } from '../../../../../services/context/TestContext';
 import { nodes } from './data';
 import useInitDatetimeTestCache from './useInitDatetimeTestCache';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useDatetimeIds()', () => {
@@ -26,7 +27,7 @@ describe('useDatetimeIds()', () => {
 		await waitForValueToChange(() => result.current, { timeout });
 
 		const { current: cachedDatetimeIds } = result;
-		const passedDatetimeIds = nodes.map(({ id }) => id);
+		const passedDatetimeIds = getGuids(nodes);
 
 		expect(cachedDatetimeIds.length).toEqual(passedDatetimeIds.length);
 

--- a/assets/src/domain/eventEditor/services/apollo/queries/prices/test/usePriceQueryOptions.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/prices/test/usePriceQueryOptions.test.ts
@@ -4,6 +4,7 @@ import usePriceQueryOptions from '../usePriceQueryOptions';
 import { ApolloMockedProvider } from '../../../../../services/context/TestContext';
 import { nodes } from '../../tickets/test/data';
 import useInitTicketTestCache from '../../tickets/test/useInitTicketTestCache';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('usePriceQueryOptions()', () => {
@@ -18,6 +19,6 @@ describe('usePriceQueryOptions()', () => {
 		);
 		await waitForValueToChange(() => result.current, { timeout });
 
-		expect(result.current.variables.where.ticketIn).toEqual(nodes.map(({ id }) => id).sort());
+		expect(result.current.variables.where.ticketIn).toEqual(getGuids(nodes).sort());
 	});
 });

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketIds.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketIds.test.ts
@@ -4,6 +4,7 @@ import useTicketIds from '../useTicketIds';
 import { ApolloMockedProvider } from '../../../../../services/context/TestContext';
 import { nodes } from './data';
 import useInitTicketTestCache from './useInitTicketTestCache';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useTicketIds()', () => {
@@ -26,7 +27,7 @@ describe('useTicketIds()', () => {
 		await waitForValueToChange(() => result.current, { timeout });
 
 		const { current: cachedTicketIds } = result;
-		const passedTicketIds = nodes.map(({ id }) => id);
+		const passedTicketIds = getGuids(nodes);
 
 		expect(cachedTicketIds.length).toEqual(passedTicketIds.length);
 

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketPrices.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketPrices.test.ts
@@ -6,6 +6,7 @@ import { nodes } from './data';
 import useInitTicketTestCache from './useInitTicketTestCache';
 import useInitPriceTestCache from '../../prices/test/useInitPriceTestCache';
 import { useRelations } from '../../../../../../../application/services/apollo/relations';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useTicketPrices', () => {
@@ -85,7 +86,7 @@ describe('useTicketPrices', () => {
 
 		const { current: cachedTicketPrices } = result;
 
-		const cachedTicketPriceIds = cachedTicketPrices.map(({ id }) => id);
+		const cachedTicketPriceIds = getGuids(cachedTicketPrices);
 
 		expect(cachedTicketPriceIds.length).toEqual(relatedTicketPriceIds.length);
 

--- a/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketQueryOptions.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/queries/tickets/test/useTicketQueryOptions.test.ts
@@ -4,6 +4,7 @@ import useTicketQueryOptions from '../useTicketQueryOptions';
 import { ApolloMockedProvider } from '../../../../../services/context/TestContext';
 import { nodes } from '../../datetimes/test/data';
 import useInitDatetimeTestCache from '../../datetimes/test/useInitDatetimeTestCache';
+import { getGuids } from '@sharedServices/predicates';
 
 const timeout = 5000; // milliseconds
 describe('useTicketQueryOptions', () => {
@@ -18,6 +19,6 @@ describe('useTicketQueryOptions', () => {
 		);
 		await waitForValueToChange(() => result.current, { timeout });
 
-		expect(result.current.variables.where.datetimeIn).toEqual(nodes.map(({ id }) => id).sort());
+		expect(result.current.variables.where.datetimeIn).toEqual(getGuids(nodes).sort());
 	});
 });

--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useDeleteTicketHandler.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useDeleteTicketHandler.ts
@@ -4,6 +4,7 @@ import useTicketPrices from '@edtrServices/apollo/queries/tickets/useTicketPrice
 import { EntityListItemProps } from '@appLayout/entityList';
 import { BackwardSubscription } from '@appServices/apollo/mutations';
 import { useTicketMutator, usePriceMutator } from '@edtrServices/apollo/mutations';
+import { getGuids } from '@sharedServices/predicates';
 
 type VoidFn = () => void;
 
@@ -17,7 +18,7 @@ const useDeleteTicketHandler = ({ id }: EntityListItemProps): VoidFn => {
 			onCompleted: (): void => {
 				// The prices that are not default or tax prices.
 				const pricesToDelete = relatedPrices.filter(({ isDefault, isTax }) => !isDefault && !isTax);
-				const priceIdsToDelete = pricesToDelete.map(({ id }) => id);
+				const priceIdsToDelete = getGuids(pricesToDelete);
 				priceIdsToDelete.forEach((id) => {
 					deletePrice({ id });
 				});

--- a/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.test.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.test.ts
@@ -17,6 +17,7 @@ import {
 	getTaxes,
 } from './index';
 import { nodes as prices } from '../../../../../eventEditor/services/apollo/queries/prices/test/data';
+import { getGuids } from '@sharedServices/predicates';
 
 describe('isPriceField', () => {
 	it('should return true if field is included in price type', () => {
@@ -214,7 +215,7 @@ describe('getPriceByDbId', () => {
 
 describe('getPriceByGuid', () => {
 	it('should return price entity with corresponding id', () => {
-		const ids = prices.map(({ id }) => id);
+		const ids = getGuids(prices);
 		ids.forEach((id) => {
 			const price = getPriceByGuid(prices, id);
 			expect(price.id).toBe(id);

--- a/assets/src/domain/shared/services/predicates/selectionById/index.test.ts
+++ b/assets/src/domain/shared/services/predicates/selectionById/index.test.ts
@@ -18,6 +18,7 @@ import {
 } from './index';
 import { nodes as datetimes } from '../../../../eventEditor/services/apollo/queries/datetimes/test/data';
 import { nodes as tickets } from '../../../../eventEditor/services/apollo/queries/tickets/test/data';
+import { getGuids } from '@sharedServices/predicates';
 
 describe('entityDbId', () => {
 	it('should return dbId for each entity', () => {
@@ -78,7 +79,7 @@ describe('findEntityByDbId', () => {
 
 describe('findEntityByGuid', () => {
 	it('should return the entity with corresponding id', () => {
-		const ids = datetimes.map(({ id }) => id);
+		const ids = getGuids(datetimes);
 
 		ids.forEach((id) => {
 			const entity = findEntityByGuid(datetimes)(id);
@@ -124,7 +125,7 @@ describe('entitiesWithDbIdInArray', () => {
 
 describe('entitiesWithGuIdInArray', () => {
 	it('should return an array of entities corresponding to provided ids', () => {
-		const ids = tickets.map(({ id }) => id);
+		const ids = getGuids(tickets);
 		const entities = entitiesWithGuIdInArray(tickets, ids);
 
 		expect(entities.length).toBe(tickets.length);


### PR DESCRIPTION
This PR fixes the issue of prices disappearing when creating a ticket which was happening because of Ticket ids not sorted when writing prices to the cache:
- Adds sorting to `ticketIn` and `datetimeIn` when writing prices and tickets cache respectively
- Updates `.map()` wherever needed to use `getGuid`.
- Closes #2632 