### PR TITLE
ButtonGroup improvs.

### DIFF
--- a/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
+++ b/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
@@ -1,16 +1,36 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
-import { ButtonGroup as ButtonGroupAdapter, ButtonGroupProps } from '@infraUI/inputs';
+import { ButtonGroup as ButtonGroupAdapter } from '@infraUI/inputs';
+import { ButtonGroupProps } from './types';
+import { cleanChildren } from './utils';
 
 import './style.scss';
 
-const ButtonGroup: React.FC<ButtonGroupProps> = ({ children, ...props }) => {
+const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttonSize, children, ...props }) => {
 	const className = classNames(props.className, 'ee-btn-group');
+	const validChildren = cleanChildren(children);
+	const clones = validChildren.map((child, index) => {
+		const isFirst = index === 0;
+		const isLast = index === validChildren.length - 1;
+
+		// @ts-ignore
+		return cloneElement(child, {
+			// @ts-ignore
+			buttonSize: buttonSize || child.props.buttonSize,
+
+			// @ts-ignore
+			...(isFirst && { className: classNames(child.props.className, 'ee-btn--first') }),
+			// @ts-ignore
+			...(isLast && { className: classNames(child.props.className, 'ee-btn--last') }),
+			// @ts-ignore
+			...(!isFirst && !isLast && { className: classNames(child.props.className, 'ee-btn--no-border-radius') }),
+		});
+	});
 
 	return (
 		<ButtonGroupAdapter {...props} className={className}>
-			{children}
+			{clones}
 		</ButtonGroupAdapter>
 	);
 };

--- a/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
+++ b/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
@@ -18,13 +18,6 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttonSize, children, ...prop
 		return cloneElement(child, {
 			// @ts-ignore
 			buttonSize: buttonSize || child.props.buttonSize,
-
-			// @ts-ignore
-			...(isFirst && { className: classNames(child.props.className, 'ee-btn--first') }),
-			// @ts-ignore
-			...(isLast && { className: classNames(child.props.className, 'ee-btn--last') }),
-			// @ts-ignore
-			...(!isFirst && !isLast && { className: classNames(child.props.className, 'ee-btn--no-border-radius') }),
 		});
 	});
 

--- a/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
+++ b/assets/src/application/ui/input/Button/ButtonGroup/index.tsx
@@ -10,13 +10,8 @@ import './style.scss';
 const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttonSize, children, ...props }) => {
 	const className = classNames(props.className, 'ee-btn-group');
 	const validChildren = cleanChildren(children);
-	const clones = validChildren.map((child, index) => {
-		const isFirst = index === 0;
-		const isLast = index === validChildren.length - 1;
-
-		// @ts-ignore
+	const clones = validChildren.map((child: any) => {
 		return cloneElement(child, {
-			// @ts-ignore
 			buttonSize: buttonSize || child.props.buttonSize,
 		});
 	});

--- a/assets/src/application/ui/input/Button/ButtonGroup/style.scss
+++ b/assets/src/application/ui/input/Button/ButtonGroup/style.scss
@@ -1,20 +1,21 @@
 .ee-btn-group {
-	.ee-btn {
-		margin-right: 0;
+	margin-right: var(--ee-margin-default);
 
-		&:first-child {
+	.ee-btn.ee-btn {
+		margin: 0;
+
+		&--no-border-radius {
+			border-radius: 0;
+		}
+
+		&--first {
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;
 		}
 
-		&:last-child {
+		&--last {
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
-		}
-
-		+ .ee-btn {
-			margin-left: 0;
-			margin-right: var(--ee-margin-default);
 		}
 	}
 }

--- a/assets/src/application/ui/input/Button/ButtonGroup/style.scss
+++ b/assets/src/application/ui/input/Button/ButtonGroup/style.scss
@@ -4,16 +4,16 @@
 	.ee-btn.ee-btn {
 		margin: 0;
 
-		&--no-border-radius {
+		&:not(:first-child):not(:last-child) {
 			border-radius: 0;
 		}
 
-		&--first {
+		&:first-child {
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;
 		}
 
-		&--last {
+		&:last-child {
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
 		}

--- a/assets/src/application/ui/input/Button/ButtonGroup/types.ts
+++ b/assets/src/application/ui/input/Button/ButtonGroup/types.ts
@@ -1,0 +1,6 @@
+import { ButtonGroupProps as ChakraButtonGroupProps } from '@infraUI/inputs';
+import { ButtonSize } from '@application/ui/input';
+
+export interface ButtonGroupProps extends ChakraButtonGroupProps {
+	buttonSize?: ButtonSize;
+}

--- a/assets/src/application/ui/input/Button/ButtonGroup/utils.ts
+++ b/assets/src/application/ui/input/Button/ButtonGroup/utils.ts
@@ -1,5 +1,5 @@
 import { Children, isValidElement } from 'react';
 
 export function cleanChildren(children) {
-	return Children.toArray(children).filter((child) => isValidElement(child));
+	return Children.toArray(children).filter(isValidElement);
 }

--- a/assets/src/application/ui/input/Button/ButtonGroup/utils.ts
+++ b/assets/src/application/ui/input/Button/ButtonGroup/utils.ts
@@ -1,0 +1,5 @@
+import { Children, isValidElement } from 'react';
+
+export function cleanChildren(children) {
+	return Children.toArray(children).filter((child) => isValidElement(child));
+}

--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/CardViewFilterButton.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/CardViewFilterButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { AppstoreFilled } from '@appDisplay/icons/svgs';
-import { Button, ButtonSize } from '@application/ui/input';
+import { Button } from '@application/ui/input';
 import { CardViewFilterButtonProps } from '../types';
 
 import { getPropsAreEqual } from '@appServices/utilities';
@@ -13,7 +13,6 @@ const CardViewFilterButton: React.FC<CardViewFilterButtonProps> = ({ listId, set
 	return (
 		<Button
 			active={view === 'card'}
-			buttonSize={ButtonSize.SMALL}
 			className='ee-filter-bar__btn'
 			icon={AppstoreFilled}
 			id={filterId}

--- a/assets/src/application/ui/layout/entityList/filterBar/buttons/EntityListViewButtonGroup.tsx
+++ b/assets/src/application/ui/layout/entityList/filterBar/buttons/EntityListViewButtonGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 
-import { ButtonGroup } from '@application/ui/input';
+import { ButtonGroup, ButtonSize } from '@application/ui/input';
 import CardViewFilterButton from './CardViewFilterButton';
 import TableViewFilterButton from './TableViewFilterButton';
 import { EntityListViewButtonGroupProps } from '../types';
@@ -15,7 +15,7 @@ const EntityListViewButtonGroup: React.FC<EntityListViewButtonGroupProps> = ({
 	view,
 }) => {
 	return (
-		<ButtonGroup>
+		<ButtonGroup buttonSize={ButtonSize.SMALL}>
 			<TableViewFilterButton listId={listId} setTableView={setTableView} view={view} />
 			<CardViewFilterButton listId={listId} setCardView={setCardView} view={view} />
 		</ButtonGroup>

--- a/assets/src/infrastructure/ui/inputs/Button/ButtonGroup.tsx
+++ b/assets/src/infrastructure/ui/inputs/Button/ButtonGroup.tsx
@@ -3,8 +3,8 @@ import { ButtonGroup as ChakraButtonGroup } from '@chakra-ui/core';
 
 import type { ButtonGroupProps } from './types';
 
-const Checkbox: React.FC<ButtonGroupProps> = (props) => {
+const ButtonGroup: React.FC<ButtonGroupProps> = (props) => {
 	return <ChakraButtonGroup {...props} />;
 };
 
-export default Checkbox;
+export default ButtonGroup;


### PR DESCRIPTION
## Problem this Pull Request solves
- Makes it possible for `ButtonGroup` to wrap more than 2 buttons
- Receives button size at the parent level, w/o the need to pass to each items individually
- Closes https://github.com/eventespresso/event-espresso-core/issues/2874

## How has this been tested
![image](https://user-images.githubusercontent.com/1477453/83045720-a4bd8b00-a04e-11ea-85fc-543c2cd38142.png)
