### PR TITLE
Fix fields to sync from TPC to ticket edit form in multi-step

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-final-form';
+import { pick } from 'ramda';
 
 import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManager/data';
 import { useDataState as useTPCDataState } from '@edtrUI/tickets/ticketPriceCalculator/data';
+import { Ticket } from '@edtrServices/apollo';
+
+// The fields that need to be synced from TPC to tikcet edit form
+// This is to avoid ticket.name being synced
+const TPC_TICKET_FIELDS_TO_SYNC: Array<keyof Ticket> = ['isTaxable', 'price', 'reverseCalculate'];
 
 /**
  * A custom hook which subscribes to TAM and TPC data and updates
@@ -21,7 +27,8 @@ const useDataListener = () => {
 
 	const { deletedPrices, prices, ticket } = useTPCDataState();
 	useEffect(() => {
-		Object.entries(ticket).forEach(([key, value]) => {
+		const fieldsToSync = pick(TPC_TICKET_FIELDS_TO_SYNC, ticket);
+		Object.entries(fieldsToSync).forEach(([key, value]) => {
 			// update value of each field in RFF state
 			mutators.updateFieldValue(key, value);
 		});

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/useDataListener.ts
@@ -6,7 +6,7 @@ import { useDataState as useTAMDataState } from '@edtrUI/ticketAssignmentsManage
 import { useDataState as useTPCDataState } from '@edtrUI/tickets/ticketPriceCalculator/data';
 import { Ticket } from '@edtrServices/apollo';
 
-// The fields that need to be synced from TPC to tikcet edit form
+// The fields that need to be synced from TPC to ticket edit form
 // This is to avoid ticket.name being synced
 const TPC_TICKET_FIELDS_TO_SYNC: Array<keyof Ticket> = ['isTaxable', 'price', 'reverseCalculate'];
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/data/useInitialState.ts
@@ -4,7 +4,7 @@ import { assocPath, pick } from 'ramda';
 import { StateInitializer } from './types';
 import { BaseProps, TpcPriceModifier } from '../types';
 import { sortByPriceOrderIdAsc } from '@sharedEntities/prices/predicates/sortingPredicates';
-import { ticketFieldsToUse } from '../utils/constants';
+import { TICKET_FIELDS_TO_USE } from '../utils/constants';
 import { useRelations } from '@appServices/apollo/relations';
 import { useTicketItem, useTicketPrices, usePriceTypes } from '@edtrServices/apollo/queries';
 import type { Ticket } from '@edtrServices/apollo/types';
@@ -27,7 +27,7 @@ const useInitialState = ({ ticketId }: BaseProps): StateInitializer => {
 
 	// get the full ticket object
 	const wholeTicket = useTicketItem({ id: ticketId });
-	const ticket: Partial<Ticket> = useMemoStringify(wholeTicket ? pick(ticketFieldsToUse, wholeTicket) : {});
+	const ticket: Partial<Ticket> = useMemoStringify(wholeTicket ? pick(TICKET_FIELDS_TO_USE, wholeTicket) : {});
 
 	// get all related prices
 	const unSortedPrices = useTicketPrices(ticketId);

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/constants.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/constants.ts
@@ -1,4 +1,10 @@
 import { Ticket } from '@edtrServices/apollo/types';
 
 // 'name' is only required for modal title
-export const ticketFieldsToUse: Array<keyof Partial<Ticket>> = ['id', 'isTaxable', 'name', 'price', 'reverseCalculate'];
+export const TICKET_FIELDS_TO_USE: Array<keyof Partial<Ticket>> = [
+	'id',
+	'isTaxable',
+	'name',
+	'price',
+	'reverseCalculate',
+];

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/shouldUpdateTicket.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/utils/shouldUpdateTicket.ts
@@ -3,7 +3,7 @@ import { pick } from 'ramda';
 import { EntityId } from '@dataServices/types';
 import { RelationsManager } from '@appServices/apollo/relations';
 import { Ticket } from '@edtrServices/apollo';
-import { ticketFieldsToUse } from './constants';
+import { TICKET_FIELDS_TO_USE } from './constants';
 
 interface ShouldUpdateTicketProps {
 	existingTicket: Ticket;
@@ -40,7 +40,7 @@ const shouldUpdateTicket = ({
 		return true;
 	}
 
-	const existingTicketJson = JSON.stringify(pick(ticketFieldsToUse, existingTicket));
+	const existingTicketJson = JSON.stringify(pick(TICKET_FIELDS_TO_USE, existingTicket));
 	const newTicketJson = JSON.stringify(newTicket);
 
 	// if ticket fields have changed


### PR DESCRIPTION
This fields fixes the issue of TPC name being synced to edit form in multi-step.

Closes #2937