### PR TITLE
Allow empty title and description for dates and tickets

### DIFF
--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -36,7 +36,7 @@ class DatetimeMutation
             $args['DTT_reg_limit'] = (int) $input['capacity'];
         }
 
-        if (! empty($input['description'])) {
+        if (isset($input['description'])) {
             $args['DTT_description'] = sanitize_text_field($input['description']);
         }
 
@@ -59,7 +59,7 @@ class DatetimeMutation
             $args['DTT_deleted'] = (bool) $input['isTrashed'];
         }
 
-        if (! empty($input['name'])) {
+        if (isset($input['name'])) {
             $args['DTT_name'] = sanitize_text_field($input['name']);
         }
 

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -39,7 +39,7 @@ class TicketMutation
             $args['datetimes'] = array_map('sanitize_text_field', (array) $input['datetimes']);
         }
 
-        if (! empty($input['description'])) {
+        if (isset($input['description'])) {
             $args['TKT_description'] = sanitize_text_field($input['description']);
         }
 
@@ -71,7 +71,7 @@ class TicketMutation
             $args['TKT_min'] = (int) $input['min'];
         }
 
-        if (! empty($input['name'])) {
+        if (isset($input['name'])) {
             $args['TKT_name'] = sanitize_text_field($input['name']);
         }
 


### PR DESCRIPTION
This PR updates the mutation data validation to allow empty title and description for dates and tickets.

Closes #3003