### PR TITLE
Remove the force premium upgrade

### DIFF
--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -305,22 +305,31 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 : false;
 
             //set hooks
-            $this->_check_for_forced_upgrade();
             $this->installHooks();
         }
 
 
         /**
          * This checks to see if there is a forced upgrade option saved from a previous saved options page trigger.
-         *  If there is then we change the slug accordingly and setup for premium update.
+         * If there is then we change the slug accordingly and setup for premium update.
          * This function will also take care of deleting any previous force_update options IF our current installed
          * plugin IS premium.
          *
+         * @deprecated $VID:$
          * @access private
          * @return void
+         * @throws EE_Error
          */
         private function _check_for_forced_upgrade()
         {
+            EE_Error::doing_it_wrong(
+                __METHOD__,
+                esc_html__(
+                    'This method is no longer in use. There is no replacement for it. The method was used to check and setup for a premium upgrade via 1-click which is no longer available from within WP admin.',
+                    'event_espresso'
+                ),
+                '$VID:$'
+            );
 
             /**
              * We ONLY execute this check if the incoming plugin being checked has a free option.
@@ -795,12 +804,6 @@ if (! class_exists('PluginUpdateEngineChecker')):
             //date.
             $this->trigger_update_check();
 
-            //if we've got a forced premium upgrade then let's add an admin notice for this with a nice button to do
-            //the upgrade right away.  We'll also handle the display of any json errors in this admin_notice.
-            if ($this->_force_premium_upgrade) {
-                add_action('admin_notices', array($this, 'show_premium_upgrade'));
-            }
-
 
             //this injects info into the returned Plugin info popup but we ONLY inject if we're not doing wp_updates
             $this->json_error = $this->get_json_error_string();
@@ -933,40 +936,12 @@ if (! class_exists('PluginUpdateEngineChecker')):
                 $this->api_secret_key = $value;
                 $this->set_api($this->api_secret_key);
 
-                //reset force_upgrade flag (but only if there's a free slug key)
+                // Reset force_upgrade flag (but only if there's a free slug key).
+                // There are no force upgrades anymore.
                 if (! empty($this->_incoming_slug['free'])) {
                     delete_site_option(
                         'pue_force_upgrade_' . $this->_incoming_slug['free'][key($this->_incoming_slug['free'])]
                     );
-                }
-
-                //now let's reset some flags if necessary?  in other words IF the user has entered a premium key and
-                //the CURRENT version is a free version (NOT a prerelease version) then we need to make sure that we
-                // ping for the right version
-                //if this condition matches then that means we've got a free active key in place (or a free version
-                // from wp WITHOUT an active key) and the user has entered a NON free API key which means they intend
-                // to check for premium access.
-                if (! empty($this->api_secret_key)
-                    && ! $this->_is_premium
-                    && ! $this->_is_prerelease
-                    && $this->_is_freerelease
-                    && false === stripos(
-                        $this->api_secret_key,
-                        'FREE'
-                    )
-                ) {
-                    $this->_use_wp_update = false;
-                    $this->slug = $this->_incoming_slug['premium'][key($this->_incoming_slug['premium'])];
-                    $this->_is_premium = true;
-                    $this->_force_premium_upgrade = true;
-                    $this->pue_install_key = 'pue_install_key_' . $this->slug;
-                    $this->optionName = 'external_updates-' . $this->slug;
-                    if (isset($this->_incoming_slug['free'])) {
-                        update_site_option(
-                            'pue_force_upgrade_' . $this->_incoming_slug['free'][key($this->_incoming_slug['free'])],
-                            $this->slug
-                        );
-                    }
                 }
 
                 $this->checkForUpdates();
@@ -1040,19 +1015,19 @@ if (! class_exists('PluginUpdateEngineChecker')):
                     $this->add_persistent_notice($response->extra_notices);
                 }
                 // This instance is for EE Core, we have a response from PUE so lets check if it contains PUE Plugin data.
-                if ( stripos($this->slug, 'event-espresso-core') !== false
+                if (stripos($this->slug, 'event-espresso-core') !== false
                     && isset($response->extra_data)
                     && !empty($response->extra_data->plugins)
-                ) {                    // Pull PUE pugin data from 'extra_data'.
+                ) {                    // Pull PUE plugin data from 'extra_data'.
                     $plugins_array = json_decode($result['body'], true);
                     $plugins = $plugins_array['extra_data']['plugins'];
                     // Pull all of the add-ons EE has active and update the local latestVersion value of each of them.
                     foreach (EE_Registry::instance()->addons as $addon) {
                         $addon_slug = $addon->getPueSlug();
-                        if( isset($response->extra_data->plugins->{ $addon_slug }) ) {
+                        if(isset($response->extra_data->plugins->{ $addon_slug })) {
                             $addon_state = get_option('external_updates-' . $addon_slug);
                             // If we don't have an addon state, get out we'll update it next time.
-                            if( empty($addon_state)) {
+                            if(empty($addon_state)) {
                                 continue;
                             }
                             // Have an addon state? Set the latestVersion value!
@@ -1542,11 +1517,22 @@ if (! class_exists('PluginUpdateEngineChecker')):
          * allows them to click a button to get the premium version.
          * Note: we'll alternatively display any json errors that may be present from the returned package.
          *
+         * @deprecated $VID:$
          * @access  public
          * @return string html
+         * @throws EE_Error
          */
         public function show_premium_upgrade()
         {
+            EE_Error::doing_it_wrong(
+                __METHOD__,
+                esc_html__(
+                    'This method is no longer in use. There is no replacement for it. The method was used to show an admin notice for a 1-click premium upgrade which is no longer available from within WP admin.',
+                    'event_espresso'
+                ),
+                '$VID:$'
+            );
+
             global $current_screen;
             $ver_option_key = 'puvererr_' . basename($this->pluginFile);
             if (empty($current_screen)) {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Resolves #1671 
This removes checking for the forced premium upgrade along with the upgrade notice.

Notice example:

![image](https://user-images.githubusercontent.com/1048561/85014544-22b51380-b16f-11ea-81a5-88289b5be91f.png)


## How has this been tested
- With EE core active, activate some other EE plugin, Stripe Gateway for example. But use an older version of this plugin, or simply change the version of your current plugin to a lower one.
- On the master branch of EE core, change the plugin version to something like 4.10.5.decaf (in the `espresso.php` file). Don't enter (or clear if present) the Support License Key in General settings. On the plugins page you should see a possible [WP] update for EE but not the Stripe gateway.
- Enter a valid license key in the General settings, click save and you should see an admin notice about a possible upgrade for EE core and the Stripe Gateway.
- Here I’d recommend downloading EE core of this `1671/remove-premium-decaf-upgrade` branch directly from the repo, and not using git. Again here, change the plugin version to  4.10.5.decaf, deactivate EE that’s on the master branch and activate EE that you just downloaded. The above upgrade notice should be gone now, but you should still see the update options for both plugins on the plugins page.
- Try updating the  Stripe Gateway.
- Try updating your "fake" EE core Decaf. It should update to the most recent Decaf version.

> Note: If you don’t see the updates it might be that you are being rate limited by our updates server. If that is true, ping me in Slack.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
