### PR TITLE
Ticket Price Calculator Enhancements

### DIFF
--- a/assets/src/application/services/hooks/usePrevNext.ts
+++ b/assets/src/application/services/hooks/usePrevNext.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 export interface PrevNext {
 	current: number;
+	goto: (index: number) => void;
 	next: VoidFunction;
 	prev: VoidFunction;
 }
@@ -9,11 +10,13 @@ export interface PrevNext {
 const usePrevNext = (initialIndex = 0): PrevNext => {
 	const [currentIndex, setCurrentIndex] = useState(initialIndex);
 
+	const goto = useCallback((index: number) => setCurrentIndex(index), [setCurrentIndex]);
+
 	const next = useCallback<VoidFunction>(() => setCurrentIndex((v) => v + 1), [setCurrentIndex]);
 
 	const prev = useCallback<VoidFunction>(() => setCurrentIndex((v) => v - 1), [setCurrentIndex]);
 
-	return useMemo(() => ({ current: currentIndex, next, prev }), [currentIndex, next, prev]);
+	return useMemo(() => ({ current: currentIndex, goto, next, prev }), [currentIndex, goto, next, prev]);
 };
 
 export default usePrevNext;

--- a/assets/src/application/ui/display/confirm/useConfirmWithButton.tsx
+++ b/assets/src/application/ui/display/confirm/useConfirmWithButton.tsx
@@ -8,7 +8,7 @@ import { ConfirmPropsWithButton } from './types';
 import useConfirmationDialog from './useConfirmationDialog';
 
 const useConfirmWithButton: React.FC<ConfirmPropsWithButton> = ({ buttonProps, ...props }) => {
-	const confirmText = buttonProps?.tooltip ?? __('Please confirm this action.');
+	const confirmText = (props.title || buttonProps?.tooltip) ?? __('Please confirm this action.');
 	const { confirmationDialog, onOpen } = useConfirmationDialog({ ...props, confirmText });
 	const btnClassName = classNames(buttonProps.icon && iconBtnClassName, buttonProps.className);
 

--- a/assets/src/application/ui/forms/espressoForm/renderers/FormRenderer.tsx
+++ b/assets/src/application/ui/forms/espressoForm/renderers/FormRenderer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { pick } from 'ramda';
+import { FormSpy } from 'react-final-form';
 
 import { FormRendererProps } from '../types';
 import Submit from '../Submit';
@@ -19,7 +20,6 @@ const FormRenderer: React.FC<FormRendererProps> = (props) => {
 		debugFields,
 		hasValidationErrors,
 		hasSubmitErrors,
-		form,
 	} = props;
 
 	const formOutput = (
@@ -40,7 +40,9 @@ const FormRenderer: React.FC<FormRendererProps> = (props) => {
 						/>
 					) : null}
 				</form>
-				{debugFields.length && <DebugInfo data={pick(debugFields, form.getState())} />}
+				{debugFields.length && (
+					<FormSpy>{({ form }) => <DebugInfo data={pick(debugFields, form.getState())} />}</FormSpy>
+				)}
 			</div>
 		</div>
 	);

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/ContentBody.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/ContentBody.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { __ } from '@wordpress/i18n';
-import { FormRenderProps } from 'react-final-form';
+import { FormSpy } from 'react-final-form';
 
 import DateFormSteps from './DateFormSteps';
 import { usePrevNext } from '@appServices/hooks';
@@ -15,40 +15,51 @@ const buttonRowStyle: CSSProperties = { display: 'flex', justifyContent: 'flex-e
 /**
  * This component is inside both RFF and TAM contexts, so we can use all of their features
  */
-const ContentBody: React.FC<FormRenderProps> = ({
-	children,
-	hasSubmitErrors,
-	hasValidationErrors,
-	submitting,
-	form,
-}) => {
+const ContentBody: React.FC = ({ children }) => {
 	// init data listener to update RFF data
-	useDataListener(form);
+	useDataListener();
 	const { current, prev, next } = usePrevNext();
 	const { hasOrphanEntities } = useTAMDataState();
 
-	const isSaveDisabled = submitting || hasValidationErrors || hasSubmitErrors;
 	const isSubmitDisabled = hasOrphanEntities();
 
+	const subscription = { submitting: true, hasValidationErrors: true, hasSubmitErrors: true };
 	return (
-		<div>
-			<DateFormSteps current={current} />
-			{/* RFF fields */}
-			{current === 0 && children}
+		<FormSpy subscription={subscription}>
+			{({ form, hasSubmitErrors, hasValidationErrors, submitting }) => {
+				const isSaveDisabled = submitting || hasValidationErrors || hasSubmitErrors;
 
-			{current === 1 && <TicketAssignmentsManager />}
-			<div style={buttonRowStyle}>
-				{current === 0 && (
-					<Button buttonText={__('Save and assign tickets')} onClick={next} isDisabled={isSaveDisabled} />
-				)}
-				{current === 1 && (
-					<>
-						<Button buttonText={__('Previous')} onClick={prev} />
-						<Button buttonText={__('Submit')} onClick={form.submit} isDisabled={isSubmitDisabled} />
-					</>
-				)}
-			</div>
-		</div>
+				return (
+					<div>
+						<DateFormSteps current={current} />
+						{/* RFF fields */}
+						{current === 0 && children}
+
+						{current === 1 && <TicketAssignmentsManager />}
+						<div style={buttonRowStyle}>
+							{current === 0 && (
+								<Button
+									buttonText={__('Save and assign tickets')}
+									onClick={next}
+									isDisabled={isSaveDisabled}
+									rightIcon='chevron-right'
+								/>
+							)}
+							{current === 1 && (
+								<>
+									<Button buttonText={__('Previous')} onClick={prev} leftIcon='chevron-left' />
+									<Button
+										buttonText={__('Submit')}
+										onClick={form.submit}
+										isDisabled={isSubmitDisabled}
+									/>
+								</>
+							)}
+						</div>
+					</div>
+				);
+			}}
+		</FormSpy>
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/useDataListener.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/useDataListener.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { FormApi } from 'final-form';
+import { useForm } from 'react-final-form';
 
 import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManager/data';
 
@@ -7,8 +7,9 @@ import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManage
  * A custom hook which subscribes to TAM data and updates
  * RFF data when needed.
  */
-const useDataListener = ({ mutators, getState }: FormApi<any>) => {
+const useDataListener = () => {
 	const { getData } = useTAMDataState();
+	const { mutators, getState } = useForm();
 	const data = getData();
 
 	const id = getState().values.id || 'NEW_DATE';

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/data/useDataState.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/data/useDataState.ts
@@ -6,7 +6,7 @@ import { useTAMContext } from '../context';
 const useDataState = (): DataStateManager => {
 	const { dataState } = useTAMContext();
 
-	return useMemo(() => dataState, [dataState.getData()]);
+	return useMemo(() => dataState, [dataState]);
 };
 
 export default useDataState;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/formValidation.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/formValidation.ts
@@ -9,16 +9,10 @@ export const validate = async (values: TicketFormShape) => {
 	return await yupToFinalFormErrors(validationSchema, values);
 };
 
-const validPriceMsg = () => __('Please enter a valid amount');
-
 const validationSchema = yup.object({
 	name: yup
 		.string()
 		.required(() => __('Name is required'))
 		.min(3, () => __('Name must be at least three characters')),
 	dateTime: dateAndTimeSchema,
-	price: yup
-		.number()
-		.typeError(validPriceMsg)
-		.min(0, validPriceMsg),
 });

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/Content.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/Content.tsx
@@ -12,20 +12,22 @@ const Content: React.FC<ContentProps> = ({ entity, onClose }) => {
 	const { createEntity, updateEntity } = useTicketMutator();
 	const mutatePrices = useMutatePrices();
 
+	const mutateTicket = useCallback(
+		(input) => {
+			return entity?.id ? updateEntity(input) : createEntity(input);
+		},
+		[createEntity, entity?.id, updateEntity]
+	);
+
 	const onSubmit = useCallback(
 		({ prices, deletedPrices, ...fields }) => {
 			mutatePrices(prices, deletedPrices).then((relatedPriceIds) => {
 				const input = { ...fields, prices: relatedPriceIds };
-
-				if (entity?.id) {
-					updateEntity(input);
-				} else {
-					createEntity(input);
-				}
+				mutateTicket(input);
 			});
 			onClose();
 		},
-		[createEntity, entity?.id, mutatePrices, updateEntity]
+		[entity?.id, mutatePrices, mutateTicket]
 	);
 	const formConfig = useTicketFormConfig(entity?.id, { onSubmit });
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentBody.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentBody.tsx
@@ -51,7 +51,7 @@ const ContentBody: React.FC = ({ children }) => {
 										rightIcon='chevron-right'
 									/>
 									<Button
-										buttonText={__('Free ticket - assign dates')}
+										buttonText={__('Skip prices - assign dates')}
 										onClick={() => goto(2)}
 										isDisabled={isSaveDisabled}
 										rightIcon='chevron-right'

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentBody.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentBody.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { __ } from '@wordpress/i18n';
-import { FormRenderProps } from 'react-final-form';
+import { FormSpy } from 'react-final-form';
 import { anyPass, isNil, isEmpty } from 'ramda';
 
 import TicketFormSteps from './TicketFormSteps';
@@ -17,54 +17,78 @@ const buttonRowStyle: CSSProperties = { display: 'flex', justifyContent: 'flex-e
 /**
  * This component is inside both RFF and TAM contexts, so we can use all of their features
  */
-const ContentBody: React.FC<FormRenderProps> = ({
-	children,
-	hasSubmitErrors,
-	hasValidationErrors,
-	submitting,
-	form,
-}) => {
+const ContentBody: React.FC = ({ children }) => {
 	// init data listener to update RFF data
-	useDataListener(form);
-	const { current, prev, next } = usePrevNext();
-	const { hasOrphanEntities } = useTAMDataState();
-
-	const isSaveDisabled = submitting || hasValidationErrors || hasSubmitErrors;
+	useDataListener();
+	const { current, goto, prev, next } = usePrevNext();
+	const { hasOrphanEntities, getData } = useTAMDataState();
 	const isSubmitDisabled = hasOrphanEntities();
 
-	const prices = form.getState().values.prices || [];
-	const isTPCSubmitDisabled = prices.length && prices.some(({ amount }) => anyPass([isNil, isEmpty])(amount));
-
+	const subscription = { submitting: true, hasValidationErrors: true, hasSubmitErrors: true };
 	return (
-		<div>
-			<TicketFormSteps current={current} />
-			{/* RFF fields */}
-			{current === 0 && children}
+		<FormSpy subscription={subscription}>
+			{({ form, hasSubmitErrors, hasValidationErrors, submitting, values }) => {
+				const isSaveDisabled = submitting || hasValidationErrors || hasSubmitErrors;
 
-			{current === 1 && <TicketPriceCalculator />}
-			{current === 2 && <TicketAssignmentsManager />}
-			<div style={buttonRowStyle}>
-				{current === 0 && (
-					<Button buttonText={__('Continue to price details')} onClick={next} isDisabled={isSaveDisabled} />
-				)}
-				{current === 1 && (
-					<>
-						<Button buttonText={__('Previous')} onClick={prev} />
-						<Button
-							buttonText={__('Save and assign dates')}
-							onClick={next}
-							isDisabled={isTPCSubmitDisabled}
-						/>
-					</>
-				)}
-				{current === 2 && (
-					<>
-						<Button buttonText={__('Previous')} onClick={prev} />
-						<Button buttonText={__('Submit')} onClick={form.submit} isDisabled={isSubmitDisabled} />
-					</>
-				)}
-			</div>
-		</div>
+				const prices = values?.prices || [];
+				const isTPCSubmitDisabled =
+					prices.length && prices.some(({ amount }) => anyPass([isNil, isEmpty])(amount));
+				return (
+					<div>
+						<TicketFormSteps current={current} />
+						{/* RFF fields */}
+						{current === 0 && children}
+
+						{current === 1 && <TicketPriceCalculator />}
+						{current === 2 && <TicketAssignmentsManager />}
+						<div style={buttonRowStyle}>
+							{current === 0 && (
+								<>
+									<Button
+										buttonText={__('Add ticket prices')}
+										onClick={next}
+										isDisabled={isSaveDisabled}
+										rightIcon='chevron-right'
+									/>
+									<Button
+										buttonText={__('Free ticket - assign dates')}
+										onClick={() => goto(2)}
+										isDisabled={isSaveDisabled}
+										rightIcon='chevron-right'
+									/>
+								</>
+							)}
+							{current === 1 && (
+								<>
+									<Button buttonText={__('Previous')} onClick={prev} leftIcon='chevron-left' />
+									<Button
+										buttonText={__('Save and assign dates')}
+										onClick={next}
+										isDisabled={isTPCSubmitDisabled}
+										rightIcon='chevron-right'
+									/>
+								</>
+							)}
+							{current === 2 && (
+								<>
+									<Button
+										buttonText={__('Ticket details')}
+										onClick={() => goto(0)}
+										leftIcon='chevron-left'
+									/>
+									<Button buttonText={__('Previous')} onClick={prev} leftIcon='chevron-left' />
+									<Button
+										buttonText={__('Submit')}
+										onClick={form.submit}
+										isDisabled={isSubmitDisabled}
+									/>
+								</>
+							)}
+						</div>
+					</div>
+				);
+			}}
+		</FormSpy>
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { FormApi } from 'final-form';
+import { useForm } from 'react-final-form';
 
 import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManager/data';
 import { useDataState as useTPCDataState } from '@edtrUI/tickets/ticketPriceCalculator/data';
@@ -8,8 +8,9 @@ import { useDataState as useTPCDataState } from '@edtrUI/tickets/ticketPriceCalc
  * A custom hook which subscribes to TAM and TPC data and updates
  * RFF data when needed.
  */
-const useDataListener = ({ mutators, getState }: FormApi<any>) => {
+const useDataListener = () => {
 	const { getData } = useTAMDataState();
+	const { mutators, getState } = useForm();
 	const data = getData();
 
 	const id = getState().values.id || 'NEW_TICKET';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultPricesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultPricesButton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { Button } from '@infraUI/inputs';
+import { useAddDefaultPrices } from '../hooks';
+
+const AddDefaultPricesButton: React.FC = () => {
+	const addDefaultPrices = useAddDefaultPrices();
+
+	return <Button onClick={addDefaultPrices} buttonText={__('Add default prices')} size='lg' />;
+};
+export default AddDefaultPricesButton;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultTaxesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultTaxesButton.tsx
@@ -1,54 +1,20 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { allPass, assocPath } from 'ramda';
 
-import { usePrices, usePriceTypes } from '@edtrServices/apollo/queries';
-import { TpcPriceModifier } from '../types';
+import { usePrices } from '@edtrServices/apollo/queries';
 import { useDataState } from '../data';
-import { isDefault, isTax } from '@sharedEntities/prices/predicates/selectionPredicates';
-import { useRelations } from '@appServices/apollo/relations';
-import { getGuids } from '@application/services/predicates';
-import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
+import { getDefaultTaxes } from '@sharedEntities/prices/predicates/selectionPredicates';
 import { Button } from '@application/ui/input';
+import { useAddDefaultTaxes } from '../hooks';
 
 const AddDefaultTaxesButton: React.FC = () => {
-	const allPriceTypes = usePriceTypes();
 	const allPrices = usePrices();
-	const defaultTaxPrices = allPrices.filter(allPass([isDefault, isTax]));
+	const defaultTaxPrices = getDefaultTaxes(allPrices);
 
-	const { prices, setPrices } = useDataState();
-	const tpcDefaultTaxPrices = prices.filter(allPass([isDefault, isTax]));
-	const { getRelations } = useRelations();
+	const { prices } = useDataState();
+	const tpcDefaultTaxPrices = getDefaultTaxes(prices);
 
-	const onAddDefaultTaxes = useCallback(() => {
-		// convert priceType array to {[id]: order}
-		const priceTypeIdOrder = allPriceTypes.reduce((acc, { id, order }) => assocPath([id], order, acc), {});
-		const priceIds = getGuids(prices);
-
-		// Filter out the taxes that have already been added
-		const newTpcDefaultTaxPrices = defaultTaxPrices.filter((price) => !priceIds.includes(price.id));
-		const newTpcDefaultTaxPriceModifiers = newTpcDefaultTaxPrices.map((price) => {
-			const priceTypes = getRelations({
-				entity: 'prices',
-				entityId: price.id,
-				relation: 'priceTypes',
-			});
-			const [priceTypeId] = priceTypes;
-			// convert price to TPC price modifier
-			const priceModifier: TpcPriceModifier = {
-				...price,
-				priceType: priceTypeId,
-				priceTypeOrder: priceTypeIdOrder[priceTypeId],
-			};
-			return priceModifier;
-		});
-
-		const newPrices = [...prices, ...newTpcDefaultTaxPriceModifiers];
-		//sort'em
-		let sortedPrices = sortByPriceOrderIdAsc(newPrices);
-		setPrices(sortedPrices);
-	}, [defaultTaxPrices, getRelations, allPriceTypes]);
-
+	const addDefaultTaxes = useAddDefaultTaxes();
 	// since we load all the default prices in EDTR
 	// so if the the number of TPC taxes is equal to number of all default taxes
 	// It means that TPC has all the possible tax prices
@@ -57,6 +23,6 @@ const AddDefaultTaxesButton: React.FC = () => {
 		return null;
 	}
 
-	return <Button onClick={onAddDefaultTaxes} buttonText={__('Add default taxes')} />;
+	return <Button onClick={addDefaultTaxes} buttonText={__('Add default taxes')} />;
 };
 export default AddDefaultTaxesButton;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultTaxesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/AddDefaultTaxesButton.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+import { allPass, assocPath } from 'ramda';
+
+import { usePrices, usePriceTypes } from '@edtrServices/apollo/queries';
+import { TpcPriceModifier } from '../types';
+import { useDataState } from '../data';
+import { isDefault, isTax } from '@sharedEntities/prices/predicates/selectionPredicates';
+import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@application/services/predicates';
+import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
+import { Button } from '@application/ui/input';
+
+const AddDefaultTaxesButton: React.FC = () => {
+	const allPriceTypes = usePriceTypes();
+	const allPrices = usePrices();
+	const defaultTaxPrices = allPrices.filter(allPass([isDefault, isTax]));
+
+	const { prices, setPrices } = useDataState();
+	const tpcDefaultTaxPrices = prices.filter(allPass([isDefault, isTax]));
+	const { getRelations } = useRelations();
+
+	const onAddDefaultTaxes = useCallback(() => {
+		// convert priceType array to {[id]: order}
+		const priceTypeIdOrder = allPriceTypes.reduce((acc, { id, order }) => assocPath([id], order, acc), {});
+		const priceIds = getGuids(prices);
+
+		// Filter out the taxes that have already been added
+		const newTpcDefaultTaxPrices = defaultTaxPrices.filter((price) => !priceIds.includes(price.id));
+		const newTpcDefaultTaxPriceModifiers = newTpcDefaultTaxPrices.map((price) => {
+			const priceTypes = getRelations({
+				entity: 'prices',
+				entityId: price.id,
+				relation: 'priceTypes',
+			});
+			const [priceTypeId] = priceTypes;
+			// convert price to TPC price modifier
+			const priceModifier: TpcPriceModifier = {
+				...price,
+				priceType: priceTypeId,
+				priceTypeOrder: priceTypeIdOrder[priceTypeId],
+			};
+			return priceModifier;
+		});
+
+		const newPrices = [...prices, ...newTpcDefaultTaxPriceModifiers];
+		//sort'em
+		let sortedPrices = sortByPriceOrderIdAsc(newPrices);
+		setPrices(sortedPrices);
+	}, [defaultTaxPrices, getRelations, allPriceTypes]);
+
+	// since we load all the default prices in EDTR
+	// so if the the number of TPC taxes is equal to number of all default taxes
+	// It means that TPC has all the possible tax prices
+	if (defaultTaxPrices.length === tpcDefaultTaxPrices.length) {
+		// do not show the button
+		return null;
+	}
+
+	return <Button onClick={onAddDefaultTaxes} buttonText={__('Add default taxes')} />;
+};
+export default AddDefaultTaxesButton;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeleteAllPricesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeleteAllPricesButton.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { ConfirmDelete } from '@appDisplay/confirm';
+import { useDataState } from '../data';
+import { ButtonType } from '@application/ui/input';
+
+const DeleteAllPricesButton: React.FC = () => {
+	const { prices, deletePrice, updateTicketPrice } = useDataState();
+
+	const buttonProps = {
+		buttonText: __('Delete all prices'),
+		buttonType: ButtonType.ACCENT,
+	};
+	const onConfirm = useCallback(() => {
+		prices.forEach(({ id, isNew, isDefault }) => {
+			deletePrice(id, isNew || isDefault);
+		});
+		// Set ticket price to 0
+		updateTicketPrice(0);
+	}, [prices, deletePrice]);
+
+	const title = __('Are you sure you want to delete all the prices? That will make the ticket free.');
+
+	return <ConfirmDelete buttonProps={buttonProps} onConfirm={onConfirm} title={title} />;
+};
+
+export default DeleteAllPricesButton;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
@@ -10,7 +10,9 @@ const DeletePriceModifierButton: React.FC<PriceModifierProps> = ({ price }) => {
 	const { deletePrice } = useDataState();
 
 	const buttonProps = { icon: () => <Trash noMargin />, tooltip: __('delete price modifier') };
-	const onConfirm = useCallback(() => deletePrice(price.id, price.isNew), [price.id, price.isNew]);
+	// new or default prices should not be deleted server-side
+	const isNewOrDefault = price.isNew || price.isDefault;
+	const onConfirm = useCallback(() => deletePrice(price.id, isNewOrDefault), [price.id, isNewOrDefault]);
 
 	return <ConfirmDelete buttonProps={buttonProps} onConfirm={onConfirm} />;
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/DefaultPricesInfo.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/DefaultPricesInfo.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { any } from 'ramda';
+import { __ } from '@wordpress/i18n';
+
+import { useDataState } from '../data';
+import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
+
+const DefaultPricesInfo = () => {
+	const { prices } = useDataState();
+	const hasDefaultPrice = any(isDefault, prices);
+	return (
+		hasDefaultPrice && (
+			<div>
+				{__('Note:')} {__('Default prices cannot be modified here.')}
+			</div>
+		)
+	);
+};
+
+export default DefaultPricesInfo;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/NoPricesBanner.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/NoPricesBanner.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { Alert } from '@infraUI/display';
+import AddDefaultPricesButton from '../buttons/AddDefaultPricesButton';
+
+const NoPricesBanner = () => {
+	const description = __('This ticket has no prices');
+	const title = __('Free ticket');
+	return (
+		<Alert description={description} status='info' title={title}>
+			<AddDefaultPricesButton />
+		</Alert>
+	);
+};
+
+export default NoPricesBanner;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/TicketPriceCalculator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/TicketPriceCalculator.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { any } from 'ramda';
+import { __ } from '@wordpress/i18n';
 
 import { DebugInfo } from '@appDisplay/index';
 import Table from './table/Table';
 import { useDataState } from '../data';
 import { useInitStateListeners } from '../stateListeners';
+import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
 
 import './styles.scss';
 
@@ -13,9 +16,16 @@ const TicketPriceCalculator: React.FC = () => {
 
 	const dataState = useDataState();
 
+	const hasDefaultPrice = any(isDefault, dataState.prices);
+
 	return (
 		<>
 			<Table prices={dataState.prices} />
+			{hasDefaultPrice && (
+				<div>
+					{__('Note:')} {__('Default prices cannot be moified here.')}
+				</div>
+			)}
 			<DebugInfo data={dataState} />
 		</>
 	);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/TicketPriceCalculator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/TicketPriceCalculator.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { any } from 'ramda';
 import { __ } from '@wordpress/i18n';
 
 import { DebugInfo } from '@appDisplay/index';
 import Table from './table/Table';
 import { useDataState } from '../data';
 import { useInitStateListeners } from '../stateListeners';
-import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
+import NoPricesBanner from './NoPricesBanner';
+import DefaultPricesInfo from './DefaultPricesInfo';
 
 import './styles.scss';
 
@@ -16,17 +16,22 @@ const TicketPriceCalculator: React.FC = () => {
 
 	const dataState = useDataState();
 
-	const hasDefaultPrice = any(isDefault, dataState.prices);
+	const debugInfo = <DebugInfo data={dataState} />;
+
+	if (!dataState.prices?.length) {
+		return (
+			<>
+				<NoPricesBanner />
+				{debugInfo}
+			</>
+		);
+	}
 
 	return (
 		<>
 			<Table prices={dataState.prices} />
-			{hasDefaultPrice && (
-				<div>
-					{__('Note:')} {__('Default prices cannot be moified here.')}
-				</div>
-			)}
-			<DebugInfo data={dataState} />
+			<DefaultPricesInfo />
+			{debugInfo}
 		</>
 	);
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
@@ -9,6 +9,7 @@ import { TicketPriceField } from '../../fields';
 import { FormatAmountFunction } from '@appServices/utilities/money/formatAmount';
 import { FooterRow } from '@appLayout/espressoTable';
 import AddDefaultTaxesButton from '../../buttons/AddDefaultTaxesButton';
+import DeleteAllPricesButton from '../../buttons/DeleteAllPricesButton';
 
 interface Props {
 	formatAmount: FormatAmountFunction;
@@ -27,13 +28,13 @@ const useFooterRowGenerator = (): FooterRowGenerator => {
 				key: 'id',
 				type: 'cell',
 				className: '',
-				value: <AddDefaultTaxesButton />,
+				value: <DeleteAllPricesButton />,
 			},
 			{
 				key: 'type',
 				type: 'cell',
 				className: '',
-				value: '',
+				value: <AddDefaultTaxesButton />,
 			},
 			{
 				key: 'name',

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
@@ -8,6 +8,7 @@ import { parsedAmount } from '@appServices/utilities/money';
 import { TicketPriceField } from '../../fields';
 import { FormatAmountFunction } from '@appServices/utilities/money/formatAmount';
 import { FooterRow } from '@appLayout/espressoTable';
+import AddDefaultTaxesButton from '../../buttons/AddDefaultTaxesButton';
 
 interface Props {
 	formatAmount: FormatAmountFunction;
@@ -26,7 +27,7 @@ const useFooterRowGenerator = (): FooterRowGenerator => {
 				key: 'id',
 				type: 'cell',
 				className: '',
-				value: '',
+				value: <AddDefaultTaxesButton />,
 			},
 			{
 				key: 'type',
@@ -65,7 +66,7 @@ const useFooterRowGenerator = (): FooterRowGenerator => {
 				key: 'actions',
 				type: 'cell',
 				className: 'ee-ticket-price-calculator__actions',
-				value: <IconButton icon={calcDirIcon} onClick={toggleCalcDir}/*  variant='outline' */ />,
+				value: <IconButton icon={calcDirIcon} onClick={toggleCalcDir} /*  variant='outline' */ />,
 			},
 		];
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/types.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/types.ts
@@ -35,7 +35,7 @@ interface UpdatePriceArgs {
 
 export interface DataStateManager extends DataState {
 	addPrice: (price: TpcPriceModifier, index?: number) => void;
-	deletePrice: (id: EntityId, isNew?: boolean) => void;
+	deletePrice: (id: EntityId, isNewOrDefault?: boolean) => void;
 	getData: () => DataState;
 	reset: VoidFunction;
 	reverseCalculate: boolean;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useDataReducer.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useDataReducer.ts
@@ -79,7 +79,7 @@ const useDataReducer = (initializer: StateInitializer): DataStateReducer => {
 							ticket: {
 								...state.ticket,
 								isTaxable,
-							}
+							},
 					  }
 					: state;
 
@@ -92,7 +92,7 @@ const useDataReducer = (initializer: StateInitializer): DataStateReducer => {
 					ticket: {
 						...state.ticket,
 						isTaxable,
-					}
+					},
 				};
 
 			case 'ADD_PRICE_TO_DELETED':

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useDataStateManager.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useDataStateManager.ts
@@ -49,8 +49,8 @@ const useDataStateManager: DataStateManagerHook = (props) => {
 		});
 	}, []);
 
-	const deletePrice: DSM['deletePrice'] = useCallback((id, isNew) => {
-		if (!isNew) {
+	const deletePrice: DSM['deletePrice'] = useCallback((id, isNewOrDefault) => {
+		if (!isNewOrDefault) {
 			dispatch({
 				type: 'ADD_PRICE_TO_DELETED',
 				id,

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
@@ -10,7 +10,9 @@ import { ticketFieldsToUse } from '../utils/constants';
 import { updatePriceModifier } from '../utils';
 import { usePriceModifier } from '../hooks';
 import { useRelations } from '@appServices/apollo/relations';
-import { useTicketItem, useTicketPrices, usePriceTypes } from '@edtrServices/apollo';
+import { useTicketItem, useTicketPrices, usePriceTypes, usePrices } from '@edtrServices/apollo/queries';
+import type { Ticket } from '@edtrServices/apollo/types';
+import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
 
 /**
  * Initializes the data state dynamically by
@@ -20,6 +22,8 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 	const { getRelations } = useRelations();
 
 	const allPriceTypes = usePriceTypes();
+	const allPrices = usePrices();
+	const defaultPrices = allPrices.filter(isDefault);
 	const [basePriceType] = allPriceTypes.filter(isBasePrice);
 
 	const defaultPriceModifier = usePriceModifier(defaultPrice);
@@ -30,37 +34,75 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 
 	// get the full ticket object
 	const wholeTicket = useTicketItem({ id: ticketId });
-	const ticket = wholeTicket && pick(ticketFieldsToUse, wholeTicket);
+	const ticket: Partial<Ticket> = wholeTicket ? pick(ticketFieldsToUse, wholeTicket) : {};
 
 	// get all related prices
 	const unSortedPrices = useTicketPrices(ticketId);
-	//sort'em
-	const sortedPrices = sortByPriceOrderIdAsc(unSortedPrices);
 
 	// convert to TPC price objects by adding
 	// "priceType" and "priceTypeOrder"
-	let prices = sortedPrices.map<TpcPriceModifier>((price) => {
+	let prices = unSortedPrices.map<TpcPriceModifier>((price) => {
 		const priceTypes = getRelations({
 			entity: 'prices',
 			entityId: price.id,
 			relation: 'priceTypes',
 		});
 		// the only priceType in the array
-		const priceTypeId = priceTypes[0];
+		const [priceTypeId] = priceTypes;
 		return { ...price, priceType: priceTypeId, priceTypeOrder: priceTypeIdOrder[priceTypeId] };
 	});
 
-	const hasBasePrice = prices.filter(isBasePrice).length;
+	// if it's a new ticket
+	if (!ticket.id) {
+		defaultPrices.forEach((price) => {
+			const priceTypes = getRelations({
+				entity: 'prices',
+				entityId: price.id,
+				relation: 'priceTypes',
+			});
+			const [priceTypeId] = priceTypes;
+			// convert price to TPC price modifier
+			const priceModifier: TpcPriceModifier = {
+				...price,
+				priceType: priceTypeId,
+				priceTypeOrder: priceTypeIdOrder[priceTypeId],
+			};
+			// if it's a tax
+			if (price.isTax) {
+				// set ticket as taxable
+				ticket.isTaxable = true;
+				// add the price as it is (without cloning)
+				prices = [...prices, priceModifier];
+			} else {
+				prices = [
+					...prices,
+					{
+						...priceModifier,
+						// clone it
+						id: '',
+						dbId: 0,
+						isNew: true,
+						// avoid default price getting duplicated
+						isDefault: false,
+					},
+				];
+			}
+		});
+	}
+	//sort'em
+	let sortedPrices = sortByPriceOrderIdAsc(prices);
+
+	const hasBasePrice = sortedPrices.filter(isBasePrice).length;
 	// if there is no basePrice
 	if (!hasBasePrice) {
 		// add the base price with `isNew` flag to make sure it's created on submit
 		// `order` as 1 to make sure it remains at the top
-		prices = [{ ...basePrice, order: 1, isNew: true }, ...prices];
+		sortedPrices = [{ ...basePrice, order: 1, isNew: true }, ...sortedPrices];
 	}
 
 	return useCallback<StateInitializer>(
 		(initialState) => {
-			return { ...initialState, ticket: ticket ?? {}, prices };
+			return { ...initialState, ticket, prices: sortedPrices };
 		},
 		[ticket, prices]
 	);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
@@ -1,18 +1,13 @@
 import { useCallback } from 'react';
 import { assocPath, pick } from 'ramda';
 
-import defaultPrice from '../defaultPriceModifier';
-import { isBasePrice } from '@sharedEntities/priceTypes/predicates/selectionPredicates';
 import { StateInitializer } from './types';
 import { BaseProps, TpcPriceModifier } from '../types';
 import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
 import { ticketFieldsToUse } from '../utils/constants';
-import { updatePriceModifier } from '../utils';
-import { usePriceModifier } from '../hooks';
 import { useRelations } from '@appServices/apollo/relations';
-import { useTicketItem, useTicketPrices, usePriceTypes, usePrices } from '@edtrServices/apollo/queries';
+import { useTicketItem, useTicketPrices, usePriceTypes } from '@edtrServices/apollo/queries';
 import type { Ticket } from '@edtrServices/apollo/types';
-import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
 
 /**
  * Initializes the data state dynamically by
@@ -22,12 +17,6 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 	const { getRelations } = useRelations();
 
 	const allPriceTypes = usePriceTypes();
-	const allPrices = usePrices();
-	const defaultPrices = allPrices.filter(isDefault);
-	const [basePriceType] = allPriceTypes.filter(isBasePrice);
-
-	const defaultPriceModifier = usePriceModifier(defaultPrice);
-	const basePrice = updatePriceModifier(defaultPriceModifier, basePriceType);
 
 	// convert priceType array to {[id]: order}
 	const priceTypeIdOrder = allPriceTypes.reduce((acc, { id, order }) => assocPath([id], order, acc), {});
@@ -38,10 +27,12 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 
 	// get all related prices
 	const unSortedPrices = useTicketPrices(ticketId);
+	//sort'em
+	const sortedPrices = sortByPriceOrderIdAsc(unSortedPrices);
 
 	// convert to TPC price objects by adding
 	// "priceType" and "priceTypeOrder"
-	let prices = unSortedPrices.map<TpcPriceModifier>((price) => {
+	const prices = sortedPrices.map<TpcPriceModifier>((price) => {
 		const priceTypes = getRelations({
 			entity: 'prices',
 			entityId: price.id,
@@ -52,57 +43,9 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 		return { ...price, priceType: priceTypeId, priceTypeOrder: priceTypeIdOrder[priceTypeId] };
 	});
 
-	// if it's a new ticket
-	if (!ticket.id) {
-		defaultPrices.forEach((price) => {
-			const priceTypes = getRelations({
-				entity: 'prices',
-				entityId: price.id,
-				relation: 'priceTypes',
-			});
-			const [priceTypeId] = priceTypes;
-			// convert price to TPC price modifier
-			const priceModifier: TpcPriceModifier = {
-				...price,
-				priceType: priceTypeId,
-				priceTypeOrder: priceTypeIdOrder[priceTypeId],
-			};
-			// if it's a tax
-			if (price.isTax) {
-				// set ticket as taxable
-				ticket.isTaxable = true;
-				// add the price as it is (without cloning)
-				prices = [...prices, priceModifier];
-			} else {
-				prices = [
-					...prices,
-					{
-						...priceModifier,
-						// clone it
-						id: '',
-						dbId: 0,
-						isNew: true,
-						// avoid default price getting duplicated
-						isDefault: false,
-					},
-				];
-			}
-		});
-	}
-	//sort'em
-	let sortedPrices = sortByPriceOrderIdAsc(prices);
-
-	const hasBasePrice = sortedPrices.filter(isBasePrice).length;
-	// if there is no basePrice
-	if (!hasBasePrice) {
-		// add the base price with `isNew` flag to make sure it's created on submit
-		// `order` as 1 to make sure it remains at the top
-		sortedPrices = [{ ...basePrice, order: 1, isNew: true }, ...sortedPrices];
-	}
-
 	return useCallback<StateInitializer>(
 		(initialState) => {
-			return { ...initialState, ticket, prices: sortedPrices };
+			return { ...initialState, ticket, prices };
 		},
 		[ticket, prices]
 	);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/PriceField.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/PriceField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useDataState } from '../data';
 import BaseField from './BaseField';
@@ -9,11 +9,14 @@ type BFP = BaseFieldProps;
 const PriceField: React.FC<PriceFieldProps> = ({ field, price, ...rest }) => {
 	const { updatePrice } = useDataState();
 
-	const getValue: BFP['getValue'] = () => price[field];
+	const getValue: BFP['getValue'] = useCallback(() => price[field], [price[field]]);
 
-	const setValue: BFP['setValue'] = (value) => {
-		updatePrice({ id: price.id, fieldValues: { [field]: value } });
-	};
+	const setValue: BFP['setValue'] = useCallback(
+		(value) => {
+			updatePrice({ id: price.id, fieldValues: { [field]: value } });
+		},
+		[updatePrice, field]
+	);
 
 	return <BaseField {...rest} getValue={getValue} setValue={setValue} name={field} />;
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/TicketPriceField.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/fields/TicketPriceField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useDataState } from '../data';
 import BaseField from './BaseField';
@@ -11,11 +11,9 @@ const TicketPriceField: React.FC<TicketPriceFieldProps> = (props) => {
 	const { ticket, updateTicketPrice } = useDataState();
 	const { afterAmount, beforeAmount } = useMoneyDisplay();
 
-	const getValue: BFP['getValue'] = (): number => ticket.price;
+	const getValue: BFP['getValue'] = useCallback(() => ticket?.price || 0, [ticket?.price]);
 
-	const setValue: BFP['setValue'] = (value) => {
-		updateTicketPrice(value);
-	};
+	const setValue: BFP['setValue'] = useCallback((value) => updateTicketPrice(value), [updateTicketPrice]);
 
 	return (
 		<div className='ee-ticket-price-field'>

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/index.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/index.ts
@@ -1,3 +1,7 @@
+export { default as useAddDefaultPrices } from './useAddDefaultPrices';
+
+export { default as useAddDefaultTaxes } from './useAddDefaultTaxes';
+
 export { default as useMutatePrices } from './useMutatePrices';
 
 export { default as usePriceModifier } from './usePriceModifier';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultPrices.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultPrices.ts
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+
+import defaultPrice from '../defaultPriceModifier';
+import { isBasePrice } from '@sharedEntities/priceTypes/predicates/selectionPredicates';
+import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
+import { updatePriceModifier } from '../utils';
+import { usePriceModifier } from '../hooks';
+import { usePriceTypes, usePrices } from '@edtrServices/apollo/queries';
+import { isDefault } from '@sharedEntities/prices/predicates/selectionPredicates';
+import { useDataState } from '../data';
+import usePriceToTpcModifier from './usePriceToTpcModifier';
+
+const useAddDefaultPrices = (): VoidFunction => {
+	const allPriceTypes = usePriceTypes();
+	const allPrices = usePrices();
+	const defaultPrices = allPrices.filter(isDefault);
+	const [basePriceType] = allPriceTypes.filter(isBasePrice);
+
+	const defaultPriceModifier = usePriceModifier(defaultPrice);
+	const basePrice = updatePriceModifier(defaultPriceModifier, basePriceType);
+
+	const convertPriceToTpcModifier = usePriceToTpcModifier();
+
+	const { setPrices } = useDataState();
+
+	return useCallback(() => {
+		const prices = defaultPrices.map((price) => {
+			const priceModifier = convertPriceToTpcModifier(price);
+			// if it's a tax
+			if (price.isTax) {
+				// return without cloning
+				return priceModifier;
+			}
+			return {
+				...priceModifier,
+				// clone it
+				id: '',
+				dbId: 0,
+				isNew: true,
+				// avoid default price getting duplicated
+				isDefault: false,
+			};
+		});
+
+		//sort'em
+		let sortedPrices = sortByPriceOrderIdAsc(prices);
+
+		const hasBasePrice = sortedPrices.filter(isBasePrice).length;
+		// if there is no basePrice
+		if (!hasBasePrice) {
+			// add the base price with `isNew` flag to make sure it's created on submit
+			// `order` as 1 to make sure it remains at the top
+			sortedPrices = [{ ...basePrice, order: 1, isNew: true }, ...sortedPrices];
+		}
+		setPrices(sortedPrices);
+	}, [basePrice, convertPriceToTpcModifier, defaultPrices, setPrices]);
+};
+
+export default useAddDefaultPrices;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultTaxes.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultTaxes.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { usePrices } from '@edtrServices/apollo/queries';
+import { useDataState } from '../data';
+import { getDefaultTaxes } from '@sharedEntities/prices/predicates/selectionPredicates';
+import { useRelations } from '@appServices/apollo/relations';
+import { getGuids } from '@application/services/predicates';
+import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
+import usePriceToTpcModifier from './usePriceToTpcModifier';
+
+const useAddDefaultTaxes = (): VoidFunction => {
+	const allPrices = usePrices();
+	const defaultTaxPrices = getDefaultTaxes(allPrices);
+
+	const { prices, setPrices } = useDataState();
+	const { getRelations } = useRelations();
+
+	const convertPriceToTpcModifier = usePriceToTpcModifier();
+
+	return useCallback(() => {
+		const priceIds = getGuids(prices);
+
+		// Filter out the taxes that have already been added
+		const newTpcDefaultTaxPrices = defaultTaxPrices.filter((price) => !priceIds.includes(price.id));
+		const newTpcDefaultTaxPriceModifiers = newTpcDefaultTaxPrices.map(convertPriceToTpcModifier);
+
+		const newPrices = [...prices, ...newTpcDefaultTaxPriceModifiers];
+		//sort'em
+		let sortedPrices = sortByPriceOrderIdAsc(newPrices);
+		setPrices(sortedPrices);
+	}, [convertPriceToTpcModifier, defaultTaxPrices, getRelations, prices, setPrices]);
+};
+
+export default useAddDefaultTaxes;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useMutatePrices.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useMutatePrices.ts
@@ -15,47 +15,51 @@ const useMutatePrices = (): Callback => {
 		async (prices, deletedPriceIds = []) => {
 			const relatedPriceIds: EntityId[] = [];
 
-			// make sure to complete all price mutatons before updating the ticket
-			await Promise.all(
-				// convert the price mutatons into promises
-				prices.map(({ isNew, isModified, ...price }) => {
-					// if it's not new or modified, no need to do anything
-					// but base price needs to be updated anyway which may been modified by revCalc
-					if (!(isNew || isModified) && !price.isBasePrice) {
-						// retain the existing relation
-						relatedPriceIds.push(price.id);
-						return Promise.resolve(price);
-					}
-					const normalizedPriceFields = cloneAndNormalizePrice(price);
-					// if it's a newly added price
-					if (isNew) {
+			if (prices?.length) {
+				// make sure to complete all price mutatons before updating the ticket
+				await Promise.all(
+					// convert the price mutatons into promises
+					prices.map(({ isNew, isModified, ...price }) => {
+						// if it's not new or modified, no need to do anything
+						// but base price needs to be updated anyway which may been modified by revCalc
+						if (!(isNew || isModified) && !price.isBasePrice) {
+							// retain the existing relation
+							relatedPriceIds.push(price.id);
+							return Promise.resolve(price);
+						}
+						const normalizedPriceFields = cloneAndNormalizePrice(price);
+						// if it's a newly added price
+						if (isNew) {
+							return new Promise((resolve, onError) => {
+								const onCompleted = ({ createEspressoPrice: { espressoPrice: price } }): void => {
+									relatedPriceIds.push(price.id);
+									resolve(price);
+								};
+								createPrice({ ...normalizedPriceFields }, { onCompleted, onError });
+							});
+						}
+						// it's surely an existing price that's been modified
 						return new Promise((resolve, onError) => {
-							const onCompleted = ({ createEspressoPrice: { espressoPrice: price } }): void => {
+							const onCompleted = ({ updateEspressoPrice: { espressoPrice: price } }): void => {
 								relatedPriceIds.push(price.id);
 								resolve(price);
 							};
-							createPrice({ ...normalizedPriceFields }, { onCompleted, onError });
+							updatePrice({ id: price.id, ...normalizedPriceFields }, { onCompleted, onError });
 						});
-					}
-					// it's surely an existing price that's been modified
-					return new Promise((resolve, onError) => {
-						const onCompleted = ({ updateEspressoPrice: { espressoPrice: price } }): void => {
-							relatedPriceIds.push(price.id);
-							resolve(price);
-						};
-						updatePrice({ id: price.id, ...normalizedPriceFields }, { onCompleted, onError });
-					});
-				})
-			);
+					})
+				);
+			}
 
-			// Delete all unlucky ones
-			await Promise.all(
-				deletedPriceIds.map((id) => {
-					return new Promise((onCompleted, onError) =>
-						deletePrice({ id, deletePermanently: true }, { onCompleted, onError })
-					);
-				})
-			);
+			if (deletedPriceIds?.length) {
+				// Delete all unlucky ones
+				await Promise.all(
+					deletedPriceIds.map((id) => {
+						return new Promise((onCompleted, onError) =>
+							deletePrice({ id, deletePermanently: true }, { onCompleted, onError })
+						);
+					})
+				);
+			}
 
 			return relatedPriceIds;
 		},

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/usePriceToTpcModifier.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/usePriceToTpcModifier.ts
@@ -1,0 +1,35 @@
+import React, { useCallback } from 'react';
+import { assocPath } from 'ramda';
+
+import { useRelations } from '@appServices/apollo/relations';
+import { Price, usePriceTypes } from '@edtrServices/apollo';
+import { TpcPriceModifier } from '../types';
+
+type Callback = (price: Price) => TpcPriceModifier;
+
+const usePriceToTpcModifier = (): Callback => {
+	const { getRelations } = useRelations();
+	const allPriceTypes = usePriceTypes();
+	const priceTypeIdOrder = allPriceTypes.reduce((acc, { id, order }) => assocPath([id], order, acc), {});
+
+	return useCallback<Callback>(
+		(price) => {
+			const priceTypes = getRelations({
+				entity: 'prices',
+				entityId: price.id,
+				relation: 'priceTypes',
+			});
+			const [priceTypeId] = priceTypes;
+			// convert to TPC price objects by adding
+			// "priceType" and "priceTypeOrder"
+			return {
+				...price,
+				priceType: priceTypeId,
+				priceTypeOrder: priceTypeIdOrder[priceTypeId],
+			};
+		},
+		[getRelations, priceTypeIdOrder]
+	);
+};
+
+export default usePriceToTpcModifier;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceAmountInput.tsx
@@ -41,15 +41,17 @@ const PriceAmountInput: React.FC<PriceModifierProps> = ({ price }) => {
 			<div>
 				<PriceField
 					className={className}
+					component={'input'}
+					// because it can affect other tickets that have this price
+					// default price amount should not be changeable
+					disabled={(reverseCalculate && price.isBasePrice) || price.isDefault}
 					field='amount'
+					format={formatParse('')}
+					formatOnBlur
+					parse={formatParse()}
+					placeholder={__('amount...')}
 					price={price}
 					type={'number'}
-					component={'input'}
-					placeholder={__('amount...')}
-					disabled={reverseCalculate && price.isBasePrice}
-					format={formatParse('')}
-					parse={formatParse()}
-					formatOnBlur
 				/>
 			</div>
 			<div className='ee-ticket-price-field__after'>{afterPrice}</div>

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceDescriptionInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceDescriptionInput.tsx
@@ -6,7 +6,15 @@ import { PriceField } from '../fields';
 
 const PriceDescriptionInput: React.FC<PriceModifierProps> = ({ price }) => {
 	return (
-		<PriceField field='description' price={price} type={'text'} component={'input'} placeholder={__('description...')} />
+		<PriceField
+			component={'input'}
+			// default prices cannot be changed in TPC
+			disabled={price.isDefault}
+			field='description'
+			placeholder={__('description...')}
+			price={price}
+			type={'text'}
+		/>
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceIdInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceIdInput.tsx
@@ -4,7 +4,7 @@ import { PriceModifierProps } from '../types';
 import { PriceField } from '../fields';
 
 const PriceIdInput: React.FC<PriceModifierProps> = ({ price }) => {
-	return <PriceField field='dbId' price={price} type={'text'} component={'input'} disabled />;
+	return <PriceField component={'input'} disabled field='dbId' price={price} type={'text'} />;
 };
 
 export default PriceIdInput;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceNameInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceNameInput.tsx
@@ -5,6 +5,16 @@ import { PriceModifierProps } from '../types';
 import { PriceField } from '../fields';
 
 const PriceNameInput: React.FC<PriceModifierProps> = ({ price }) => {
-	return <PriceField field='name' price={price} type={'text'} component={'input'} placeholder={__('label...')} />;
+	return (
+		<PriceField
+			component={'input'}
+			// default prices cannot be changed in TPC
+			disabled={price.isDefault}
+			field='name'
+			placeholder={__('label...')}
+			price={price}
+			type={'text'}
+		/>
+	);
 };
 export default PriceNameInput;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceTypeInput.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/inputs/PriceTypeInput.tsx
@@ -11,7 +11,13 @@ const PriceTypeInput: React.FC<PriceModifierProps> = ({ price }) => {
 	const options = price.isBasePrice ? priceTypes : modifierOptions;
 
 	return (
-		<PriceField field='priceType' price={price} component={'select'} disabled={price.isBasePrice}>
+		<PriceField
+			component={'select'}
+			// price type cannot be changed for base/default price
+			disabled={price.isBasePrice || price.isDefault}
+			field='priceType'
+			price={price}
+		>
 			{options.map((option) => (
 				<option key={option.id} value={option.id}>
 					{option.name}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/stateListeners/useInitStateListeners.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/stateListeners/useInitStateListeners.ts
@@ -17,8 +17,9 @@ const useStateListeners = (): void => {
 	}, [getData, setPrices]);
 
 	const updateTicketTotal = useCallback(() => {
-		const ticketTotal = calculateTicketTotal(getData());
-		updateTicketPrice(parsedAmount(formatAmount(ticketTotal)));
+		let ticketTotal = calculateTicketTotal(getData());
+		ticketTotal = parsedAmount(formatAmount(ticketTotal));
+		updateTicketPrice(isNaN(ticketTotal) ? 0 : ticketTotal);
 	}, [getData, updateTicketPrice]);
 
 	const calculatePrice = useCallback(() => {

--- a/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { filter, find, includes, propEq } from 'ramda';
+import { allPass, filter, find, includes, propEq } from 'ramda';
 
 import { EntityId, EntityDbId } from '@dataServices/types';
 import { Price } from '@edtrServices/apollo/types';
@@ -40,3 +40,4 @@ export const getPriceByGuid = (prices: Price[], guid: EntityId): Price => findEn
 // returns array of prices that satisfy predicate
 export const getPriceModifiers = (prices: Price[]): Price[] => filter(isNotBasePrice, prices);
 export const getTaxes = (prices: Price[]): Price[] => filter(isTax, prices);
+export const getDefaultTaxes = (prices: Price[]): Price[] => filter(allPass([isDefault, isTax]), prices);

--- a/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
+++ b/assets/src/domain/shared/entities/prices/predicates/selectionPredicates/index.ts
@@ -28,6 +28,10 @@ export const isNotPercent = propEq('isPercent', false);
 export const isTax = propEq('isTax', true);
 export const isNotTax = propEq('isTax', false);
 
+// is a default price ?
+export const isDefault = propEq('isDefault', true);
+export const isNotDefault = propEq('isDefault', false);
+
 // returns price if found in array of prices
 export const getBasePrice = (prices: Price[]): Price => find(isBasePrice)(prices);
 export const getPriceByDbId = (prices: Price[], dbId: EntityDbId): Price => findEntityByDbId(prices)(dbId);

--- a/assets/src/infrastructure/ui/inputs/Button/Button.tsx
+++ b/assets/src/infrastructure/ui/inputs/Button/Button.tsx
@@ -11,7 +11,7 @@ const Button = React.forwardRef<ButtonType, ButtonProps>(({ children, buttonText
 	const text = children || buttonText;
 
 	return (
-		<ChakraButton {...props} className={className} leftIcon={icon} ref={ref}>
+		<ChakraButton leftIcon={icon} {...props} className={className} ref={ref}>
 			{text}
 		</ChakraButton>
 	);

--- a/core/domain/services/graphql/connection_resolvers/PriceConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/PriceConnectionResolver.php
@@ -101,6 +101,9 @@ class PriceConnectionResolver extends AbstractConnectionResolver
             $input_fields = $this->sanitizeInputFields($this->args['where']);
 
             // Use the proper operator.
+            if (! empty($input_fields['PRC_ID']) && is_array($input_fields['PRC_ID'])) {
+                $input_fields['PRC_ID'] = ['in', $input_fields['PRC_ID']];
+            }
             if (! empty($input_fields['Ticket.TKT_ID']) && is_array($input_fields['Ticket.TKT_ID'])) {
                 $input_fields['Ticket.TKT_ID'] = ['in', $input_fields['Ticket.TKT_ID']];
             }
@@ -147,6 +150,8 @@ class PriceConnectionResolver extends AbstractConnectionResolver
     public function sanitizeInputFields(array $where_args)
     {
         $arg_mapping = [
+            'in'              => 'PRC_ID',
+            'idIn'            => 'PRC_ID',
             'ticket'          => 'Ticket.TKT_ID',
             'ticketIn'        => 'Ticket.TKT_ID',
             'ticketIdIn'      => 'Ticket.TKT_ID',
@@ -161,7 +166,7 @@ class PriceConnectionResolver extends AbstractConnectionResolver
         return $this->sanitizeWhereArgsForInputFields(
             $where_args,
             $arg_mapping,
-            ['ticket', 'ticketIn', 'priceType', 'priceTypeIn']
+            ['in', 'ticket', 'ticketIn', 'priceType', 'priceTypeIn']
         );
     }
 }

--- a/core/domain/services/graphql/connections/TicketPricesConnection.php
+++ b/core/domain/services/graphql/connections/TicketPricesConnection.php
@@ -2,7 +2,6 @@
 
 namespace EventEspresso\core\domain\services\graphql\connections;
 
-use EE_Base_Class;
 use EEM_Price;
 use EventEspresso\core\domain\services\graphql\connection_resolvers\PriceConnectionResolver;
 use EventEspresso\core\services\graphql\connections\ConnectionBase;
@@ -42,7 +41,7 @@ class TicketPricesConnection extends ConnectionBase
             'toType'             => $this->namespace . 'Price',
             'fromFieldName'      => 'prices',
             'connectionTypeName' => "{$this->namespace}TicketPricesConnection",
-            'connectionArgs'     => self::get_connection_args(),
+            'connectionArgs'     => TicketPricesConnection::get_connection_args(),
             'resolve'            => [$this, 'resolveConnection'],
         ];
     }
@@ -78,11 +77,11 @@ class TicketPricesConnection extends ConnectionBase
             [
                 'in'              => [
                     'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Limit pices to the given globally unique IDs', 'event_espresso'),
+                    'description' => esc_html__('Limit prices to the given globally unique IDs', 'event_espresso'),
                 ],
                 'idIn'            => [
                     'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Limit pices to the given IDs', 'event_espresso'),
+                    'description' => esc_html__('Limit prices to the given IDs', 'event_espresso'),
                 ],
                 'ticket'          => [
                     'type'        => 'ID',

--- a/core/domain/services/graphql/connections/TicketPricesConnection.php
+++ b/core/domain/services/graphql/connections/TicketPricesConnection.php
@@ -76,39 +76,47 @@ class TicketPricesConnection extends ConnectionBase
     {
         return array_merge(
             [
-                'ticket' => [
+                'in'              => [
+                    'type'        => ['list_of' => 'ID'],
+                    'description' => esc_html__('Limit pices to the given globally unique IDs', 'event_espresso'),
+                ],
+                'idIn'            => [
+                    'type'        => ['list_of' => 'ID'],
+                    'description' => esc_html__('Limit pices to the given IDs', 'event_espresso'),
+                ],
+                'ticket'          => [
                     'type'        => 'ID',
                     'description' => esc_html__('Globally unique ticket ID to get the prices for.', 'event_espresso'),
                 ],
-                'ticketIn' => [
+                'ticketIn'        => [
                     'type'        => ['list_of' => 'ID'],
                     'description' => esc_html__('Globally unique ticket IDs to get the prices for.', 'event_espresso'),
                 ],
-                'ticketId' => [
+                'ticketId'        => [
                     'type'        => 'Int',
                     'description' => esc_html__('Ticket ID to get the prices for.', 'event_espresso'),
                 ],
-                'ticketIdIn' => [
+                'ticketIdIn'      => [
                     'type'        => ['list_of' => 'Int'],
                     'description' => esc_html__('Ticket IDs to get the prices for.', 'event_espresso'),
                 ],
-                'priceType' => [
+                'priceType'       => [
                     'type'        => 'ID',
                     'description' => esc_html__('Globally unique price type ID to get the prices for.', 'event_espresso'),
                 ],
-                'priceTypeIn' => [
+                'priceTypeIn'     => [
                     'type'        => ['list_of' => 'ID'],
                     'description' => esc_html__('Globally unique price type IDs to get the prices for.', 'event_espresso'),
                 ],
-                'priceTypeId' => [
+                'priceTypeId'     => [
                     'type'        => 'Int',
                     'description' => esc_html__('Price type ID to get the prices for.', 'event_espresso'),
                 ],
-                'priceTypeIdIn' => [
+                'priceTypeIdIn'   => [
                     'type'        => ['list_of' => 'Int'],
                     'description' => esc_html__('Price type IDs to get the prices for.', 'event_espresso'),
                 ],
-                'priceBaseType' => [
+                'priceBaseType'   => [
                     'type'        => 'PriceBaseTypeEnum',
                     'description' => esc_html__('Price Base type.', 'event_espresso'),
                 ],

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -84,7 +84,8 @@ class TicketMutation
             $args['TKT_parent'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
         }
 
-        if (! empty($input['price'])) {
+        // price can be 0
+        if (array_key_exists('price', $input)) {
             $args['TKT_price'] = (float) $input['price'];
         }
 

--- a/core/domain/services/graphql/mutators/TicketCreate.php
+++ b/core/domain/services/graphql/mutators/TicketCreate.php
@@ -59,7 +59,8 @@ class TicketCreate extends EntityMutator
                 if (! empty($prices)) {
                     TicketMutation::setRelatedPrices($entity, $prices);
                 } else {
-                    TicketMutation::addDefaultPrices($entity, $model);
+                    // we do this client-side
+                    // TicketMutation::addDefaultPrices($entity, $model);
                 }
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(


### PR DESCRIPTION
This PR refactors TPC to handle all the default price stuff client-side. Here is the list of changes in this PR:
- Adds support for price id param in prices GQL query
- Adds default prices to DOM data
- Enhances `usePrevNext` to add `goto` method
- Uses `FormSpy` in date/ticket edit form body to subscribe to form data for improved performance
- Improves ticket and price mutation in TPC
- Separates out logic by creating `useAddDefaultPrices`, `useAddDefaultTaxes`, `usePriceToTpcModifier` and the corresponding buttons.
- Creates `DeleteAllPricesButton` to nuke prices
- Creates No prices banner to show when there are no prices
- Improves TPC state management
- Adds price predicates related to `isDefault` prop

Closes #2863