### PR TITLE
Add Status Labels to Date and Ticket Sidebars; closes #2625.

### DIFF
--- a/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/index.tsx
+++ b/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/index.tsx
@@ -12,8 +12,10 @@ const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = React.memo(
 	({ className, displayDate = DisplayStartOrEndDate.start, labels, ...props }) => {
 		const startDate = parseISO(props.startDate) || PLUS_ONE_MONTH;
 		const endDate = parseISO(props.endDate) || PLUS_TWO_MONTHS;
-		const headerText = switchTenseForDate(startDate, labels?.headerPast ?? '', labels?.headerFuture ?? '');
-		const footerText = switchTenseForDate(endDate, labels?.footerPast ?? '', labels?.footerFuture ?? '');
+		const { footer = '', footerPast, footerFuture, header = '', headerPast, headerFuture } = labels;
+		const footerText = footerPast && footerFuture ? switchTenseForDate(endDate, footerPast, footerFuture) : footer;
+		const headerText =
+			headerPast && headerFuture ? switchTenseForDate(startDate, headerPast, headerFuture) : header;
 
 		const start = (
 			<BiggieCalendarDate

--- a/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/types.ts
+++ b/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/types.ts
@@ -1,8 +1,10 @@
 import { DisplayStartOrEndDate } from '@sharedServices/filterState';
 
-interface CalendarDateLabels {
+export interface CalendarDateLabels {
+	header?: string;
 	headerPast?: string;
 	headerFuture?: string;
+	footer?: string;
 	footerPast?: string;
 	footerFuture?: string;
 }
@@ -11,7 +13,7 @@ export interface CalendarDateSwitcherProps {
 	className?: string;
 	displayDate: DisplayStartOrEndDate;
 	endDate: string;
-	labels?: CalendarDateLabels;
+	labels: CalendarDateLabels;
 	showDate?: boolean;
 	startDate: string;
 }

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCard.tsx
@@ -5,7 +5,7 @@ import { CalendarDateSwitcher } from '@appCalendars/dateDisplay';
 import DateActionsMenu from '../actionsMenu/DateActionsMenu';
 
 import { DatetimeProvider } from '@edtrServices/context/DatetimeContext';
-import statusBgColorClassName from '@sharedEntities/datetimes/helpers/statusBgColorClassName';
+import { getStatusTextLabel, statusBgColorClassName } from '@sharedEntities/datetimes/helpers';
 
 import EntityCard from '@appLayout/EntityCard';
 import { useDatesListFilterState } from '@edtrServices/filterState';
@@ -14,9 +14,9 @@ import Details from './Details';
 import type { DateItemProps } from '../types';
 
 const DateCard: React.FC<DateItemProps> = ({ entity: date }) => {
-	const { displayStartOrEndDate } = useDatesListFilterState();
-
 	const bgClassName = statusBgColorClassName(date);
+	const { displayStartOrEndDate } = useDatesListFilterState();
+	const footer = getStatusTextLabel(date);
 
 	return date ? (
 		<DatetimeProvider id={date.id}>
@@ -29,6 +29,7 @@ const DateCard: React.FC<DateItemProps> = ({ entity: date }) => {
 						className={bgClassName}
 						displayDate={displayStartOrEndDate}
 						endDate={date.endDate}
+						labels={{ footer }}
 						startDate={date.startDate}
 					/>
 				}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCard.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCard.tsx
@@ -6,15 +6,15 @@ import TicketActionsMenu from '../actionsMenu/TicketActionsMenu';
 import Details from './Details';
 import TicketProvider from '@edtrServices/context/TicketContext';
 import EntityCard from '@appLayout/EntityCard';
-import statusBgColorClassName from '@sharedEntities/tickets/helpers/statusBgColorClassName';
+import { getStatusTextLabel, statusBgColorClassName } from '@sharedEntities/tickets/helpers';
 import { useTicketsListFilterState } from '@edtrServices/filterState';
 import { getPropsAreEqual } from '@appServices/utilities';
 import type { TicketItemProps } from '../types';
 
 const TicketCard: React.FC<TicketItemProps> = ({ entity: ticket }) => {
 	const { displayStartOrEndDate } = useTicketsListFilterState();
-
 	const bgClassName = statusBgColorClassName(ticket);
+	const footer = getStatusTextLabel(ticket);
 
 	return ticket ? (
 		<TicketProvider id={ticket.id}>
@@ -27,6 +27,7 @@ const TicketCard: React.FC<TicketItemProps> = ({ entity: ticket }) => {
 						className={bgClassName}
 						displayDate={displayStartOrEndDate}
 						endDate={ticket.endDate}
+						labels={{ footer }}
 						startDate={ticket.startDate}
 					/>
 				}

--- a/assets/src/domain/shared/entities/datetimes/helpers/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/helpers/index.ts
@@ -1,2 +1,4 @@
 export { default as getBackgroundColorClassName } from './getBackgroundColorClassName';
+export { default as getStatusTextLabel } from './getStatusTextLabel';
 export { default as status } from './status';
+export { default as statusBgColorClassName } from './statusBgColorClassName';

--- a/assets/src/domain/shared/entities/tickets/helpers/index.ts
+++ b/assets/src/domain/shared/entities/tickets/helpers/index.ts
@@ -1,2 +1,4 @@
 export { default as getBackgroundColorClassName } from './getBackgroundColorClassName';
+export { default as getStatusTextLabel } from './getStatusTextLabel';
 export { default as status } from './status';
+export { default as statusBgColorClassName } from './statusBgColorClassName';


### PR DESCRIPTION
## Problem this Pull Request solves
- Had used `getStatusTextLabel` in context of `CalendarDateSwitcher` for each entity.
- Closes: https://github.com/eventespresso/event-espresso-core/issues/2625
