### PR TITLE
Frontend Routes

### DIFF
--- a/core/domain/entities/routing/handlers/frontend/FrontendRequests.php
+++ b/core/domain/entities/routing/handlers/frontend/FrontendRequests.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\frontend;
+
+use EE_Dependency_Map;
+use EE_Maintenance_Mode;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+use EventEspresso\core\services\loaders\LoaderInterface;
+use EventEspresso\core\services\request\RequestInterface;
+
+/**
+ * Class FrontendRequests
+ * registers dependencies and loads resources for all non-authorized standard HTTP requests
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\frontend
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class FrontendRequests extends Route
+{
+
+    /**
+     * @var EE_Maintenance_Mode $maintenance_mode
+     */
+    private $maintenance_mode;
+
+
+    /**
+     * returns true if the current request matches this route
+     * child classes can override and use Request directly to match route with request
+     * or supply a RouteMatchSpecification class and just use the below
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return ($this->request->isFrontend() || $this->request->isFrontAjax()) && ! $this->maintenance_mode->level();
+    }
+
+
+    /**
+     * FrontendRequests constructor.
+     *
+     * @param EE_Dependency_Map   $dependency_map
+     * @param EE_Maintenance_Mode $maintenance_mode
+     * @param LoaderInterface     $loader
+     * @param RequestInterface    $request
+     */
+    public function __construct(
+        EE_Dependency_Map $dependency_map,
+        EE_Maintenance_Mode $maintenance_mode,
+        LoaderInterface $loader,
+        RequestInterface $request
+    ) {
+        $this->maintenance_mode = $maintenance_mode;
+        parent::__construct($dependency_map, $loader, $request);
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EE_Front_Controller',
+            [
+                'EE_Registry'              => EE_Dependency_Map::load_from_cache,
+                'EE_Request_Handler'       => EE_Dependency_Map::load_from_cache,
+                'EE_Module_Request_Router' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        do_action('AHEE__EE_System__load_controllers__load_front_controllers');
+        $this->loader->getShared('EE_Front_Controller');
+        return true;
+    }
+}

--- a/core/domain/entities/routing/handlers/frontend/ShortcodeRequests.php
+++ b/core/domain/entities/routing/handlers/frontend/ShortcodeRequests.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\frontend;
+
+use EE_Config;
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class ShortcodeRequests
+ * registers dependencies and loads resources for all requests where shortcodes may be present
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class ShortcodeRequests extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     * child classes can override and use Request directly to match route with request
+     * or supply a RouteMatchSpecification class and just use the below
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return $this->request->isFrontend() || $this->request->isIframe() || $this->request->isAjax();
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoCancelled',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoCheckout',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoEventAttendees',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoEvents',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoThankYou',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoTicketSelector',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\shortcodes\EspressoTxnPage',
+            ['EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        // load, register, and add shortcodes the new way
+        $this->loader->getShared(
+            'EventEspresso\core\services\shortcodes\ShortcodesManager',
+            [
+                // and the old way, but we'll put it under control of the new system
+                EE_Config::getLegacyShortcodesManager(),
+            ]
+        );
+        return true;
+    }
+}


### PR DESCRIPTION
see: #2870

adds the following admin Route classes:

- FrontendRequests
registers dependencies and loads resources for all non-authorized standard HTTP requests

 - ShortcodeRequests
registers dependencies and loads resources for all requests where shortcodes may be present