### PR TITLE
Recalculate base price when ticket price changes | Closes #2807

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+
+import { EntityId } from '@dataServices/types';
+import { useInitialState } from '@edtrUI/tickets/ticketPriceCalculator/data';
+import { calculateBasePrice } from '@edtrUI/tickets/ticketPriceCalculator/utils';
+import { isBasePrice } from '@sharedEntities/priceTypes/predicates';
+import { usePriceMutator } from '@edtrServices/apollo/mutations';
+
+const useRecalculateBasePrice = (ticketId: EntityId): VoidFunction => {
+	// This will give us the exact state expected by `calculateBasePrice()`
+	const getDataState = useInitialState({ ticketId });
+	const { updateEntity } = usePriceMutator();
+
+	return useCallback(() => {
+		// get the list of updated prices with the amount of base price updated
+		const newPrices = calculateBasePrice(getDataState(null));
+		// the price if present should be the basePrice
+		const [basePrice] = newPrices.filter(isBasePrice);
+
+		// if we are lucky
+		if (basePrice?.id) {
+            const { id, amount } = basePrice;
+            // update the base price
+			updateEntity({ id, amount });
+		}
+	}, [getDataState, updateEntity]);
+};
+
+export default useRecalculateBasePrice;

--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
@@ -19,8 +19,8 @@ const useRecalculateBasePrice = (ticketId: EntityId): VoidFunction => {
 
 		// if we are lucky
 		if (basePrice?.id) {
-            const { id, amount } = basePrice;
-            // update the base price
+			const { id, amount } = basePrice;
+			// update the base price
 			updateEntity({ id, amount });
 		}
 	}, [getDataState, updateEntity]);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/index.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/index.ts
@@ -1,5 +1,7 @@
 export { default as useDataState } from './useDataState';
 
+export { default as useInitialState } from './useInitialState';
+
 export { default as useDataStateManager } from './useDataStateManager';
 
 export * from './types';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/test/useInitialState.test.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/test/useInitialState.test.ts
@@ -8,19 +8,6 @@ const mockTicket = tickets[0];
 
 const timeout = 5000; // milliseconds
 describe('TPC:useInitialState', () => {
-	it('throws an error when a non-existent ticket id is passed', () => {
-		const { result } = renderHook(
-			() => {
-				return useInitialState({ ticketId: 'fake-id' });
-			},
-			{
-				wrapper: TestWrapper,
-			}
-		);
-
-		expect(() => result.current(null)).toThrow();
-	});
-
 	it('returns the computed initial state for the passed ticketId', async () => {
 		const { result, waitForNextUpdate } = renderHook(
 			() => {

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
@@ -30,7 +30,7 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 
 	// get the full ticket object
 	const wholeTicket = useTicketItem({ id: ticketId });
-	const ticket = pick(ticketFieldsToUse, wholeTicket);
+	const ticket = wholeTicket && pick(ticketFieldsToUse, wholeTicket);
 
 	// get all related prices
 	const unSortedPrices = useTicketPrices(ticketId);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useOnSubmitPrices.ts
@@ -29,7 +29,8 @@ const useOnSubmitPrices = (): VoidFunction => {
 			// convert the price mutatons into promises
 			prices.map(({ isNew, isModified, ...price }) => {
 				// if it's not new or modified, no need to do anything
-				if (!(isNew || isModified)) {
+				// but base price needs to be updated anyway which may been modified by revCalc
+				if (!(isNew || isModified) && !price.isBasePrice) {
 					// retain the existing relation
 					relatedPriceIds.push(price.id);
 					return Promise.resolve(price);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
@@ -5,7 +5,7 @@ import type { TicketItemProps } from '../types';
 import { useTicketMutator } from '@edtrServices/apollo/mutations';
 import { getPropsAreEqual } from '@appServices/utilities';
 import CurrencyInput from '@appInputs/CurrencyInput';
-import useRecalculateBasePrice from '@edtrUI/tickets/hooks/useRecalculateBasePrice';
+import useRecalculateBasePrice from '../../hooks/useRecalculateBasePrice';
 
 interface EditablePriceProps extends TicketItemProps {
 	className?: string;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
@@ -5,6 +5,7 @@ import type { TicketItemProps } from '../types';
 import { useTicketMutator } from '@edtrServices/apollo/mutations';
 import { getPropsAreEqual } from '@appServices/utilities';
 import CurrencyInput from '@appInputs/CurrencyInput';
+import useRecalculateBasePrice from '@edtrUI/tickets/hooks/useRecalculateBasePrice';
 
 interface EditablePriceProps extends TicketItemProps {
 	className?: string;
@@ -12,12 +13,13 @@ interface EditablePriceProps extends TicketItemProps {
 
 const EditablePrice: React.FC<EditablePriceProps> = ({ entity: ticket, className }) => {
 	const { updateEntity } = useTicketMutator(ticket.id);
-
+	const recalculateBasePrice = useRecalculateBasePrice(ticket.id);
 	const onChangePrice = useCallback(
 		({ amount: price }: any): void => {
 			price = parseFloat(price);
 			if (price !== ticket.price) {
-				updateEntity({ price });
+				updateEntity({ price, reverseCalculate: true });
+				recalculateBasePrice();
 			}
 		},
 		[ticket.cacheId]


### PR DESCRIPTION
This fixes the bug to update related base price when ticket price changes:
- Creates `useRecalculateBasePrice` hook
- Wires ticket price update to recalculate base price