### PR TITLE
do a GET request when View Details button is clicked

### DIFF
--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -687,7 +687,7 @@ class DisplayTicketSelector
                 __LINE__
             );
         }
-        $view_details_btn = '<form method="POST" action="';
+        $view_details_btn = '<form method="GET" action="';
         $view_details_btn .= apply_filters(
             'FHEE__EE_Ticket_Selector__display_view_details_btn__btn_url',
             $this->event->get_permalink(),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The Alternative Registration URL tries to do a `<form method="POST" action="{alternative.registration.url}">` when ticket selector setting for event listing is set to not display (and you get the View Details button). Some servers will not allow POSTing to any URL on their site, resulting in a 403 error or similar. See also:
https://eventespresso.com/topic/alternative-registration-page-link-not-working-2/
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Start on Master branch:
- [x] Set up an event to have an Alternative Registration URL, set URL to https://buildyourfuture.withgoogle.com/events/tech-challenge/
- [x] In Event Espresso > Events > Templates, set Display Ticket Selector to No
- [x] View event list page, and click the View Details button for the event with the Alternative Registration URL
Note that you're taken to a blank page
- [x] hit the back button
- [x] Now switch to this PR's branch, refresh the event list page
- [x] click the View Details button for the event with the Alternative Registration URL
- [x] Verify you're directed to the Alternative Registration page
- [x] On another event listed on the event list page, verify you're directed to the correct event when clicking the View Details button

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
