### PR TITLE
Fix TAM entity details in multi step

### DIFF
--- a/assets/src/application/services/hooks/index.ts
+++ b/assets/src/application/services/hooks/index.ts
@@ -4,6 +4,8 @@ export { default as useLogIfChanged } from './useLogIfChanged';
 
 export { default as useMemoStringify } from './useMemoStringify';
 
+export { default as useMemoLazy } from './useMemoLazy';
+
 export { default as usePrevNext } from './usePrevNext';
 
 export { default as useRect } from './useRect';

--- a/assets/src/application/services/hooks/useMemoLazy.ts
+++ b/assets/src/application/services/hooks/useMemoLazy.ts
@@ -1,0 +1,30 @@
+import { useRef, useCallback } from 'react';
+
+/**
+ * This custom hook can be used to memoize a value lazily
+ * i.e. its returned callback can be used at the places where a hook cannot be used
+ * e.g. inside callbacks, loops etc.
+ *
+ * The value should be JSON.stringifiable
+ */
+const useMemoLazy = <T>(value: T): ((v: T) => T) => {
+	const prevValue = useRef(value);
+	/**
+	 * The callback will return new value only if its string value has changed
+	 */
+	return useCallback((newValue: T): T => {
+		const prevStr = JSON.stringify(prevValue.current);
+		const newStr = JSON.stringify(newValue);
+		// if the string value of new and old value is same,
+		if (prevStr === newStr) {
+			// return the exiting value
+			return prevValue.current;
+		}
+		// otherwise update the existing value
+		prevValue.current = newValue;
+		// and return it
+		return newValue;
+	}, []);
+};
+
+export default useMemoLazy;

--- a/assets/src/application/services/hooks/useMemoLazy.ts
+++ b/assets/src/application/services/hooks/useMemoLazy.ts
@@ -17,7 +17,7 @@ const useMemoLazy = <T>(value: T): ((v: T) => T) => {
 		const newStr = JSON.stringify(newValue);
 		// if the string value of new and old value is same,
 		if (prevStr === newStr) {
-			// return the exiting value
+			// return the existing value
 			return prevValue.current;
 		}
 		// otherwise update the existing value

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/ContentWrapper.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/ContentWrapper.tsx
@@ -3,29 +3,25 @@ import { __ } from '@wordpress/i18n';
 
 import { withContext as withTAMContext } from '@edtrUI/ticketAssignmentsManager/context';
 import ContentBody from './ContentBody';
-import { Datetime } from '@edtrServices/apollo';
 import { ContentWrapperProps } from './types';
-import { useMemoStringify } from '@application/services/hooks';
+import { withEntityFormDetails } from '@sharedUI/entityEditModal';
 
 /**
  * This component is inside RFF context, so we can use all of RFF features.
  */
 const ContentWrapper: React.FC<ContentWrapperProps> = (props) => {
-	const { values } = props.form.getState();
-
-	const datetime = useMemoStringify({
-		...values,
-		id: values.id ?? 'NEW_DATE',
-		dbId: values.dbId ?? 0,
-	}) as Datetime;
-
-	return withTAMContext(
-		ContentBody,
-		{
-			assignmentType: 'forDate',
-			entity: datetime,
-		},
-		props
+	// provide entity details to TAM from edit form
+	return withEntityFormDetails(
+		({ entity }) =>
+			withTAMContext(
+				ContentBody,
+				{
+					assignmentType: 'forDate',
+					entity,
+				},
+				props
+			),
+		'NEW_DATE'
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/types.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/multiStep/types.ts
@@ -2,6 +2,7 @@ import { Disclosure } from '@application/services/utilities/types';
 import { EntityId } from '@dataServices/types';
 import { Datetime } from '@edtrServices/apollo/types';
 import { FormRenderProps } from 'react-final-form';
+import { DateFormShape } from '../types';
 
 export interface ContainerProps extends Omit<Disclosure, 'onOpen'> {
 	datetimeId?: EntityId;
@@ -12,4 +13,4 @@ export interface ContentProps {
 	onClose: VoidFunction;
 }
 
-export interface ContentWrapperProps extends FormRenderProps {}
+export interface ContentWrapperProps extends FormRenderProps<DateFormShape> {}

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/types.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/types.ts
@@ -1,6 +1,6 @@
-import { DatetimeBaseInput } from '@edtrServices/apollo/mutations';
+import { UpdateDatetimeInput } from '@edtrServices/apollo/mutations';
 import { DateAndTime } from '@sharedServices/utils/dateAndTime';
 
-export interface DateFormShape extends DatetimeBaseInput, DateAndTime {
+export interface DateFormShape extends UpdateDatetimeInput, DateAndTime {
 	dateTime?: DateAndTime;
 }

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/components/table/DateCell.tsx
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/components/table/DateCell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { parseISO } from 'date-fns';
 import classNames from 'classnames';
+import { __ } from '@wordpress/i18n';
 
 import { RenderCellProps } from '../../types';
 import { getBackgroundColorClassName } from '@sharedEntities/datetimes/helpers';
@@ -17,7 +18,7 @@ const DateCell: React.FC<RenderCellProps> = ({ datetime }) => {
 	return (
 		<div className='date-cell-content'>
 			<div className={stripeClassName}></div>
-			<div className='ee-focus-priority-8'>ID: {datetime.dbId}</div>
+			<div className='ee-focus-priority-8'>{`${__('ID')}: ${datetime.dbId}`}</div>
 			<div className='ee-focus-priority-5 date-cell-content__name'>{datetime.name}</div>
 			<div className='ee-focus-priority-6'>{startDate}</div>
 		</div>

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/components/table/HeaderCell.tsx
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/components/table/HeaderCell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { parseISO } from 'date-fns';
 import classNames from 'classnames';
+import { __ } from '@wordpress/i18n';
 
 import { getBackgroundColorClassName } from '@sharedEntities/tickets/helpers';
 import { RenderCellProps } from '../../types';
@@ -17,9 +18,9 @@ const HeaderCell: React.FC<RenderCellProps> = ({ ticket }) => {
 	return (
 		<div className='header-cell-content__wrapper'>
 			<div className='header-cell-content'>
-				<div className='ee-focus-priority-8 header-cell-content__id'>ID: {ticket.dbId}</div>
+				<div className='ee-focus-priority-8 header-cell-content__id'>{`${__('ID')}: ${ticket.dbId}`}</div>
 				<div className='ee-focus-priority-5 header-cell-content__name'>{ticket.name}</div>
-				<div className='ee-focus-priority-8 header-cell-content__price'>{`${currency.sign} ${ticket.price}`}</div>
+				<div className='ee-focus-priority-8 header-cell-content__price'>{`${currency.sign} ${ticket.price || 0}`}</div>
 			</div>
 			<div className={startDateClassName}>{startDate}</div>
 		</div>

--- a/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/data/useDatesAndTickets.ts
+++ b/assets/src/domain/eventEditor/ui/ticketAssignmentsManager/data/useDatesAndTickets.ts
@@ -1,4 +1,3 @@
-import { useDatetimeItem, useTicketItem } from '@edtrServices/apollo/queries';
 import { DatesAndTickets } from '../types';
 import { useTAMContext } from '../context';
 import useFilteredDatetimes from './useFilteredDatetimes';
@@ -11,9 +10,6 @@ const useDatesAndTickets = (): DatesAndTickets => {
 	const filteredDatetimes = useFilteredDatetimes();
 	const filteredTickets = useFilteredTickets();
 
-	const singleDatetime = useDatetimeItem({ id: entity?.id }) || entity as Datetime;
-	const singleTicket = useTicketItem({ id: entity?.id }) || entity as Ticket;
-
 	switch (assignmentType) {
 		case 'forAll':
 			return {
@@ -22,13 +18,13 @@ const useDatesAndTickets = (): DatesAndTickets => {
 			};
 		case 'forDate':
 			return {
-				datetimes: [singleDatetime],
+				datetimes: [entity as Datetime],
 				tickets: filteredTickets,
 			};
 		case 'forTicket':
 			return {
 				datetimes: filteredDatetimes,
-				tickets: [singleTicket],
+				tickets: [entity as Ticket],
 			};
 	}
 };

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentWrapper.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/ContentWrapper.tsx
@@ -4,9 +4,8 @@ import { __ } from '@wordpress/i18n';
 import { withContext as withTAMContext } from '@edtrUI/ticketAssignmentsManager/context';
 import { withContext as withTPCContext } from '@edtrUI/tickets/ticketPriceCalculator/context';
 import ContentBody from './ContentBody';
-import { Ticket } from '@edtrServices/apollo';
 import { ContentWrapperProps } from './types';
-import { useMemoStringify } from '@application/services/hooks';
+import { withEntityFormDetails } from '@sharedUI/entityEditModal';
 
 const WithTPC: React.FC<ContentWrapperProps> = (props) => {
 	const { values } = props.form.getState();
@@ -22,21 +21,18 @@ const WithTPC: React.FC<ContentWrapperProps> = (props) => {
  * This component is inside RFF context, so we can use all of RFF features.
  */
 const ContentWrapper: React.FC<ContentWrapperProps> = (props) => {
-	const { values } = props.form.getState();
-
-	const ticket = useMemoStringify({
-		...values,
-		id: values.id ?? 'NEW_TICKET',
-		dbId: values.dbId ?? 0,
-	}) as Ticket;
-
-	return withTAMContext(
-		WithTPC,
-		{
-			assignmentType: 'forTicket',
-			entity: ticket,
-		},
-		props
+	// provide entity details to TAM from edit form
+	return withEntityFormDetails(
+		({ entity }) =>
+			withTAMContext(
+				WithTPC,
+				{
+					assignmentType: 'forTicket',
+					entity,
+				},
+				props
+			),
+		'NEW_TICKET'
 	);
 };
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/types.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/multiStep/types.ts
@@ -2,6 +2,7 @@ import { Disclosure } from '@application/services/utilities/types';
 import { EntityId } from '@dataServices/types';
 import { Ticket } from '@edtrServices/apollo/types';
 import { FormRenderProps } from 'react-final-form';
+import { TicketFormShape } from '../types';
 
 export interface ContainerProps extends Omit<Disclosure, 'onOpen'> {
 	ticketId?: EntityId;
@@ -12,4 +13,4 @@ export interface ContentProps {
 	onClose: VoidFunction;
 }
 
-export interface ContentWrapperProps extends FormRenderProps {}
+export interface ContentWrapperProps extends FormRenderProps<TicketFormShape> {}

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/types.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/types.ts
@@ -1,6 +1,6 @@
 import { DateAndTime } from '@sharedServices/utils/dateAndTime';
-import { TicketBaseInput } from '@edtrServices/apollo/mutations';
+import { UpdateTicketInput } from '@edtrServices/apollo/mutations';
 
-export interface TicketFormShape extends TicketBaseInput, DateAndTime {
+export interface TicketFormShape extends UpdateTicketInput, DateAndTime {
 	dateTime?: DateAndTime;
 }

--- a/assets/src/domain/shared/ui/entityEditModal/index.ts
+++ b/assets/src/domain/shared/ui/entityEditModal/index.ts
@@ -1,3 +1,7 @@
 export { default as Container } from './Container';
 
+export { default as EntityEditModal } from './EntityEditModal';
+
+export { default as withEntityFormDetails } from './withEntityFormDetails';
+
 export * from './types';

--- a/assets/src/domain/shared/ui/entityEditModal/withEntityFormDetails.tsx
+++ b/assets/src/domain/shared/ui/entityEditModal/withEntityFormDetails.tsx
@@ -1,0 +1,37 @@
+import React, { useRef } from 'react';
+import { FormSpy } from 'react-final-form';
+
+import { Datetime, Ticket } from '@edtrServices/apollo';
+import { BaseProps } from '@edtrUI/ticketAssignmentsManager';
+import { useMemoStringify, useTimeZoneTime, useMemoLazy } from '@application/services/hooks';
+import { processDateAndTime } from '@sharedServices/utils/dateAndTime';
+/**
+ * This HOC provides the current entity detail to the underlying component
+ * in multi-step form by subscribing to RFF.
+ */
+const withEntityFormDetails = <T extends Datetime | Ticket>(
+	Component: React.ComponentType<Partial<BaseProps<T>>>,
+	newEntityId: string
+): JSX.Element => {
+	const { siteTimeToUtc } = useTimeZoneTime();
+
+    const lazyMemo = useMemoLazy<T>(null);
+    // We only need value here.
+	const subscription = useMemoStringify({ values: true });
+	return (
+		<FormSpy subscription={subscription}>
+			{({ values: { dateTime, ...values } }) => {
+				const entity = lazyMemo({
+					...values,
+                    id: values.id ?? newEntityId,
+                    dbId: values.dbId ?? 0,
+					...processDateAndTime(dateTime, siteTimeToUtc),
+				} as T);
+
+				return <Component entity={entity} />;
+			}}
+		</FormSpy>
+	);
+};
+
+export default withEntityFormDetails;


### PR DESCRIPTION
This PR fixes the issue of entity details in multi-step form not being synced with TAM step with the following changes:
- Creates `useMemoLazy` 😎 
- Creates `withEntityFormDetails` HOC to share between date and ticket multi-step form
- Updates date and ticket muti-step to use the entity details from edit form
- Fixes and improves TAM to use the supplied entity details

Closes #2954 


