### PR TITLE
Add registrationCount to TicketRegistrationsLink | Closes #2658

### DIFF
--- a/assets/src/application/ui/display/ItemCount/index.tsx
+++ b/assets/src/application/ui/display/ItemCount/index.tsx
@@ -15,9 +15,9 @@ interface ItemCountProps extends BadgeProps {
 const ItemCount: React.FC<ItemCountProps> = ({
 	children,
 	count,
-	emphasizeZero = true,
+	emphasizeZero,
 	title = ' ',
-	zeroCountChar = '!',
+	zeroCountChar,
 	...props
 }) => {
 	const className = classNames(props.className, 'ee-item-count', {
@@ -25,7 +25,7 @@ const ItemCount: React.FC<ItemCountProps> = ({
 		'ee-item-count--no-items': count === 0 && emphasizeZero,
 	});
 	const offset = props.offset || [7, 7];
-	const value = count > 0 ? count : zeroCountChar;
+	const value = count === 0 && typeof zeroCountChar !== 'undefined' ? zeroCountChar : count;
 
 	const countNode = (
 		<Tooltip title={title}>

--- a/assets/src/application/ui/display/ItemCount/index.tsx
+++ b/assets/src/application/ui/display/ItemCount/index.tsx
@@ -7,14 +7,22 @@ import { getPropsAreEqual } from '@appServices/utilities';
 import './style.scss';
 
 interface ItemCountProps extends BadgeProps {
-	zeroCountChar?: string | JSX.Element;
 	children: React.ReactNode;
+	emphasizeZero?: boolean;
+	zeroCountChar?: string | JSX.Element;
 }
 
-const ItemCount: React.FC<ItemCountProps> = ({ children, count, title = ' ', zeroCountChar = '!', ...props }) => {
+const ItemCount: React.FC<ItemCountProps> = ({
+	children,
+	count,
+	emphasizeZero = true,
+	title = ' ',
+	zeroCountChar = '!',
+	...props
+}) => {
 	const className = classNames(props.className, 'ee-item-count', {
 		'ee-item-count--has-items': count > 0,
-		'ee-item-count--no-items': count === 0,
+		'ee-item-count--no-items': count === 0 && emphasizeZero,
 	});
 	const offset = props.offset || [7, 7];
 	const value = count > 0 ? count : zeroCountChar;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/AssignTicketsButton.tsx
@@ -29,7 +29,7 @@ const AssignTicketsButton: React.FC<EntityListItemProps> = React.memo(({ id }) =
 	};
 
 	return (
-		<ItemCount count={count} title={title}>
+		<ItemCount count={count} title={title} zeroCountChar='!' emphasizeZero>
 			<EspressoButton
 				icon={Icon.TICKET}
 				tooltip={__('assign tickets')}
@@ -40,8 +40,7 @@ const AssignTicketsButton: React.FC<EntityListItemProps> = React.memo(({ id }) =
 	);
 });
 
-
 export default withIsLoaded<EntityListItemProps>(TypeName.tickets, ({ loaded, id }) => {
 	/* Hide TAM unless tickets are loaded */
 	return loaded && <AssignTicketsButton id={id} />;
-});;
+});

--- a/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
@@ -10,6 +10,7 @@ import { Ticket } from '@edtrServices/apollo/types';
 import useConfig from '@appServices/config/useConfig';
 import useEventId from '@edtrServices/apollo/queries/events/useEventId';
 import { getPropsAreEqual } from '@appServices/utilities';
+import ItemCount from '@appDisplay/ItemCount';
 
 interface Props {
 	ticket: Ticket;
@@ -26,19 +27,22 @@ const TicketRegistrationsLink: React.FC<Props> = ({ ticket }) => {
 		ticket_id: ticket.dbId,
 		return: 'edit',
 	});
-	const title = __('view registrations for this ticket.');
+	const buttonTitle = __('view registrations for this ticket.');
+	const countTitle = __('total registrations.');
 
 	return (
-		<Tooltip title={title}>
-			<a
-				href={regListUrl}
-				className={'ee-editor-details-reg-url-link'}
-				target={'_blank'}
-				rel={'noopener norefferer'}
-			>
-				<EspressoIcon icon={Icon.GROUPS} svgSize={24} />
-			</a>
-		</Tooltip>
+		<ItemCount count={ticket.registrationCount} title={countTitle} zeroCountChar={'0'} emphasizeZero={false}>
+			<Tooltip title={buttonTitle}>
+				<a
+					href={regListUrl}
+					className={'ee-editor-details-reg-url-link'}
+					target={'_blank'}
+					rel={'noopener norefferer'}
+				>
+					<EspressoIcon icon={Icon.GROUPS} svgSize={24} />
+				</a>
+			</Tooltip>
+		</ItemCount>
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
@@ -31,7 +31,7 @@ const TicketRegistrationsLink: React.FC<Props> = ({ ticket }) => {
 	const countTitle = __('total registrations.');
 
 	return (
-		<ItemCount count={ticket.registrationCount} title={countTitle} zeroCountChar={'0'} emphasizeZero={false}>
+		<ItemCount count={ticket.registrationCount} title={countTitle}>
 			<Tooltip title={buttonTitle}>
 				<a
 					href={regListUrl}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/AssignDatesButton.tsx
@@ -33,7 +33,7 @@ const AssignDatesButton: React.FC<EntityListItemProps> = React.memo(({ id }) => 
 	const tooltipProps = { placement: 'right' };
 
 	return (
-		<ItemCount count={count} title={title}>
+		<ItemCount count={count} title={title} zeroCountChar='!' emphasizeZero>
 			<EspressoButton
 				icon={Icon.CALENDAR}
 				tooltip={__('assign dates')}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/tableView/useBodyRowGenerator.tsx
@@ -13,6 +13,7 @@ import TicketQuantity from '../cardView/TicketQuantity';
 import { BodyRowGeneratorFn } from '@appLayout/entityList';
 import { TicketsFilterStateManager } from '@edtrServices/filterState';
 import { EditableName } from '../editable';
+import TicketRegistrationsLink from '../../TicketRegistrationsLink';
 
 import '@application/ui/styles/root/entity-status.css';
 
@@ -89,7 +90,7 @@ const useBodyRowGenerator = (): TicketsTableBodyRowGen => {
 				type: 'cell',
 				className:
 					'ee-ticket-list-cell ee-ticket-list-col-registrations ee-rspnsv-table-column-smaller ee-centered-column',
-				value: registrationCount, // should be count of related registrations
+				value: <TicketRegistrationsLink ticket={ticket} />,
 			},
 			{
 				key: 'actions',


### PR DESCRIPTION
This PR makes the following changes:
- Enhances `ItemCount` component to add `emphasizeZero` prop
- Adds `registrationCount` to `TicketRegistrationsLink`
- Adds `TicketRegistrationsLink` to `TableView`

`emphasizeZero={false}` vs `emphasizeZero={true}`
![image](https://user-images.githubusercontent.com/18226415/78662342-d71ff700-78ed-11ea-87e9-15643ef3e237.png)
