### PR TITLE
Shared Routes

### DIFF
--- a/core/domain/entities/routing/handlers/shared/AssetRequests.php
+++ b/core/domain/entities/routing/handlers/shared/AssetRequests.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\shared;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class AssetRequests
+ * loads for any type of request where asset managers are required
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class AssetRequests extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return $this->request->isAdmin()
+               || $this->request->isFrontend()
+               || $this->request->isIframe()
+               || $this->request->isWordPressApi();
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $default_dependencies = [
+            'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
+            'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
+            'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
+        ];
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\assets\ReactAssetManager',
+            $default_dependencies
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\assets\CoreAssetManager',
+            [
+                'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
+                'EE_Currency_Config'                                 => EE_Dependency_Map::load_from_cache,
+                'EE_Template_Config'                                 => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\editor\BlockRegistrationManager',
+            [
+                'EventEspresso\core\services\assets\BlockAssetManagerCollection'     => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\entities\editor\BlockCollection'          => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\routing\RouteMatchSpecificationManager' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'                        => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\editor\CoreBlocksAssetManager',
+            [
+                'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\blocks\EventAttendeesBlockRenderer',
+            [
+                'EventEspresso\core\domain\Domain' => EE_Dependency_Map::load_from_cache,
+                'EEM_Attendee'                     => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\editor\blocks\EventAttendees',
+            [
+                'EventEspresso\core\domain\entities\editor\CoreBlocksAssetManager'      => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'                           => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\services\blocks\EventAttendeesBlockRenderer' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        $this->loader->getShared('EventEspresso\core\services\assets\Registry');
+        $this->loader->getShared('EventEspresso\core\domain\services\assets\CoreAssetManager');
+        if ($this->canLoadBlocks()) {
+            $this->loader->getShared(
+                'EventEspresso\core\services\editor\BlockRegistrationManager'
+            );
+        }
+        return true;
+    }
+
+
+    /**
+     * Return whether blocks can be registered/loaded or not.
+     *
+     * @return bool
+     * @since $VID:$
+     */
+    private function canLoadBlocks()
+    {
+        return apply_filters('FHEE__EE_System__canLoadBlocks', true)
+               && function_exists('register_block_type')
+               // don't load blocks if in the Divi page builder editor context
+               // @see https://github.com/eventespresso/event-espresso-core/issues/814
+               && ! $this->request->getRequestParam('et_fb', false);
+    }
+}

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\shared;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class GQLRequests
+ * loads for any type of request where GraphQL requests may occur
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class GQLRequests extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return PHP_VERSION_ID > 70000
+               && (
+                   $this->request->isGQL()
+                   || $this->request->isUnitTesting()
+                   || (
+                       $this->request->isAdmin()
+                       && $this->request->getRequestParam('page') === 'espresso_events'
+                       && (
+                           $this->request->getRequestParam('action') === 'create_new'
+                           || $this->request->getRequestParam('action') === 'edit'
+                       )
+                   )
+               );
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\GraphQLManager',
+            [
+                'EventEspresso\core\services\graphql\ConnectionsManager' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\graphql\DataLoaderManager'  => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\graphql\EnumsManager'       => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\graphql\InputsManager'      => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\graphql\TypesManager'       => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\TypesManager',
+            [
+                'EventEspresso\core\services\graphql\types\TypeCollection' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\InputsManager',
+            [
+                'EventEspresso\core\services\graphql\inputs\InputCollection' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\EnumsManager',
+            [
+                'EventEspresso\core\services\graphql\enums\EnumCollection' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\ConnectionsManager',
+            [
+                'EventEspresso\core\services\graphql\connections\ConnectionCollection' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\graphql\DataLoaderManager',
+            [
+                'EventEspresso\core\services\graphql\loaders\DataLoaderCollection' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Datetime',
+            ['EEM_Datetime' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Attendee',
+            ['EEM_Attendee' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Event',
+            ['EEM_Event' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Ticket',
+            ['EEM_Ticket' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Price',
+            ['EEM_Price' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\PriceType',
+            ['EEM_Price_Type' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Venue',
+            ['EEM_Venue' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\State',
+            ['EEM_State' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\Country',
+            ['EEM_Country' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\EventDatetimesConnection',
+            ['EEM_Datetime' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryDatetimesConnection',
+            ['EEM_Datetime' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryAttendeesConnection',
+            ['EEM_Attendee' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\DatetimeTicketsConnection',
+            ['EEM_Ticket' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryTicketsConnection',
+            ['EEM_Ticket' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\TicketPricesConnection',
+            ['EEM_Price' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryPricesConnection',
+            ['EEM_Price' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryPriceTypesConnection',
+            ['EEM_Price_Type' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\TicketDatetimesConnection',
+            ['EEM_Datetime' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\EventVenuesConnection',
+            ['EEM_Venue' => EE_Dependency_Map::load_from_cache]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+
+        if (! class_exists('WPGraphQL')) {
+            require_once EE_THIRD_PARTY . 'wp-graphql/wp-graphql.php';
+        }
+        // load handler for EE GraphQL requests
+        $graphQL_manager = $this->loader->getShared(
+            'EventEspresso\core\services\graphql\GraphQLManager'
+        );
+        $graphQL_manager->init();
+        return true;
+    }
+}

--- a/core/domain/entities/routing/handlers/shared/RestApiRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RestApiRequests.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\shared;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class RestApiRequests
+ * registers dependencies and loads resources for REST API requests
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class RestApiRequests extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return $this->request->isWordPressApi();
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\CalculatedModelFields',
+            [
+                'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => EE_Dependency_Map::load_from_cache
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory',
+            ['EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\controllers\model\Read',
+            ['EventEspresso\core\libraries\rest_api\CalculatedModelFields' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\calculations\Datetime',
+            [
+                'EEM_Datetime'     => EE_Dependency_Map::load_from_cache,
+                'EEM_Registration' => EE_Dependency_Map::load_from_cache
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\calculations\Event',
+            [
+                'EEM_Event'        => EE_Dependency_Map::load_from_cache,
+                'EEM_Registration' => EE_Dependency_Map::load_from_cache
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\calculations\Registration',
+            ['EEM_Registration' => EE_Dependency_Map::load_from_cache]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        // rest api handled by module for now
+        return true;
+    }
+}

--- a/core/domain/entities/routing/handlers/shared/SessionRequests.php
+++ b/core/domain/entities/routing/handlers/shared/SessionRequests.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\shared;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class Shortcodes
+ * registers dependencies and loads resources for requests where EE_Session may be required
+ *
+ * @package EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   \$VID:$
+ */
+class SessionRequests extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return $this->request->isAdmin() || $this->request->isEeAjax() || $this->request->isFrontend();
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EE_Session',
+            [
+                'EventEspresso\core\services\cache\TransientCacheStorage'  => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\values\session\SessionLifespan' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'              => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\session\SessionStartHandler'  => EE_Dependency_Map::load_from_cache,
+                'EE_Encryption'                                            => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\services\session\SessionStartHandler',
+            ['EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        $this->loader->getShared('EE_Session');
+        return true;
+    }
+}

--- a/core/domain/entities/routing/handlers/shared/SessionRequests.php
+++ b/core/domain/entities/routing/handlers/shared/SessionRequests.php
@@ -6,7 +6,7 @@ use EE_Dependency_Map;
 use EventEspresso\core\domain\entities\routing\handlers\Route;
 
 /**
- * Class Shortcodes
+ * Class SessionRequests
  * registers dependencies and loads resources for requests where EE_Session may be required
  *
  * @package EventEspresso\core\domain\entities\routing\handlers\shared

--- a/core/domain/entities/routing/handlers/shared/WordPressHeartbeat.php
+++ b/core/domain/entities/routing/handlers/shared/WordPressHeartbeat.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\shared;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\Route;
+
+/**
+ * Class WordPressHeartbeat
+ * registers dependencies and loads resources for handling WordPress Heartbeat requests
+ *
+ * @package \EventEspresso\core\domain\entities\routing\handlers\shared
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class WordPressHeartbeat extends Route
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        return $this->request->isWordPressHeartbeat();
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\admin\ajax\WordpressHeartbeat',
+            [
+                'EventEspresso\core\services\loaders\Loader'  => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\admin\ajax\EventEditorHeartbeat',
+            [
+                'EventEspresso\core\domain\Domain' => EE_Dependency_Map::load_from_cache,
+                'EE_Environment_Config'            => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        $this->loader->getShared('EventEspresso\core\domain\services\admin\ajax\WordpressHeartbeat');
+        return true;
+    }
+}


### PR DESCRIPTION
see: #2870

adds the following admin Route classes:

- AssetRequests: loads for any type of request where asset managers are required

- GQLRequests: loads for any type of request where GraphQL requests may occur

- RestApiRequests: registers dependencies and loads resources for REST API requests

- SessionRequests: registers dependencies and loads resources for requests where EE_Session may be required

- WordPressHeartbeat: registers dependencies and loads resources for handling WordPress Heartbeat requests