### PR TITLE
EDTR Pagination | Closes #2676

### DIFF
--- a/assets/src/application/ui/layout/entityList/pagination/EntityPagination.tsx
+++ b/assets/src/application/ui/layout/entityList/pagination/EntityPagination.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Pagination } from 'antd';
-import { PaginationProps } from 'antd/lib/pagination';
+import { Pagination, PaginationProps } from '@infraUI/navigation';
 
 import { EntityListFilterStateManager } from '../filterBar';
 import './style.scss';
 
-interface EntityPaginationProps<ELFS extends EntityListFilterStateManager> extends PaginationProps {
+interface EntityPaginationProps<ELFS extends EntityListFilterStateManager> extends Partial<PaginationProps> {
 	filterState: ELFS;
 }
 
@@ -16,8 +15,7 @@ interface EntityPaginationProps<ELFS extends EntityListFilterStateManager> exten
  */
 const EntityPagination: React.FC<EntityPaginationProps<any>> = ({
 	filterState,
-	pageSizeOptions = ['2', '6', '12', '24', '48'],
-	showSizeChanger = true,
+	showPerPageChanger = true,
 	showTotal,
 	...rest
 }) => {
@@ -28,12 +26,12 @@ const EntityPagination: React.FC<EntityPaginationProps<any>> = ({
 		<div className={className}>
 			<Pagination
 				{...rest}
-				current={pageNumber}
-				defaultPageSize={6}
-				onChange={setPageNumber}
-				onShowSizeChange={setPerPage}
-				pageSizeOptions={pageSizeOptions}
-				showSizeChanger={showSizeChanger}
+				defaultPerPage={6}
+				onChangePageNumber={setPageNumber}
+				onChangePerPage={setPerPage}
+				pageNumber={pageNumber}
+				perPage={perPage}
+				showPerPageChanger={showPerPageChanger}
 				showTotal={showTotal}
 				total={total}
 			/>

--- a/assets/src/infrastructure/ui/inputs/Select.tsx
+++ b/assets/src/infrastructure/ui/inputs/Select.tsx
@@ -39,7 +39,12 @@ const Select: React.FC<SelectProps> = ({ children, options = [], onChange, onCha
 	);
 
 	return (
-		<ChakraSelect {...props} onChange={onChangeHandler}>
+		<ChakraSelect
+			// fix the double icon issue
+			icon={() => null}
+			{...props}
+			onChange={onChangeHandler}
+		>
 			{childNodes}
 		</ChakraSelect>
 	);

--- a/assets/src/infrastructure/ui/navigation/index.ts
+++ b/assets/src/infrastructure/ui/navigation/index.ts
@@ -1,0 +1,1 @@
+export * from './pagination';

--- a/assets/src/infrastructure/ui/navigation/pagination/ItemRender.tsx
+++ b/assets/src/infrastructure/ui/navigation/pagination/ItemRender.tsx
@@ -1,0 +1,11 @@
+import type { PaginationProps as RcPaginationProps } from 'rc-pagination';
+
+type ItemType = 'prev' | 'next' | 'jump-prev' | 'jump-next' | 'page';
+/**
+ * Can be used to customize the rendering of pangination items
+ */
+const ItemRender: RcPaginationProps['itemRender'] = (page, type: ItemType, element) => {
+	return element;
+};
+
+export default ItemRender;

--- a/assets/src/infrastructure/ui/navigation/pagination/Pagination.tsx
+++ b/assets/src/infrastructure/ui/navigation/pagination/Pagination.tsx
@@ -1,0 +1,65 @@
+import React, { CSSProperties } from 'react';
+import RcPagination from 'rc-pagination';
+import 'rc-pagination/assets/index.css';
+import defaultLocale from 'rc-pagination/lib/locale/en_US';
+
+import { PaginationProps } from './types';
+import PerPage from './PerPage';
+import defaultItemRender from './ItemRender';
+
+/* Temporary */
+const wrapperStyle: CSSProperties = {
+	display: 'flex',
+	flexDirection: 'row',
+	padding: '1em',
+};
+const paginationStyle: CSSProperties = {
+	display: 'flex',
+	marginRight: '1em',
+};
+
+const Pagination: React.FC<PaginationProps> = ({
+	defaultPageNumber = 1,
+	defaultPerPage,
+	hideOnSinglePage = true,
+	locale = defaultLocale,
+	onChangePageNumber,
+	onChangePerPage,
+	pageNumber,
+	perPage,
+	perPageOptions = ['2', '6', '12', '24', '48'],
+	showPerPageChanger,
+	total,
+	...rest
+}) => {
+	return (
+		<div style={wrapperStyle}>
+			<RcPagination
+				{...rest}
+				current={pageNumber}
+				defaultCurrent={defaultPageNumber}
+				hideOnSinglePage={hideOnSinglePage}
+				itemRender={defaultItemRender}
+				locale={locale}
+				onChange={onChangePageNumber}
+				pageSize={perPage}
+				showSizeChanger={false}
+				total={total}
+				style={paginationStyle}
+			/>
+			{showPerPageChanger && (
+				<PerPage
+					defaultPerPage={defaultPerPage}
+					locale={locale}
+					onChangePerPage={onChangePerPage}
+					pageNumber={pageNumber}
+					perPage={perPage}
+					perPageOptions={perPageOptions}
+					total={total}
+				/>
+			)}
+		</div>
+	);
+};
+
+export default Pagination;

--- a/assets/src/infrastructure/ui/navigation/pagination/PerPage.tsx
+++ b/assets/src/infrastructure/ui/navigation/pagination/PerPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { Select, SelectProps } from '@infraUI/inputs';
+import { PerPageProps } from './types';
+
+const calculatePageNumber = (newPerPage: number, prevPerPage: number, total: number): number => {
+	const perPage = typeof newPerPage === 'undefined' ? prevPerPage : newPerPage;
+	return Math.floor((total - 1) / perPage) + 1;
+};
+
+const PerPage: React.FC<PerPageProps> = ({ locale, onChangePerPage, pageNumber, perPage, perPageOptions, total }) => {
+	const buildOptionText = (value: string) => `${value} ${locale?.items_per_page}`;
+
+	const changePerPage: SelectProps['onChangeValue'] = (newPerPage) => {
+		const parsedNewPerPage = parseInt(newPerPage as string, 10);
+		const newPageNumber = calculatePageNumber(parsedNewPerPage as number, perPage, total);
+		let pageNum = pageNumber > newPageNumber ? newPageNumber : pageNumber;
+		// fix the issue:
+		// Once 'total' is 0, 'pageNumber' in 'onChangePerPage' is 0, which is not correct.
+		if (newPageNumber === 0) {
+			pageNum = pageNumber;
+		}
+
+		if (typeof onChangePerPage === 'function') {
+			onChangePerPage(pageNum, parsedNewPerPage as number);
+		}
+	};
+
+	return (
+		<Select onChangeValue={changePerPage} value={perPage} variant='unstyled'>
+			{perPageOptions.map((opt, i) => (
+				<option key={i} value={opt}>
+					{buildOptionText(opt)}
+				</option>
+			))}
+		</Select>
+	);
+};
+
+export default PerPage;

--- a/assets/src/infrastructure/ui/navigation/pagination/index.ts
+++ b/assets/src/infrastructure/ui/navigation/pagination/index.ts
@@ -1,0 +1,3 @@
+export { default as Pagination } from './Pagination';
+
+export * from './types';

--- a/assets/src/infrastructure/ui/navigation/pagination/types.ts
+++ b/assets/src/infrastructure/ui/navigation/pagination/types.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export interface PaginationProps extends PerPageProps {
+	defaultPageNumber?: number;
+	hideOnSinglePage?: boolean;
+	onChangePageNumber: (pageNumber: number, perPage: number) => void;
+	showPerPageChanger: boolean;
+	showTotal?: (total: number, range: [number, number]) => React.ReactNode;
+}
+
+export interface PerPageProps {
+	className?: string;
+	defaultPerPage: number;
+	locale?: Locale;
+	onChangePerPage: (newPageNumber: number, newPerPage: number) => void;
+	pageNumber: number;
+	perPage: number;
+	perPageOptions?: string[];
+	total: number;
+}
+
+export interface Locale {
+	items_per_page?: string;
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"graphql-tag": "^2.10.3",
 		"invariant": "^2.2.4",
 		"ramda": "^0.27.0",
+		"rc-pagination": "^2.2.0",
 		"react": "^16.13.1",
 		"react-app-polyfill": "^1.0.6",
 		"react-beautiful-dnd": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14002,7 +14002,7 @@ rc-notification@~4.0.0:
     rc-animate "2.x"
     rc-util "^4.0.4"
 
-rc-pagination@~2.2.0:
+rc-pagination@^2.2.0, rc-pagination@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-2.2.0.tgz#8daaab1b6ad664da2ddea842f86687b692eb775d"
   integrity sha512-fXempMD/kvHu8tsiW70uPjn1pI4mdD62xFG9drcBh17gj5CbCjazrjpWS615RSauk3b2BBgIcAJzREAMvlAkFQ==


### PR DESCRIPTION
This PR creates pagination component using `rc-pagination` which is a lightweight component. I have not used its per page selector because that is internally coupled with their own `Select` component. I used our own `Select` component from `@infraUI/inputs` to create per page selector.
- Adds `rc-pagination` to deps
- Creates `Pagination` adapter in `/infrastructure/ui/navigation/pagination`
- Updates pagination consumer components
- Fixes double icon issue in `Select` component

Here is the keyboard a11y demo
![demo](https://user-images.githubusercontent.com/18226415/79214674-861d7f00-7e68-11ea-99e4-d32a2843b757.gif)
