### PR TITLE
Fix confirm_email being automatically added to address info.

### DIFF
--- a/core/db_models/EEM_Question.model.php
+++ b/core/db_models/EEM_Question.model.php
@@ -331,8 +331,7 @@ class EEM_Question extends EEM_Soft_Delete_Base
                     EEM_Attendee::system_question_state,
                     EEM_Attendee::system_question_country,
                     EEM_Attendee::system_question_zip,
-                    EEM_Attendee::system_question_phone,
-                    EEM_Attendee::system_question_email_confirm
+                    EEM_Attendee::system_question_phone
                 );
                 break;
         }

--- a/core/db_models/EEM_Question.model.php
+++ b/core/db_models/EEM_Question.model.php
@@ -331,7 +331,8 @@ class EEM_Question extends EEM_Soft_Delete_Base
                     EEM_Attendee::system_question_state,
                     EEM_Attendee::system_question_country,
                     EEM_Attendee::system_question_zip,
-                    EEM_Attendee::system_question_phone
+                    EEM_Attendee::system_question_phone,
+                    EEM_Attendee::system_question_email_confirm
                 );
                 break;
         }

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -1096,7 +1096,7 @@ class EEH_Activation implements ResettableInterface
                     $QST_ID = $wpdb->insert_id;
 
                     // skip adding email_confirm to a question group
-                    if ( $QST_system === 'email_confirm' ) {
+                    if ($QST_system === 'email_confirm') {
                         continue;
                     }
 

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -1094,6 +1094,12 @@ class EEH_Activation implements ResettableInterface
                         array('%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d', '%d')
                     );
                     $QST_ID = $wpdb->insert_id;
+
+                    // skip adding email_confirm to a question group
+                    if ( $QST_system === 'email_confirm' ) {
+                        continue;
+                    }
+
                     // QUESTION GROUP QUESTIONS
                     if (in_array($QST_system, array('fname', 'lname', 'email'))) {
                         $system_question_we_want = EEM_Question_Group::system_personal;

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -898,19 +898,15 @@ class EEH_Activation implements ResettableInterface
         $SQL = "SELECT QST_system FROM $table_name WHERE QST_system != ''";
         // what we have
         $questions = $wpdb->get_col($SQL);
-        // what we should have
-        $QST_systems = array(
-            'fname',
-            'lname',
-            'email',
-            'email_confirm',
-            'address',
-            'address2',
-            'city',
-            'country',
-            'state',
-            'zip',
-            'phone',
+        // all system questions
+        $personal_system_group_questions = ['fname', 'lname', 'email'];
+        $address_system_group_questions = ['address', 'address2', 'city', 'country', 'state', 'zip', 'phone'];
+        $system_questions_not_in_group = ['email_confirm'];
+        // merge all of the system questions we should have
+        $QST_systems = array_merge(
+            $personal_system_group_questions,
+            $address_system_group_questions,
+            $system_questions_not_in_group
         );
         $order_for_group_1 = 1;
         $order_for_group_2 = 1;

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -1091,16 +1091,14 @@ class EEH_Activation implements ResettableInterface
                     );
                     $QST_ID = $wpdb->insert_id;
 
-                    // skip adding email_confirm to a question group
-                    if ($QST_system === 'email_confirm') {
-                        continue;
-                    }
-
                     // QUESTION GROUP QUESTIONS
-                    if (in_array($QST_system, array('fname', 'lname', 'email'))) {
+                    if (in_array($QST_system, $personal_system_group_questions)) {
                         $system_question_we_want = EEM_Question_Group::system_personal;
-                    } else {
+                    } else if (in_array($QST_system, $address_system_group_questions)) {
                         $system_question_we_want = EEM_Question_Group::system_address;
+                    } else {
+                        // QST_system should not be assigned to any group
+                        continue;
                     }
                     if (isset($QSG_IDs[ $system_question_we_want ])) {
                         $QSG_ID = $QSG_IDs[ $system_question_we_want ];

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -138,6 +138,7 @@ class EEH_Activation implements ResettableInterface
         EEH_Activation::insert_default_status_codes();
         EEH_Activation::generate_default_message_templates();
         EEH_Activation::create_no_ticket_prices_array();
+        EEH_Activation::removeEmailConfirmFromAddressGroup();
 
         EEH_Activation::validate_messages_system();
         EEH_Activation::insert_default_payment_methods();
@@ -1094,7 +1095,7 @@ class EEH_Activation implements ResettableInterface
                     // QUESTION GROUP QUESTIONS
                     if (in_array($QST_system, $personal_system_group_questions)) {
                         $system_question_we_want = EEM_Question_Group::system_personal;
-                    } else if (in_array($QST_system, $address_system_group_questions)) {
+                    } elseif (in_array($QST_system, $address_system_group_questions)) {
                         $system_question_we_want = EEM_Question_Group::system_address;
                     } else {
                         // QST_system should not be assigned to any group
@@ -1667,5 +1668,27 @@ class EEH_Activation implements ResettableInterface
     {
         self::$_default_creator_id                             = null;
         self::$_initialized_db_content_already_in_this_request = false;
+    }
+
+    /**
+     * Removes 'email_confirm' from the Address info question group on activation
+     * @return void
+     */
+    public static function removeEmailConfirmFromAddressGroup()
+    {
+
+        // Pull the email_confirm question ID.
+        $email_confirm_question_id = EEM_Question::instance()->get_Question_ID_from_system_string(
+            EEM_Attendee::system_question_email_confirm
+        );
+        // Remove the email_confirm question group from the address group questions.
+        EEM_Question_Group_Question::instance()->delete(
+            array(
+                array(
+                    'QST_ID' => $email_confirm_question_id,
+                    'Question_Group.QSG_system' => EEM_Question_Group::system_address,
+                ),
+            )
+        );
     }
 }


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/confirm-email-address/

Confirmed on my site.

The new confirm_email system question is automatically added to the address question group (as it's a system question it is automatically added to either Personal info or Address Info).

This branch skips that on activation but also allows the email_confirm question to show up in the address info question group so users can fix this themselves.

We should probably remove that again and add some code to automatically remove that new system question from the group but this gets a quick fix out the door.

## How has this been tested
On a site that is NOT running 4.10.5 already, update to this branch.

Enable the address question on an event and confirm that the confirm email question doesn't show in that group when registering.

---

On a site already running 4.10.5, before switching to this branch if you don't have an event with address info enabled, enable it and open the registration form.

You'll see the 'confirm email' question in that group on the front end.

Switch to this branch and retest, the confirm email question should no longer show.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
