### PR TITLE
Edit form improvements | Partially closes #2819

### DIFF
--- a/assets/src/application/ui/display/DebugInfo.tsx
+++ b/assets/src/application/ui/display/DebugInfo.tsx
@@ -13,6 +13,10 @@ const Pre = styled.pre`
 	background-color: #26203d;
 `;
 
+const Div = styled.div`
+	margin-top: 3em;
+`;
+
 interface DebugInfoProps {
 	data: any;
 	asJson?: boolean;
@@ -38,10 +42,10 @@ const DebugInfo: React.FC<DebugInfoProps> = ({ data, asJson = true, asCollapse =
 	const handleToggle = useCallback(() => setShow(!show), [show]);
 
 	return (
-		<>
-			<Button buttonText={buttonText} onClick={handleToggle} />
+		<Div>
+			<Button buttonText={buttonText} onClick={handleToggle} size="md" />
 			<Collapse isOpen={show}>{output}</Collapse>
-		</>
+		</Div>
 	);
 };
 

--- a/assets/src/application/ui/forms/espressoForm/styles.scss
+++ b/assets/src/application/ui/forms/espressoForm/styles.scss
@@ -58,88 +58,18 @@
 	}
 
 	.section-body {
+		.form-item {
+			margin: var(--ee-margin-default) 0;
+		}
 		.form-item-pair {
 			width: 50%;
 			display: inline-flex;
-		}
-
-		.ant-input,
-		.ant-picker,
-		.ant-input-number {
-			background: var(--ee-background-color);
-			border: 2px solid var(--ee-color-grey-10);
-			border-radius: var(--ee-border-radius-small);
-			box-shadow: none;
-			color: var(--ee-default-text-color);
-			font-size: var(--ee-font-size-default);
-			min-height: unset;
-			min-width: 120px;
-			padding: var(--ee-padding-micro) var(--ee-padding-tiny);
-			vertical-align: middle;
-			width: 100%;
-			&:focus,
-			&.ant-picker-focused,
-			&.ant-input-number-focused {
-				border-color: var(--ee-color-primary-low-contrast);
-				box-shadow: 0 0 0 1px var(--ee-color-primary-low-contrast);
+			padding-right: var(--ee-margin-default);
+			margin: var(--ee-margin-default) 0;
+			label {
+				display: flex;
+				align-items: center;
 			}
-		}
-
-		.ant-input-group-addon {
-			background: var(--ee-color-grey-14);
-			border: 2px solid var(--ee-color-grey-10);
-			border-radius: var(--ee-border-radius-small);
-			color: var(--ee-text-on-grey-14);
-			padding: 3px 0 0;
-			vertical-align: middle;
-
-			&:focus {
-				border-color: var(--ee-color-primary-low-contrast);
-				box-shadow: 0 0 0 1px var(--ee-color-primary-low-contrast);
-			}
-		}
-
-		/* button on the left */
-		.ant-input-group-addon:first-child {
-			border-top-right-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-
-		/* button on the right */
-		.ant-input + .ant-input-group-addon {
-			border-top-left-radius: 0;
-			border-bottom-left-radius: 0;
-		}
-
-		.ant-input-group {
-			&:focus {
-				border-color: var(--ee-color-primary-low-contrast);
-				box-shadow: 0 0 0 1px var(--ee-color-primary-low-contrast);
-			}
-
-			> .ant-input:first-child {
-				border-right: 0;
-				border-top-right-radius: 0;
-				border-bottom-right-radius: 0;
-			}
-
-			> .ant-input:last-child {
-				border-left: 0;
-				border-top-left-radius: 0;
-				border-bottom-left-radius: 0;
-			}
-		}
-
-		.ant-input-group > .ant-input:focus + .ant-input-group-addon {
-			border-color: var(--ee-color-primary-low-contrast);
-			box-shadow: 0 0 0 1px var(--ee-color-primary-low-contrast);
-		}
-
-		.ant-input-number-input,
-		.ant-input-number-input:focus {
-			border: none;
-			box-shadow: none;
-			outline: none;
 		}
 	}
 
@@ -178,13 +108,6 @@
 			.field-group-item {
 				flex: 0 50%;
 				padding: 0 0.5em;
-			}
-		}
-	}
-	@media (max-width: 575px) {
-		.section-body {
-			.ant-form-item .ant-form-item-label {
-				padding: 0;
 			}
 		}
 	}

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -53,6 +53,10 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 		},
 	};
 
+	const adjacentFormItemProps = {
+		className: 'form-item-pair',
+	};
+
 	return {
 		...config,
 		onSubmit: onSubmitFrom,
@@ -135,11 +139,13 @@ const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormCo
 							),
 							'\n'
 						),
+						formControlProps: adjacentFormItemProps,
 					},
 					{
 						name: 'isTrashed',
 						label: __('Trash'),
 						fieldType: 'switch',
+						formControlProps: adjacentFormItemProps,
 					},
 				],
 			},

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -53,9 +53,6 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 
 	const adjacentFormItemProps = {
 		className: 'form-item-pair',
-		labelCol: { span: 10 },
-		wrapperCol: { span: 12 },
-		labelAlign: 'right' as 'right',
 	};
 
 	const initialValues: TicketFormShape = {
@@ -107,19 +104,11 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 							),
 							' \n'
 						),
-						fieldType: 'text',
+						fieldType: 'number',
+						formControlProps: adjacentFormItemProps,
 						addonAfter: id ? (
 							<TicketPriceCalculatorButton ticketId={id} style={{ margin: 0, height: 'auto' }} />
 						) : null,
-						formItemProps: adjacentFormItemProps,
-					},
-					{
-						name: 'isTaxable',
-						label: __('Taxable'),
-						fieldType: 'switch',
-						info: __(
-							'If enabled, all configured taxes will be applied to the price of this ticket upon purchase.'
-						),
 					},
 				],
 			},
@@ -166,8 +155,8 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'quantity',
 						label: __('Quantity For Sale'),
 						fieldType: 'number',
+						formControlProps: adjacentFormItemProps,
 						parseAsInfinity: true,
-						formItemProps: adjacentFormItemProps,
 						min: -1,
 						info: sprintf(
 							__(
@@ -181,7 +170,7 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						label: __('Number of Uses'),
 						fieldType: 'number',
 						parseAsInfinity: true,
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 						min: 0,
 						info: sprintf(
 							__(
@@ -194,7 +183,7 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'min',
 						label: __('Minimum Quantity'),
 						fieldType: 'number',
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 						min: 0,
 						info: sprintf(
 							__(
@@ -208,7 +197,7 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						label: __('Maximum Quantity'),
 						fieldType: 'number',
 						parseAsInfinity: true,
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 						min: -1,
 						info: sprintf(
 							__(
@@ -221,21 +210,21 @@ const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFo
 						name: 'isRequired',
 						label: __('Required Ticket'),
 						fieldType: 'switch',
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 						info: __('If enabled, the ticket will appear first in frontend ticket lists.'),
 					},
 					{
 						name: 'isDefault',
 						label: __('Default Ticket'),
 						fieldType: 'switch',
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 						info: __('If enabled, the ticket will appear on all new events.'),
 					},
 					{
 						name: 'isTrashed',
 						label: __('Trash'),
 						fieldType: 'switch',
-						formItemProps: adjacentFormItemProps,
+						formControlProps: adjacentFormItemProps,
 					},
 				],
 			},


### PR DESCRIPTION
This PR:
- Removes Taxable input from Edit Ticket form
- Splits inputs in the "Details" section of the Edit Ticket form into two columns
- Fixes price input to not accept regular text
- Splits inputs in the "Details" section of the Edit Date form into two columns
- Adds an additional margin between form rows of `var(--ee-margin-default)`

## Date Edit Form
![Dates example](https://user-images.githubusercontent.com/18226415/81925615-62cc2800-95fe-11ea-814b-ddf74cc6ab57.jpg)

## Ticket Edit Form
![Tickets example](https://user-images.githubusercontent.com/18226415/81925660-6eb7ea00-95fe-11ea-81a6-f106dc8e37ca.jpg)

