### PR TITLE
Fix modal closing on Month/Year Selector in Datepicker

### DIFF
--- a/assets/src/domain/shared/ui/entityEditModal/EntityEditModal.tsx
+++ b/assets/src/domain/shared/ui/entityEditModal/EntityEditModal.tsx
@@ -11,6 +11,7 @@ const EntityEditModal: React.FC<EntityEditModalProps> = ({ isOpen, onClose, titl
 		<Modal
 			bodyClassName='ee-entity-edit-modal__body'
 			className='ee-entity-edit-modal'
+			closeOnOverlayClick={false}
 			isOpen={isOpen}
 			onClose={onClose}
 			title={title}


### PR DESCRIPTION
This PR fixes the issue of month/year selector closing the whole modal by disabling close on overlay click. That seems to be the only option until Chakra has a datepicker, because Base UI doesn't give any option to control the month/year selector popover.

Closes #2940