### PR TITLE
Fix Inline Edit Tooltips

### DIFF
--- a/assets/src/application/ui/calendars/dateDisplay/BiggieCalendarDate/style.scss
+++ b/assets/src/application/ui/calendars/dateDisplay/BiggieCalendarDate/style.scss
@@ -10,7 +10,7 @@
 		height: 100%;
 		min-height: calc(var(--ee-padding-micro) * 45);
 		min-width: calc(var(--ee-padding-micro) * 34);
-		padding: var(--ee-padding-tiny) var(--ee-padding-micro);
+		padding: var(--ee-padding-micro);
 		text-align: center;
 		width: 100%;
 		vertical-align: bottom;
@@ -34,7 +34,7 @@
 		&__month {
 			font-size: calc(var(--ee-font-size-tiny) * 2);
 			font-weight: bold;
-			line-height: calc(var(--ee-font-size-tiny) * 2);
+			line-height: calc(var(--ee-font-size-tiny) * 2.5);
 		}
 
 		&__month-day-sep {
@@ -45,7 +45,7 @@
 			opacity: 0.8;
 			font-size: calc(var(--ee-font-size-big) * 2);
 			font-weight: bold;
-			line-height: calc(var(--ee-font-size-big) * 2);
+			line-height: calc(var(--ee-font-size-big) * 1.5);
 			text-shadow: var(--ee-text-shadow-inset);
 		}
 

--- a/assets/src/application/ui/display/TimezoneTimeInfo/style.scss
+++ b/assets/src/application/ui/display/TimezoneTimeInfo/style.scss
@@ -15,6 +15,7 @@
 		background-color: var(--ee-background-color);
 		border: 2px solid var(--ee-color-primary-super-low-contrast);
 		border-radius: var(--ee-border-radius-small);
+		box-shadow: var(--ee-box-shadow-small);
 		color: var(--ee-default-text-color-high-contrast);
 		font-weight: normal;
 		left: 0;
@@ -23,6 +24,10 @@
 
 		[x-arrow] {
 			display: none;
+		}
+
+		header {
+			margin: 0 0 var(--ee-margin-smaller);
 		}
 	}
 

--- a/assets/src/application/ui/input/CurrencyInput/index.tsx
+++ b/assets/src/application/ui/input/CurrencyInput/index.tsx
@@ -11,6 +11,7 @@ interface CurrencyInputProps {
 	onChange?: (result?: { amount: string | number; id: string }) => void;
 	placeholder?: string;
 	tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+	tooltip?: string;
 	wrapperProps?: React.HTMLAttributes<Element>;
 }
 
@@ -20,6 +21,7 @@ const CurrencyInput: React.FC<CurrencyInputProps> = ({
 	onChange = nullFunc,
 	tag = 'p',
 	wrapperProps = {},
+	...props
 }) => {
 	const { formatAmount, beforeAmount, afterAmount } = useMoneyDisplay();
 	const before = beforeAmount ? <span className={'ee-currency-input__before-amount'}>{beforeAmount} </span> : '';
@@ -41,6 +43,7 @@ const CurrencyInput: React.FC<CurrencyInputProps> = ({
 		<Wrapper className={'ee-currency-input'} {...wrapperProps}>
 			{before}
 			<InlineEditText
+				{...props}
 				as='span'
 				fitText={false}
 				key={id}

--- a/assets/src/application/ui/input/InlineEditInput/InlineEditInfinity.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/InlineEditInfinity.tsx
@@ -8,22 +8,22 @@ import { isInfinite } from '@application/services';
 import TabbableText from './TabbableText'
 import { TextProps } from './types';
 
-const Preview: React.FC<InlineEditPreviewProps> = ({ value, onRequestEdit, isEditing }) => {
-    const isInfinity = isInfinite(value);
-    const className = classNames('ee-inline-edit__infinity', {
-        'ee-infinity-sign': isInfinity,
-    });
+const Preview: React.FC<InlineEditPreviewProps> = ({ value, onRequestEdit, isEditing, ...props }) => {
+	const isInfinity = isInfinite(value);
+	const className = classNames('ee-inline-edit__infinity', {
+		'ee-infinity-sign': isInfinity,
+	});
 
-    if (isEditing) {
-        return null;
-    }
+	if (isEditing) {
+		return null;
+	}
 
-    const output = isInfinity ? '∞' : value;
+	const output = isInfinity ? '∞' : value;
 
-    return <TabbableText className={className} onRequestEdit={onRequestEdit} text={output} />;
+	return <TabbableText {...props} className={className} onRequestEdit={onRequestEdit} text={output} />;
 };
 
-const InlineEditInfinity: React.FC<TextProps> = ({ onChangeValue, value, ...rest }) => {
+const InlineEditInfinity: React.FC<TextProps> = ({ onChangeValue, value, ...props }) => {
     const isInfinity = isInfinite(value);
 
     const onChangeHandler = useCallback<TextProps['onChangeValue']>(
@@ -38,7 +38,7 @@ const InlineEditInfinity: React.FC<TextProps> = ({ onChangeValue, value, ...rest
 
     return (
         <InlineEdit
-            {...rest}
+            {...props}
             inputType='number'
             onChangeValue={onChangeHandler}
             Preview={Preview}

--- a/assets/src/application/ui/input/InlineEditInput/InlineEditText.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/InlineEditText.tsx
@@ -7,12 +7,12 @@ import { TextFit } from '@infraUI/layout/textfit';
 import TabbableText from './TabbableText'
 import { TextProps } from './types';
 
-const Preview: React.FC<InlineEditPreviewProps> = ({ fitText, isEditing, onRequestEdit, tooltip, value }) => {
+const Preview: React.FC<InlineEditPreviewProps> = ({ fitText, isEditing, onRequestEdit, tooltip, value, ...props }) => {
 	if (isEditing) {
 		return null;
 	}
 
-	const textInput = <TabbableText onRequestEdit={onRequestEdit} text={value} tooltip={tooltip} />;
+	const textInput = <TabbableText {...props} onRequestEdit={onRequestEdit} text={value} tooltip={tooltip} />;
 
 	if (value.length > 30) {
 		return <Dotdotdot clamp={2}>{textInput}</Dotdotdot>;

--- a/assets/src/application/ui/input/InlineEditInput/InlineEditTextArea.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/InlineEditTextArea.tsx
@@ -6,14 +6,14 @@ import { InlineEdit, InlineEditPreviewProps } from '@infraUI/inputs';
 import TabbableText from './TabbableText'
 import { TextAreaProps } from './types';
 
-const Preview: React.FC<InlineEditPreviewProps> = ({ isEditing, onRequestEdit, value, }) => {
+const Preview: React.FC<InlineEditPreviewProps> = ({ isEditing, onRequestEdit, value, ...props }) => {
 	if (isEditing) {
 		return null;
 	}
 
 	return (
 		<Dotdotdot clamp={3}>
-			<TabbableText onRequestEdit={onRequestEdit} text={value} />
+			<TabbableText {...props} onRequestEdit={onRequestEdit} text={value} />
 		</Dotdotdot>
 	);
 };

--- a/assets/src/application/ui/input/InlineEditInput/TabbableText/index.tsx
+++ b/assets/src/application/ui/input/InlineEditInput/TabbableText/index.tsx
@@ -17,7 +17,7 @@ const TabbableText: React.FC<TabbableTextProps> = ({ onRequestEdit, icon, text, 
         }
     };
 
-    const tooltip = props.tooltip || __('Click to edit title...')
+    const tooltip = props.tooltip || __('Click to edit...')
 
     return (
         <Tooltip tooltip={tooltip}>

--- a/assets/src/application/ui/input/InlineEditInput/TabbableText/style.scss
+++ b/assets/src/application/ui/input/InlineEditInput/TabbableText/style.scss
@@ -7,8 +7,9 @@
 	display: inline-flex;
 	justify-content: center;
 	outline: none !important;
-	margin-top: calc(var(--ee-margin-tiny) * -1); // to offset border & padding of input
 	padding: var(--ee-padding-micro);
+	min-height: var(--ee-icon-button-size);
+	min-width: var(--ee-icon-button-size);
 
 	&:hover {
 		border-color: var(--ee-color-primary-low-contrast);

--- a/assets/src/application/ui/layout/EntityCard/styles.scss
+++ b/assets/src/application/ui/layout/EntityCard/styles.scss
@@ -61,7 +61,7 @@
 				height: 2rem;
 				letter-spacing: var(--ee-letter-spacing-font-size-huge);
 				line-height: calc(var(--ee-line-height-modifier) * 0.75);
-				margin: var(--ee-margin-micro) 0 var(--ee-margin-smaller);
+				margin: 0 0 var(--ee-margin-smaller);
 				padding: 0;
 				text-align: center;
 				width: 100%;

--- a/assets/src/application/ui/layout/dropdownMenu/styles.scss
+++ b/assets/src/application/ui/layout/dropdownMenu/styles.scss
@@ -14,28 +14,24 @@
 
 		.ee-dropdown-menu__list & {
 			font-size: var(--ee-font-size-default);
-			min-height: 2.25rem;
+			min-height: 2.5rem;
+			padding: var(--ee-padding-tiny);
 		}
 
 		&:last-child {
 			margin-bottom: 0;
 		}
 
-		// chakra dropdown is not tabbable, this was added in case this component will be tabbable in future versions
-		&:focus {
+		&:focus[role='menuitem'],
+		&:hover[role='menuitem'] {
 			background-color: var(--ee-color-grey-13);
 			box-shadow: none;
 			color: var(--ee-default-text-color-high-contrast);
-			outline-offset: -2px;
-			outline: 1px dotted var(--ee-color-grey-8);
 		}
 
-		&:hover {
-			background: var(--ee-color-grey-14);
-		}
-
-		svg {
-			margin-right: var(--ee-margin-smaller);
+		svg,
+		svg.ee-svg {
+			margin: 0 var(--ee-margin-small) 0 0;
 		}
 	}
 }

--- a/assets/src/application/ui/layout/entityList/style.scss
+++ b/assets/src/application/ui/layout/entityList/style.scss
@@ -14,10 +14,10 @@
 			color: var(--ee-color-grey-11);
 			font-family: 'Segoe UI', Candara, 'Bitstream Vera Sans', 'DejaVu Sans', 'Bitstream Vera Sans',
 				'Trebuchet MS', Verdana, 'Verdana Ref', sans-serif;
-			font-size: calc(var(--ee-font-size-huge) * 2.5);
+			font-size: calc(var(--ee-font-size-huge) * 2.25);
 			font-weight: 800;
 			line-height: calc(var(--ee-line-height-modifier) * 0.875);
-			margin: var(--ee-margin-default) 0 var(--ee-margin-micro);
+			margin: var(--ee-margin-smaller) 0 0;
 			text-shadow: var(--ee-text-shadow-inset-light);
 
 			@include max782px {

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCapacity.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCapacity.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import parseInfinity from '@appServices/utilities/number/parseInfinity';
 import { InlineEditInfinity, TextProps } from '@appInputs/InlineEditInput';
@@ -29,7 +30,13 @@ const DateCapacity: React.FC<DateItemProps> = ({ entity: datetime }) => {
 		[datetime.cacheId, ticketQuantityForCapacity, updateRelatedTickets, updateEntity]
 	);
 
-	return <InlineEditInfinity onChangeValue={onChange} value={`${datetime.capacity}`} />;
+	return (
+		<InlineEditInfinity
+			onChangeValue={onChange}
+			value={`${datetime.capacity}`}
+			tooltip={__('Click to edit capacity...')}
+		/>
+	);
 };
 
 export default React.memo(DateCapacity, getPropsAreEqual(['entity']));

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketQuantity.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketQuantity.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { __ } from '@wordpress/i18n';
 
 import parseInfinity from '@appServices/utilities/number/parseInfinity';
 import { InlineEditInfinity, TextProps } from '@appInputs/InlineEditInput';
@@ -19,7 +20,13 @@ const TicketQuantity: React.FC<TicketItemProps> = ({ entity: ticket }) => {
 		[ticket.cacheId]
 	);
 
-	return <InlineEditInfinity onChangeValue={onChange} value={`${ticket.quantity}`} />;
+	return (
+		<InlineEditInfinity
+			onChangeValue={onChange}
+			value={`${ticket.quantity}`}
+			tooltip={__('Click to edit quantity...')}
+		/>
+	);
 };
 
 export default React.memo(TicketQuantity, getPropsAreEqual(['entity', 'cacheId']));

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
@@ -36,6 +36,7 @@ const EditablePrice: React.FC<EditablePriceProps> = ({ entity: ticket, className
 			wrapperProps={wrapperProps}
 			onChange={onChangePrice}
 			tag={'h3'}
+			tooltip={__('Click to edit ticket total...')}
 		/>
 	);
 };


### PR DESCRIPTION
ALL of the inline editable inputs such as datetime description, datetime capacity, ticket description, and ticket quantity all had "Click to edit title..." as their tooltips.

This PR fixes that by adding the appropriate tooltip text where it had not yet been set, and also by couriering props through from the inline edit parent components to their  `Preview` components.

This PR also tweaks some css for some minor alignment and spacing issues