### PR TITLE
fix loading for block assets

### DIFF
--- a/assets/src/application/services/utilities/dom/domReady.ts
+++ b/assets/src/application/services/utilities/dom/domReady.ts
@@ -1,0 +1,17 @@
+/**
+ * TypeScript copy of @wordpress/dom-ready
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/dom-ready/src/index.js
+ */
+const domReady = (callback: VoidFunction): void => {
+	if (
+		document?.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document?.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return callback();
+	}
+
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document?.addEventListener('DOMContentLoaded', callback);
+};
+
+export default domReady;

--- a/assets/src/application/services/utilities/dom/index.ts
+++ b/assets/src/application/services/utilities/dom/index.ts
@@ -1,3 +1,4 @@
 export { default as canUseDOM } from './canUseDOM';
+export { default as domReady } from './domReady';
 export { default as getHTMLElementClientRect } from './getHTMLElementClientRect';
 export { default as renderDomElement } from './renderDomElement';

--- a/assets/src/domain/blocks/event-attendees/index.tsx
+++ b/assets/src/domain/blocks/event-attendees/index.tsx
@@ -1,29 +1,27 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+import { canUseDOM, domReady } from '@appServices/utilities/dom';
+
 import attributes from './attributes';
 import EventAttendeesEdit from './edit';
 import type { EventAttendeesAttributes } from './types';
 import './style.scss';
 
-registerBlockType<EventAttendeesAttributes>('eventespresso/event-attendees', {
-	title: __('Event Attendees', 'event_espresso'),
+const registerEventAttendeesBlock: VoidFunction = () => {
+	registerBlockType<EventAttendeesAttributes>('eventespresso/event-attendees', {
+		title: __('Event Attendees', 'event_espresso'),
+		description: __('Displays a list of people that have registered for the specified event', 'event_espresso'),
+		icon: 'groups',
+		category: 'event-espresso',
+		keywords: [__('event', 'event_espresso'), __('attendees', 'event_espresso'), __('list', 'event_espresso')],
+		attributes,
+		edit: EventAttendeesEdit,
+		save() {
+			return null;
+		},
+		// TODO migrate attributes to use GUID
+	});
+};
 
-	description: __('Displays a list of people that have registered for the specified event', 'event_espresso'),
-
-	icon: 'groups',
-
-	category: 'event-espresso',
-
-	keywords: [__('event', 'event_espresso'), __('attendees', 'event_espresso'), __('list', 'event_espresso')],
-
-	attributes,
-
-	edit: EventAttendeesEdit,
-
-	save() {
-		return null;
-	},
-
-	// TODO migrate attributes to use GUID
-});
+canUseDOM && domReady(registerEventAttendeesBlock);

--- a/assets/src/domain/blocks/event-attendees/index.tsx
+++ b/assets/src/domain/blocks/event-attendees/index.tsx
@@ -1,27 +1,21 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
-import { canUseDOM, domReady } from '@appServices/utilities/dom';
-
 import attributes from './attributes';
 import EventAttendeesEdit from './edit';
 import type { EventAttendeesAttributes } from './types';
 import './style.scss';
 
-const registerEventAttendeesBlock: VoidFunction = () => {
-	registerBlockType<EventAttendeesAttributes>('eventespresso/event-attendees', {
-		title: __('Event Attendees', 'event_espresso'),
-		description: __('Displays a list of people that have registered for the specified event', 'event_espresso'),
-		icon: 'groups',
-		category: 'event-espresso',
-		keywords: [__('event', 'event_espresso'), __('attendees', 'event_espresso'), __('list', 'event_espresso')],
-		attributes,
-		edit: EventAttendeesEdit,
-		save() {
-			return null;
-		},
-		// TODO migrate attributes to use GUID
-	});
-};
-
-canUseDOM && domReady(registerEventAttendeesBlock);
+registerBlockType<EventAttendeesAttributes>('eventespresso/event-attendees', {
+	title: __('Event Attendees', 'event_espresso'),
+	description: __('Displays a list of people that have registered for the specified event', 'event_espresso'),
+	icon: 'groups',
+	category: 'event-espresso',
+	keywords: [__('event', 'event_espresso'), __('attendees', 'event_espresso'), __('list', 'event_espresso')],
+	attributes,
+	edit: EventAttendeesEdit,
+	save() {
+		return null;
+	},
+	// TODO migrate attributes to use GUID
+});

--- a/assets/src/domain/index.ts
+++ b/assets/src/domain/index.ts
@@ -3,6 +3,7 @@ import './shared/services/publicPath';
 const domain = window?.eeDomain;
 
 if (domain) {
+	// todo remove this at some point in the future
 	console.log(`%c importing: /domain/${domain}/entryPoint.ts`, 'color: SkyBlue;');
 	import(
 		/* webpackExclude: /(shared)/ */

--- a/assets/src/domain/index.ts
+++ b/assets/src/domain/index.ts
@@ -3,15 +3,12 @@ import './shared/services/publicPath';
 const domain = window?.eeDomain;
 
 if (domain) {
+	console.log(`%c importing: /domain/${domain}/entryPoint.ts`, 'color: SkyBlue;');
 	import(
 		/* webpackExclude: /(shared)/ */
 		/* webpackChunkName: "[request]" */
 		`./${domain}/entryPoint.ts`
-	)
-		.then(() => {
-			console.log('domain', domain);
-		})
-		.catch(console.error);
+	).catch(console.error);
 } else {
 	console.error('No domain supplied');
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -158,7 +158,7 @@ module.exports = function (webpackEnv) {
 		// These are the "entry points" to our application.
 		// This means they will be the "root" imports that are included in JS bundle.
 		entry: {
-			'eventespresso-main': [paths.appIndexJs],
+			'eventespresso-core-app': [paths.appIndexJs],
 		},
 
 		output: {

--- a/core/domain/entities/editor/Block.php
+++ b/core/domain/entities/editor/Block.php
@@ -56,14 +56,9 @@ abstract class Block implements BlockInterface
      */
     private $supported_routes;
 
-    /**
-     * @var WP_Block_Type $wp_block_type
-     */
-    private $wp_block_type;
-
 
     /**
-     * BlockLoader constructor.
+     * Block constructor.
      *
      * @param BlockAssetManagerInterface $block_asset_manager
      * @param RequestInterface           $request
@@ -89,7 +84,7 @@ abstract class Block implements BlockInterface
      */
     public function namespacedBlockType()
     {
-        return self::NAME_SPACE . '/' . $this->block_type;
+        return Block::NAME_SPACE . '/' . $this->block_type;
     }
 
 
@@ -112,14 +107,6 @@ abstract class Block implements BlockInterface
         return $this->block_asset_manager;
     }
 
-
-    /**
-     * @param WP_Block_Type $wp_block_type
-     */
-    protected function setWpBlockType($wp_block_type)
-    {
-        $this->wp_block_type = $wp_block_type;
-    }
 
     /**
      * returns an array of fully qualified class names
@@ -190,21 +177,17 @@ abstract class Block implements BlockInterface
         $args = array(
             'attributes'    => $this->attributes(),
             'editor_script' => $this->block_asset_manager->getEditorScriptHandle(),
-            'editor_style'  => $this->block_asset_manager->getEditorStyleHandle(),
             'script'        => $this->block_asset_manager->getScriptHandle(),
-            'style'         => $this->block_asset_manager->getStyleHandle(),
         );
         if ($this->isDynamic()) {
             $args['render_callback'] = array($this, 'renderBlock');
         }
-        $wp_block_type = register_block_type(
+        return register_block_type(
             new WP_Block_Type(
                 $this->namespacedBlockType(),
                 $args
             )
         );
-        $this->setWpBlockType($wp_block_type);
-        return $wp_block_type;
     }
 
 
@@ -227,5 +210,20 @@ abstract class Block implements BlockInterface
             $this->namespacedBlockType(),
             array(),
         );
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function loadGraphQLRelayAutoloader()
+    {
+        if (! class_exists('GraphQLRelay')) {
+            $autoloader = EE_THIRD_PARTY . 'wp-graphql/vendor/autoload.php';
+            if (! file_exists($autoloader)) {
+                return;
+            }
+            require_once $autoloader;
+        }
     }
 }

--- a/core/domain/entities/editor/CoreBlocksAssetManager.php
+++ b/core/domain/entities/editor/CoreBlocksAssetManager.php
@@ -14,10 +14,8 @@ use EventEspresso\core\services\assets\BlockAssetManager;
  */
 class CoreBlocksAssetManager extends BlockAssetManager
 {
-    const JS_HANDLE_CORE_BLOCKS_EDITOR = 'eventespresso-core-blocks';
-    const CSS_HANDLE_CORE_BLOCKS_EDITOR = 'eventespresso-core-blocks';
-    const JS_HANDLE_CORE_BLOCKS = 'eventespresso-core-blocks-frontend';
-    const CSS_HANDLE_CORE_BLOCKS = 'eventespresso-core-blocks-frontend';
+    const JS_HANDLE_CORE_BLOCKS_EDITOR = 'eventespresso-core-app';
+    const JS_HANDLE_CORE_BLOCKS = 'eventespresso-core-app';
 
 
     /**
@@ -25,9 +23,7 @@ class CoreBlocksAssetManager extends BlockAssetManager
      */
     public function setAssetHandles()
     {
-        $this->setEditorScriptHandle(self::JS_HANDLE_CORE_BLOCKS_EDITOR);
-        $this->setEditorStyleHandle(self::CSS_HANDLE_CORE_BLOCKS_EDITOR);
-        $this->setScriptHandle(self::JS_HANDLE_CORE_BLOCKS);
-        $this->setStyleHandle(self::CSS_HANDLE_CORE_BLOCKS);
+        $this->setEditorScriptHandle(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS_EDITOR);
+        $this->setScriptHandle(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS);
     }
 }

--- a/core/domain/entities/editor/blocks/EventAttendees.php
+++ b/core/domain/entities/editor/blocks/EventAttendees.php
@@ -54,7 +54,7 @@ class EventAttendees extends Block
      */
     public function initialize()
     {
-        $this->setBlockType(self::BLOCK_TYPE);
+        $this->setBlockType(EventAttendees::BLOCK_TYPE);
         $this->setSupportedRoutes(
             array(
                 'EventEspresso\core\domain\entities\route_match\specifications\admin\EspressoStandardPostTypeEditor',
@@ -128,6 +128,9 @@ class EventAttendees extends Block
     private function getAttributesMap()
     {
         return array(
+            'event'             => 'sanitize_text_field',
+            'datetime'          => 'sanitize_text_field',
+            'ticket'            => 'sanitize_text_field',
             'eventId'           => 'absint',
             'datetimeId'        => 'absint',
             'ticketId'          => 'absint',
@@ -185,8 +188,10 @@ class EventAttendees extends Block
     public function renderBlock(array $attributes = array())
     {
         $attributes = $this->sanitizeAttributes($attributes);
-        return (is_archive() || is_front_page() || is_home()) && ! $attributes['displayOnArchives']
-            ? ''
-            : $this->renderer->render($attributes);
+        if (! (bool) $attributes['displayOnArchives'] && (is_archive() || is_front_page() || is_home())) {
+            return '';
+        }
+        $this->loadGraphQLRelayAutoloader();
+        return $this->renderer->render($attributes);
     }
 }

--- a/core/domain/entities/editor/blocks/EventAttendees.php
+++ b/core/domain/entities/editor/blocks/EventAttendees.php
@@ -57,7 +57,6 @@ class EventAttendees extends Block
         $this->setBlockType(EventAttendees::BLOCK_TYPE);
         $this->setSupportedRoutes(
             array(
-                'EventEspresso\core\domain\entities\route_match\specifications\admin\EspressoStandardPostTypeEditor',
                 'EventEspresso\core\domain\entities\route_match\specifications\admin\WordPressPostTypeEditor',
                 'EventEspresso\core\domain\entities\route_match\specifications\frontend\EspressoBlockRenderer',
                 'EventEspresso\core\domain\entities\route_match\specifications\frontend\AnyFrontendRequest'

--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -8,7 +8,6 @@ use EE_Registry;
 use EE_Template_Config;
 use EED_Core_Rest_Api;
 use EEH_DTT_Helper;
-use EEH_Qtip_Loader;
 use EventEspresso\core\domain\Domain;
 use EventEspresso\core\domain\DomainInterface;
 use EventEspresso\core\domain\values\assets\JavascriptAsset;

--- a/core/domain/services/assets/EspressoAdminAssetManager.php
+++ b/core/domain/services/assets/EspressoAdminAssetManager.php
@@ -38,10 +38,6 @@ class EspressoAdminAssetManager extends AssetManager
         $joyride = filter_var(apply_filters('FHEE_load_joyride', false), FILTER_VALIDATE_BOOLEAN);
         $this->registerJavascript($joyride);
         $this->registerStyleSheets($joyride);
-        add_action(
-            'AHEE__EventEspresso_core_services_assets_Registry__registerScripts__before_script',
-            [$this, 'loadQtipJs']
-        );
     }
 
 
@@ -93,6 +89,7 @@ class EspressoAdminAssetManager extends AssetManager
             '2.1',
             true
         )->enqueueAsset();
+        $this->loadQtipJs();
     }
 
 
@@ -125,15 +122,12 @@ class EspressoAdminAssetManager extends AssetManager
 
     /**
      * registers assets for cleaning your ears
-     *
-     * @param JavascriptAsset $script
      */
-    public function loadQtipJs(JavascriptAsset $script)
+    public function loadQtipJs()
     {
         // qtip is turned OFF by default, but prior to the wp_enqueue_scripts hook,
         // can be turned back on again via: add_filter('FHEE_load_qtip', '__return_true' );
-        if (apply_filters('FHEE_load_qtip', false)
-        ) {
+        if (apply_filters('FHEE_load_qtip', false)) {
             $qtip_loader = EEH_Qtip_Loader::instance();
             if ($qtip_loader instanceof EEH_Qtip_Loader) {
                 $qtip_loader->register_and_enqueue();

--- a/core/domain/services/assets/EspressoEditorAssetManager.php
+++ b/core/domain/services/assets/EspressoEditorAssetManager.php
@@ -17,7 +17,7 @@ use EventEspresso\core\services\collections\DuplicateCollectionIdentifierExcepti
  */
 class EspressoEditorAssetManager extends ReactAssetManager
 {
-    const JS_HANDLE_EDITOR = 'eventespresso-main';
+    const JS_HANDLE_EDITOR = 'eventespresso-core-app';
 
     /**
      * @throws InvalidDataTypeException

--- a/core/domain/services/assets/WordpressPluginsPageAssetManager.php
+++ b/core/domain/services/assets/WordpressPluginsPageAssetManager.php
@@ -21,7 +21,7 @@ use EventEspresso\core\services\collections\DuplicateCollectionIdentifierExcepti
  */
 class WordpressPluginsPageAssetManager extends ReactAssetManager
 {
-    const JS_HANDLE_WP_PLUGINS_PAGE = 'eventespresso-main';
+    const JS_HANDLE_WP_PLUGINS_PAGE = 'eventespresso-core-app';
 
     /**
      * @var ExitModal $exit_modal

--- a/core/domain/services/blocks/EventAttendeesBlockRenderer.php
+++ b/core/domain/services/blocks/EventAttendeesBlockRenderer.php
@@ -43,6 +43,7 @@ class EventAttendeesBlockRenderer extends BlockRenderer
      */
     public function render(array $attributes)
     {
+        $attributes = $this->parseGlobalIDs($attributes);
         $template_args['attributes'] = $attributes;
         $template_args['attendees'] = $this->attendee_model->get_all($this->getQueryParams($attributes));
         return EEH_Template::display_template(
@@ -50,6 +51,34 @@ class EventAttendeesBlockRenderer extends BlockRenderer
             $template_args,
             true
         );
+    }
+
+
+    /**
+     * Get query parameters for model query.
+     *
+     * @param array $attributes
+     * @return array
+     */
+    private function parseGlobalIDs(array $attributes)
+    {
+        // if ticket ID is set, then that's all we need to run the query
+        $ticket = isset($attributes['ticket']) ? $attributes['ticket'] : '';
+        $datetime = isset($attributes['datetime']) ? $attributes['datetime'] : '';
+        $event = isset($attributes['event']) ? $attributes['event'] : '';
+        if ($ticket !== '') {
+            $ticketId = $this->parseGUID($ticket);
+            $attributes['ticketId'] = $ticketId;
+        } elseif ($datetime !== '') {
+            $datetimeId = $this->parseGUID($datetime);
+            $attributes['datetimeId'] = $datetimeId;
+        } elseif ($event !== '') {
+            $eventId = $this->parseGUID($event);
+            $attributes['eventId'] = $eventId;
+        }
+        // remove unnecessary data so it doesn't get added to the query vars
+        unset($attributes['ticket'], $attributes['datetime'], $attributes['event']);
+        return $attributes;
     }
 
 

--- a/core/services/assets/BlockAssetManager.php
+++ b/core/services/assets/BlockAssetManager.php
@@ -154,6 +154,10 @@ abstract class BlockAssetManager extends AssetManager implements BlockAssetManag
         if ($this->assets->hasJavascriptAsset($handle)){
             return $this->assets->getJavascriptAsset($handle);
         }
+        $dependencies = array_merge(
+            $dependencies,
+            ['wp-blocks']
+        );
         return $this
             ->addJs($handle, $dependencies)->setRequiresTranslation()
             ->setInlineDataCallback(

--- a/core/services/assets/BlockAssetManager.php
+++ b/core/services/assets/BlockAssetManager.php
@@ -134,9 +134,9 @@ abstract class BlockAssetManager extends AssetManager implements BlockAssetManag
     public function addAssets()
     {
         $this->addEditorScript($this->getEditorScriptHandle());
-        $this->addEditorStyle($this->getEditorStyleHandle());
+        // $this->addEditorStyle($this->getEditorStyleHandle());
         $this->addScript($this->getScriptHandle());
-        $this->addStyle($this->getStyleHandle());
+        // $this->addStyle($this->getStyleHandle());
     }
 
 
@@ -154,7 +154,17 @@ abstract class BlockAssetManager extends AssetManager implements BlockAssetManag
         if ($this->assets->hasJavascriptAsset($handle)){
             return $this->assets->getJavascriptAsset($handle);
         }
-        return $this->addJs($handle, $dependencies)->setRequiresTranslation();
+        return $this
+            ->addJs($handle, $dependencies)->setRequiresTranslation()
+            ->setInlineDataCallback(
+                static function () {
+                    wp_add_inline_script(
+                        'eventespresso-core-app',
+                        "var eeDomain='blocks';",
+                        'before'
+                    );
+                }
+            );
     }
 
 

--- a/core/services/blocks/BlockRenderer.php
+++ b/core/services/blocks/BlockRenderer.php
@@ -2,6 +2,7 @@
 namespace EventEspresso\core\services\blocks;
 
 use EventEspresso\core\domain\DomainInterface;
+use GraphQLRelay\Relay;
 
 /**
  * BlockRenderer
@@ -53,5 +54,18 @@ abstract class BlockRenderer implements BlockRendererInterface
     public function templateRootPath()
     {
         return $this->template_root_path;
+    }
+
+
+    /**
+     * converts GraphQL GUID into EE DB ID
+     *
+     * @param string $GUID
+     * @return int
+     */
+    protected function parseGUID($GUID)
+    {
+        $parts = Relay::fromGlobalId($GUID);
+        return ! empty($parts['id']) ? $parts['id'] : 0;
     }
 }


### PR DESCRIPTION
### in this PR

- changes primary entry point name from 'eventespresso-main' to 'eventespresso-core-app'

- sets 'blocks' domain and loads assets for routes requiring GB blocks

- fixes SSR for Event Attendees block by parsing DBIDs from GUIDs


### outstanding issue

The Event Espresso block category appears in the GB editor and the Event Attendees block can be loaded, configured, saved, and rendered on the frontend correctly. However, refreshing the editor page (even after having saved the post) and/or leaving the editor and returning to the same post, results in the following error appearing where the Event Attendees block was previously:

> Your site doesn’t include support for the "eventespresso/event-attendees" block. You can leave this block intact or remove it entirely.

without doing anything else, you can re-add the block and have everything work as before, but the previously saved block is now completely broken. If you refresh at this point you will now have two of the above errors.

It appears that the problem may be caused by incorrect loading order in the JS, according to similar issues I found online:

- https://github.com/WordPress/gutenberg/issues/13793
- https://wordpress.stackexchange.com/questions/355536/your-site-doesn-t-include-support-for-the-block-after-registering-a-block

I attempted to apply a fix based on that second link, but it did not work. I've left that code in for the time being.