### PR TITLE
Entity reorder mutation | Closes #2720

### DIFF
--- a/core/domain/services/graphql/enums/ModelNameEnum.php
+++ b/core/domain/services/graphql/enums/ModelNameEnum.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\enums;
+
+use EEM_Datetime;
+use EEM_Ticket;
+use EventEspresso\core\services\graphql\enums\EnumBase;
+
+/**
+ * Class ModelNameEnum
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\enums
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class ModelNameEnum extends EnumBase
+{
+
+    /**
+     * ModelNameEnum constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'ModelNameEnum');
+        $this->setDescription(esc_html__('Entity model name', 'event_espresso'));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return array
+     * @since $VID:$
+     */
+    protected function getValues()
+    {
+        return [
+            'DATETIME'     => [
+                'value'       => EEM_Datetime::instance()->item_name(),
+            ],
+            'TICKET'     => [
+                'value'       => EEM_Ticket::instance()->item_name(),
+            ],
+        ];
+    }
+}

--- a/core/domain/services/graphql/mutators/EntityReorder.php
+++ b/core/domain/services/graphql/mutators/EntityReorder.php
@@ -2,10 +2,9 @@
 
 namespace EventEspresso\core\domain\services\graphql\mutators;
 
-use EEM_Datetime;
-use EE_Datetime;
-use EventEspresso\core\domain\services\graphql\types\Datetime;
-use EventEspresso\core\domain\services\graphql\data\mutations\DatetimeMutation;
+use EE_Registry;
+use EEM_Base;
+use EE_Base_Class;
 
 use EE_Error;
 use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
@@ -26,8 +25,6 @@ class EntityReorder
     /**
      * Defines the mutation data modification closure.
      *
-     * @param EEM_Datetime $model
-     * @param Datetime     $type
      * @return callable
      */
     public static function mutateAndGetPayload()
@@ -48,18 +45,105 @@ class EntityReorder
          */
         return static function ($input, AppContext $context, ResolveInfo $info) {
             /**
-         * Stop now if a user isn't allowed to reorder.
-         */
+             * Stop now if a user isn't allowed to reorder.
+             */
             if (! current_user_can('ee_edit_events')) {
                 throw new UserError(
                     esc_html__('Sorry, you are not allowed to reorder entities', 'event_espresso')
                 );
             }
-            // $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
 
-            return [
-                'ok' => true,
-            ];
+            $entityGuids = ! empty($input['entityIds']) ? array_map('sanitize_text_field', (array) $input['entityIds']) : [];
+            $entityType  = ! empty($input['entityType']) ? sanitize_text_field($input['entityType']) : null;
+
+            /**
+             * Make sure we have the IDs and entity type
+             */
+            if (empty($entityGuids) || empty($entityType)) {
+                throw new UserError(
+                    // translators: the placeholders are the names of the fields
+                    sprintf(esc_html__('%1$s and %2$s are required.', 'event_espresso'), 'entityIds', 'entityType')
+                );
+            }
+
+            $model = EE_Registry::instance()->load_model($entityType);
+
+            if (!($model instanceof EEM_Base)) {
+                throw new UserError(esc_html__('Some error occured. Did you supply a valid entity type?', 'event_espresso'));
+            }
+
+            // convert GUIDs to DB IDs
+            $entityDbids = array_map(function ($entityGuid) {
+                $id_parts = Relay::fromGlobalId($entityGuid);
+                return ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
+            }, (array) $entityGuids);
+            // remove 0 values
+            $entityDbids = array_filter($entityDbids);
+
+            /**
+             * If we could not get DB IDs for some GUIDs
+             */
+            if (count($entityDbids) !== count($entityGuids)) {
+                throw new UserError(esc_html__('No entities found to update.', 'event_espresso'));
+            }
+
+            // e.g. DTT_ID, TKT_ID
+            $primaryKey = $model->get_primary_key_field()->get_name();
+            // e.g. "DTT_ID" will give us "DTT"
+            $keyPrefix = explode('_', $primaryKey)[0];
+            $deletedKey  = $keyPrefix . '_deleted'; // e.g. "TKT_deleted"
+
+            $entities = $model::instance()->get_all([
+                [
+                    $primaryKey => ['IN', $entityDbids],
+                    $deletedKey => ['IN', [true, false]],
+                ],
+            ]);
+
+            /**
+             * If we could not get exactly same number of entities for the given DB IDs
+             */
+            if (count($entityDbids) !== count($entities)) {
+                throw new UserError(esc_html__('No entities found to update..', 'event_espresso'));
+            }
+
+            // Make sure we have an instance for every ID.
+            foreach ($entityDbids as $entityDbid) {
+                if (isset($entities[ $entityDbid ]) && $entities[ $entityDbid ] instanceof EE_Base_Class) {
+                    continue;
+                }
+                throw new UserError(esc_html__('No entities found to update...', 'event_espresso'));
+            }
+
+            $orderKey  = $keyPrefix . '_order'; // e.g. "TKT_order"
+
+            $ok = false;
+
+            // We do not want to continue reorder if one fails.
+            // Thus wrap whole loop in try-catch
+            try {
+                foreach ($entityDbids as $order => $entityDbid) {
+                    $args = [
+                        $orderKey => $order + 1,
+                    ];
+                    $entities[ $entityDbid ]->save($args);
+                }
+                $ok = true;
+            } catch (Exception $exception) {
+                new ExceptionStackTraceDisplay(
+                    new RuntimeException(
+                        sprintf(
+                            esc_html__(
+                                'Failed to update order because of the following error(s): %1$s',
+                                'event_espresso'
+                            ),
+                            $exception->getMessage()
+                        )
+                    )
+                );
+            }
+
+            return compact('ok');
         };
     }
 }

--- a/core/domain/services/graphql/mutators/EntityReorder.php
+++ b/core/domain/services/graphql/mutators/EntityReorder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\mutators;
+
+use EEM_Datetime;
+use EE_Datetime;
+use EventEspresso\core\domain\services\graphql\types\Datetime;
+use EventEspresso\core\domain\services\graphql\data\mutations\DatetimeMutation;
+
+use EE_Error;
+use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
+use Exception;
+use InvalidArgumentException;
+use ReflectionException;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use RuntimeException;
+use WPGraphQL\AppContext;
+use GraphQL\Error\UserError;
+use GraphQLRelay\Relay;
+
+class EntityReorder
+{
+    /**
+     * Defines the mutation data modification closure.
+     *
+     * @param EEM_Datetime $model
+     * @param Datetime     $type
+     * @return callable
+     */
+    public static function mutateAndGetPayload()
+    {
+        /**
+         * Updates an entity.
+         *
+         * @param array       $input   The input for the mutation
+         * @param AppContext  $context The AppContext passed down to all resolvers
+         * @param ResolveInfo $info    The ResolveInfo passed down to all resolvers
+         * @return array
+         * @throws UserError
+         * @throws ReflectionException
+         * @throws InvalidArgumentException
+         * @throws InvalidInterfaceException
+         * @throws InvalidDataTypeException
+         * @throws EE_Error
+         */
+        return static function ($input, AppContext $context, ResolveInfo $info) {
+            /**
+         * Stop now if a user isn't allowed to reorder.
+         */
+            if (! current_user_can('ee_edit_events')) {
+                throw new UserError(
+                    esc_html__('Sorry, you are not allowed to reorder entities', 'event_espresso')
+                );
+            }
+            // $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
+
+            return [
+                'ok' => true,
+            ];
+        };
+    }
+}

--- a/core/domain/services/graphql/mutators/EntityReorder.php
+++ b/core/domain/services/graphql/mutators/EntityReorder.php
@@ -49,7 +49,7 @@ class EntityReorder
              */
             if (! current_user_can('ee_edit_events')) {
                 throw new UserError(
-                    esc_html__('Sorry, you are not allowed to reorder entities', 'event_espresso')
+                    esc_html__('Sorry, you do not have the required permissions to reorder entities', 'event_espresso')
                 );
             }
 
@@ -69,7 +69,12 @@ class EntityReorder
             $model = EE_Registry::instance()->load_model($entityType);
 
             if (!($model instanceof EEM_Base)) {
-                throw new UserError(esc_html__('Some error occured. Did you supply a valid entity type?', 'event_espresso'));
+                throw new UserError(
+                    esc_html__(
+                        'A valid data model could not be obtained. Did you supply a valid entity type?',
+                        'event_espresso'
+                    )
+                );
             }
 
             // convert GUIDs to DB IDs
@@ -84,7 +89,9 @@ class EntityReorder
              * If we could not get DB IDs for some GUIDs
              */
             if (count($entityDbids) !== count($entityGuids)) {
-                throw new UserError(esc_html__('No entities found to update.', 'event_espresso'));
+                throw new UserError(
+                    esc_html__('Sorry, update cancelled due to missing or invalid entity IDs.', 'event_espresso')
+                );
             }
 
             // e.g. DTT_ID, TKT_ID
@@ -104,7 +111,7 @@ class EntityReorder
              * If we could not get exactly same number of entities for the given DB IDs
              */
             if (count($entityDbids) !== count($entities)) {
-                throw new UserError(esc_html__('No entities found to update..', 'event_espresso'));
+                throw new UserError(esc_html__('Sorry, update cancelled due to missing entities.', 'event_espresso'));
             }
 
             // Make sure we have an instance for every ID.
@@ -112,7 +119,7 @@ class EntityReorder
                 if (isset($entities[ $entityDbid ]) && $entities[ $entityDbid ] instanceof EE_Base_Class) {
                     continue;
                 }
-                throw new UserError(esc_html__('No entities found to update...', 'event_espresso'));
+                throw new UserError(esc_html__('Sorry, update cancelled due to invalid entities.', 'event_espresso'));
             }
 
             $orderKey  = $keyPrefix . '_order'; // e.g. "TKT_order"

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -17,6 +17,7 @@ use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
 use EventEspresso\core\domain\services\graphql\mutators\DatetimeCreate;
 use EventEspresso\core\domain\services\graphql\mutators\DatetimeDelete;
 use EventEspresso\core\domain\services\graphql\mutators\DatetimeUpdate;
+use EventEspresso\core\domain\services\graphql\mutators\EntityReorder;
 use InvalidArgumentException;
 use ReflectionException;
 use WPGraphQL\AppContext;
@@ -304,6 +305,36 @@ class Datetime extends TypeBase
                     ],
                 ],
                 'mutateAndGetPayload' => DatetimeCreate::mutateAndGetPayload($this->model, $this),
+            ]
+        );
+        
+        // Register mutation to update an entity.
+        register_graphql_mutation(
+            'reordoer' . $this->namespace . 'Entities',
+            [
+                'inputFields'         => [
+                    'Ids'      => [
+                        'type'        => [
+                            'non_null' => ['list_of' => 'ID'],
+                        ],
+                        'description' => esc_html__('List of entity guids in the order that is desired.', 'event_espresso'),
+                    ],
+                    'entityType' => [
+                        'type'        => [
+                            'non_null' => $this->namespace . 'ModelNameEnum',
+                        ],
+                        'description' => esc_html__('The entity type of the IDs', 'event_espresso'),
+                    ],
+                ],
+                'outputFields'        => [
+                    'ok' => [
+                        'type'    => 'Boolean',
+                        'resolve' => function ($payload) {
+                            return (bool) $payload['ok'];
+                        },
+                    ],
+                ],
+                'mutateAndGetPayload' => EntityReorder::mutateAndGetPayload(),
             ]
         );
     }

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -317,13 +317,13 @@ class Datetime extends TypeBase
                         'type'        => [
                             'non_null' => ['list_of' => 'ID'],
                         ],
-                        'description' => esc_html__('List of entity guids in the order that is desired.', 'event_espresso'),
+                        'description' => esc_html__('The reordered list of entity GUIDs.', 'event_espresso'),
                     ],
                     'entityType' => [
                         'type'        => [
                             'non_null' => $this->namespace . 'ModelNameEnum',
                         ],
-                        'description' => esc_html__('The entity type of the IDs', 'event_espresso'),
+                        'description' => esc_html__('The entity type for the IDs', 'event_espresso'),
                     ],
                 ],
                 'outputFields'        => [

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -313,7 +313,7 @@ class Datetime extends TypeBase
             'reordoer' . $this->namespace . 'Entities',
             [
                 'inputFields'         => [
-                    'Ids'      => [
+                    'entityIds'  => [
                         'type'        => [
                             'non_null' => ['list_of' => 'ID'],
                         ],

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -310,7 +310,7 @@ class Datetime extends TypeBase
         
         // Register mutation to update an entity.
         register_graphql_mutation(
-            'reordoer' . $this->namespace . 'Entities',
+            'reorder' . $this->namespace . 'Entities',
             [
                 'inputFields'         => [
                     'entityIds'  => [

--- a/docs/GraphQL-API/README.md
+++ b/docs/GraphQL-API/README.md
@@ -4,13 +4,15 @@ Event Espresso GraphQL API is based on [WP GraphQL](https://github.com/wp-graphq
 
 ## Examples
 
-- Query
-  - [Event](./query/event.md)
-  - [Event Relations](./query/eventRelations.md)
-  - [Datetime](./query/datetime.md)
-  - [Ticket](./query/ticket.md)
-  - [Price](./query/price.md)
-  - [PriceType](./query/priceType.md)
-- Mutations
-  - [Datetime](./mutations/datetime.md)
-  - [Ticket](./mutations/ticket.md)
+-   Query
+    -   [Event](./query/event.md)
+    -   [Event Relations](./query/eventRelations.md)
+    -   [Datetime](./query/datetime.md)
+    -   [Ticket](./query/ticket.md)
+    -   [Price](./query/price.md)
+    -   [PriceType](./query/priceType.md)
+-   Mutations
+    -   [Datetime](./mutations/datetime.md)
+    -   [Ticket](./mutations/ticket.md)
+    -   [Price](./mutations/price.md)
+    -   [Common](./mutations/common.md)

--- a/docs/GraphQL-API/mutations/common.md
+++ b/docs/GraphQL-API/mutations/common.md
@@ -1,0 +1,27 @@
+# common mutation examples
+
+## `reorderEspressoEntities`
+
+This mutation updates the order field of the supplied entities. The entityIds must be in the same order that is desired.
+
+```gql
+mutation REORDER_ENTITIES($input: ReorderEspressoEntitiesInput!) {
+	reorderEspressoEntities(input: $input) {
+		ok
+	}
+}
+```
+
+### Query variables for `reorderEspressoEntities`
+
+```json
+{
+	"input": {
+		"clientMutationId": "xyz",
+		"entityIds": ["RGF0ZXRpbWU6MjA=", "RGF0ZXRpbWU6MTk=", "RGF0ZXRpbWU6MjE=", "RGF0ZXRpbWU6MjI="],
+		"entityType": "DATETIME" // or "TICKET"
+	}
+}
+```
+
+**Note**: You should also pass the trashed entities if you want their order to be updated.


### PR DESCRIPTION
This PR adds a new mutation to GQL backend to handle sorting/reordering of the entities.