### PR TITLE
Fix Assets Not Loading for EDTR

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -129,10 +129,11 @@ module.exports = function (webpackEnv) {
 		react: 'React',
 		'react-dom': 'ReactDOM',
 		jquery: 'jQuery',
+		lodash: '_',
 	};
 
 	// Define WordPress dependencies
-	const wpPackages = ['components', 'element', 'blocks', 'i18n', 'block-editor'];
+	const wpPackages = ['components', 'element', 'blocks', 'i18n', 'block-editor', 'keycodes', 'url'];
 	// Setup externals for all WordPress dependencies
 	wpPackages.forEach((wpPackage) => {
 		externals['@wordpress/' + wpPackage] = {

--- a/core/domain/services/assets/EspressoEditorAssetManager.php
+++ b/core/domain/services/assets/EspressoEditorAssetManager.php
@@ -48,7 +48,10 @@ class EspressoEditorAssetManager extends ReactAssetManager
                 ReactAssetManager::JS_HANDLE_REACT,
                 ReactAssetManager::JS_HANDLE_REACT_DOM,
                 CoreAssetManager::JS_HANDLE_JS_CORE,
+                'wp-components',
                 'wp-i18n',
+                'wp-keycodes',
+                'wp-url',
             ]
         )->setRequiresTranslation();
     }


### PR DESCRIPTION
This PR fixes the asset loading for EDTR by externalizing lodash and all other wp packages.

Closes #2931 