### PR TITLE
Update Unit Tests to Support Newer Versions of PHPUnit

### DIFF
--- a/tests/includes/CoreLoader.php
+++ b/tests/includes/CoreLoader.php
@@ -70,8 +70,8 @@ class CoreLoader
                 $folder = $this->findWordpressTests(__DIR__);
                 define('WP_TESTS_DIR', $folder);
             }
-            echo "\nWP_TESTS_DIR: " . WP_TESTS_DIR . "\n\n";
-            echo "\nEE_TESTS_DIR: " . EE_TESTS_DIR;
+            echo "\nWP_TESTS_DIR: " . WP_TESTS_DIR;
+            echo "\nEE_TESTS_DIR: " . EE_TESTS_DIR . "\n\n";
             // define('EE_REST_API_DEBUG_MODE', true);
         }
     }

--- a/tests/includes/CoreLoader.php
+++ b/tests/includes/CoreLoader.php
@@ -12,6 +12,8 @@ class CoreLoader
 {
     public function init()
     {
+        echo "\nINITIALIZING EVENT ESPRESSO UNIT TESTS";
+        echo "\n--------------------------------------";
         $this->setConstants();
         $this->preLoadWPandEE();
         $this->loadWP();
@@ -23,6 +25,27 @@ class CoreLoader
             EVENT_ESPRESSO_UPLOAD_DIR . 'logs/benchmarking-master.html',  false
         );
     }
+
+
+    /**
+     * @param string $folder
+     * @return string|null
+     * @since $VID:$
+     */
+    private function findWordpressTests($folder = '')
+    {
+        static $depth = 10;
+        echo ".";
+        if (file_exists($folder . '/includes/functions.php')) {
+            return $folder;
+        }
+        if ($depth > 0) {
+            $depth--;
+            return $this->findWordpressTests(dirname($folder));
+        }
+        return null;
+    }
+
 
     protected function setConstants()
     {
@@ -43,23 +66,12 @@ class CoreLoader
             if (file_exists($_tests_dir . '/includes/functions.php')) {
                 define('WP_TESTS_DIR', $_tests_dir);
             } else {
-                define(
-                    'WP_TESTS_DIR',
-                    dirname(
-                        dirname(
-                            dirname(
-                                dirname(
-                                    dirname(
-                                        dirname(
-                                            __DIR__
-                                        )
-                                    )
-                                )
-                            )
-                        )
-                    ) . '/tests/phpunit'
-                );
+                echo "\n\n Attempting to find WP_TESTS_DIR ";
+                $folder = $this->findWordpressTests(__DIR__);
+                define('WP_TESTS_DIR', $folder);
             }
+            echo "\nWP_TESTS_DIR: " . WP_TESTS_DIR . "\n\n";
+            echo "\nEE_TESTS_DIR: " . EE_TESTS_DIR;
             // define('EE_REST_API_DEBUG_MODE', true);
         }
     }
@@ -69,7 +81,7 @@ class CoreLoader
     {
         //if WordPress test suite isn't found then we can't do anything.
         if (! is_readable(WP_TESTS_DIR . '/includes/functions.php')) {
-            die("The WordPress PHPUnit test suite could not be found.\n");
+            die("The WordPress PHPUnit test suite could not be found at: " . WP_TESTS_DIR);
         }
         require_once WP_TESTS_DIR . '/includes/functions.php';
         require_once EE_PLUGIN_DIR . 'core/Psr4Autoloader.php';

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -828,7 +828,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param string $error_message
      * @return void
      */
-    public function assertHTMLEquals($expected, $actual, $error_message = null)
+    public function assertHTMLEquals($expected, $actual, $error_message = '')
     {
         $expected_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $expected);
         $actual_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $actual);
@@ -936,7 +936,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
             ) {
                 $value = $auto_made_thing_seed;
             } elseif ($field instanceof EE_Primary_Key_String_Field) {
-                $value = "$auto_made_thing_seed";
+                $value = (string) $auto_made_thing_seed;
             } elseif ($field instanceof EE_Email_Field) {
                 $value = $auto_made_thing_seed . 'ee@ee' . $auto_made_thing_seed . '.dev';
             } elseif ($field instanceof EE_Text_Field_Base) {
@@ -1364,14 +1364,18 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * This should call the appropriate method regardless of version
      *
      * @param string $exception
+     * @param null   $code
      * @throws \PHPUnit\Framework\Exception
      */
-    public function setExceptionExpected($exception)
+    public function setExceptionExpected($exception, $code = null)
     {
         if (method_exists($this, 'expectException')) {
             parent::expectException($exception);
         } elseif (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException($exception);
+        }
+        if ($code !== null && method_exists($this, 'expectExceptionCode')) {
+            parent::expectExceptionCode($code);
         }
     }
 
@@ -1393,4 +1397,86 @@ class EE_UnitTestCase extends WP_UnitTestCase
         require_once EE_PUBLIC . 'template_tags.php';
     }
 
+
+    /**
+     * @param string   $hook_name
+     * @param callable $callback
+     * @param bool|int $equals
+     * @param bool     $is_action
+     * @since $VID:$
+     */
+    protected function assertHookIsSet($hook_name, callable $callback, $equals, $is_action = true)
+    {
+        $has_hook = $is_action ? 'has_action' : 'has_filter';
+        $actual = $has_hook($hook_name, $callback);
+        if ($actual === false) {
+            // produces error message like:
+            // The `EE_Admin::filter_plugin_actions()` callback is NOT registered to the "plugin_action_links" action when it should be.
+            $message = sprintf(
+                'The `%1$s` callback is NOT registered to the "%2$s" %3$s when it should be.',
+                is_array($callback) ? get_class($callback[0]) . "::{$callback[1]}()" : $callback,
+                $hook_name,
+                $is_action ? 'action' : 'filter'
+            );
+        } else {
+            // produces error message like:
+            // The `EE_Admin::admin_init()` callback is registered to the "admin_init" action
+            // at priority 100 when it should be registered at priority 10.
+            $message = sprintf(
+                'The `%1$s` callback is registered to the "%2$s" %3$s at priority %4$s when it should be registered at priority %5$s.',
+                is_array($callback) ? get_class($callback[0]) . "::{$callback[1]}()" : $callback,
+                $hook_name,
+                $is_action ? 'action' : 'filter',
+                $actual,
+                $equals
+            );
+        }
+        $this->assertEquals($equals, $actual, $message);
+    }
+
+
+    /**
+     * @param string   $action
+     * @param callable $callback
+     * @param bool|int $priority
+     * @since $VID:$
+     */
+    protected function assertActionSet($action, callable $callback, $priority = true)
+    {
+        $this->assertHookIsSet($action, $callback, $priority);
+    }
+
+
+    /**
+     * @param string   $action
+     * @param callable $callback
+     * @since $VID:$
+     */
+    protected function assertActionNotSet($action, callable $callback)
+    {
+        $this->assertHookIsSet($action, $callback, false);
+    }
+
+
+    /**
+     * @param string   $filter
+     * @param callable $callback
+     * @param bool|int $priority
+     * @since $VID:$
+     */
+    protected function assertFilterSet($filter, callable $callback, $priority = true)
+    {
+        $this->assertHookIsSet($filter, $callback, $priority, false);
+    }
+
+
+    /**
+     * @param string   $filter
+     * @param callable $callback
+     * @since $VID:$
+     */
+    protected function assertFilterNotSet($filter, callable $callback)
+    {
+        $this->assertHookIsSet($filter, $callback, false, false);
+    }
 }

--- a/tests/includes/EspressoPHPUnitFrameworkTestCase.php
+++ b/tests/includes/EspressoPHPUnitFrameworkTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EventEspresso\tests\includes;
+
+use PHPUnit\Framework\Exception;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class EspressoPHPUnitFrameworkTestCase
+ * Description
+ *
+ * @package EETests\bootstrap\
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class EspressoPHPUnitFrameworkTestCase extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * \PHPUnit\Framework\TestCase::expectException() only exists in PHPUnit version 5.7+
+     * but on Travis-CI we test using PHPUnit 4.8 because it supports PHP versions < 5.6
+     * This should call the appropriate method regardless of version
+     *
+     * @param string $exception
+     * @throws Exception
+     */
+    public function setExceptionExpected($exception, $code = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            parent::expectException($exception);
+        } elseif (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($exception);
+        }
+        if ($code !== null && method_exists($this, 'expectExceptionCode')) {
+            parent::expectExceptionCode($code);
+        }
+    }
+}

--- a/tests/includes/listener-loader.php
+++ b/tests/includes/listener-loader.php
@@ -1,0 +1,10 @@
+<?php
+
+$phpunit_version = function_exists('tests_get_phpunit_version')
+    ? tests_get_phpunit_version()
+    : '6.0';
+if (version_compare($phpunit_version, '7.0', '>=')) {
+    require __DIR__ . '/phpunit7/speed-trap-listener.php';
+} else {
+    require __DIR__ . '/speed-trap-listener.php';
+}

--- a/tests/includes/phpunit7/speed-trap-listener.php
+++ b/tests/includes/phpunit7/speed-trap-listener.php
@@ -57,7 +57,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError(PHPUnit\Framework\Test $test, Throwable $t, float $time): void
     {
     }
 
@@ -70,7 +70,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param float                     $time
      * @since Method available since Release 5.1.0
      */
-    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
+    public function addWarning(PHPUnit\Framework\Test $test, PHPUnit\Framework\Warning $e, float $time): void
     {
     }
 
@@ -82,8 +82,11 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param PHPUnit_Framework_AssertionFailedError $e
      * @param float                                  $time
      */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
+    public function addFailure(
+        PHPUnit\Framework\Test $test,
+        PHPUnit\Framework\AssertionFailedError $e,
+        float $time
+    ): void {
     }
 
 
@@ -94,7 +97,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addIncompleteTest(PHPUnit\Framework\Test $test, Throwable $t, float $time): void
     {
     }
 
@@ -107,7 +110,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param float                  $time
      * @since  Method available since Release 4.0.0
      */
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addRiskyTest(PHPUnit\Framework\Test $test, Throwable $t, float $time): void
     {
     }
 
@@ -119,7 +122,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param Exception              $e
      * @param float                  $time
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addSkippedTest(PHPUnit\Framework\Test $test, Throwable $t, float $time): void
     {
     }
 
@@ -129,7 +132,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      *
      * @param PHPUnit_Framework_Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test)
+    public function startTest(PHPUnit\Framework\Test $test): void
     {
     }
 
@@ -140,7 +143,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      * @param PHPUnit_Framework_Test $test
      * @param float                  $time
      */
-    public function endTest(PHPUnit_Framework_Test $test, $time)
+    public function endTest(PHPUnit\Framework\Test $test, float $time): void
     {
         if (! $test instanceof PHPUnit_Framework_TestCase) {
             return;
@@ -160,7 +163,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      *
      * @param PHPUnit_Framework_TestSuite $suite
      */
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(PHPUnit\Framework\TestSuite $suite): void
     {
         $this->suites++;
     }
@@ -171,7 +174,7 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      *
      * @param PHPUnit_Framework_TestSuite $suite
      */
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite(PHPUnit\Framework\TestSuite $suite): void
     {
         $this->suites--;
 
@@ -308,7 +311,8 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      */
     protected function renderFooter()
     {
-        if ($hidden = $this->getHiddenCount($this->slow)) {
+        $hidden = $this->getHiddenCount($this->slow);
+        if ($hidden) {
             echo sprintf('...and there %s %s more above your threshold hidden from view', 1 === $hidden ? 'is' : 'are',
                 $hidden);
         }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -13,10 +13,12 @@
                 <directory>../acceptance_tests</directory>
                 <directory>../assets</directory>
                 <directory>../bin</directory>
+                <directory>../config</directory>
                 <directory>../docs</directory>
                 <directory>../eslint</directory>
                 <directory>../languages</directory>
                 <directory>../node_modules</directory>
+                <directory>../scripts</directory>
                 <directory>../public</directory>
                 <directory>../tests</directory>
                 <directory>../vendor</directory>
@@ -25,8 +27,8 @@
         </whitelist>
     </filter>
 	<testsuites>
-		<testsuite>
-			<directory suffix=".php">./testcases/</directory>
+        <testsuite name="default">
+            <directory suffix=".php">./testcases/</directory>
 		</testsuite>
 	</testsuites>
 	<groups>
@@ -37,8 +39,8 @@
         </exclude>
     </groups>
 	<listeners>
-		<listener class="SpeedTrapListener" file="includes/speed-trap-listener.php">
-			<arguments>
+        <listener class="SpeedTrapListener" file="includes/listener-loader.php">
+            <arguments>
 				<array>
 					<element key="slowThreshold">
 						<integer>2000</integer>


### PR DESCRIPTION
Current unit tests fail if you run versions of PHPUnit above 5.x with the following error:

```
PHP Fatal error:  Declaration of SpeedTrapListener::addError(PHPUnit_Framework_Test $test, Exception $e, $time)
must be compatible with PHPUnit\Framework\TestListener::addError(PHPUnit\Framework\Test $test, Throwable $t, float $time): void
in /mnt/a/www/dev.test/wp-content/plugins/event-espresso-core/tests/includes/speed-trap-listener.php on line 58

PHP Stack trace:
PHP   1. {main}() /usr/local/bin/phpunit:0
PHP   2. PHPUnit\TextUI\Command::main() /usr/local/bin/phpunit:614
PHP   3. PHPUnit\TextUI\Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:162
PHP   4. PHPUnit\TextUI\TestRunner->doRun() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:206
PHP   5. PHPUnit\TextUI\TestRunner->handleConfiguration() phar:///usr/local/bin/phpunit/phpunit/TextUI/TestRunner.php:161
PHP   6. require_once() phar:///usr/local/bin/phpunit/phpunit/TextUI/TestRunner.php:1089
```

This PR updates our unit test setup to fix the above issues

