### PR TITLE
Stop setting extra meta for every message

### DIFF
--- a/core/db_classes/EE_Message.class.php
+++ b/core/db_classes/EE_Message.class.php
@@ -869,15 +869,17 @@ class EE_Message extends EE_Base_Class implements EEI_Admin_Links
     public function set_messenger_is_executing()
     {
         $this->set_STS_ID(EEM_Message::status_messenger_executing);
-        $this->set_error_message(
-            esc_html__(
-                'A message with this status indicates that there was a problem that occurred while the message was being
-                processed by the messenger.  It is still possible that the message was sent successfully, but at some
-                point during the processing there was a failure.  This usually is indicative of a timeout issue with PHP 
-                or memory limits being reached.  If you see this repeatedly you may want to consider upgrading the memory 
-                available to PHP on your server.',
-                'event_espresso'
-            )
-        );
+        if (EEM_Message::debug()) {
+            $this->set_error_message(
+                esc_html__(
+                    'A message with this status indicates that there was a problem that occurred while the message was being
+                    processed by the messenger.  It is still possible that the message was sent successfully, but at some
+                    point during the processing there was a failure.  This usually is indicative of a timeout issue with PHP 
+                    or memory limits being reached.  If you see this repeatedly you may want to consider upgrading the memory 
+                    available to PHP on your server.',
+                    'event_espresso'
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
There is an 'error' set in extra meta each time a message changes status to EEM_Message::status_messenger_executing.

I think the intention is that if you see that error often you need to update your server config etc. So its set incase the request doesn't complete etc.

But it's on every messenger when it changes the status to 'executing' and then isn't removed. I know I could add some code to remove when finished but I don't remember ever getting a report of that error on the forums and if there is instances of the message queue going crazy we can just add `EE_DEBUG_MESSAGES` to `wp-config.php` for stuff like this and work from there.


## Problem this Pull Request solves
Trigger a registration message within Event Espresso, either by registering onto an Event or manually triggering a message.

Then check the `esp_extra_meta` table and find the last entry (sort but row ID and find the last row) with something like:

`28401 | 5034 | Message | MSG_error | A message with this status indicates that there wa..`

Each time a message is generated and sent it adds another row of the above.

Now, switch to this branch and add a couple of registrations so you trigger messages again.

Check `esp_extra_meta` again and confirm there are no additional entries for the above additional registrations and that you actually received the messages.

Enable `EE_DEBUG_MESSAGES` by adding `define( 'EE_DEBUG_MESSAGES', true);` to `wp-config.php`

Trigger more messages and check `esp_extra_meta` again, this time, because EE_DEBUG_MESSAGES is enabled you **should** see those DB entries being added to the table each time a message is generated again.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
