### PR TITLE
Make sure the site isn't Multisite enabled when sideloading the POT file

### DIFF
--- a/core/EE_Load_Textdomain.core.php
+++ b/core/EE_Load_Textdomain.core.php
@@ -88,7 +88,7 @@ class EE_Load_Textdomain extends EE_Base
         /** @var EEH_Sideloader $sideloader */
         $sideloader = EE_Registry::instance()->load_helper('Sideloader', $sideloader_args, false);
         // don't sideload the .POT file if Multisite is enabled
-        if(! is_multisite()) {
+        if (! is_multisite()) {
             $sideloader->sideload();
         }
 

--- a/core/EE_Load_Textdomain.core.php
+++ b/core/EE_Load_Textdomain.core.php
@@ -87,7 +87,10 @@ class EE_Load_Textdomain extends EE_Base
         );
         /** @var EEH_Sideloader $sideloader */
         $sideloader = EE_Registry::instance()->load_helper('Sideloader', $sideloader_args, false);
-        $sideloader->sideload();
+        // don't sideload the .POT file if Multisite is enabled
+        if(! is_multisite()) {
+            $sideloader->sideload();
+        }
 
         // if locale is "en_US" then lets just get out, since Event Espresso core is already "en_US"
         if (EE_Load_Textdomain::$locale === 'en_US') {

--- a/core/EE_Load_Textdomain.core.php
+++ b/core/EE_Load_Textdomain.core.php
@@ -87,8 +87,8 @@ class EE_Load_Textdomain extends EE_Base
         );
         /** @var EEH_Sideloader $sideloader */
         $sideloader = EE_Registry::instance()->load_helper('Sideloader', $sideloader_args, false);
-        // don't sideload the .POT file if Multisite is enabled
-        if (! is_multisite()) {
+        // sideload the .POT file only for main site of the network, or if not running Multisite.
+        if (is_main_site()) {
             $sideloader->sideload();
         }
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
In #616 we started sideloading the .POT file from GitHub. It turns out we don't want to re-download the .POT file every time a new site is added to a Multisite network. Also, we do not want to re-download the .POT file every time each site is updated, which would really slow down updates for Eventsmart.
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
On a Multisite enabled site, check the EE plugin's /languages folder. If there's already an event_espresso.pot file there, you can delete it.
Then load this branch.
Then add a new site to the network. 
No event_espresso.pot file should be downloaded to the EE plugin's /languages folder.

You could also test on a single (not multisite) site: 
Delete the `ee_lang_check_`* option(s), refresh any page on the site, then check the plugin's /languages folder. The event_espresso.pot file should be downloaded there.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
