### PR TITLE
Replace AntD Tooltip with Chakra UI Tooltip; closes #2672.

### DIFF
--- a/assets/src/application/ui/calendars/dateDisplay/CalendarPageDate/index.tsx
+++ b/assets/src/application/ui/calendars/dateDisplay/CalendarPageDate/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { parseISO, isValid } from 'date-fns';
-import { Tooltip } from 'antd';
 import { __ } from '@wordpress/i18n';
 
+import { Tooltip } from '@infraUI/display';
 import { useTimeZoneTime } from '@appServices/hooks';
 
 import './style.scss';

--- a/assets/src/application/ui/calendars/dateDisplay/TimezoneTimeInfo/index.tsx
+++ b/assets/src/application/ui/calendars/dateDisplay/TimezoneTimeInfo/index.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { GlobalOutlined } from '@ant-design/icons';
-import { Popover, Tooltip } from 'antd';
-import useTimeZoneTime from '../../../../services/hooks/useTimeZoneTime';
+import { Popover } from 'antd';
+
+import { Tooltip } from '@infraUI/display';
+import { useTimeZoneTime } from '@appServices/hooks';
 
 import './style.scss';
 
@@ -37,7 +39,7 @@ const TimezoneTimeInfo: React.FC<OffsetInfoProps> = ({ className, date, inline =
 	return (
 		<Popover content={content} title={__('This Date Converted To:')} trigger={'click'} align={{ offset: [0, -60] }}>
 			<div className={htmlClassName}>
-				<Tooltip title={__('click for timezone\ninformation')} mouseEnterDelay={1}>
+				<Tooltip title={__('click for timezone\ninformation')} showDelay={1}>
 					<GlobalOutlined />
 				</Tooltip>
 			</div>

--- a/assets/src/application/ui/display/ItemCount/index.tsx
+++ b/assets/src/application/ui/display/ItemCount/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Badge, Tooltip } from 'antd';
-import { BadgeProps } from 'antd/lib/badge';
 import classNames from 'classnames';
+import { Badge } from 'antd';
+import { BadgeProps } from 'antd/lib/badge';
+
+import { Tooltip } from '@infraUI/display';
 import { getPropsAreEqual } from '@appServices/utilities';
 
 import './style.scss';

--- a/assets/src/application/ui/display/withTooltip/withTooltip.tsx
+++ b/assets/src/application/ui/display/withTooltip/withTooltip.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Tooltip as DefaultTooltip } from 'antd';
 import { __ } from '@wordpress/i18n';
+
 import { isEmpty } from '@appServices/utilities/string';
 import { withTooltipProps } from './types';
 

--- a/assets/src/application/ui/forms/espressoForm/renderers/FieldRenderer.tsx
+++ b/assets/src/application/ui/forms/espressoForm/renderers/FieldRenderer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Tooltip } from 'antd';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { Icon } from '@chakra-ui/core';
 
-import { MappedField } from '../adapters';
 import { FieldRendererProps } from '../types';
 import { FormControl, FormErrorMessage, FormHelperText, FormLabel } from '@infraUI/forms';
+import { MappedField } from '../adapters';
+import { Tooltip } from '@infraUI/display';
 
 const FieldRenderer: React.FC<FieldRendererProps> = (props) => {
 	const { after, before, desc, formControlProps, info, label, required, ...rest } = props;
@@ -19,14 +19,6 @@ const FieldRenderer: React.FC<FieldRendererProps> = (props) => {
 
 	const tooltipKey = info ? props.input.name + '-tooltip' : null;
 
-	const fieldInfo = info ? (
-		<span id={tooltipKey}>
-			<Tooltip placement='right' title={info}>
-				<InfoCircleOutlined className='tooltip' />
-			</Tooltip>
-		</span>
-	) : null;
-
 	const errorMessage = meta.touched && (meta.error || meta.submitError);
 
 	return (
@@ -37,7 +29,11 @@ const FieldRenderer: React.FC<FieldRendererProps> = (props) => {
 		>
 			<FormLabel htmlFor={props.input.name}>
 				{label}
-				{fieldInfo}
+				{info && (
+					<Tooltip placement='right' title={info}>
+						<Icon marginLeft='var(--ee-margin-micro)' name='info-outline' />
+					</Tooltip>
+				)}
 			</FormLabel>
 			{before}
 			<MappedField aria-label={label} aria-describedby={tooltipKey} {...rest} />

--- a/assets/src/application/ui/layout/dropdownMenu/DropdownToggle.tsx
+++ b/assets/src/application/ui/layout/dropdownMenu/DropdownToggle.tsx
@@ -2,28 +2,31 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { DropdownToggleProps } from './types';
-import { MenuToggle } from '@infraUI/layout/menu';
-import { EspressoIcon, Icon, withTooltip } from '@application/ui/display';
+import { EspressoIcon, Icon } from '@application/ui/display';
 import { IconButton } from '@chakra-ui/core';
+import { MenuToggle } from '@infraUI/layout/menu';
+import { Tooltip } from '@infraUI/display';
 
 const DropdownToggle = React.forwardRef<typeof MenuToggle, DropdownToggleProps>(
-	({ icon = Icon.MORE, isOpen, ...toggleProps }, ref) => {
+	({ icon = Icon.MORE, isOpen, tooltip, ...toggleProps }, ref) => {
 		const className = classNames('components-dropdown-menu__toggle', toggleProps.className, {
 			'is-opened': isOpen,
 		});
 
 		return (
-			<MenuToggle
-				as={IconButton}
-				// @ts-ignore
-				icon={() => <EspressoIcon icon={icon} />}
-				variant='ghost'
-				{...toggleProps}
-				className={className}
-				ref={ref}
-			/>
+			<Tooltip title={tooltip}>
+				<MenuToggle
+					as={IconButton}
+					// @ts-ignore
+					icon={() => <EspressoIcon icon={icon} />}
+					variant='ghost'
+					{...toggleProps}
+					className={className}
+					ref={ref}
+				/>
+			</Tooltip>
 		);
 	}
 );
 
-export default withTooltip(DropdownToggle);
+export default DropdownToggle;

--- a/assets/src/application/ui/layout/dropdownMenu/DropdownToggle.tsx
+++ b/assets/src/application/ui/layout/dropdownMenu/DropdownToggle.tsx
@@ -14,6 +14,7 @@ const DropdownToggle = React.forwardRef<typeof MenuToggle, DropdownToggleProps>(
 		});
 
 		return (
+			//TODO: refactor this to take advantage of `withTooltip` when and if that will be based off chakra
 			<Tooltip title={tooltip}>
 				<MenuToggle
 					as={IconButton}

--- a/assets/src/domain/eventEditor/ui/datetimes/DateRegistrationsLink.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/DateRegistrationsLink.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { addQueryArgs } from '@wordpress/url';
-import { Tooltip } from 'antd';
 import { __ } from '@wordpress/i18n';
 
 import { ADMIN_ROUTES } from '@sharedConstants/adminRoutes';
 import { Datetime } from '@edtrServices/apollo/types';
 import { EspressoIcon, Icon } from '@appDisplay/espressoIcon';
 import getAdminUrl from '@sharedServices/utils/url/getAdminUrl';
+import { getPropsAreEqual } from '@appServices/utilities';
+import { Tooltip } from '@infraUI/display';
 import useConfig from '@appServices/config/useConfig';
 import useEventId from '@edtrServices/apollo/queries/events/useEventId';
-import { getPropsAreEqual } from '@appServices/utilities';
 
 interface Props {
 	datetime: Datetime;

--- a/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/TicketRegistrationsLink.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { addQueryArgs } from '@wordpress/url';
-import { Tooltip } from 'antd';
 import { __ } from '@wordpress/i18n';
 
 import { ADMIN_ROUTES } from '@sharedConstants/adminRoutes';
 import { EspressoIcon, Icon } from '@appDisplay/espressoIcon';
 import getAdminUrl from '@sharedServices/utils/url/getAdminUrl';
+import { getPropsAreEqual } from '@appServices/utilities';
 import { Ticket } from '@edtrServices/apollo/types';
+import { Tooltip } from '@infraUI/display';
 import useConfig from '@appServices/config/useConfig';
 import useEventId from '@edtrServices/apollo/queries/events/useEventId';
-import { getPropsAreEqual } from '@appServices/utilities';
+
 import ItemCount from '@appDisplay/ItemCount';
 
 interface Props {

--- a/assets/src/infrastructure/ui/display/Tooltip/index.tsx
+++ b/assets/src/infrastructure/ui/display/Tooltip/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Tooltip as ChakraTooltip } from '@chakra-ui/core';
+
+import type { TooltipProps } from '../types';
+import './style.scss';
+
+const Tooltip: React.FC<TooltipProps> = (props) => {
+	const ariaLabel = props.title || props['aria-label'];
+	const label = props.title;
+
+	return <ChakraTooltip {...props} aria-label={ariaLabel} className='ee-tooltip' label={label} />;
+};
+
+export default Tooltip;

--- a/assets/src/infrastructure/ui/display/Tooltip/style.scss
+++ b/assets/src/infrastructure/ui/display/Tooltip/style.scss
@@ -1,0 +1,5 @@
+.ee-tooltip {
+	position: relative;
+	width: auto;
+	z-index: 1401;
+}

--- a/assets/src/infrastructure/ui/display/index.ts
+++ b/assets/src/infrastructure/ui/display/index.ts
@@ -1,0 +1,3 @@
+export { default as Tooltip } from './Tooltip';
+
+export * from './types';

--- a/assets/src/infrastructure/ui/display/types.ts
+++ b/assets/src/infrastructure/ui/display/types.ts
@@ -1,0 +1,6 @@
+import { TooltipProps as ChakraTooltipProps } from '@chakra-ui/core';
+
+export interface TooltipProps extends Omit<ChakraTooltipProps, 'aria-label'> {
+	['aria-label']?: string;
+	title: string;
+}


### PR DESCRIPTION

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
- Adds `Tooltip` adaptor which would work with existing end consumers:
 - `\application\ui\calendars\dateDisplay\CalendarPageDate`
 - `\application\ui\calendars\dateDisplay\TimezoneTimeInfo`
 - `\application\ui\display\ItemCount` 
 - `\application\ui\forms\espressoForm\renderers\FieldRenderer.tsx`
 - `\domain\eventEditor\ui\datetimes\DateRegistrationsLink.tsx`
 - `\domain\eventEditor\ui\tickets\TicketRegistrationsLink.tsx`
