### PR TITLE
Fix logic for loading custom espresso_default.css from /uploads/

### DIFF
--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -370,8 +370,8 @@ class CoreAssetManager extends AssetManager
         if ($this->template_config->enable_default_style && ! is_admin()) {
             $this->addStylesheet(
                 CoreAssetManager::CSS_HANDLE_DEFAULT,
-                is_readable(EVENT_ESPRESSO_UPLOAD_DIR . 'css/style.css')
-                    ? EVENT_ESPRESSO_UPLOAD_DIR . 'css/espresso_default.css'
+                is_readable(EVENT_ESPRESSO_UPLOAD_DIR . 'css/espresso_default.css')
+                    ? EVENT_ESPRESSO_UPLOAD_URL . 'css/espresso_default.css'
                     : EE_GLOBAL_ASSETS_URL . 'css/espresso_default.css',
                 array('dashicons')
             );

--- a/core/templates/global_assets/css/espresso_default.css
+++ b/core/templates/global_assets/css/espresso_default.css
@@ -1,11 +1,11 @@
 /*******************************************************/
-/****                     -==ATTENTION==-                     ****/
+/****                -==ATTENTION==-                ****/
 /****         MOVE THIS FILE BEFORE EDITING         ****/
-/****                                                                           ****/
-/****                   Please move this file to:                ****/
-/****   wp-content/uploads/espresso/templates  ****/
-/****                  directory before editing                 ****/
-/****                                                                           ****/
+/****                                               ****/
+/****           Please move this file to:           ****/
+/****        wp-content/uploads/espresso/css        ****/
+/****           directory before editing            ****/
+/****                                               ****/
 /*******************************************************/
 
 
@@ -1258,11 +1258,11 @@ a[href*="message_type=receipt"]:visited {
 }
 
 /*******************************************************/
-/****                     -==ATTENTION==-                     ****/
+/****                -==ATTENTION==-                ****/
 /****         MOVE THIS FILE BEFORE EDITING         ****/
-/****                                                                           ****/
-/****                   Please move this file to:                ****/
-/****   wp-content/uploads/espresso/templates  ****/
-/****                  directory before editing                 ****/
-/****                                                                           ****/
+/****                                               ****/
+/****           Please move this file to:           ****/
+/****        wp-content/uploads/espresso/css        ****/
+/****           directory before editing            ****/
+/****                                               ****/
 /*******************************************************/


### PR DESCRIPTION



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->
## Problem this Pull Request solves
If someone were to copy the espresso_default.css stylesheet to /wp-content/uploads/espresso/css, their copy would not load. The logic was kind of broken, and the URL to stylesheet needs to be provided, not the path.

<!-- Please describe your changes in the context of the problem they solve -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

- [x] Copy the espresso_default.css into /wp-content/uploads/espresso/css
- [x] Make a noticeable change to some styles and clear browser cache
- [x] Check an event page to verify the change takes effect
- [x] Also verify if no espresso_default.css in /wp-content/uploads/espresso/css then the stylesheet provided by the plugin loads as expected

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
