### PR TITLE
Fix price decimal places

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
@@ -5,17 +5,15 @@ import { useInitialState } from '@edtrUI/tickets/ticketPriceCalculator/data';
 import { calculateBasePrice } from '@edtrUI/tickets/ticketPriceCalculator/utils';
 import { isBasePrice } from '@sharedEntities/priceTypes/predicates';
 import { usePriceMutator } from '@edtrServices/apollo/mutations';
-import { useMoneyDisplay } from '@application/services';
 
 const useRecalculateBasePrice = (ticketId: EntityId): VoidFunction => {
 	// This will give us the exact state expected by `calculateBasePrice()`
 	const getDataState = useInitialState({ ticketId });
 	const { updateEntity } = usePriceMutator();
-	const { formatAmount } = useMoneyDisplay();
 
 	return useCallback(() => {
 		// get the list of updated prices with the amount of base price updated
-		const newPrices = calculateBasePrice(getDataState(null), formatAmount);
+		const newPrices = calculateBasePrice(getDataState(null));
 		// the price if present should be the basePrice
 		const [basePrice] = newPrices.filter(isBasePrice);
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/test/data.calculations.test.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/test/data.calculations.test.ts
@@ -9,7 +9,6 @@ import defaultPrice from '../../defaultPriceModifier';
 import TestWrapper from './TestWrapper';
 import { getBasePrice } from '@sharedEntities/prices/predicates/selectionPredicates';
 import { calculateBasePrice, calculateTicketTotal } from '../../utils';
-import { useMoneyDisplay } from '@application/services';
 
 const timeout = 5000; // milliseconds
 describe('TPC:data.calculations', () => {
@@ -81,7 +80,6 @@ describe('TPC:data.calculations', () => {
 				return {
 					dataState: useDataState(),
 					baseType: usePriceTypeForPrice(defaultPriceModifier.id),
-					moneyDisplay: useMoneyDisplay(),
 					defaultPriceModifier,
 				};
 			},
@@ -134,7 +132,7 @@ describe('TPC:data.calculations', () => {
 		expect(basePriceBefore.amount).not.toEqual(basePriceAfter.amount);
 
 		// calculate the expected base price
-		const newPrices = calculateBasePrice(result.current.dataState.getData(), result.current.moneyDisplay.formatAmount);
+		const newPrices = calculateBasePrice(result.current.dataState.getData());
 		const calculatedBasePrice = getBasePrice(newPrices);
 
 		expect(calculatedBasePrice.amount).toEqual(basePriceAfter.amount);
@@ -190,7 +188,6 @@ describe('TPC:data.calculations', () => {
 			() => {
 				return {
 					dataState: useDataState(),
-					moneyDisplay: useMoneyDisplay(),
 				};
 			},
 			{
@@ -226,7 +223,7 @@ describe('TPC:data.calculations', () => {
 		expect(basePriceBefore.amount).not.toEqual(basePriceAfter.amount);
 
 		// calculate the expected base price
-		const newPrices = calculateBasePrice(result.current.dataState.getData(), result.current.moneyDisplay.formatAmount);
+		const newPrices = calculateBasePrice(result.current.dataState.getData());
 		const calculatedBasePrice = getBasePrice(newPrices);
 
 		expect(calculatedBasePrice.amount).toEqual(basePriceAfter.amount);
@@ -237,7 +234,6 @@ describe('TPC:data.calculations', () => {
 			() => {
 				return {
 					dataState: useDataState(),
-					moneyDisplay: useMoneyDisplay(),
 				};
 			},
 			{
@@ -274,7 +270,7 @@ describe('TPC:data.calculations', () => {
 		expect(basePriceBefore.amount).not.toEqual(basePriceAfter.amount);
 
 		// calculate the expected base price
-		const newPrices = calculateBasePrice(result.current.dataState.getData(), result.current.moneyDisplay.formatAmount);
+		const newPrices = calculateBasePrice(result.current.dataState.getData());
 		const calculatedBasePrice = getBasePrice(newPrices);
 
 		expect(calculatedBasePrice.amount).toEqual(basePriceAfter.amount);
@@ -329,7 +325,6 @@ describe('TPC:data.calculations', () => {
 			() => {
 				return {
 					dataState: useDataState(),
-					moneyDisplay: useMoneyDisplay(),
 				};
 			},
 			{
@@ -366,7 +361,7 @@ describe('TPC:data.calculations', () => {
 		expect(basePriceBefore.amount).not.toEqual(basePriceAfter.amount);
 
 		// calculate the expected base price
-		const newPrices = calculateBasePrice(result.current.dataState.getData(), result.current.moneyDisplay.formatAmount);
+		const newPrices = calculateBasePrice(result.current.dataState.getData());
 		const calculatedBasePrice = getBasePrice(newPrices);
 
 		expect(calculatedBasePrice.amount).toEqual(basePriceAfter.amount);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/PriceField.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/PriceField.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useDataState } from '../data';
 import BaseField from './BaseField';
-import { BaseFieldProps, FieldValue, PriceFieldProps } from './types';
+import { BaseFieldProps, PriceFieldProps } from './types';
 
 type BFP = BaseFieldProps;
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 
 import { PriceModifierProps } from '../types';
 import { PriceField } from '../fields';
-import { useMoneyDisplay, parsedAmount } from '@appServices/utilities/money';
+import { useMoneyDisplay, parsedAmount, formatAmount } from '@appServices/utilities/money';
 import { useDataState } from '../data';
 
 import './styles.scss';
@@ -13,7 +13,7 @@ const percentSign = '%';
 
 const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 	const { reverseCalculate } = useDataState();
-	const { currency, formatAmount } = useMoneyDisplay();
+	const { currency } = useMoneyDisplay();
 	const sign = price.isPercent ? percentSign : currency.sign;
 	let b4Price = '';
 	let afterPrice = sign;
@@ -30,6 +30,11 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 		'ee-input__price-field--has-error': Number(price?.amount ?? 0) === 0,
 	});
 
+	const formatParse = (defaultValue = null) => (amount: any) => {
+		const parsedValue = parsedAmount(amount);
+		return isNaN(parsedValue) ? defaultValue : parsedValue;
+	};
+
 	return (
 		<div className='ee-ticket-price-field'>
 			<div className='ee-ticket-price-field__before'>{b4Price}</div>
@@ -42,11 +47,8 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 					component={'input'}
 					placeholder={__('amount...')}
 					disabled={reverseCalculate && price.isBasePrice}
-					format={(amount) => formatAmount(amount) || ''}
-					parse={(amount) => {
-						const parsedValue = parsedAmount(amount);
-						return isNaN(parsedValue) ? null : parsedValue;
-					}}
+					format={formatParse('')}
+					parse={formatParse()}
 					formatOnBlur
 				/>
 			</div>

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/stateListeners/useInitStateListeners.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/stateListeners/useInitStateListeners.ts
@@ -5,20 +5,20 @@ import { calculateBasePrice, calculateTicketTotal } from '../utils';
 import usePriceChangeListener from './usePriceChangeListener';
 import usePriceTypeChangeListener from './usePriceTypeChangeListener';
 import useTicketTotalChangeListener from './useTicketTotalChangeListener';
-import { useMoneyDisplay } from '@application/services';
+import { parsedAmount, useMoneyDisplay } from '@application/services';
 
 const useStateListeners = (): void => {
 	const { getData, reverseCalculate, setPrices, updateTicketPrice } = useDataState();
 	const { formatAmount } = useMoneyDisplay();
 
 	const updateBasePrice = useCallback(() => {
-		const newPrices = calculateBasePrice(getData(), formatAmount);
+		const newPrices = calculateBasePrice(getData());
 		setPrices(newPrices);
 	}, [getData, setPrices]);
 
 	const updateTicketTotal = useCallback(() => {
 		const ticketTotal = calculateTicketTotal(getData());
-		updateTicketPrice(parseFloat(formatAmount(ticketTotal)));
+		updateTicketPrice(parsedAmount(formatAmount(ticketTotal)));
 	}, [getData, updateTicketPrice]);
 
 	const calculatePrice = useCallback(() => {

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/calculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/calculateBasePrice.ts
@@ -6,9 +6,9 @@ import { DataState } from '../data';
 import { isNotBasePrice } from '@sharedEntities/prices/predicates/selectionPredicates';
 import { sortByPriceOrderIdDesc } from '@sharedEntities/prices/predicates/sortingPredicates';
 import { updateBasePriceAmount } from '@sharedEntities/prices/predicates/updatePredicates';
-import { FormatAmountFunction } from '@application/services/utilities/money/formatAmount';
+import { parsedAmount } from '@application/services/utilities/money';
 
-const calculateBasePrice = (state: DataState, formatAmount: FormatAmountFunction): DataState['prices'] => {
+const calculateBasePrice = (state: DataState): DataState['prices'] => {
 	const ticket = state?.ticket;
 	if (!ticket) {
 		return state.prices;
@@ -24,9 +24,11 @@ const calculateBasePrice = (state: DataState, formatAmount: FormatAmountFunction
 	// now extract the value for "total" or set to 0
 	const ticketTotal = ticket?.price || 0;
 	const newBasePrice = reduce<TpcPriceModifier, number>(basePriceCalculator, ticketTotal, sortedModifiers);
+	// Save the price upto 6 decimals places
+	const amount = parsedAmount(newBasePrice).toFixed(6);
 	const newPrices = updateBasePriceAmount<TpcPriceModifier>({
 		prices: state.prices,
-		amount: parseFloat(formatAmount(newBasePrice)),
+		amount: parsedAmount(amount),
 	});
 	return newPrices;
 };


### PR DESCRIPTION
This PR fixes the issue with decimal places caused by reverse calculate. Here is the set behavior:
- If user changes the price amount, decimal places are saved exactly as entered
- If Base Price is calculated using reverse calculate, then it's limited to 6 decimal places
- Ticket Price is always formatted as per currency config

Closes #2819 