### PR TITLE
Add Foreign Key Alias

### DIFF
--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -5436,7 +5436,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // then check if that alias exists in the incoming data
             // AND that the actual PK the $FK_alias represents matches the $qualified_column (full PK)
             foreach ($this->foreign_key_aliases as $FK_alias => $PK_column) {
-                if (isset($cols_n_values[ $FK_alias ]) && $PK_column === $qualified_column) {
+                if ($PK_column === $qualified_column && isset($cols_n_values[ $FK_alias ])) {
                     $value = $cols_n_values[ $FK_alias ];
                     break;
                 }

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -6,7 +6,6 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\ModelConfigurationException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\interfaces\ResettableInterface;
-use EventEspresso\core\services\orm\ModelFieldFactory;
 use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
@@ -272,6 +271,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     protected $_has_primary_key_field = null;
 
     /**
+     * @var array $foreign_key_aliases
+     */
+    protected $foreign_key_aliases = [];
+
+    /**
      * Whether or not this model is based off a table in WP core only (CPTs should set
      * this to FALSE, but if we were to make an EE_WP_Post model, it should set this to true).
      * This should be true for models that deal with data that should exist independent of EE.
@@ -288,7 +292,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * null until initialized by hasPasswordField()
      */
     protected $has_password_field;
-    
+
     /**
      * @var EE_Password_Field|null Automatically set when calling getPasswordField()
      */
@@ -5378,6 +5382,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $table_obj->get_fully_qualified_pk_column(),
                 $table_obj->get_pk_column()
             );
+            // no PK?  ok check if there is a foreign key alias set for this table
+            if ($table_pk_value === null && ! empty($this->foreign_key_aliases)) {
+                // then check if that alias exists in the incoming data
+                foreach ($this->foreign_key_aliases as $FK_alias) {
+                    $table_pk_value = isset($cols_n_values[ $FK_alias ]) ? $cols_n_values[ $FK_alias ] : null;
+                }
+            }
             // there is a primary key on this table and its not set. Use defaults for all its columns
             if ($table_pk_value === null && $table_obj->get_pk_column()) {
                 foreach ($this->_get_fields_for_table($table_alias) as $field_name => $field_obj) {

--- a/core/db_models/EEM_Event_Message_Template.model.php
+++ b/core/db_models/EEM_Event_Message_Template.model.php
@@ -1,15 +1,13 @@
 <?php
 
- /**
+/**
  *  EEM_Event_Message_Template
  *  Model for relation table between EEM_Message_Template_Group and EEM_Event
  *
- * @package     Event Espresso
- * @subpackage  models
- * @since           4.3.0
+ * @package          Event Espresso
+ * @subpackage       models
+ * @since            4.3.0
  * @author           Darren Ethier
- *
- * ------------------------------------------------------------------------
  */
 class EEM_Event_Message_Template extends EEM_Base
 {
@@ -17,79 +15,113 @@ class EEM_Event_Message_Template extends EEM_Base
     // private instance of the EEM_Event_Message_Template object
     protected static $_instance = null;
 
+
     /**
-     * private constructor to prevent direct creation
-     * @Constructor
-     * @access private
-     * @return void
+     * protected constructor to prevent direct creation
+     *
+     * @param null $timezone
+     * @throws EE_Error
      */
     protected function __construct($timezone = null)
     {
-        $this->singlular_item = __('Event Message Template', 'event_espresso');
-        $this->plural_item = __('Event Message Templates', 'event_espresso');
+        $this->singular_item = esc_html__('Event Message Template', 'event_espresso');
+        $this->plural_item = esc_html__('Event Message Templates', 'event_espresso');
 
-        $this->_tables = array(
-            'Event_Message_Template'=> new EE_Primary_Table('esp_event_message_template', 'EMT_ID')
-        );
-        $this->_fields = array(
-            'Event_Message_Template'=>array(
-                'EMT_ID'=>new EE_Primary_Key_Int_Field('EMT_ID', __('Event Message Template ID', 'event_espresso')),
-                'EVT_ID'=>new EE_Foreign_Key_Int_Field('EVT_ID', __('The ID to the Event', 'event_espresso'), false, 0, 'Event'),
-                'GRP_ID'=>new EE_Foreign_Key_Int_Field('GRP_ID', __('The ID to the Message Template Group', 'event_espresso'), false, 0, 'Message_Template_Group')
-            ));
-        $this->_model_relations = array(
-            'Event'=>new EE_Belongs_To_Relation(),
-            'Message_Template_Group'=>new EE_Belongs_To_Relation()
-        );
+        $this->_tables = [
+            'Event_Message_Template' => new EE_Primary_Table('esp_event_message_template', 'EMT_ID'),
+        ];
+        $this->_fields = [
+            'Event_Message_Template' => [
+                'EMT_ID' => new EE_Primary_Key_Int_Field(
+                    'EMT_ID',
+                    esc_html__('Event Message Template ID', 'event_espresso')
+                ),
+                'EVT_ID' => new EE_Foreign_Key_Int_Field(
+                    'EVT_ID',
+                    esc_html__('The ID to the Event', 'event_espresso'),
+                    false,
+                    0,
+                    'Event'
+                ),
+                'GRP_ID' => new EE_Foreign_Key_Int_Field(
+                    'GRP_ID',
+                    esc_html__('The ID to the Message Template Group', 'event_espresso'),
+                    false,
+                    0,
+                    'Message_Template_Group'
+                ),
+            ],
+        ];
+        $this->_model_relations = [
+            'Event'                  => new EE_Belongs_To_Relation(),
+            'Message_Template_Group' => new EE_Belongs_To_Relation(),
+        ];
         $path_to_event = 'Event';
-        $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public($path_to_event);
-        $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
-        $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event);
-        $this->_cap_restriction_generators[ EEM_Base::caps_delete ] = new EE_Restriction_Generator_Event_Related_Protected($path_to_event, EEM_Base::caps_edit);
+        $this->_cap_restriction_generators[ EEM_Base::caps_read ] = new EE_Restriction_Generator_Event_Related_Public(
+            $path_to_event
+        );
+        $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected(
+            $path_to_event
+        );
+        $this->_cap_restriction_generators[ EEM_Base::caps_edit ] = new EE_Restriction_Generator_Event_Related_Protected(
+            $path_to_event
+        );
+        $this->_cap_restriction_generators[ EEM_Base::caps_delete ] = new EE_Restriction_Generator_Event_Related_Protected(
+            $path_to_event,
+            EEM_Base::caps_edit
+        );
         parent::__construct($timezone);
     }
-
 
 
     /**
      * helper method to simply return an array of event ids for events attached to the given
      * message template group.
      *
-     * @since 4.3.0
-     *
-     * @param  int    $GRP_ID The MTP group we want attached events for.
+     * @param int $GRP_ID The MTP group we want attached events for.
      * @return  array               An array of event ids.
+     * @throws EE_Error
+     * @since 4.3.0
      */
     public function get_attached_event_ids($GRP_ID)
     {
-        $event_ids = $this->_get_all_wpdb_results(array( array( 'GRP_ID' => $GRP_ID ) ), ARRAY_N, 'EVT_ID');
+        $event_ids = $this->_get_all_wpdb_results([['GRP_ID' => $GRP_ID]], ARRAY_N, 'EVT_ID');
         $event_ids = call_user_func_array('array_merge', $event_ids);
         return $event_ids;
     }
 
 
-
     /**
      * helper method for clearing event/group relations for the given event ids and grp ids.
-     * @param  array $GRP_IDs  An array of GRP_IDs. Optional. If empty then there must be EVTIDs.
-     * @param  array $EVT_IDs  An array of EVT_IDs.  Optional. If empty then there must be
-     *                                 GRPIDs.
+     *
+     * @param array $GRP_IDs An array of GRP_IDs. Optional. If empty then there must be EVT IDs.
+     * @param array $EVT_IDs An array of EVT_IDs.  Optional. If empty then there must be GRP IDs.
      * @return int             How many rows were deleted.
+     * @throws EE_Error
+     * @throws EE_Error
      */
-    public function delete_event_group_relations($GRP_IDs = array(), $EVT_IDs = array())
+    public function delete_event_group_relations($GRP_IDs = [], $EVT_IDs = [])
     {
         if (empty($GRP_IDs) && empty($EVT_IDs)) {
-            throw new EE_Error(sprintf(__('%s requires either an array of GRP_IDs or EVT_IDs or both, but both cannot be empty.', 'event_espresso'), __METHOD__));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        '%s requires either an array of GRP_IDs or EVT_IDs or both, but both cannot be empty.',
+                        'event_espresso'
+                    ),
+                    __METHOD__
+                )
+            );
         }
 
-        if (!empty($GRP_IDs)) {
-            $where['GRP_ID'] = array( 'IN', (array) $GRP_IDs );
+        $where = [];
+        if (! empty($GRP_IDs)) {
+            $where['GRP_ID'] = ['IN', (array) $GRP_IDs];
+        }
+        if (! empty($EVT_IDs)) {
+            $where['EVT_ID'] = ['IN', (array) $EVT_IDs];
         }
 
-        if (!empty($EVT_IDs)) {
-            $where['EVT_ID'] = array( 'IN', (array) $EVT_IDs );
-        }
-
-        return $this->delete(array( $where ), false);
+        return $this->delete([$where], false);
     }
 }

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -41,31 +41,82 @@ class EEM_Payment_Method extends EEM_Base
     {
         $this->singular_item = __('Payment Method', 'event_espresso');
         $this->plural_item = __('Payment Methods', 'event_espresso');
-        $this->_tables = ['Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID')];
+        $this->_tables = [
+            'Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID')
+        ];
         $this->_fields = [
             'Payment_Method' => [
-                'PMD_ID'              => new EE_Primary_Key_Int_Field('PMD_ID', __("ID", 'event_espresso')),
-                'PMD_type'            => new EE_Plain_Text_Field('PMD_type',
-                    __("Payment Method Type", 'event_espresso'), false, 'Admin_Only'),
-                'PMD_name'            => new EE_Plain_Text_Field('PMD_name', __("Name", 'event_espresso'), false),
-                'PMD_desc'            => new EE_Post_Content_Field('PMD_desc', __("Description", 'event_espresso'),
-                    false, ''),
-                'PMD_admin_name'      => new EE_Plain_Text_Field('PMD_admin_name',
-                    __("Admin-Only Name", 'event_espresso'), true),
-                'PMD_admin_desc'      => new EE_Post_Content_Field('PMD_admin_desc',
-                    __("Admin-Only Description", 'event_espresso'), true),
-                'PMD_slug'            => new EE_Slug_Field('PMD_slug', __("Slug", 'event_espresso'), false),
-                'PMD_order'           => new EE_Integer_Field('PMD_order', __("Order", 'event_espresso'), false, 0),
-                'PMD_debug_mode'      => new EE_Boolean_Field('PMD_debug_mode', __("Debug Mode On?", 'event_espresso'),
-                    false, false),
-                'PMD_wp_user'         => new EE_WP_User_Field('PMD_wp_user',
-                    __("Payment Method Creator ID", 'event_espresso'), false),
-                'PMD_open_by_default' => new EE_Boolean_Field('PMD_open_by_default',
-                    __("Open by Default?", 'event_espresso'), false, false),
-                'PMD_button_url'      => new EE_Plain_Text_Field('PMD_button_url', __("Button URL", 'event_espresso'),
-                    true, ''),
-                'PMD_scope'           => new EE_Serialized_Text_Field('PMD_scope', __("Usable From?", 'event_espresso'),
-                    false, []), // possible values currently are 'CART','ADMIN','API'
+                'PMD_ID'              => new EE_Primary_Key_Int_Field(
+                    'PMD_ID',
+                    __('ID', 'event_espresso')
+                ),
+                'PMD_type'            => new EE_Plain_Text_Field(
+                    'PMD_type',
+                    __('Payment Method Type', 'event_espresso'),
+                    false,
+                    'Admin_Only'
+                ),
+                'PMD_name'            => new EE_Plain_Text_Field(
+                    'PMD_name',
+                    __('Name', 'event_espresso'),
+                    false
+                ),
+                'PMD_desc'            => new EE_Post_Content_Field(
+                    'PMD_desc',
+                    __('Description', 'event_espresso'),
+                    false,
+                    ''
+                ),
+                'PMD_admin_name'      => new EE_Plain_Text_Field(
+                    'PMD_admin_name',
+                    __('Admin-Only Name', 'event_espresso'),
+                    true
+                ),
+                'PMD_admin_desc'      => new EE_Post_Content_Field(
+                    'PMD_admin_desc',
+                    __('Admin-Only Description', 'event_espresso'),
+                    true
+                ),
+                'PMD_slug'            => new EE_Slug_Field(
+                    'PMD_slug',
+                    __('Slug', 'event_espresso'),
+                    false
+                ),
+                'PMD_order'           => new EE_Integer_Field(
+                    'PMD_order',
+                    __('Order', 'event_espresso'),
+                    false,
+                    0
+                ),
+                'PMD_debug_mode'      => new EE_Boolean_Field(
+                    'PMD_debug_mode',
+                    __('Debug Mode On?', 'event_espresso'),
+                    false,
+                    false
+                ),
+                'PMD_wp_user'         => new EE_WP_User_Field(
+                    'PMD_wp_user',
+                    __('Payment Method Creator ID', 'event_espresso'),
+                    false
+                ),
+                'PMD_open_by_default' => new EE_Boolean_Field(
+                    'PMD_open_by_default',
+                    __('Open by Default?', 'event_espresso'),
+                    false,
+                    false
+                ),
+                'PMD_button_url'      => new EE_Plain_Text_Field(
+                    'PMD_button_url',
+                    __('Button URL', 'event_espresso'),
+                    true,
+                    ''
+                ),
+                'PMD_scope'           => new EE_Serialized_Text_Field(
+                    'PMD_scope',
+                    __('Usable From?', 'event_espresso'),
+                    false,
+                    []// possible values currently are 'CART','ADMIN','API'
+                ),
             ],
         ];
         $this->_model_relations = [

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -4,18 +4,15 @@ use EventEspresso\core\domain\entities\notifications\PersistentAdminNotice;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 
 /**
- *
  * Payment Method Model
- *
  * For storing all payment methods (things that interact between EE and gateways).
  * As of 4.3, payment methods are NOT singletons so there can be multiple instances of payment methods
  * of the same type, with different details. Eg, multiple paypal standard gateways so different
  * events can have their proceeds going to different paypal accounts
  *
  * @package             Event Espresso
- * @subpackage  includes/models/EEM_Checkin.model.php
- * @author             Mike Nelson
- *
+ * @subpackage          includes/models/EEM_Checkin.model.php
+ * @author              Mike Nelson
  */
 class EEM_Payment_Method extends EEM_Base
 {
@@ -27,82 +24,97 @@ class EEM_Payment_Method extends EEM_Base
     const scope_api = 'API';
 
     /**
-     *
      * @type EEM_Payment_Method
      */
     protected static $_instance = null;
 
 
-
     /**
      * private constructor to prevent direct creation
+     *
      * @Constructor
      * @access   protected
-     * @return EEM_Payment_Method
+     * @param null $timezone
+     * @throws EE_Error
      */
     protected function __construct($timezone = null)
     {
-        $this->singlular_item = __('Payment Method', 'event_espresso');
+        $this->singular_item = __('Payment Method', 'event_espresso');
         $this->plural_item = __('Payment Methods', 'event_espresso');
-        $this->_tables = array( 'Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID') );
-        $this->_fields = array(
-            'Payment_Method' => array(
-                'PMD_ID' => new EE_Primary_Key_Int_Field('PMD_ID', __("ID", 'event_espresso')),
-                'PMD_type' => new EE_Plain_Text_Field('PMD_type', __("Payment Method Type", 'event_espresso'), false, 'Admin_Only'),
-                'PMD_name' => new EE_Plain_Text_Field('PMD_name', __("Name", 'event_espresso'), false),
-                'PMD_desc' => new EE_Post_Content_Field('PMD_desc', __("Description", 'event_espresso'), false, ''),
-                'PMD_admin_name' => new EE_Plain_Text_Field('PMD_admin_name', __("Admin-Only Name", 'event_espresso'), true),
-                'PMD_admin_desc' => new EE_Post_Content_Field('PMD_admin_desc', __("Admin-Only Description", 'event_espresso'), true),
-                'PMD_slug' => new EE_Slug_Field('PMD_slug', __("Slug", 'event_espresso'), false),
-                'PMD_order' => new EE_Integer_Field('PMD_order', __("Order", 'event_espresso'), false, 0),
-                'PMD_debug_mode' => new EE_Boolean_Field('PMD_debug_mode', __("Debug Mode On?", 'event_espresso'), false, false),
-                'PMD_wp_user' => new EE_WP_User_Field('PMD_wp_user', __("Payment Method Creator ID", 'event_espresso'), false),
-                'PMD_open_by_default' => new EE_Boolean_Field('PMD_open_by_default', __("Open by Default?", 'event_espresso'), false, false), 'PMD_button_url' => new EE_Plain_Text_Field('PMD_button_url', __("Button URL", 'event_espresso'), true, ''),
-                'PMD_scope' => new EE_Serialized_Text_Field('PMD_scope', __("Usable From?", 'event_espresso'), false, array()), // possible values currently are 'CART','ADMIN','API'
-        ) );
-        $this->_model_relations = array(
-            'Payment' => new EE_Has_Many_Relation(),
-            'Currency' => new EE_HABTM_Relation('Currency_Payment_Method'),
+        $this->_tables = ['Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID')];
+        $this->_fields = [
+            'Payment_Method' => [
+                'PMD_ID'              => new EE_Primary_Key_Int_Field('PMD_ID', __("ID", 'event_espresso')),
+                'PMD_type'            => new EE_Plain_Text_Field('PMD_type',
+                    __("Payment Method Type", 'event_espresso'), false, 'Admin_Only'),
+                'PMD_name'            => new EE_Plain_Text_Field('PMD_name', __("Name", 'event_espresso'), false),
+                'PMD_desc'            => new EE_Post_Content_Field('PMD_desc', __("Description", 'event_espresso'),
+                    false, ''),
+                'PMD_admin_name'      => new EE_Plain_Text_Field('PMD_admin_name',
+                    __("Admin-Only Name", 'event_espresso'), true),
+                'PMD_admin_desc'      => new EE_Post_Content_Field('PMD_admin_desc',
+                    __("Admin-Only Description", 'event_espresso'), true),
+                'PMD_slug'            => new EE_Slug_Field('PMD_slug', __("Slug", 'event_espresso'), false),
+                'PMD_order'           => new EE_Integer_Field('PMD_order', __("Order", 'event_espresso'), false, 0),
+                'PMD_debug_mode'      => new EE_Boolean_Field('PMD_debug_mode', __("Debug Mode On?", 'event_espresso'),
+                    false, false),
+                'PMD_wp_user'         => new EE_WP_User_Field('PMD_wp_user',
+                    __("Payment Method Creator ID", 'event_espresso'), false),
+                'PMD_open_by_default' => new EE_Boolean_Field('PMD_open_by_default',
+                    __("Open by Default?", 'event_espresso'), false, false),
+                'PMD_button_url'      => new EE_Plain_Text_Field('PMD_button_url', __("Button URL", 'event_espresso'),
+                    true, ''),
+                'PMD_scope'           => new EE_Serialized_Text_Field('PMD_scope', __("Usable From?", 'event_espresso'),
+                    false, []), // possible values currently are 'CART','ADMIN','API'
+            ],
+        ];
+        $this->_model_relations = [
+            'Payment'     => new EE_Has_Many_Relation(),
+            'Currency'    => new EE_HABTM_Relation('Currency_Payment_Method'),
             'Transaction' => new EE_Has_Many_Relation(),
-            'WP_User' => new EE_Belongs_To_Relation(),
-        );
+            'WP_User'     => new EE_Belongs_To_Relation(),
+        ];
         parent::__construct($timezone);
     }
 
 
-
     /**
      * Gets one by the slug provided
+     *
      * @param string $slug
-     * @return EE_Payment_Method
+     * @return EE_Base_Class|EE_Payment_Method|EE_Soft_Delete_Base_Class|NULL
+     * @throws EE_Error
      */
     public function get_one_by_slug($slug)
     {
-        return $this->get_one(array( array( 'PMD_slug' => $slug ) ));
+        return $this->get_one([['PMD_slug' => $slug]]);
     }
-
 
 
     /**
      * Gets all the acceptable scopes for payment methods.
      * Keys are their names as store din the DB, and values are nice names for displaying them
+     *
      * @return array
      */
     public function scopes()
     {
         return apply_filters(
             'FHEE__EEM_Payment_Method__scopes',
-            array(
-                self::scope_cart        => __("Front-end Registration Page", 'event_espresso'),
-                self::scope_admin   => __("Admin Registration Page (no online processing)", 'event_espresso')
-            )
+            [
+                EEM_Payment_Method::scope_cart  => __('Front-end Registration Page', 'event_espresso'),
+                EEM_Payment_Method::scope_admin => __(
+                    'Admin Registration Page (no online processing)',
+                    'event_espresso'
+                ),
+            ]
         );
     }
 
 
-
     /**
      * Determines if this is an valid scope
+     *
      * @param string $scope like one of EEM_Payment_Method::instance()->scopes()
      * @return boolean
      */
@@ -111,75 +123,86 @@ class EEM_Payment_Method extends EEM_Base
         $scopes = $this->scopes();
         if (isset($scopes[ $scope ])) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
-
 
 
     /**
      * Gets all active payment methods
+     *
      * @param string $scope one of
      * @param array  $query_params
+     * @return EE_Base_Class[]|EE_Payment_Method[]
      * @throws EE_Error
-     * @return EE_Payment_Method[]
      */
-    public function get_all_active($scope = null, $query_params = array())
+    public function get_all_active($scope = null, $query_params = [])
     {
         if (! isset($query_params['order_by']) && ! isset($query_params['order'])) {
-            $query_params['order_by'] = array( 'PMD_order' => 'ASC', 'PMD_ID' => 'ASC' );
+            $query_params['order_by'] = ['PMD_order' => 'ASC', 'PMD_ID' => 'ASC'];
         }
         return $this->get_all($this->_get_query_params_for_all_active($scope, $query_params));
     }
 
+
     /**
      * Counts all active gateways in the specified scope
+     *
      * @param string $scope one of EEM_Payment_Method::scope_*
-     * @param array $query_params
+     * @param array  $query_params
      * @return int
+     * @throws EE_Error
+     * @throws EE_Error
      */
-    public function count_active($scope = null, $query_params = array())
+    public function count_active($scope = null, $query_params = [])
     {
         return $this->count($this->_get_query_params_for_all_active($scope, $query_params));
     }
 
-    /**
-     * Creates the $query_params that can be passed into any EEM_Payment_Method as their $query_params
-     * argument to get all active for a given scope
-     * @param string $scope one of the constants EEM_Payment_Method::scope_*
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @throws EE_Error
-     */
-    protected function _get_query_params_for_all_active($scope = null, $query_params = array())
-    {
-        if ($scope) {
-            if ($this->is_valid_scope($scope)) {
-                return array_replace_recursive(array( array( 'PMD_scope' => array( 'LIKE', "%$scope%" ) ) ), $query_params);
-            } else {
-                throw new EE_Error(sprintf(__("'%s' is not a valid scope for a payment method", "event_espresso"), $scope));
-            }
-        } else {
-            $acceptable_scopes = array();
-            $count = 0;
-            foreach ($this->scopes() as $scope_name => $desc) {
-                $count++;
-                $acceptable_scopes[ 'PMD_scope*' . $count ] = array( 'LIKE', '%' . $scope_name . '%' );
-            }
-            return array_replace_recursive(array( array( 'OR*active_scope' => $acceptable_scopes ) ), $query_params);
-        }
-    }
 
     /**
      * Creates the $query_params that can be passed into any EEM_Payment_Method as their $query_params
      * argument to get all active for a given scope
-     * @param string $scope one of the constants EEM_Payment_Method::scope_*
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     *
+     * @param string $scope        one of the constants EEM_Payment_Method::scope_*
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      */
-    public function get_query_params_for_all_active($scope = null, $query_params = array())
+    protected function _get_query_params_for_all_active($scope = null, $query_params = [])
+    {
+        if ($scope) {
+            if ($this->is_valid_scope($scope)) {
+                return array_replace_recursive([['PMD_scope' => ['LIKE', "%$scope%"]]], $query_params);
+            } else {
+                throw new EE_Error(sprintf(__("'%s' is not a valid scope for a payment method", "event_espresso"),
+                    $scope));
+            }
+        } else {
+            $acceptable_scopes = [];
+            $count = 0;
+            foreach ($this->scopes() as $scope_name => $desc) {
+                $count++;
+                $acceptable_scopes[ 'PMD_scope*' . $count ] = ['LIKE', '%' . $scope_name . '%'];
+            }
+            return array_replace_recursive([['OR*active_scope' => $acceptable_scopes]], $query_params);
+        }
+    }
+
+
+    /**
+     * Creates the $query_params that can be passed into any EEM_Payment_Method as their $query_params
+     * argument to get all active for a given scope
+     *
+     * @param string $scope        one of the constants EEM_Payment_Method::scope_*
+     * @param array  $query_params
+     * @return array
+     * @throws EE_Error
+     *@see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     */
+    public function get_query_params_for_all_active($scope = null, $query_params = [])
     {
         return $this->_get_query_params_for_all_active($scope, $query_params);
     }
@@ -187,36 +210,40 @@ class EEM_Payment_Method extends EEM_Base
 
     /**
      * Gets one active payment method. see @get_all_active for documentation
+     *
      * @param string $scope
      * @param array  $query_params
-     * @return EE_Payment_Method
+     * @return EE_Base_Class|EE_Payment_Method|EE_Soft_Delete_Base_Class|NULL
+     * @throws EE_Error
+     * @throws EE_Error
      */
-    public function get_one_active($scope = null, $query_params = array())
+    public function get_one_active($scope = null, $query_params = [])
     {
         return $this->get_one($this->_get_query_params_for_all_active($scope, $query_params));
     }
 
 
-
     /**
      * Gets one payment method of that type, regardless of whether its active or not
+     *
      * @param string $type
-     * @return EE_Payment_Method
+     * @return EE_Base_Class|EE_Payment_Method|EE_Soft_Delete_Base_Class|NULL
+     * @throws EE_Error
      */
     public function get_one_of_type($type)
     {
-        return $this->get_one(array( array( 'PMD_type' => $type ) ));
+        return $this->get_one([['PMD_type' => $type]]);
     }
-
 
 
     /**
      * Overrides parent ot also check by the slug
-     * @see EEM_Base::ensure_is_obj()
+     *
      * @param string|int|EE_Payment_Method $base_class_obj_or_id
      * @param boolean                      $ensure_is_in_db
-     * @return EE_Payment_Method
+     * @return EE_Base_Class|EE_Payment_Method|EE_Soft_Delete_Base_Class|int|string
      * @throws EE_Error
+     * @see EEM_Base::ensure_is_obj()
      */
     public function ensure_is_obj($base_class_obj_or_id, $ensure_is_in_db = false)
     {
@@ -233,16 +260,22 @@ class EEM_Payment_Method extends EEM_Base
         } catch (EE_Error $e) {
             // handle it outside the catch
         }
-        throw new EE_Error(sprintf(__("'%s' is neither a Payment Method ID, slug, nor object.", "event_espresso"), $base_class_obj_or_id));
+        throw new EE_Error(
+            sprintf(
+                __("'%s' is neither a Payment Method ID, slug, nor object.", 'event_espresso'),
+                $base_class_obj_or_id
+            )
+        );
     }
-
 
 
     /**
      * Gets the ID of this object, or if its a string finds the object's id
      * associated with that slug
+     *
      * @param mixed $base_obj_or_id_or_slug
      * @return int
+     * @throws EE_Error
      */
     public function ensure_is_ID($base_obj_or_id_or_slug)
     {
@@ -254,10 +287,14 @@ class EEM_Payment_Method extends EEM_Base
     }
 
 
-
     /**
-     * Verifies the button urls on all the passed payment methods have a valid button url. If not, resets them to their default.
-     * @param EE_Payment_Method[] $payment_methods. If NULL is provided defaults to all payment methods active in the cart
+     * Verifies the button urls on all the passed payment methods have a valid button url.
+     * If not, resets them to their default.
+     *
+     * @param EE_Payment_Method[] $payment_methods if NULL, defaults to all payment methods active in the cart
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @throws EE_Error
      */
     public function verify_button_urls($payment_methods = null)
     {
@@ -268,23 +305,22 @@ class EEM_Payment_Method extends EEM_Base
                 // though this is a caffeinated install, reset it to the default.
                 $current_button_url = $payment_method->button_url();
                 if (empty($current_button_url)
-                || (
+                    || (
                         strpos($current_button_url, 'decaf') !== false
                         && strpos($payment_method->type_obj()->default_button_url(), 'decaf') === false
                     )
                 ) {
                     $payment_method->save(
                         [
-                            'PMD_button_url' => $payment_method->type_obj()->default_button_url()
+                            'PMD_button_url' => $payment_method->type_obj()->default_button_url(),
                         ]
                     );
                 }
             } catch (EE_Error $e) {
-                $payment_method->set_active(false);
+                $payment_method->deactivate();
             }
         }
     }
-
 
 
     /**
@@ -295,13 +331,15 @@ class EEM_Payment_Method extends EEM_Base
      * @param array $rows
      * @return EE_Payment_Method[]
      * @throws InvalidDataTypeException
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _create_objects($rows = array())
+    protected function _create_objects($rows = [])
     {
         EE_Registry::instance()->load_lib('Payment_Method_Manager');
         $payment_methods = parent::_create_objects($rows);
         /* @var $payment_methods EE_Payment_Method[] */
-        $usable_payment_methods = array();
+        $usable_payment_methods = [];
         foreach ($payment_methods as $key => $payment_method) {
             if (EE_Payment_Method_Manager::instance()->payment_method_type_exists($payment_method->type())) {
                 $usable_payment_methods[ $key ] = $payment_method;
@@ -337,21 +375,22 @@ class EEM_Payment_Method extends EEM_Base
     }
 
 
-
     /**
      * Gets all the payment methods which can be used for transaction
      * (according to the relations between payment methods and events, and
      * the currencies used for the transaction and their relation to payment methods)
+     *
      * @param EE_Transaction $transaction
-     * @param string    $scope @see EEM_Payment_Method::get_all_for_events
+     * @param string         $scope @see EEM_Payment_Method::get_all_for_events
      * @return EE_Payment_Method[]
+     * @throws EE_Error
      */
     public function get_all_for_transaction($transaction, $scope)
     {
         // give addons a chance to override what payment methods are chosen based on the transaction
         return apply_filters(
             'FHEE__EEM_Payment_Method__get_all_for_transaction__payment_methods',
-            $this->get_all_active($scope, array( 'group_by' => 'PMD_type' )),
+            $this->get_all_active($scope, ['group_by' => 'PMD_type']),
             $transaction,
             $scope
         );
@@ -360,23 +399,26 @@ class EEM_Payment_Method extends EEM_Base
 
     /**
      * Returns the payment method used for the last payment made for a registration.
+     * Note: if an offline payment method was selected on the related transaction then this will have no payment
+     * methods returned. It will ONLY return a payment method for a PAYMENT recorded against the registration.
      *
-     * Note: if an offline payment method was selected on the related transaction then this will have no payment methods returned.
-     * It will ONLY return a payment method for a PAYMENT recorded against the registration.
-     *
-     * @param EE_Registration|int $registration_or_reg_id  Either the EE_Registration object or the id for the registration.
+     * @param EE_Registration|int $registration_or_reg_id Either the EE_Registration object or the id for the
+     *                                                    registration.
      * @return EE_Payment|null
+     * @throws EE_Error
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function get_last_used_for_registration($registration_or_reg_id)
     {
         $registration_id = EEM_Registration::instance()->ensure_is_ID($registration_or_reg_id);
 
-        $query_params = array(
-            0 => array(
+        $query_params = [
+            0          => [
                 'Payment.Registration.REG_ID' => $registration_id,
-            ),
-            'order_by' => array( 'Payment.PAY_ID' => 'DESC' )
-        );
+            ],
+            'order_by' => ['Payment.PAY_ID' => 'DESC'],
+        ];
         return $this->get_one($query_params);
     }
 }

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -227,19 +227,21 @@ class EEM_Payment_Method extends EEM_Base
         if ($scope) {
             if ($this->is_valid_scope($scope)) {
                 return array_replace_recursive([['PMD_scope' => ['LIKE', "%$scope%"]]], $query_params);
-            } else {
-                throw new EE_Error(sprintf(__("'%s' is not a valid scope for a payment method", "event_espresso"),
-                    $scope));
             }
-        } else {
-            $acceptable_scopes = [];
-            $count = 0;
-            foreach ($this->scopes() as $scope_name => $desc) {
-                $count++;
-                $acceptable_scopes[ 'PMD_scope*' . $count ] = ['LIKE', '%' . $scope_name . '%'];
-            }
-            return array_replace_recursive([['OR*active_scope' => $acceptable_scopes]], $query_params);
+            throw new EE_Error(
+                sprintf(
+                    __("'%s' is not a valid scope for a payment method", 'event_espresso'),
+                    $scope
+                )
+            );
         }
+        $acceptable_scopes = [];
+        $count = 0;
+        foreach ($this->scopes() as $scope_name => $desc) {
+            $count++;
+            $acceptable_scopes[ 'PMD_scope*' . $count ] = ['LIKE', '%' . $scope_name . '%'];
+        }
+        return array_replace_recursive([['OR*active_scope' => $acceptable_scopes]], $query_params);
     }
 
 

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -10,9 +10,9 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
  * of the same type, with different details. Eg, multiple paypal standard gateways so different
  * events can have their proceeds going to different paypal accounts
  *
- * @package             Event Espresso
- * @subpackage          includes/models/EEM_Checkin.model.php
- * @author              Mike Nelson
+ * @package    Event Espresso
+ * @subpackage includes/models/EEM_Checkin.model.php
+ * @author     Mike Nelson
  */
 class EEM_Payment_Method extends EEM_Base
 {
@@ -32,88 +32,86 @@ class EEM_Payment_Method extends EEM_Base
     /**
      * private constructor to prevent direct creation
      *
-     * @Constructor
-     * @access   protected
      * @param null $timezone
      * @throws EE_Error
      */
     protected function __construct($timezone = null)
     {
-        $this->singular_item = __('Payment Method', 'event_espresso');
-        $this->plural_item = __('Payment Methods', 'event_espresso');
+        $this->singular_item = esc_html__('Payment Method', 'event_espresso');
+        $this->plural_item = esc_html__('Payment Methods', 'event_espresso');
         $this->_tables = [
-            'Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID')
+            'Payment_Method' => new EE_Primary_Table('esp_payment_method', 'PMD_ID'),
         ];
         $this->_fields = [
             'Payment_Method' => [
                 'PMD_ID'              => new EE_Primary_Key_Int_Field(
                     'PMD_ID',
-                    __('ID', 'event_espresso')
+                    esc_html__('ID', 'event_espresso')
                 ),
                 'PMD_type'            => new EE_Plain_Text_Field(
                     'PMD_type',
-                    __('Payment Method Type', 'event_espresso'),
+                    esc_html__('Payment Method Type', 'event_espresso'),
                     false,
                     'Admin_Only'
                 ),
                 'PMD_name'            => new EE_Plain_Text_Field(
                     'PMD_name',
-                    __('Name', 'event_espresso'),
+                    esc_html__('Name', 'event_espresso'),
                     false
                 ),
                 'PMD_desc'            => new EE_Post_Content_Field(
                     'PMD_desc',
-                    __('Description', 'event_espresso'),
+                    esc_html__('Description', 'event_espresso'),
                     false,
                     ''
                 ),
                 'PMD_admin_name'      => new EE_Plain_Text_Field(
                     'PMD_admin_name',
-                    __('Admin-Only Name', 'event_espresso'),
+                    esc_html__('Admin-Only Name', 'event_espresso'),
                     true
                 ),
                 'PMD_admin_desc'      => new EE_Post_Content_Field(
                     'PMD_admin_desc',
-                    __('Admin-Only Description', 'event_espresso'),
+                    esc_html__('Admin-Only Description', 'event_espresso'),
                     true
                 ),
                 'PMD_slug'            => new EE_Slug_Field(
                     'PMD_slug',
-                    __('Slug', 'event_espresso'),
+                    esc_html__('Slug', 'event_espresso'),
                     false
                 ),
                 'PMD_order'           => new EE_Integer_Field(
                     'PMD_order',
-                    __('Order', 'event_espresso'),
+                    esc_html__('Order', 'event_espresso'),
                     false,
                     0
                 ),
                 'PMD_debug_mode'      => new EE_Boolean_Field(
                     'PMD_debug_mode',
-                    __('Debug Mode On?', 'event_espresso'),
+                    esc_html__('Debug Mode On?', 'event_espresso'),
                     false,
                     false
                 ),
                 'PMD_wp_user'         => new EE_WP_User_Field(
                     'PMD_wp_user',
-                    __('Payment Method Creator ID', 'event_espresso'),
+                    esc_html__('Payment Method Creator ID', 'event_espresso'),
                     false
                 ),
                 'PMD_open_by_default' => new EE_Boolean_Field(
                     'PMD_open_by_default',
-                    __('Open by Default?', 'event_espresso'),
+                    esc_html__('Open by Default?', 'event_espresso'),
                     false,
                     false
                 ),
                 'PMD_button_url'      => new EE_Plain_Text_Field(
                     'PMD_button_url',
-                    __('Button URL', 'event_espresso'),
+                    esc_html__('Button URL', 'event_espresso'),
                     true,
                     ''
                 ),
                 'PMD_scope'           => new EE_Serialized_Text_Field(
                     'PMD_scope',
-                    __('Usable From?', 'event_espresso'),
+                    esc_html__('Usable From?', 'event_espresso'),
                     false,
                     []// possible values currently are 'CART','ADMIN','API'
                 ),
@@ -153,8 +151,8 @@ class EEM_Payment_Method extends EEM_Base
         return apply_filters(
             'FHEE__EEM_Payment_Method__scopes',
             [
-                EEM_Payment_Method::scope_cart  => __('Front-end Registration Page', 'event_espresso'),
-                EEM_Payment_Method::scope_admin => __(
+                EEM_Payment_Method::scope_cart  => esc_html__('Front-end Registration Page', 'event_espresso'),
+                EEM_Payment_Method::scope_admin => esc_html__(
                     'Admin Registration Page (no online processing)',
                     'event_espresso'
                 ),
@@ -203,7 +201,6 @@ class EEM_Payment_Method extends EEM_Base
      * @param array  $query_params
      * @return int
      * @throws EE_Error
-     * @throws EE_Error
      */
     public function count_active($scope = null, $query_params = [])
     {
@@ -215,12 +212,11 @@ class EEM_Payment_Method extends EEM_Base
      * Creates the $query_params that can be passed into any EEM_Payment_Method as their $query_params
      * argument to get all active for a given scope
      *
-     * @param string $scope        one of the constants EEM_Payment_Method::scope_*
-     * @param array  $query_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see
-     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param string $scope one of the constants EEM_Payment_Method::scope_*
+     * @param array  $query_params
+     * @return array
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     protected function _get_query_params_for_all_active($scope = null, $query_params = [])
     {
@@ -230,7 +226,7 @@ class EEM_Payment_Method extends EEM_Base
             }
             throw new EE_Error(
                 sprintf(
-                    __("'%s' is not a valid scope for a payment method", 'event_espresso'),
+                    esc_html__("'%s' is not a valid scope for a payment method", 'event_espresso'),
                     $scope
                 )
             );
@@ -249,11 +245,11 @@ class EEM_Payment_Method extends EEM_Base
      * Creates the $query_params that can be passed into any EEM_Payment_Method as their $query_params
      * argument to get all active for a given scope
      *
-     * @param string $scope        one of the constants EEM_Payment_Method::scope_*
+     * @param string $scope one of the constants EEM_Payment_Method::scope_*
      * @param array  $query_params
      * @return array
      * @throws EE_Error
-     *@see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function get_query_params_for_all_active($scope = null, $query_params = [])
     {
@@ -267,7 +263,6 @@ class EEM_Payment_Method extends EEM_Base
      * @param string $scope
      * @param array  $query_params
      * @return EE_Base_Class|EE_Payment_Method|EE_Soft_Delete_Base_Class|NULL
-     * @throws EE_Error
      * @throws EE_Error
      */
     public function get_one_active($scope = null, $query_params = [])
@@ -315,7 +310,7 @@ class EEM_Payment_Method extends EEM_Base
         }
         throw new EE_Error(
             sprintf(
-                __("'%s' is neither a Payment Method ID, slug, nor object.", 'event_espresso'),
+                esc_html__("'%s' is neither a Payment Method ID, slug, nor object.", 'event_espresso'),
                 $base_class_obj_or_id
             )
         );
@@ -347,11 +342,12 @@ class EEM_Payment_Method extends EEM_Base
      * @param EE_Payment_Method[] $payment_methods if NULL, defaults to all payment methods active in the cart
      * @throws EE_Error
      * @throws ReflectionException
-     * @throws EE_Error
      */
     public function verify_button_urls($payment_methods = null)
     {
-        $payment_methods = is_array($payment_methods) ? $payment_methods : $this->get_all_active(EEM_Payment_Method::scope_cart);
+        $payment_methods = is_array($payment_methods)
+            ? $payment_methods
+            : $this->get_all_active(EEM_Payment_Method::scope_cart);
         foreach ($payment_methods as $payment_method) {
             try {
                 // If there is really no button URL at all, or if the button URLs still point to decaf folder even
@@ -383,8 +379,8 @@ class EEM_Payment_Method extends EEM_Base
      *
      * @param array $rows
      * @return EE_Payment_Method[]
-     * @throws InvalidDataTypeException
      * @throws EE_Error
+     * @throws InvalidDataTypeException
      * @throws ReflectionException
      */
     protected function _create_objects($rows = [])
@@ -411,7 +407,7 @@ class EEM_Payment_Method extends EEM_Base
                 new PersistentAdminNotice(
                     'auto-deactivated-' . $payment_method->type(),
                     sprintf(
-                        __(
+                        esc_html__(
                             'The payment method %1$s was automatically deactivated because it appears its associated Event Espresso Addon was recently deactivated.%2$sIt can be reactivated on the %3$sPlugins admin page%4$s, then you can reactivate the payment method.',
                             'event_espresso'
                         ),
@@ -458,8 +454,6 @@ class EEM_Payment_Method extends EEM_Base
      * @param EE_Registration|int $registration_or_reg_id Either the EE_Registration object or the id for the
      *                                                    registration.
      * @return EE_Payment|null
-     * @throws EE_Error
-     * @throws EE_Error
      * @throws EE_Error
      */
     public function get_last_used_for_registration($registration_or_reg_id)

--- a/core/db_models/EEM_WP_User.model.php
+++ b/core/db_models/EEM_WP_User.model.php
@@ -21,7 +21,6 @@ class EEM_WP_User extends EEM_Base
     protected static $_instance;
 
 
-
     /**
      *    constructor
      *
@@ -32,8 +31,8 @@ class EEM_WP_User extends EEM_Base
      */
     protected function __construct($timezone = null, ModelFieldFactory $model_field_factory)
     {
-        $this->singular_item = __('WP_User', 'event_espresso');
-        $this->plural_item = __('WP_Users', 'event_espresso');
+        $this->singular_item = esc_html__('WP_User', 'event_espresso');
+        $this->plural_item = esc_html__('WP_Users', 'event_espresso');
         global $wpdb;
         $this->_tables = array(
             'WP_User' => new EE_Primary_Table($wpdb->users, 'ID', true),
@@ -42,46 +41,46 @@ class EEM_WP_User extends EEM_Base
             'WP_User' => array(
                 'ID'                  => $model_field_factory->createPrimaryKeyIntField(
                     'ID',
-                    __('WP_User ID', 'event_espresso')
+                    esc_html__('WP_User ID', 'event_espresso')
                 ),
                 'user_login'          => $model_field_factory->createPlainTextField(
                     'user_login',
-                    __('User Login', 'event_espresso'),
+                    esc_html__('User Login', 'event_espresso'),
                     false
                 ),
                 'user_pass'           => $model_field_factory->createPlainTextField(
                     'user_pass',
-                    __('User Password', 'event_espresso'),
+                    esc_html__('User Password', 'event_espresso'),
                     false
                 ),
                 'user_nicename'       => $model_field_factory->createPlainTextField(
                     'user_nicename',
-                    __(' User Nice Name', 'event_espresso'),
+                    esc_html__(' User Nice Name', 'event_espresso'),
                     false
                 ),
                 'user_email'          => $model_field_factory->createEmailField(
                     'user_email',
-                    __('User Email', 'event_espresso'),
+                    esc_html__('User Email', 'event_espresso'),
                     false,
                     null
                 ),
                 'user_registered'     => $model_field_factory->createDatetimeField(
                     'user_registered',
-                    __('Date User Registered', 'event_espresso'),
+                    esc_html__('Date User Registered', 'event_espresso'),
                     $timezone
                 ),
                 'user_activation_key' => $model_field_factory->createPlainTextField(
                     'user_activation_key',
-                    __('User Activation Key', 'event_espresso'),
+                    esc_html__('User Activation Key', 'event_espresso'),
                     false
                 ),
                 'user_status'         => $model_field_factory->createIntegerField(
                     'user_status',
-                    __('User Status', 'event_espresso')
+                    esc_html__('User Status', 'event_espresso')
                 ),
                 'display_name'        => $model_field_factory->createPlainTextField(
                     'display_name',
-                    __('Display Name', 'event_espresso'),
+                    esc_html__('Display Name', 'event_espresso'),
                     false
                 ),
             ),
@@ -91,6 +90,7 @@ class EEM_WP_User extends EEM_Base
             // all models are related to the change log
             // 'Change_Log'     => new EE_Has_Many_Relation(),
             'Event'          => new EE_Has_Many_Relation(),
+            'Message'        => new EE_Has_Many_Relation(),
             'Payment_Method' => new EE_Has_Many_Relation(),
             'Price'          => new EE_Has_Many_Relation(),
             'Price_Type'     => new EE_Has_Many_Relation(),
@@ -98,7 +98,6 @@ class EEM_WP_User extends EEM_Base
             'Question_Group' => new EE_Has_Many_Relation(),
             'Ticket'         => new EE_Has_Many_Relation(),
             'Venue'          => new EE_Has_Many_Relation(),
-            'Message'        => new EE_Has_Many_Relation(),
         );
         $this->foreign_key_aliases = [
             'Event.EVT_wp_user'          => 'WP_User.ID',
@@ -107,8 +106,8 @@ class EEM_WP_User extends EEM_Base
             'Price_Type.PRT_wp_user'     => 'WP_User.ID',
             'Question.QST_wp_user'       => 'WP_User.ID',
             'Question_Group.QSG_wp_user' => 'WP_User.ID',
-            'Venue.TKT_wp_user'          => 'WP_User.ID',
             'Ticket.VNU_wp_user'         => 'WP_User.ID',
+            'Venue.TKT_wp_user'          => 'WP_User.ID',
         ];
         $this->_wp_core_model = true;
         $this->_caps_slug = 'users';
@@ -122,7 +121,6 @@ class EEM_WP_User extends EEM_Base
     }
 
 
-
     /**
      * We don't need a foreign key to the WP_User model, we just need its primary key
      *
@@ -133,7 +131,6 @@ class EEM_WP_User extends EEM_Base
     {
         return $this->primary_key_name();
     }
-
 
 
     /**

--- a/core/db_models/EEM_WP_User.model.php
+++ b/core/db_models/EEM_WP_User.model.php
@@ -100,6 +100,16 @@ class EEM_WP_User extends EEM_Base
             'Venue'          => new EE_Has_Many_Relation(),
             'Message'        => new EE_Has_Many_Relation(),
         );
+        $this->foreign_key_aliases = [
+            'Event.EVT_wp_user',
+            'Payment_Method.PMD_wp_user',
+            'Price.PRC_wp_user',
+            'Price_Type.PRT_wp_user',
+            'Question.QST_wp_user',
+            'Question_Group.QSG_wp_user',
+            'Venue.TKT_wp_user',
+            'Ticket.VNU_wp_user',
+        ];
         $this->_wp_core_model = true;
         $this->_caps_slug = 'users';
         $this->_cap_contexts_to_cap_action_map[ EEM_Base::caps_read ] = 'list';

--- a/core/db_models/EEM_WP_User.model.php
+++ b/core/db_models/EEM_WP_User.model.php
@@ -101,14 +101,14 @@ class EEM_WP_User extends EEM_Base
             'Message'        => new EE_Has_Many_Relation(),
         );
         $this->foreign_key_aliases = [
-            'Event.EVT_wp_user',
-            'Payment_Method.PMD_wp_user',
-            'Price.PRC_wp_user',
-            'Price_Type.PRT_wp_user',
-            'Question.QST_wp_user',
-            'Question_Group.QSG_wp_user',
-            'Venue.TKT_wp_user',
-            'Ticket.VNU_wp_user',
+            'Event.EVT_wp_user'          => 'WP_User.ID',
+            'Payment_Method.PMD_wp_user' => 'WP_User.ID',
+            'Price.PRC_wp_user'          => 'WP_User.ID',
+            'Price_Type.PRT_wp_user'     => 'WP_User.ID',
+            'Question.QST_wp_user'       => 'WP_User.ID',
+            'Question_Group.QSG_wp_user' => 'WP_User.ID',
+            'Venue.TKT_wp_user'          => 'WP_User.ID',
+            'Ticket.VNU_wp_user'         => 'WP_User.ID',
         ];
         $this->_wp_core_model = true;
         $this->_caps_slug = 'users';

--- a/core/db_models/fields/EE_Email_Field.php
+++ b/core/db_models/fields/EE_Email_Field.php
@@ -1,6 +1,7 @@
 <?php
 use EventEspresso\core\domain\services\factories\EmailAddressFactory;
 use EventEspresso\core\domain\services\validation\email\EmailValidationException;
+use EventEspresso\core\domain\values\EmailAddress;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
@@ -42,8 +43,8 @@ class EE_Email_Field extends EE_Text_Field_Base
     public function prepare_for_set($email_address)
     {
         try {
-            $email_address = EmailAddressFactory::create($email_address);
-            return $email_address->get();
+            $email_address_obj = EmailAddressFactory::create($email_address);
+            return $email_address_obj instanceof EmailAddress ? $email_address_obj->get() : '';
         } catch (EmailValidationException $e) {
             return '';
         }


### PR DESCRIPTION
see #2911

this PR:

- adds a `$foreign_key_aliases` property to `EEM_Base`

- sets values for that array  in`EEM_WP_User`

- then in `EEM_Base::_deduce_fields_n_values_from_cols_n_values()`, if no Primary Key value is found for a table in the incoming `$cols_n_values` data, we check if any values exist in the `$foreign_key_aliases` for the table. If any of those values match the keys in the incoming `$cols_n_values` data, then we use that value for `$table_pk_value`

- corrects a null pointer exception (golden rule violation) in `EE_Email_Field`

- fixes property name typo, phpdocs, and formatting in `EEM_Payment_Method`


### testing notes

I'm not sure of how to reproduce the bug via normal plugin operation as I discovered it while coding and the error was interfering with the code I was working on. This was happening during regular plugin activation and I'm guessing that WP normally just ate the error and allowed the plugin to continue to activate. So here are some **suggested** steps to try although I don't know whether these would have revealed the issue before:

- perform standard new activation on a fresh site

- [ ] confirm (possibly via directly examining the db) that the default payment methods have been associated with your user account. Bonus points if your user ID is NOT `1` but it is correctly assigned.

- the changes in this PR should only affect logic that involves relations with the `WP_User` model, so test any logic you can think of where the current WP User matters, for example:

     - test the functionality of the EE WP User add-on

     - test various capabilities such as event ownership and edit permissions

- [ ] confirm that the registration process functions as expected

