### PR TITLE
Fix TPC tax deletion issue

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeleteAllPricesButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeleteAllPricesButton.tsx
@@ -5,24 +5,31 @@ import { ConfirmDelete } from '@appDisplay/confirm';
 import { useDataState } from '../data';
 import { ButtonType } from '@application/ui/input';
 import { useMemoStringify } from '@application/services/hooks';
+import { useRemoveDefaultTax } from '../hooks';
 
 const DeleteAllPricesButton: React.FC = () => {
-	const { prices, deletePrice, updateTicketPrice } = useDataState();
+	const { prices, deletePrice, ticket, updateTicketPrice } = useDataState();
+	const removeDefaultTax = useRemoveDefaultTax(ticket?.id);
 
 	const buttonProps = useMemoStringify({
 		buttonText: __('Delete all prices'),
 		buttonType: ButtonType.ACCENT,
 	});
 	const onConfirm = useCallback(() => {
-		prices.forEach(({ id, isNew, isDefault }) => {
-			deletePrice(id, isNew || isDefault);
+		prices.forEach((price) => {
+			// delete the price from TPC state
+			deletePrice(price.id, price.isNew || price.isDefault);
+			// Remove default tax from relations
+			removeDefaultTax(price);
 		});
 		// Set ticket price to 0
 		updateTicketPrice(0);
-	}, [prices, deletePrice]);
+	}, [prices, deletePrice, removeDefaultTax]);
 
 	const title = __('Delete all prices?');
-	const message = __('Are you sure you want to delete all of this ticket\'s prices and make it free? This action is permanent and can not be undone.');
+	const message = __(
+		"Are you sure you want to delete all of this ticket's prices and make it free? This action is permanent and can not be undone."
+	);
 
 	return <ConfirmDelete buttonProps={buttonProps} onConfirm={onConfirm} message={message} title={title} />;
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/DeletePriceModifierButton.tsx
@@ -5,14 +5,21 @@ import { ConfirmDelete } from '@appDisplay/confirm';
 import { Trash } from '@appDisplay/icons/svgs';
 import { PriceModifierProps } from '../types';
 import { useDataState } from '../data';
+import { useRemoveDefaultTax } from '../hooks';
 
 const DeletePriceModifierButton: React.FC<PriceModifierProps> = ({ price }) => {
-	const { deletePrice } = useDataState();
+	const { deletePrice, ticket } = useDataState();
+	const removeDefaultTax = useRemoveDefaultTax(ticket?.id);
 
 	const buttonProps = useMemo(() => ({ icon: () => <Trash noMargin />, tooltip: __('delete price modifier') }), []);
 	// new or default prices should not be deleted server-side
 	const isNewOrDefault = price.isNew || price.isDefault;
-	const onConfirm = useCallback(() => deletePrice(price.id, isNewOrDefault), [price.id, isNewOrDefault]);
+	const onConfirm = useCallback(() => {
+		// delete the price from TPC state
+		deletePrice(price.id, isNewOrDefault);
+		// Remove default tax from relations
+		removeDefaultTax(price);
+	}, [price.id, isNewOrDefault, removeDefaultTax]);
 
 	return <ConfirmDelete buttonProps={buttonProps} onConfirm={onConfirm} />;
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/index.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/index.ts
@@ -4,8 +4,12 @@ export { default as useAddDefaultTaxes } from './useAddDefaultTaxes';
 
 export { default as useMutatePrices } from './useMutatePrices';
 
+export { default as useOnSubmitPrices } from './useOnSubmitPrices';
+
 export { default as usePriceModifier } from './usePriceModifier';
 
-export { default as useOnSubmitPrices } from './useOnSubmitPrices';
+export { default as useRemoveAllTaxes } from './useRemoveAllTaxes';
+
+export { default as useRemoveDefaultTax } from './useRemoveDefaultTax';
 
 export { default as useTicketPriceCalculator } from './useTicketPriceCalculator';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useRemoveAllTaxes.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useRemoveAllTaxes.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+
+import { useDataState } from '../data';
+import useRemoveDefaultTax from './useRemoveDefaultTax';
+import { isTax } from '@sharedEntities/priceTypes/predicates';
+
+const useRemoveAllTaxes = (): VoidFunction => {
+	const { deletePrice, prices, ticket } = useDataState();
+	const removeDefaultTax = useRemoveDefaultTax(ticket?.id);
+
+	return useCallback(() => {
+		const taxPrices = prices.filter(isTax);
+		taxPrices.forEach((taxPrice) => {
+			// delete the price from TPC state
+			deletePrice(taxPrice.id, taxPrice.isNew || taxPrice.isDefault);
+			// Remove default tax from relations
+			removeDefaultTax(taxPrice);
+		});
+	}, [deletePrice, prices, removeDefaultTax]);
+};
+
+export default useRemoveAllTaxes;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useRemoveDefaultTax.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/hooks/useRemoveDefaultTax.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+
+import { useRelations } from '@application/services/apollo/relations';
+import { isDefaultTax } from '@sharedEntities/prices/predicates/selectionPredicates';
+import { EntityId } from '@dataServices/types';
+import { TpcPriceModifier } from '../types';
+
+/**
+ * Default tax needs to be removed only from ticket relations
+ */
+const useRemoveDefaultTax = (ticketId: EntityId) => {
+	const { removeRelation } = useRelations();
+
+	return useCallback(
+		(price: TpcPriceModifier) => {
+			// if it's a default tax and we are editing an existing ticket, not creating a new one
+			// why would we remove a relation that does not exist ¯\_(ツ)_/¯
+			if (isDefaultTax(price) && ticketId) {
+				removeRelation({
+					entity: 'tickets',
+					entityId: ticketId,
+					relation: 'prices',
+					relationId: price.id,
+				});
+			}
+		},
+		[removeRelation, ticketId]
+	);
+};
+
+export default useRemoveDefaultTax;

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -89,8 +89,9 @@ class TicketMutation
             $args['TKT_price'] = (float) $input['price'];
         }
 
-        if (! empty($input['prices'])) {
-            $args['prices'] = array_map('sanitize_text_field', (array) $input['prices']);
+        // prices can be an empty array when all prices are deleted
+        if (array_key_exists('prices', $input) && is_array($input['prices'])) {
+            $args['prices'] = array_map('sanitize_text_field', $input['prices']);
         }
 
         if (array_key_exists('quantity', $input)) {

--- a/core/domain/services/graphql/mutators/TicketUpdate.php
+++ b/core/domain/services/graphql/mutators/TicketUpdate.php
@@ -36,7 +36,7 @@ class TicketUpdate extends EntityMutator
                 $entity = EntityMutator::getEntityFromInputData($model, $input);
 
                 $datetimes = [];
-                $prices = [];
+                $prices = null;
 
                 $args = TicketMutation::prepareFields($input);
 
@@ -44,7 +44,7 @@ class TicketUpdate extends EntityMutator
                     $datetimes = $args['datetimes'];
                     unset($args['datetimes']);
                 }
-                if (isset($args['prices'])) {
+                if (array_key_exists('prices', $args)) {
                     $prices = $args['prices'];
                     unset($args['prices']);
                 }
@@ -54,7 +54,8 @@ class TicketUpdate extends EntityMutator
                 if (! empty($datetimes)) {
                     TicketMutation::setRelatedDatetimes($entity, $datetimes);
                 }
-                if (! empty($prices)) {
+                // if prices array is passed.
+                if (is_array($prices)) {
                     TicketMutation::setRelatedPrices($entity, $prices);
                 }
             } catch (Exception $exception) {


### PR DESCRIPTION
This PR fixes the issue of default tax not being removed from a ticket with the following changes:
- Allows empty `prices` array in GQL schema to be handled in ticket update mutation
- Creates tax removal hooks - `useRemoveAllTaxes` (for #2949) and `useRemoveDefaultTax`
- Wires up price deletion buttons
Closes #2934