### PR TITLE
Ensure Locale Option Is Set

### DIFF
--- a/core/EE_Load_Textdomain.core.php
+++ b/core/EE_Load_Textdomain.core.php
@@ -91,6 +91,8 @@ class EE_Load_Textdomain extends EE_Base
 
         // if locale is "en_US" then lets just get out, since Event Espresso core is already "en_US"
         if (EE_Load_Textdomain::$locale === 'en_US') {
+            // but set option first else we'll forever be downloading the pot file
+            update_option($language_check_option_name, 1);
             return;
         }
         $repo_locale_URL = $repo_base_URL . '-' . EE_Load_Textdomain::$locale;

--- a/core/EE_Load_Textdomain.core.php
+++ b/core/EE_Load_Textdomain.core.php
@@ -37,14 +37,14 @@ class EE_Load_Textdomain extends EE_Base
         EE_Load_Textdomain::loadTranslationsForLocale();
         // now load the textdomain
         if (!empty(EE_Load_Textdomain::$locale)) {
-            $old_mo_path = EE_LANGUAGES_SAFE_DIR . 'event_espresso-' . EE_Load_Textdomain::$locale . '.mo';
-            if (is_readable($old_mo_path)) {
+            $github_mo_path = EE_LANGUAGES_SAFE_DIR . 'event_espresso-' . EE_Load_Textdomain::$locale . '.mo';
+            if (is_readable($github_mo_path)) {
                 load_plugin_textdomain('event_espresso', false, EE_LANGUAGES_SAFE_LOC);
                 return;
             }
-            $EE4_mo_path = EE_LANGUAGES_SAFE_DIR . 'event_espresso-4-' . EE_Load_Textdomain::$locale . '.mo';
-            if (is_readable($EE4_mo_path)) {
-                load_textdomain('event_espresso', $EE4_mo_path);
+            $glotpress_mo_path = EE_LANGUAGES_SAFE_DIR . 'event_espresso-4-' . EE_Load_Textdomain::$locale . '.mo';
+            if (is_readable($glotpress_mo_path)) {
+                load_textdomain('event_espresso', $glotpress_mo_path);
                 return;
             }
         }


### PR DESCRIPTION
A little bit of confusing code in `EE_Load_Textdomain` resulted in repeated attempts to download a `.pot` file for the current locale if the locale happened to be `en_US` (but what are the chances of that happening?)

This PR fixes that issue by ensuring that the "lang_check" WP option is always set once the `.pot` file has been downloaded.

This PR also cleans up all of the other logic in the file to improve readability for whoever works on this next