### PR TITLE
Fix duplicate key warning in TPC

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultPrices.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useAddDefaultPrices.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import defaultPrice from '../defaultPriceModifier';
 import { isBasePrice } from '@sharedEntities/priceTypes/predicates/selectionPredicates';
@@ -34,7 +35,7 @@ const useAddDefaultPrices = (): VoidFunction => {
 			return {
 				...priceModifier,
 				// clone it
-				id: '',
+				id: uuidv4(),
 				dbId: 0,
 				isNew: true,
 				// avoid default price getting duplicated


### PR DESCRIPTION
This PR adds `uuid` to the cloned prices in TPC to avoid keys being duplicated when price id is empty string.
Closes #2905