### PR TITLE
JSON+LD output: Allow multiple event statuses to be passed in via filter

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -61,7 +61,7 @@ class EEH_Schema
                 $event_status = 'EventScheduled';
         }
         $template_args['event_attendance_mode'] = 'OfflineEventAttendanceMode';
-        $template_args['event_status'] = $event_status;
+        $template_args['event_status'] = '"https://schema.org/' . $event_status . '"';
         $template_args['currency'] = EE_Registry::instance()->CFG->currency->code;
         foreach ($event->tickets() as $original_ticket) {
             // clone tickets so that date formats don't override those for the original ticket

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -25,7 +25,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
   "description": <?php echo wp_json_encode($event_description); ?>,
   "url": "<?php echo $event_permalink; ?>",
   "eventAttendanceMode": "https://schema.org/<?php echo $event_attendance_mode; ?>",
-  "eventStatus": "https://schema.org/<?php echo $event_status; ?>",
+  "eventStatus": [ <?php echo $event_status; ?> ],
   "offers": [
     <?php
     $i = 0;


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See: https://eventespresso.com/topic/eventattendancemode-tags-for-schema/#post-310388

A few tweaks to the way we pass in the status to the template will help allow for showing more than one event status.
See also:
https://developers.google.com/search/docs/data-types/event#eventstatus

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
View the source of the event page and copy the ld+json event schema output and paste into the Structured data Testing Tool available here:
https://search.google.com/structured-data/testing-tool/u/0/

If you want to test the filter hook, here's some example code:
```
add_filter(
    'FHEE__EEH_Schema__add_json_linked_data_for_event__template_args',
    'my_custom_json_linked_data_function',
    10,
    3
);
function my_custom_json_linked_data_function(
    $template_args,
    $event,
    $VNU_ID
) {
    $template_args['event_status'] .= ', "https://schema.org/EventMovedOnline"';
    return $template_args;
}
```
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)