### PR TITLE
Trash and permanent deletion for entities | Closes #2731

### DIFF
--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/index.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/index.ts
@@ -27,10 +27,11 @@ export const DELETE_DATETIME = gql`
 	mutation DELETE_DATETIME($input: DeleteEspressoDatetimeInput!) {
 		deleteEspressoDatetime(input: $input) {
 			espressoDatetime {
-				id
+				...datetimeAttributes
 			}
 		}
 	}
+	${DATETIME_ATTRIBUTES}
 `;
 
 export { default as useDatetimeMutator } from './useDatetimeMutator';

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/data.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/data.ts
@@ -12,7 +12,7 @@ import { mutations } from '../..';
 export const mockedDatetimes = {
 	[MutationType.Create]: { ...datetimes[0], id: datetimes[0].id + '-alpha' }, // make sure to change the ID to make it different}
 	[MutationType.Update]: datetimes[0],
-	[MutationType.Delete]: { id: datetimes[0].id, __typename: datetimes[0].__typename },
+	[MutationType.Delete]: datetimes[0],
 };
 
 export const getMutationMocks = (

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/deleteDatetime.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/test/deleteDatetime.test.ts
@@ -84,24 +84,13 @@ describe('deleteDatetime', () => {
 			relation: 'tickets',
 		});
 
-		expect(relatedTicketIds.length).toBe(0);
-
-		// check if all the passed tickets are related to the datetime
-		ticketIds.forEach((ticketId) => {
-			const relatedDatetimeIds = mutationResult.current.relationsManager.getRelations({
-				entity: 'tickets',
-				entityId: ticketId,
-				relation: 'datetimes',
-			});
-
-			expect(relatedDatetimeIds).not.toContain(mockedDatetime.id);
-		});
+		expect(relatedTicketIds.length).toBe(2);
 	});
 
 	it('checks for relation update after mutation - permanent delete', async () => {
+		const testInput = { deletePermanently: true };
 		// Add related ticket Ids to the mutation input
-
-		mutationMocks = getMutationMocks({}, MutationType.Delete);
+		mutationMocks = getMutationMocks(testInput, MutationType.Delete);
 
 		const wrapper = ApolloMockedProvider(mutationMocks);
 
@@ -118,7 +107,7 @@ describe('deleteDatetime', () => {
 		await waitForValueToChange(() => mutationResult.current, { timeout });
 
 		act(() => {
-			mutationResult.current.mutator.deleteEntity({});
+			mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve
@@ -130,7 +119,7 @@ describe('deleteDatetime', () => {
 			relation: 'tickets',
 		});
 
-		expect(relatedTicketIds.length).toBe(2);
+		expect(relatedTicketIds.length).toBe(0);
 
 		// check if all the passed tickets are related to the datetime
 		ticketIds.forEach((ticketId) => {

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/types.ts
@@ -25,4 +25,5 @@ export interface UpdateDatetimeInput extends DatetimeBaseInput {
 
 export interface DeleteDatetimeInput {
 	id?: EntityId;
+	deletePermanently?: boolean;
 }

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/updateTicketCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/updateTicketCache.ts
@@ -52,7 +52,6 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, action }: CacheUpdat
 	// write the data to cache without
 	// mutating the cache directly
 	proxy.writeQuery<TicketsList>(writeOptions);
-	console.log('ticket');
 };
 
 export default updateTicketCache;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/updateTicketCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/updateTicketCache.ts
@@ -1,6 +1,7 @@
 import { CacheUpdaterFnArgs } from '../types';
 import { GET_TICKETS, ReadQueryOptions, WriteQueryOptions } from '@edtrServices/apollo/queries';
 import { TicketsList } from '@edtrServices/apollo/types';
+import { sortBy, identity } from 'ramda';
 
 const updateTicketCache = ({ proxy, datetimeIn, datetimeId, action }: CacheUpdaterFnArgs): void => {
 	const queryOptions: ReadQueryOptions = {
@@ -31,7 +32,7 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, action }: CacheUpdat
 			newDatetimeIn = [...datetimeIn, datetimeId];
 			break;
 		case 'remove':
-			newDatetimeIn = datetimeIn.filter((id: string) => id !== datetimeId);
+			newDatetimeIn = datetimeIn.filter((id) => id !== datetimeId);
 			break;
 		default:
 			newDatetimeIn = datetimeIn;
@@ -43,7 +44,7 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, action }: CacheUpdat
 		data,
 		variables: {
 			where: {
-				datetimeIn: newDatetimeIn,
+				datetimeIn: sortBy(identity, newDatetimeIn),
 			},
 		},
 	};
@@ -51,6 +52,7 @@ const updateTicketCache = ({ proxy, datetimeIn, datetimeId, action }: CacheUpdat
 	// write the data to cache without
 	// mutating the cache directly
 	proxy.writeQuery<TicketsList>(writeOptions);
+	console.log('ticket');
 };
 
 export default updateTicketCache;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useDatetimeMutationHandler.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useDatetimeMutationHandler.ts
@@ -22,7 +22,7 @@ const useDatetimeMutationHandler = (): MutationHandler => {
 	const getMutationVariables = useMutationVariables();
 	const getOptimisticResponse = useOptimisticResponse();
 
-	const mutationHandler: MutationHandler = <MI>(mutationType: MutationType, input: MI) => {
+	const mutationHandler: MutationHandler = (mutationType, input) => {
 		const variables = getMutationVariables(mutationType, input);
 		const optimisticResponse = getOptimisticResponse(mutationType, input);
 
@@ -45,7 +45,7 @@ const useDatetimeMutationHandler = (): MutationHandler => {
 					onUpdateDatetime({ datetime, tickets });
 					break;
 				case MutationType.Delete:
-					onDeleteDatetime({ proxy, datetimes, datetime });
+					onDeleteDatetime({ proxy, datetimes, datetime, deletePermanently: input?.deletePermanently });
 					break;
 			}
 		};

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnDeleteDatetime.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOnDeleteDatetime.ts
@@ -1,38 +1,44 @@
 import updateTicketCache from './updateTicketCache';
 import useUpdateDatetimeCache from './useUpdateDatetimeCache';
-import { DatetimeMutationCallbackFn, DatetimeMutationCallbackFnArgs, CacheUpdaterFn } from '../types';
+import { DatetimeMutationCallbackFn, DatetimeMutationCallbackFnArgs } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
 import { getGuids } from '@appServices/predicates';
 
 const useOnDeleteDatetime = (): DatetimeMutationCallbackFn => {
 	const { dropRelations, removeRelation } = useRelations();
 
-	const updateDatetimeCache: CacheUpdaterFn = useUpdateDatetimeCache();
+	const updateDatetimeCache = useUpdateDatetimeCache();
 
-	const onDeleteDatetime = ({ proxy, datetimes, datetime }: DatetimeMutationCallbackFnArgs): void => {
-		if (datetime.id) {
+	const onDeleteDatetime = ({
+		proxy,
+		datetimes,
+		datetime,
+		deletePermanently,
+	}: DatetimeMutationCallbackFnArgs): void => {
+		const action = deletePermanently ? 'remove' : 'update';
+		if (datetime.id && deletePermanently) {
 			const { nodes = [] } = datetimes;
-			const datetimeIn = getGuids(nodes).sort();
+			const datetimeIn = getGuids(nodes);
 			const { id: datetimeId } = datetime;
 
 			// Update tickets cache for the changed datetimes,
 			// to avoid refetching of tickets.
-			updateTicketCache({ proxy, datetimeIn, datetimeId, action: 'remove' });
+			updateTicketCache({ proxy, datetimeIn, datetimeId, action });
 
 			// Remove the datetime from all ticket relations
 			removeRelation({
 				entity: 'datetimes',
-				entityId: datetime.id,
+				entityId: datetimeId,
 				relation: 'tickets',
 			});
 			// Drop all the relations for the datetime
 			dropRelations({
 				entity: 'datetimes',
-				entityId: datetime.id,
+				entityId: datetimeId,
 			});
 		}
 		// Update datetime cache after tickets cache is updated.
-		updateDatetimeCache({ proxy, datetimes, datetime, action: 'remove' });
+		updateDatetimeCache({ proxy, datetimes, datetime: { ...datetime, isTrashed: true }, action });
 	};
 
 	return onDeleteDatetime;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOptimisticResponse.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/datetimes/useOptimisticResponse.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { pathOr } from 'ramda';
 import { useApolloClient } from '@apollo/react-hooks';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -54,7 +53,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 		} catch (error) {
 			// do nothing
 		}
-		const datetime = pathOr<Datetime>(null, ['datetime'], data);
+		const datetime = data?.datetime;
 
 		switch (mutationType) {
 			case MutationType.Create:

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/deletePrice.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/test/deletePrice.test.ts
@@ -83,22 +83,13 @@ describe('deletePrice', () => {
 		});
 
 		expect(relatedTicketIds.length).toBe(1);
-
-		// check if all the passed tickets are related to the price
-		ticketIds.forEach((ticketId) => {
-			const relatedPriceIds = mutationResult.current.relationsManager.getRelations({
-				entity: 'tickets',
-				entityId: ticketId,
-				relation: 'prices',
-			});
-
-			expect(relatedPriceIds).not.toContain(mockedPrice.id);
-		});
 	});
 
 	it('checks for ticket relation update after mutation - permanent delete', async () => {
+		const testInput = { deletePermanently: true };
+
 		// Add related ticket Ids to the mutation input
-		mutationMocks = getMutationMocks({}, MutationType.Delete);
+		mutationMocks = getMutationMocks(testInput, MutationType.Delete);
 
 		const wrapper = ApolloMockedProvider(mutationMocks);
 
@@ -115,7 +106,7 @@ describe('deletePrice', () => {
 		await waitForValueToChange(() => mutationResult.current, { timeout });
 
 		act(() => {
-			mutationResult.current.mutator.deleteEntity({});
+			mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve
@@ -175,7 +166,9 @@ describe('deletePrice', () => {
 	});
 
 	it('checks for priceType relation update after mutation - permanent delete', async () => {
-		mutationMocks = getMutationMocks({}, MutationType.Delete);
+		const testInput = { deletePermanently: true };
+
+		mutationMocks = getMutationMocks(testInput, MutationType.Delete);
 
 		const wrapper = ApolloMockedProvider(mutationMocks);
 
@@ -192,7 +185,7 @@ describe('deletePrice', () => {
 		await waitForValueToChange(() => mutationResult.current, { timeout });
 
 		act(() => {
-			mutationResult.current.mutator.deleteEntity({ deletePermanently: true });
+			mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/types.ts
@@ -23,4 +23,5 @@ export interface UpdatePriceInput extends PriceBaseInput {
 
 export interface DeletePriceInput {
 	id?: EntityId;
+	deletePermanently?: boolean;
 }

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/useOnDeletePrice.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/useOnDeletePrice.ts
@@ -1,15 +1,16 @@
 import useUpdatePriceCache from './useUpdatePriceCache';
-import { PriceMutationCallbackFn, PriceMutationCallbackFnArgs, CacheUpdaterFn } from '../types';
+import { PriceMutationCallbackFn, PriceMutationCallbackFnArgs } from '../types';
 import { useRelations } from '@appServices/apollo/relations';
 
 const useOnDeletePrice = (): PriceMutationCallbackFn => {
 	const { dropRelations, removeRelation } = useRelations();
 
-	const updatePriceCache: CacheUpdaterFn = useUpdatePriceCache();
+	const updatePriceCache = useUpdatePriceCache();
 
-	const onDeletePrice = ({ proxy, prices, price }: PriceMutationCallbackFnArgs): void => {
+	const onDeletePrice = ({ proxy, prices, price, deletePermanently }: PriceMutationCallbackFnArgs): void => {
 		const { id: priceId } = price;
-		if (priceId) {
+		const action = deletePermanently ? 'remove' : 'update';
+		if (priceId && deletePermanently) {
 			// Remove the price from all tickets relations
 			removeRelation({
 				entity: 'prices',
@@ -23,7 +24,7 @@ const useOnDeletePrice = (): PriceMutationCallbackFn => {
 			});
 		}
 		// Update price cache.
-		updatePriceCache({ proxy, prices, price, action: 'remove' });
+		updatePriceCache({ proxy, prices, price: { ...price, isTrashed: true }, action });
 	};
 
 	return onDeletePrice;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/prices/usePriceMutationHandler.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/prices/usePriceMutationHandler.ts
@@ -60,7 +60,7 @@ const usePriceMutationHandler = (): MutationHandler => {
 					onUpdatePrice({ price, priceTypeId });
 					break;
 				case MutationType.Delete:
-					onDeletePrice({ proxy, prices, price });
+					onDeletePrice({ proxy, prices, price, deletePermanently: input?.deletePermanently });
 					break;
 			}
 		};

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/index.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/index.ts
@@ -31,10 +31,11 @@ export const DELETE_TICKET = gql`
 	mutation DELETE_TICKET($input: DeleteEspressoTicketInput!) {
 		deleteEspressoTicket(input: $input) {
 			espressoTicket {
-				id
+				...ticketAttributes
 			}
 		}
 	}
+	${TICKET_ATTRIBUTES}
 `;
 
 export { default as useTicketMutator } from './useTicketMutator';

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/data.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/data.ts
@@ -14,7 +14,7 @@ const prices = { ...priceEdge, __typename: 'EspressoTicketPricesConnectionEdge' 
 export const mockedTickets = {
 	[MutationType.Create]: { ...tickets[0], id: tickets[0].id + '-alpha' }, // make sure to change the ID to make it different}
 	[MutationType.Update]: { ...tickets[0], prices },
-	[MutationType.Delete]: { id: tickets[0].id, __typename: tickets[0].__typename },
+	[MutationType.Delete]: tickets[0],
 };
 
 export const getMutationMocks = (

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/data.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/data.ts
@@ -60,7 +60,7 @@ export const getMockResult = (mutationInput: MutationInput, mutationType: Mutati
 				__typename: `${ucFirst(mutationType.toLowerCase())}EspressoTicketPayload`,
 				espressoTicket:
 					MutationType.Delete === mutationType
-						? mockedTickets[mutationType]
+						? { ...mockedTickets[mutationType], ...input }
 						: { ...mockedTickets[mutationType], ...input, prices },
 			},
 		},

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/deleteTicket.test.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/test/deleteTicket.test.ts
@@ -86,23 +86,12 @@ describe('deleteTicket', () => {
 		});
 
 		expect(relatedDatetimeIds.length).toBe(1);
-
-		// check if all the passed datetimes are related to the ticket
-		datetimeIds.forEach((datetimeId) => {
-			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
-				entity: 'datetimes',
-				entityId: datetimeId,
-				relation: 'tickets',
-			});
-
-			expect(relatedTicketIds).not.toContain(mockedTicket.id);
-		});
 	});
 
 	it('checks for datetime relation update after mutation - permanent delete', async () => {
+		const testInput = { deletePermanently: true };
 		// Add related datetime Ids to the mutation input
-
-		mutationMocks = getMutationMocks({}, MutationType.Delete);
+		mutationMocks = getMutationMocks(testInput, MutationType.Delete);
 
 		const wrapper = ApolloMockedProvider(mutationMocks);
 
@@ -119,7 +108,7 @@ describe('deleteTicket', () => {
 		await waitForValueToChange(() => mutationResult.current, { timeout });
 
 		act(() => {
-			mutationResult.current.mutator.deleteEntity({ deletePermanently: true });
+			mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve
@@ -176,21 +165,11 @@ describe('deleteTicket', () => {
 		});
 
 		expect(relatedPriceIds.length).toBe(2);
-
-		// check if all the passed prices are related to the ticket
-		priceIds.forEach((priceId) => {
-			const relatedTicketIds = mutationResult.current.relationsManager.getRelations({
-				entity: 'prices',
-				entityId: priceId,
-				relation: 'tickets',
-			});
-
-			expect(relatedTicketIds).not.toContain(mockedTicket.id);
-		});
 	});
 
 	it('checks for price relation update after mutation - permanent delete', async () => {
-		mutationMocks = getMutationMocks({}, MutationType.Delete);
+		const testInput = { deletePermanently: true };
+		mutationMocks = getMutationMocks(testInput, MutationType.Delete);
 
 		const wrapper = ApolloMockedProvider(mutationMocks);
 
@@ -207,7 +186,7 @@ describe('deleteTicket', () => {
 		await waitForValueToChange(() => mutationResult.current, { timeout });
 
 		act(() => {
-			mutationResult.current.mutator.deleteEntity({ deletePermanently: true });
+			mutationResult.current.mutator.deleteEntity(testInput);
 		});
 
 		// wait for mutation promise to resolve

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/types.ts
@@ -33,4 +33,5 @@ export interface UpdateTicketInput extends TicketBaseInput {
 
 export interface DeleteTicketInput {
 	id?: EntityId;
+	deletePermanently?: boolean;
 }

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/updatePriceCache.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/updatePriceCache.ts
@@ -1,4 +1,4 @@
-import { assocPath, pathOr, uniqBy } from 'ramda';
+import { assocPath, pathOr, uniqBy, sortBy, identity } from 'ramda';
 
 import { CacheUpdaterFnArgs } from '../types';
 import { DEFAULT_PRICE_LIST_DATA, GET_PRICES } from '@edtrServices/apollo/queries';
@@ -32,7 +32,7 @@ const updatePriceCache = ({ proxy, prices = null, ticketIn, ticketId, action }: 
 			newTicketIn = [...ticketIn, ticketId];
 			break;
 		case 'remove':
-			newTicketIn = ticketIn.filter((id: string) => id !== ticketId);
+			newTicketIn = ticketIn.filter((id) => id !== ticketId);
 			break;
 		default:
 			newTicketIn = ticketIn;
@@ -61,7 +61,7 @@ const updatePriceCache = ({ proxy, prices = null, ticketIn, ticketId, action }: 
 		data,
 		variables: {
 			where: {
-				ticketIn: newTicketIn,
+				ticketIn: sortBy(identity, newTicketIn),
 			},
 		},
 	};

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnCreateTicket.ts
@@ -15,7 +15,7 @@ const useOnCreateTicket = (): TicketMutationCallbackFn => {
 	const onCreateTicket = ({ proxy, datetimeIds, ticket, tickets, prices }: TicketMutationCallbackFnArgs): void => {
 		if (ticket.id) {
 			const { nodes = [] } = tickets;
-			const ticketIn = getGuids(nodes).sort();
+			const ticketIn = getGuids(nodes);
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOnDeleteTicket.ts
@@ -9,15 +9,16 @@ const useOnDeleteTicket = (): TicketMutationCallbackFn => {
 
 	const updateTicketCache = useUpdateTicketCache();
 
-	const onDeleteTicket = ({ proxy, tickets, ticket }: TicketMutationCallbackFnArgs): void => {
-		if (ticket.id) {
+	const onDeleteTicket = ({ proxy, tickets, ticket, deletePermanently }: TicketMutationCallbackFnArgs): void => {
+		const action = deletePermanently ? 'remove' : 'update';
+		if (ticket.id && deletePermanently) {
 			const { nodes = [] } = tickets;
-			const ticketIn = getGuids(nodes).sort();
+			const ticketIn = getGuids(nodes);
 			const { id: ticketId } = ticket;
 
 			// Update prices cache for the changed tickets,
 			// to avoid refetching of prices.
-			updatePriceCache({ proxy, ticketIn, ticketId, action: 'remove' });
+			updatePriceCache({ proxy, ticketIn, ticketId, action });
 
 			// Remove the ticket from all datetime relations
 			removeRelation({
@@ -38,7 +39,7 @@ const useOnDeleteTicket = (): TicketMutationCallbackFn => {
 			});
 		}
 		// Update ticket cache after price cache is updated.
-		updateTicketCache({ proxy, tickets, ticket, action: 'remove' });
+		updateTicketCache({ proxy, tickets, ticket: { ...ticket, isTrashed: true }, action });
 	};
 
 	return onDeleteTicket;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOptimisticResponse.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useOptimisticResponse.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { pathOr } from 'ramda';
 import { useApolloClient } from '@apollo/react-hooks';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -62,7 +61,7 @@ const useOptimisticResponse = (): OptimisticResCb => {
 		} catch (error) {
 			// do nothing
 		}
-		const ticket = pathOr<Ticket>(null, ['ticket'], data);
+		const ticket = data?.ticket;
 
 		switch (mutationType) {
 			case MutationType.Create:

--- a/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useTicketMutationHandler.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/tickets/useTicketMutationHandler.ts
@@ -52,7 +52,7 @@ const useTicketMutationHandler = (): MutationHandler => {
 					onUpdateTicket({ proxy, tickets, ticket, datetimeIds, priceIds });
 					break;
 				case MutationType.Delete:
-					onDeleteTicket({ proxy, tickets, ticket });
+					onDeleteTicket({ proxy, tickets, ticket, deletePermanently: input?.deletePermanently });
 					break;
 			}
 		};

--- a/assets/src/domain/eventEditor/services/apollo/mutations/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/types.ts
@@ -10,8 +10,12 @@ export interface MutationCallbackFnArgs {
 	proxy?: DataProxy;
 }
 
+interface CommponArgs {
+	deletePermanently?: boolean;
+}
+
 /* Datetime specific */
-export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs {
+export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
 	datetime: Datetime;
 	datetimes?: DatetimeEdge;
 	tickets?: string[];
@@ -19,7 +23,7 @@ export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs {
 export type DatetimeMutationCallbackFn = (args: DatetimeMutationCallbackFnArgs) => void;
 
 /* Ticket specific */
-export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs {
+export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
 	ticket: Ticket;
 	tickets?: TicketEdge;
 	datetimeIds?: string[];
@@ -29,7 +33,7 @@ export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs {
 export type TicketMutationCallbackFn = (args: TicketMutationCallbackFnArgs) => void;
 
 /* Price specific */
-export interface PriceMutationCallbackFnArgs extends MutationCallbackFnArgs {
+export interface PriceMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
 	price: Price;
 	prices?: PriceEdge;
 	priceTypeId?: string;
@@ -80,7 +84,10 @@ export interface MutatorGeneratedObject {
 	variables: OperationVariables;
 }
 
-export type MutationHandler = <MI = MutationInput>(mutationType: MutationType, input: MI) => MutatorGeneratedObject;
+export type MutationHandler = <MI extends MutationInput = MutationInput>(
+	mutationType: MutationType,
+	input: MI
+) => MutatorGeneratedObject;
 
 export interface MutationInputWithId {
 	clientMutationId: string;

--- a/assets/src/domain/eventEditor/services/apollo/mutations/types.ts
+++ b/assets/src/domain/eventEditor/services/apollo/mutations/types.ts
@@ -10,12 +10,12 @@ export interface MutationCallbackFnArgs {
 	proxy?: DataProxy;
 }
 
-interface CommponArgs {
+interface CommonArgs {
 	deletePermanently?: boolean;
 }
 
 /* Datetime specific */
-export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
+export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs, CommonArgs {
 	datetime: Datetime;
 	datetimes?: DatetimeEdge;
 	tickets?: string[];
@@ -23,7 +23,7 @@ export interface DatetimeMutationCallbackFnArgs extends MutationCallbackFnArgs, 
 export type DatetimeMutationCallbackFn = (args: DatetimeMutationCallbackFnArgs) => void;
 
 /* Ticket specific */
-export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
+export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs, CommonArgs {
 	ticket: Ticket;
 	tickets?: TicketEdge;
 	datetimeIds?: string[];
@@ -33,7 +33,7 @@ export interface TicketMutationCallbackFnArgs extends MutationCallbackFnArgs, Co
 export type TicketMutationCallbackFn = (args: TicketMutationCallbackFnArgs) => void;
 
 /* Price specific */
-export interface PriceMutationCallbackFnArgs extends MutationCallbackFnArgs, CommponArgs {
+export interface PriceMutationCallbackFnArgs extends MutationCallbackFnArgs, CommonArgs {
 	price: Price;
 	prices?: PriceEdge;
 	priceTypeId?: string;

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/dropdown/TrashDate.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/actionsMenu/dropdown/TrashDate.tsx
@@ -5,15 +5,20 @@ import { Trash } from '@application/ui/layout/entityActionsMenu/entityMenuItems'
 import { useDatetimeMutator } from '@edtrServices/apollo/mutations';
 
 import { DateMainMenuProps } from './types';
+import { isTrashed } from '@sharedServices/predicates';
 
 const TrashDate: React.FC<DateMainMenuProps> = ({ datetime, ...props }) => {
 	if (!datetime) return null;
 
-	const id = datetime.id;
-	const { deleteEntity } = useDatetimeMutator(id);
-	const onClick = useCallback(() => deleteEntity({ id }), [id]);
+	const { id, cacheId } = datetime;
+	const trashed = isTrashed(datetime);
 
-	return <Trash {...props} onClick={onClick} title={__('trash datetime')} />;
+	const { deleteEntity } = useDatetimeMutator(id);
+	const onClick = useCallback(() => deleteEntity({ id, deletePermanently: trashed }), [cacheId, trashed]);
+
+	const title = trashed ? __('delete permanently') : __('trash datetime');
+
+	return <Trash {...props} onClick={onClick} title={title} />;
 };
 
 export default TrashDate;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.ts
@@ -59,7 +59,9 @@ const useOnSubmitPrices = (): VoidFunction => {
 		// Delete all unlucky ones
 		await Promise.all(
 			deletedPriceIds.map((id) => {
-				return new Promise((onCompleted, onError) => deletePrice({ id }, { onCompleted, onError }));
+				return new Promise((onCompleted, onError) =>
+					deletePrice({ id, deletePermanently: true }, { onCompleted, onError })
+				);
 			})
 		);
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/dropdown/TrashTicket.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/actionsMenu/dropdown/TrashTicket.tsx
@@ -5,15 +5,20 @@ import { Trash } from '@application/ui/layout/entityActionsMenu/entityMenuItems'
 import { useTicketMutator } from '@edtrServices/apollo/mutations';
 
 import { TicketMainMenuProps } from './types';
+import { isTrashed } from '@sharedServices/predicates';
 
 const TrashTicket: React.FC<TicketMainMenuProps> = ({ ticket, ...props }) => {
 	if (!ticket) return null;
 
-	const id = ticket.id;
-	const { deleteEntity } = useTicketMutator(id);
-	const onClick = useCallback(() => deleteEntity({ id }), [id]);
+	const trashed = isTrashed(ticket);
+	const { id, cacheId } = ticket;
 
-	return <Trash {...props} onClick={onClick} title={__('trash ticket')} />;
+	const { deleteEntity } = useTicketMutator(id);
+	const onClick = useCallback(() => deleteEntity({ id, deletePermanently: trashed }), [cacheId, trashed]);
+
+	const title = trashed ? __('delete permanently') : __('trash ticket');
+
+	return <Trash {...props} onClick={onClick} title={title} />;
 };
 
 export default TrashTicket;

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/salesFilter.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/salesFilter.ts
@@ -2,17 +2,14 @@ import { Datetime } from '@edtrServices/apollo';
 import { DatetimeSales } from '@edtrServices/filterState';
 
 import aboveCapacity from './aboveCapacity';
-import allDates from './allDates';
 import belowCapacity from './belowCapacity';
-import notTrashed from '../../../../services/predicates/filters/notTrashed';
 
 import { SalesFilter } from './types';
 
 /**
  * reduces dates array based on value of the "sales" filter
  */
-const salesFilter = ({ dates: entities, sales = DatetimeSales.all }: SalesFilter): Datetime[] => {
-	const dates = notTrashed(entities);
+const salesFilter = ({ dates, sales = DatetimeSales.all }: SalesFilter): Datetime[] => {
 	switch (sales) {
 		case DatetimeSales.above50Capacity:
 			return aboveCapacity({ dates, capacity: 50 });
@@ -20,8 +17,6 @@ const salesFilter = ({ dates: entities, sales = DatetimeSales.all }: SalesFilter
 			return aboveCapacity({ dates, capacity: 75 });
 		case DatetimeSales.above90Capacity:
 			return aboveCapacity({ dates, capacity: 90 });
-		case DatetimeSales.all:
-			return allDates(dates);
 		case DatetimeSales.below50Capacity:
 			return belowCapacity({ dates, capacity: 50 });
 		default:

--- a/assets/src/domain/shared/entities/datetimes/predicates/filters/statusFilter.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/filters/statusFilter.ts
@@ -3,14 +3,13 @@ import { DatetimeStatus } from '@edtrServices/filterState';
 
 import activeOnly from './activeOnly';
 import activeUpcoming from './activeUpcoming';
-import allDates from './allDates';
 import expiredOnly from './expiredOnly';
 import nextActiveUpcomingOnly from './nextActiveUpcomingOnly';
 import recentlyExpiredOnly from './recentlyExpiredOnly';
 import soldOutOnly from './soldOutOnly';
 import upcomingOnly from './upcomingOnly';
-import notTrashed from '../../../../services/predicates/filters/notTrashed';
-import trashedOnly from '../../../../services/predicates/filters/trashedOnly';
+import notTrashed from '@sharedServices/predicates/filters/notTrashed';
+import trashedOnly from '@sharedServices/predicates/filters/trashedOnly';
 
 import { StatusFilter } from './types';
 
@@ -25,7 +24,7 @@ const statusFilter = ({ dates: entities, status = DatetimeStatus.activeUpcoming 
 		case DatetimeStatus.activeUpcoming:
 			return activeUpcoming(dates);
 		case DatetimeStatus.all:
-			return allDates(dates);
+			return entities;
 		case DatetimeStatus.expiredOnly:
 			return expiredOnly(dates);
 		case DatetimeStatus.nextActiveUpcomingOnly:
@@ -35,7 +34,7 @@ const statusFilter = ({ dates: entities, status = DatetimeStatus.activeUpcoming 
 		case DatetimeStatus.soldOutOnly:
 			return soldOutOnly(dates);
 		case DatetimeStatus.trashedOnly:
-			return trashedOnly(dates);
+			return trashedOnly(entities);
 		case DatetimeStatus.upcomingOnly:
 			return upcomingOnly(dates);
 		default:

--- a/assets/src/domain/shared/entities/datetimes/predicates/sorters/index.ts
+++ b/assets/src/domain/shared/entities/datetimes/predicates/sorters/index.ts
@@ -1,4 +1,4 @@
-import { prop, sortBy as sortByFn } from 'ramda';
+import { prop, sort, sortBy as sortByFn } from 'ramda';
 import { compareAsc, parseISO } from 'date-fns';
 
 import { Datetime } from '@edtrServices/apollo';
@@ -18,9 +18,9 @@ interface SortDates {
 const sorters = ({ dates, sortBy = 'date' }: SortDates): Datetime[] => {
 	switch (sortBy) {
 		case 'date':
-			return dates.sort(({ startDate: dateLeft }, { startDate: dateRight }) =>
-				compareAsc(parseISO(dateLeft), parseISO(dateRight))
-			);
+			return sort(({ startDate: dateLeft }, { startDate: dateRight }) => {
+				return compareAsc(parseISO(dateLeft), parseISO(dateRight));
+			}, dates);
 		case 'id':
 			return sortByFn(prop('dbId'))(dates);
 		case 'name':

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/salesFilter.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/salesFilter.ts
@@ -2,7 +2,6 @@ import { Ticket } from '@edtrServices/apollo';
 import { TicketsSales } from '@edtrServices/filterState';
 import percentSoldAtOrAbove from './percentSoldAtOrAbove';
 import percentSoldBelow from './percentSoldBelow';
-import notTrashed from '../../../../services/predicates/filters/notTrashed';
 
 import { SalesFilter } from './types';
 
@@ -13,8 +12,7 @@ import { SalesFilter } from './types';
  * @param {string} show    value for the "show" filter
  * @return {Array}         filtered tickets array
  */
-export const salesFilter = ({ tickets: entities, sales = TicketsSales.all }: SalesFilter): Ticket[] => {
-	const tickets = notTrashed(entities);
+export const salesFilter = ({ tickets, sales = TicketsSales.all }: SalesFilter): Ticket[] => {
 	switch (sales) {
 		case TicketsSales.above50Sold:
 			return percentSoldAtOrAbove({ percentage: 50, tickets });
@@ -22,9 +20,6 @@ export const salesFilter = ({ tickets: entities, sales = TicketsSales.all }: Sal
 			return percentSoldAtOrAbove({ percentage: 75, tickets });
 		case TicketsSales.above90Sold:
 			return percentSoldAtOrAbove({ percentage: 90, tickets });
-		case TicketsSales.all:
-			// we don't normally want to show trashed tickets
-			return entities;
 		case TicketsSales.below50Sold:
 			return percentSoldBelow({ percentage: 50, tickets });
 		default:

--- a/assets/src/domain/shared/entities/tickets/predicates/filters/statusFilter.ts
+++ b/assets/src/domain/shared/entities/tickets/predicates/filters/statusFilter.ts
@@ -6,8 +6,8 @@ import nextOnSaleOrPendingOnly from './nextOnSaleOrPendingOnly';
 import onSaleOnly from './onSaleOnly';
 import pendingOnly from './pendingOnly';
 import soldOutOnly from './soldOutOnly';
-import notTrashed from '../../../../services/predicates/filters/notTrashed';
-import trashedOnly from '../../../../services/predicates/filters/trashedOnly';
+import notTrashed from '@sharedServices/predicates/filters/notTrashed';
+import trashedOnly from '@sharedServices/predicates/filters/trashedOnly';
 
 import { StatusFilter } from './types';
 

--- a/core/domain/services/admin/events/editor/AdvancedEditorData.php
+++ b/core/domain/services/admin/events/editor/AdvancedEditorData.php
@@ -535,12 +535,6 @@ QUERY;
      */
     public static function getRelationalData($eventId)
     {
-        $prefixes = [
-            'datetimes'  => 'DTT',
-            'tickets'    => 'TKT',
-            'prices'     => 'PRC',
-            'priceTypes' => 'PRT',
-        ];
         $data = [
             'datetimes'  => [],
             'tickets'    => [],
@@ -557,19 +551,20 @@ QUERY;
             'tickets' => $eem_ticket,
         ];
         // Get the IDs of event datetimes.
-        $datetimeIds = $eem_datetime->get_col([[
-            'EVT_ID'      => $eventId,
-            'DTT_deleted' => ['IN', [true, false]],
-        ]]);
+        $datetimeIds = $eem_datetime->get_col([
+            [
+                'EVT_ID'      => $eventId,
+                'DTT_deleted' => ['IN', [true, false]],
+            ],
+            'default_where_conditions' => 'minimum',
+        ]);
         foreach ($datetimeIds as $datetimeId) {
             $GID = self::convertToGlobalId($eem_datetime->item_name(), $datetimeId);
             foreach ($related_models as $key => $model) {
-                $deletedKey = "{$prefixes[$key]}_deleted";
                 // Get the IDs of related entities for the datetime ID.
                 $Ids = $model->get_col([
                     [
                         'Datetime.DTT_ID' => $datetimeId,
-                        $deletedKey       => ['IN', [true, false]],
                     ],
                     'default_where_conditions' => 'minimum',
                 ]);
@@ -583,21 +578,20 @@ QUERY;
             'prices'    => $eem_price,
         ];
         // Get the IDs of all datetime tickets.
-        $ticketIds = $eem_ticket->get_col([[
-            'Datetime.DTT_ID' => ['IN', $datetimeIds],
-            'TKT_deleted'     => ['IN', [true, false]],
-        ]]);
+        $ticketIds = $eem_ticket->get_col([
+            [
+                'Datetime.DTT_ID' => ['IN', $datetimeIds],
+            ],
+            'default_where_conditions' => 'minimum',
+            ]);
         foreach ($ticketIds as $ticketId) {
             $GID = self::convertToGlobalId($eem_ticket->item_name(), $ticketId);
 
             foreach ($related_models as $key => $model) {
-                $deletedKey = "{$prefixes[$key]}_deleted";
-
                 // Get the IDs of related entities for the ticket ID.
                 $Ids = $model->get_col([
                     [
                         'Ticket.TKT_ID' => $ticketId,
-                        $deletedKey     => ['IN', [true, false]],
                     ],
                     'default_where_conditions' => 'minimum',
                 ]);
@@ -611,18 +605,15 @@ QUERY;
             'priceTypes' => $eem_price_type,
         ];
         // Get the IDs of all ticket prices.
-        $priceIds = $eem_price->get_col([['Ticket.TKT_ID' => ['in', $ticketIds]]]);
+        $priceIds = $eem_price->get_col([['Ticket.TKT_ID' => ['IN', $ticketIds]]]);
         foreach ($priceIds as $priceId) {
             $GID = self::convertToGlobalId($eem_price->item_name(), $priceId);
 
             foreach ($related_models as $key => $model) {
-                $deletedKey = "{$prefixes[$key]}_deleted";
-
                 // Get the IDs of related entities for the price ID.
                 $Ids = $model->get_col([
                     [
                         'Price.PRC_ID' => $priceId,
-                        $deletedKey    => ['IN', [true, false]],
                     ],
                     'default_where_conditions' => 'minimum',
                 ]);

--- a/core/domain/services/admin/events/editor/AdvancedEditorData.php
+++ b/core/domain/services/admin/events/editor/AdvancedEditorData.php
@@ -554,7 +554,6 @@ QUERY;
         $datetimeIds = $eem_datetime->get_col([
             [
                 'EVT_ID'      => $eventId,
-                'DTT_deleted' => ['IN', [true, false]],
             ],
             'default_where_conditions' => 'minimum',
         ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
 
 "@ant-design/icons@^4.0.0":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.0.6.tgz#a1b9860d4de5dece59ba98d0025b07a3d13cba2a"
-  integrity sha512-Hvly7PhImdZo5+UnpRPSpqcYFttTEE9ELCgir6R9cPe99IHciLv97EZTshYTFp4T6i2q0x9nuSLpG11UFeu4Dg==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.1.0.tgz#444edcc3822d5b43b2b038d6f893cd7f7dfcc48d"
+  integrity sha512-R1aIPJboGq4nVYwW7s0v/V2g6yiY27Kec5ldfK3mWHskw7bihPOKwxkHbITuSJcVNJsSvA6LNMlKZoY1u8DIKQ==
   dependencies:
     "@ant-design/colors" "^3.1.0"
     "@ant-design/icons-svg" "^4.0.0"
@@ -2148,9 +2148,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*", "@types/node@>=6", "@types/node@^13.11.0":
-  version "13.13.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
-  integrity sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==
+  version "13.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
+  integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3456,9 +3456,9 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
     color-convert "^2.0.1"
 
 antd@^4.1.1:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-4.1.4.tgz#ea86d9e6742d8d01c7e84e423bb4d31403bec02e"
-  integrity sha512-YRF/nrAq4R+olKRJxEDqeO4xkTvx+U6ovIQjGew1JDiEHMMhSftpvpYg2Iu5hRdFL66uxQk6VYngMttBpuYm9Q==
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-4.1.5.tgz#3eb67a5162186dec6b096e74a8b35952ab229040"
+  integrity sha512-UGiuQJBc5uSvDsBt+C3Q4sD6YG/MSZSjftsnTwKM73xJyYDHuQnBOUU0O1HokOW17+Hr1AFbep8IPhs4S2pKRQ==
   dependencies:
     "@ant-design/icons" "^4.0.0"
     "@ant-design/react-slick" "~0.25.5"
@@ -3471,7 +3471,7 @@ antd@^4.1.1:
     omit.js "^1.0.2"
     prop-types "^15.7.2"
     raf "^3.4.1"
-    rc-animate "~2.10.2"
+    rc-animate "~2.11.0"
     rc-cascader "~1.0.0"
     rc-checkbox "~2.2.0"
     rc-collapse "~1.11.3"
@@ -3498,7 +3498,7 @@ antd@^4.1.1:
     rc-tree "~3.1.0"
     rc-tree-select "~3.1.0"
     rc-trigger "~4.0.0"
-    rc-upload "~3.0.0"
+    rc-upload "~3.0.4"
     rc-util "^4.20.0"
     rc-virtual-list "^1.1.0"
     resize-observer-polyfill "^1.5.1"
@@ -4235,9 +4235,9 @@ body-scroll-lock@^2.6.4:
   integrity sha512-hS53SQ8RhM0e4DsQ3PKz6Gr2O7Kpdh59TWU98GHjaQznL7y4dFycEPk7pFQAikqBaUSCArkc5E3pe7CWIt2fZA==
 
 body-scroll-lock@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.1.tgz#bacb9ebf64fef2498392a3b779f4943af2004fad"
-  integrity sha512-BYcnBAv6r3iKFDeYgG3ZMiOtxHDcHaev84he4vU4nB062A9MSUHsbVkrgsiSZlGCcWqoqGKCKTytSUhzuEjiCQ==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.2.tgz#97df9bb3b17a0140c4a09b3568d146ae9af6b981"
+  integrity sha512-PtItUun94iIupKry8J/h6SfRCLWZnly77KbPsTSKALmxfR282L8R0Ujkv7bydSZvLxAJS4sBJ3y/E6X8gYkGrQ==
 
 bonjour@^3.5.0:
   version "3.5.0"
@@ -4636,9 +4636,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001043:
-  version "1.0.30001046"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001046.tgz#7a06d3e8fd8aa7f4d21c9a2e313f35f2d06b013e"
-  integrity sha512-CsGjBRYWG6FvgbyGy+hBbaezpwiqIOLkxQPY4A4Ea49g1eNsnQuESB+n4QM0BKii1j80MyJ26Ir5ywTQkbRE4g==
+  version "1.0.30001048"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz#4bb4f1bc2eb304e5e1154da80b93dee3f1cf447e"
+  integrity sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4737,9 +4737,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
-  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -4747,7 +4747,7 @@ chokidar@^3.3.0:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.3.0"
+    readdirp "~3.4.0"
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -5107,9 +5107,9 @@ concat-stream@^1.5.0:
     typedarray "^0.0.6"
 
 concurrently@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.1.0.tgz#05523986ba7aaf4b58a49ddd658fab88fa783132"
-  integrity sha512-9ViZMu3OOCID3rBgU31mjBftro2chOop0G2u1olq1OuwRBVRw/GxHTg80TVJBUTJfoswMmEUeuOg1g1yu1X2dA==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.2.0.tgz#ead55121d08a0fc817085584c123cedec2e08975"
+  integrity sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==
   dependencies:
     chalk "^2.4.2"
     date-fns "^2.0.1"
@@ -6224,9 +6224,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.413:
-  version "1.3.417"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.417.tgz#7663efb1e81911d56be8f39d12cdc63b86011ee1"
-  integrity sha512-IMNamkpoT3lVSHC16QPx3lbLt/WBuoPtAmMGLbVVJTwKR/rjohP+Y+j4xHSSgvylICvT5HOnnPha+uJMqwmUWg==
+  version "1.3.418"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.418.tgz#840021191f466b803a873e154113620c9f53cec6"
+  integrity sha512-i2QrQtHes5fK/F9QGG5XacM5WKEuR322fxTYF9e8O9Gu0mc0WmjjwGpV8c7Htso6Zf2Di18lc3SIPxmMeRFBug==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7104,7 +7104,7 @@ find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.2.0:
+find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -8616,9 +8616,9 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
     isobject "^3.0.1"
 
 is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
+  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -9268,7 +9268,7 @@ jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest-worker@^25.1.0, jest-worker@^25.4.0:
+jest-worker@^25.4.0:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.4.0.tgz#ee0e2ceee5a36ecddf5172d6d7e0ab00df157384"
   integrity sha512-ghAs/1FtfYpMmYQ0AHqxV62XPvKdUDIBBApMZfly+E9JEmYh2K45G0R5dWxx986RN12pRCxsViwQVtGl+N4whw==
@@ -11028,7 +11028,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.2:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -11312,7 +11312,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -12451,23 +12451,10 @@ rc-align@^3.0.0-rc.0:
     rc-util "^4.12.0"
     resize-observer-polyfill "^1.5.1"
 
-rc-animate@2.x, rc-animate@^2.10.0, rc-animate@^2.10.1, rc-animate@^2.10.2, rc-animate@^2.9.2:
+rc-animate@2.x, rc-animate@^2.10.0, rc-animate@^2.10.1, rc-animate@^2.10.2, rc-animate@^2.9.2, rc-animate@~2.11.0:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.11.1.tgz#2666eeb6f1f2a495a13b2af09e236712278fdb2c"
   integrity sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.6"
-    css-animation "^1.3.2"
-    prop-types "15.x"
-    raf "^3.4.0"
-    rc-util "^4.15.3"
-    react-lifecycles-compat "^3.0.4"
-
-rc-animate@~2.10.2:
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.10.3.tgz#163d5e29281a4ff82d53ee7918eeeac856b756f9"
-  integrity sha512-A9qQ5Y8BLlM7EhuCO3fWb/dChndlbWtY/P5QvPqBU7h4r5Q2QsvsbpTGgdYZATRDZbTRnJXXfVk9UtlyS7MBLg==
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.6"
@@ -12730,9 +12717,9 @@ rc-tree-select@~3.1.0:
     rc-util "^4.17.0"
 
 rc-tree@^3.1.0, rc-tree@~3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-3.1.5.tgz#eb1c0d40f34ae2ad1ab8c951174c06e6a64957a6"
-  integrity sha512-LOUfsJg5XxtA4FKgGkuVwnbBlnh3VVtySF7LMp4ko0n8oIUBYnn2vs6WG41kuH0V4tLTlQhvCFup/6JEKL01sg==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-3.1.6.tgz#5aca662801954be2e00609898d427f16ca9023e5"
+  integrity sha512-K43uIcLnDDoynrkcRSPzkYCrc3mh96/N3DhIDeSv8UdJXMgt0u8KonyuT4y/4GhFPENBuq45ASwcuxvH4uy0Sg==
   dependencies:
     classnames "2.x"
     prop-types "^15.5.8"
@@ -12753,7 +12740,7 @@ rc-trigger@^4.0.0, rc-trigger@~4.0.0:
     rc-animate "^2.10.2"
     rc-util "^4.20.0"
 
-rc-upload@~3.0.0:
+rc-upload@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-3.0.4.tgz#5fd8ba9eefc1e466225240ae997404693d86fa09"
   integrity sha512-dTCvj1iHxjHG0qo5UyN2ZmtueG9GG3xrOhOwnjsehaoOvl0TOjLbHkUIPPqLZk+wHb57Ue4KB7c3+IMgkDoBvw==
@@ -12762,9 +12749,9 @@ rc-upload@~3.0.0:
     classnames "^2.2.5"
 
 rc-util@^4.0.4, rc-util@^4.11.0, rc-util@^4.12.0, rc-util@^4.13.0, rc-util@^4.14.0, rc-util@^4.15.3, rc-util@^4.16.1, rc-util@^4.17.0, rc-util@^4.20.0, rc-util@^4.20.1, rc-util@^4.3.0, rc-util@^4.5.1, rc-util@^4.6.0, rc-util@^4.8.0, rc-util@^4.9.0:
-  version "4.20.3"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.3.tgz#c4d4ee6171cf685dc75572752a764310325888d3"
-  integrity sha512-NBBc9Ad5yGAVTp4jV+pD7tXQGqHxGM2onPSZFyVoJ5fuvRF+ZgzSjZ6RXLPE0pVVISRJ07h+APgLJPBcAeZQlg==
+  version "4.20.5"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.5.tgz#f7c77569e971ae6a8ad56f899cadd22275398325"
+  integrity sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==
   dependencies:
     add-dom-event-listener "^1.1.0"
     prop-types "^15.5.10"
@@ -13285,12 +13272,12 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
-  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
   dependencies:
-    picomatch "^2.0.7"
+    picomatch "^2.2.1"
 
 reakit-system@^0.11.0:
   version "0.11.0"
@@ -13835,11 +13822,9 @@ rsvp@^4.8.4:
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.2.0, run-async@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
-  integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
-  dependencies:
-    is-promise "^2.1.0"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -14057,6 +14042,11 @@ serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.0.0.tgz#492e489a2d77b7b804ad391a5f5d97870952548e"
+  integrity sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -15046,21 +15036,21 @@ terser-webpack-plugin@^1.4.3:
     worker-farm "^1.7.0"
 
 terser-webpack-plugin@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz#5ad971acce5c517440ba873ea4f09687de2f4a81"
-  integrity sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.6.tgz#a4014b311a61f87c6a1b217ef4f5a75bd0665a69"
+  integrity sha512-I8IDsQwZrqjdmOicNeE8L/MhwatAap3mUrtcAKJuilsemUNcX+Hier/eAzwStVqhlCxq0aG3ni9bK/0BESXkTg==
   dependencies:
     cacache "^13.0.1"
-    find-cache-dir "^3.2.0"
-    jest-worker "^25.1.0"
-    p-limit "^2.2.2"
-    schema-utils "^2.6.4"
-    serialize-javascript "^2.1.2"
+    find-cache-dir "^3.3.1"
+    jest-worker "^25.4.0"
+    p-limit "^2.3.0"
+    schema-utils "^2.6.6"
+    serialize-javascript "^3.0.0"
     source-map "^0.6.1"
-    terser "^4.4.3"
+    terser "^4.6.12"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2, terser@^4.4.3, terser@^4.6.2, terser@^4.6.3:
+terser@^4.1.2, terser@^4.6.12, terser@^4.6.2, terser@^4.6.3:
   version "4.6.12"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.12.tgz#44b98aef8703fdb09a3491bf79b43faffc5b4fee"
   integrity sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==
@@ -16350,9 +16340,9 @@ ws@^6.1.2, ws@^6.2.1:
     async-limiter "~1.0.0"
 
 ws@^7.0.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
-  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.5.tgz#abb1370d4626a5a9cd79d8de404aa18b3465d10d"
+  integrity sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR segregates temporary and permanent deletions
- Adds `deletePermanently` prop to mutation input
- Updates datetime/ticket/price mutation to add support for trash and permanent delete
- Updates Trash buttons for trash and permanent deletion
- Sets TPC prices to be deleted permanently by default
- Updates filters and sorters to fix the bug related to trashed entities not shown
- Updates DOM data to make sure relations are loaded for deleted entities