### PR TITLE
Fix filter bar buttons tooltip | Closes #2652

### DIFF
--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/CardViewFilterButton.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/CardViewFilterButton.tsx
@@ -6,8 +6,9 @@ import { __ } from '@wordpress/i18n';
 import { CardViewFilterButtonProps } from '../types';
 import { EspressoButton, EspressoButtonType } from '@application/ui/input';
 import { LabelPosition } from '@application/ui/display';
+import { getPropsAreEqual } from '@appServices/utilities';
 
-const CardViewFilterButton: React.FC<CardViewFilterButtonProps> = React.memo(({ listId, setCardView, view }) => {
+const CardViewFilterButton: React.FC<CardViewFilterButtonProps> = ({ listId, setCardView, view }) => {
 	const className = classNames('ee-filter-bar__btn', { 'ee-filter-bar__btn--active': view === 'card' });
 	const filterId = `ee-card-view-btn-${listId}`;
 
@@ -15,16 +16,15 @@ const CardViewFilterButton: React.FC<CardViewFilterButtonProps> = React.memo(({ 
 		<EspressoButton
 			buttonType={EspressoButtonType.MINIMAL}
 			className={className}
-			disabled={view === 'card'}
 			icon={<AppstoreFilled />}
 			id={filterId}
 			label={__('card view')}
-			onClick={setCardView}
+			onClick={view !== 'card' ? setCardView : null}
 			tooltip={__('card view')}
 			labelClassName={'ee-filter-bar__btn-wrap'}
 			labelPosition={LabelPosition.BOTTOM_CENTER}
 		/>
 	);
-});
+};
 
-export default CardViewFilterButton;
+export default React.memo(CardViewFilterButton, getPropsAreEqual(['listId'], ['view']));

--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/TableViewFilterButton.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/TableViewFilterButton.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { EspressoButton, EspressoButtonType, Icon } from '@application/ui/input';
 import { LabelPosition } from '@application/ui/display';
 import { TableViewFilterButtonProps } from '../types';
+import { getPropsAreEqual } from '@appServices/utilities';
 
 const TableViewFilterButton: React.FC<TableViewFilterButtonProps> = React.memo(({ listId, setTableView, view }) => {
 	const className = classNames('ee-filter-bar__btn', { 'ee-filter-bar__btn--active': view === 'table' });
@@ -14,11 +15,10 @@ const TableViewFilterButton: React.FC<TableViewFilterButtonProps> = React.memo((
 		<EspressoButton
 			buttonType={EspressoButtonType.MINIMAL}
 			className={className}
-			disabled={view === 'table'}
 			icon={Icon.TABLE_VIEW}
 			id={filterId}
 			label={__('table view')}
-			onClick={setTableView}
+			onClick={view !== 'table' ? setTableView : null}
 			tooltip={__('table view')}
 			labelClassName={'ee-filter-bar__btn-wrap'}
 			labelPosition={LabelPosition.BOTTOM_CENTER}
@@ -26,4 +26,4 @@ const TableViewFilterButton: React.FC<TableViewFilterButtonProps> = React.memo((
 	);
 });
 
-export default TableViewFilterButton;
+export default React.memo(TableViewFilterButton, getPropsAreEqual(['listId'], ['view']));

--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/ToggleFiltersButton.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/ToggleFiltersButton.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { EspressoButton, EspressoButtonType, Icon } from '@appInputs/EspressoButton';
 import { LabelPosition } from '@application/ui/display';
 import { ToggleFiltersButtonProps } from '../types';
+import { getPropsAreEqual } from '@appServices/utilities';
 
 const ToggleFiltersButton: React.FC<ToggleFiltersButtonProps> = React.memo(({ listId, showFilters, toggleFilters }) => {
 	const className = classNames('ee-filter-bar__btn', { 'ee-filter-bar__btn--active': showFilters });
@@ -26,4 +27,4 @@ const ToggleFiltersButton: React.FC<ToggleFiltersButtonProps> = React.memo(({ li
 	);
 });
 
-export default ToggleFiltersButton;
+export default React.memo(ToggleFiltersButton, getPropsAreEqual(['listId'], ['showFilters']));

--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/ToggleLegendButton.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/ToggleLegendButton.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { EspressoButton, EspressoButtonType } from '@appInputs/EspressoButton';
 import { LabelPosition } from '@application/ui/display';
 import { ToggleLegendButtonProps } from '../types';
+import { getPropsAreEqual } from '@appServices/utilities';
 
 const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({ listId, showLegend, toggleLegend }) => {
 	const className = classNames('ee-filter-bar__btn', { 'ee-filter-bar__btn--active': showLegend });
@@ -19,7 +20,7 @@ const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({ listId, showLeg
 		</animated.div>
 	);
 	const filterId = `ee-toggle-legend-btn-${listId}`;
-	const tooltip = __(`${showLegend ? 'hide' : 'show'} legend`);
+	const tooltip = showLegend ? __('hide legend') : __('show legend');
 
 	return (
 		<EspressoButton
@@ -36,4 +37,4 @@ const ToggleLegendButton: React.FC<ToggleLegendButtonProps> = ({ listId, showLeg
 	);
 };
 
-export default ToggleLegendButton;
+export default React.memo(ToggleLegendButton, getPropsAreEqual(['listId'], ['showLegend']));


### PR DESCRIPTION
This PR fixes the issue of filter bar buttons tooltip not closing. The issue was because of the current view button getting disabled thus preventing `focus` and `blur` events.