### PR TITLE
Add Tooltip to TPC Reverse Calculate Button

### DIFF
--- a/assets/src/application/ui/display/withTooltip/style.scss
+++ b/assets/src/application/ui/display/withTooltip/style.scss
@@ -1,8 +1,13 @@
 @import 'application/ui/styles/mixins/breakpoints.scss';
 
+:root {
+	--ee-tooltip-background-color: #cdeaff;
+	// --ee-text-on-blue-super-high-contrast
+}
+
 .ee-tooltip.ee-tooltip {
-	background-color: var(--ee-text-on-blue-super-high-contrast);
-	border: 2px solid var(--ee-text-on-blue-super-high-contrast);
+	background-color: var(--ee-tooltip-background-color);
+	border: 2px solid var(--ee-tooltip-background-color);
 	border-radius: var(--ee-border-radius-small);
 	box-shadow: var(--ee-box-shadow-tiny);
 	color: var(--ee-text-on-blue-low-contrast);
@@ -10,7 +15,6 @@
 	letter-spacing: 2px;
 	padding: var(--ee-padding-tiny) var(--ee-padding-smaller);
 	position: relative;
-	// text-shadow: var(--ee-text-shadow-inset);
 	width: auto;
 	word-spacing: 0.15rem;
 	z-index: 1401;
@@ -26,7 +30,7 @@
 		max-width: 75%;
 		white-space: normal;
 
-		&__btn-wrap {
+		&__wrap {
 			display: flex;
 			flex-flow: row nowrap;
 		}

--- a/assets/src/application/ui/display/withTooltip/withTooltip.tsx
+++ b/assets/src/application/ui/display/withTooltip/withTooltip.tsx
@@ -33,7 +33,7 @@ const withTooltip = <P extends withTooltipProps>(WrappedComponent: React.Compone
 			});
 			tooltipProps = { ...tooltipProps, className: 'ee-mobile-help-text__tooltip' };
 			toolTipped = (
-				<div className='ee-mobile-help-text__btn-wrap'>
+				<div className='ee-mobile-help-text__wrap'>
 					<WrappedComponent
 						{ ...(props as P) }
 						ref={ forwardedRef }

--- a/assets/src/application/ui/display/withTooltip/withTooltip.tsx
+++ b/assets/src/application/ui/display/withTooltip/withTooltip.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { __ } from '@wordpress/i18n';
 
 import { Tooltip, TooltipProps } from '@infraUI/display';
 import { withTooltipProps } from './types';

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/ReverseCalculateButton.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/buttons/ReverseCalculateButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import { IconButton } from '@application/ui/input';
+import { DownCircleFilled, UpCircleFilled } from '@appDisplay/icons/svgs';
+
+interface ReverseCalculateButtonProps {
+	reverseCalculate: boolean;
+	toggleCalcDir: VoidFunction;
+}
+
+const ReverseCalculateButton: React.FC<ReverseCalculateButtonProps> = ({ reverseCalculate, toggleCalcDir }) => {
+	const calcDirIcon = reverseCalculate ? UpCircleFilled : DownCircleFilled;
+	const calcDirTooltip = reverseCalculate
+		? __(
+				'Ticket base price is being reverse calculated from bottom to top starting with the ticket total. Entering a new ticket total will reverse calculate the ticket base price after applying all price modifiers in reverse. Click to turn off reverse calculations'
+		  )
+		: __(
+				'Ticket total is being calculated normally from top to bottom starting from the base price. Entering a new ticket base price will recalculate the ticket total after applying all price modifiers. Click to turn on reverse calculations'
+		  );
+
+	return <IconButton icon={calcDirIcon} onClick={toggleCalcDir} tooltip={calcDirTooltip} />;
+};
+
+export default ReverseCalculateButton;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketPriceCalculator/components/table/useFooterRowGenerator.tsx
@@ -2,12 +2,11 @@ import React, { useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { Cell } from '@appLayout/espressoTable';
-import { DownCircleFilled, UpCircleFilled } from '@appDisplay/icons/svgs';
-import { IconButton } from '@application/ui/input';
+import { FooterRow } from '@appLayout/espressoTable';
+import { FormatAmountFunction } from '@appServices/utilities/money/formatAmount';
 import { parsedAmount } from '@appServices/utilities/money';
 import { TicketPriceField } from '../../fields';
-import { FormatAmountFunction } from '@appServices/utilities/money/formatAmount';
-import { FooterRow } from '@appLayout/espressoTable';
+import ReverseCalculateButton from '../../buttons/ReverseCalculateButton';
 
 interface Props {
 	formatAmount: FormatAmountFunction;
@@ -19,7 +18,6 @@ type FooterRowGenerator = (props: Props) => FooterRow;
 
 const useFooterRowGenerator = (): FooterRowGenerator => {
 	return useCallback<FooterRowGenerator>(({ formatAmount, reverseCalculate, toggleCalcDir }: Props) => {
-		const calcDirIcon = reverseCalculate ? UpCircleFilled : DownCircleFilled;
 
 		const cells: Array<Cell> = [
 			{
@@ -65,7 +63,7 @@ const useFooterRowGenerator = (): FooterRowGenerator => {
 				key: 'actions',
 				type: 'cell',
 				className: 'ee-ticket-price-calculator__actions',
-				value: <IconButton icon={calcDirIcon} onClick={toggleCalcDir} /*  variant='outline' */ />,
+				value: <ReverseCalculateButton reverseCalculate={reverseCalculate} toggleCalcDir={toggleCalcDir} />,
 			},
 		];
 


### PR DESCRIPTION
The reverse calculate button in the Ticket Price Calculator did not have any tooltip or help text, but is far too complex for people to understand based solely on an arrow pointing up or down.

This PR:

 - adds a tooltip to the TPC Reverse Calculate Button whose text changes based on the current value of the `ticket.reverseCaclulate` property

 - lightens the background color for the tooltips for higher contrast and therefore better a11y