### PR TITLE
Add filters to GQL shema for addons

### DIFF
--- a/core/domain/services/graphql/connection_resolvers/AttendeeConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AttendeeConnectionResolver.php
@@ -130,12 +130,24 @@ class AttendeeConnectionResolver extends AbstractConnectionResolver
 
         list($query_args, $where_params) = $this->mapOrderbyInputArgs($query_args, $where_params, 'ATT_ID');
 
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__attendee_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
         $query_args[] = $where_params;
 
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__attendee_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 
 

--- a/core/domain/services/graphql/connection_resolvers/DatetimeConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/DatetimeConnectionResolver.php
@@ -149,12 +149,24 @@ class DatetimeConnectionResolver extends AbstractConnectionResolver
             );
         }
 
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__datetime_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
         $query_args[] = $where_params;
 
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__datetime_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 
 

--- a/core/domain/services/graphql/connection_resolvers/PriceConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/PriceConnectionResolver.php
@@ -134,12 +134,24 @@ class PriceConnectionResolver extends AbstractConnectionResolver
             ];
         }
 
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__price_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
         $query_args[] = $where_params;
 
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__price_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 
 

--- a/core/domain/services/graphql/connection_resolvers/PriceTypeConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/PriceTypeConnectionResolver.php
@@ -71,9 +71,23 @@ class PriceTypeConnectionResolver extends AbstractConnectionResolver
         // Avoid multiple entries by join.
         $query_args['group_by'] = 'PRT_ID';
 
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__priceType_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
+        $query_args[] = $where_params;
+
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__priceType_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 }

--- a/core/domain/services/graphql/connection_resolvers/TicketConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/TicketConnectionResolver.php
@@ -103,12 +103,24 @@ class TicketConnectionResolver extends AbstractConnectionResolver
 
         list($query_args, $where_params) = $this->mapOrderbyInputArgs($query_args, $where_params, 'TKT_ID');
 
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__ticket_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
         $query_args[] = $where_params;
 
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__ticket_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 
 

--- a/core/domain/services/graphql/connection_resolvers/VenueConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/VenueConnectionResolver.php
@@ -8,7 +8,6 @@ use EE_Event;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use InvalidArgumentException;
-use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\Model\Post;
 
 /**
@@ -60,28 +59,22 @@ class VenueConnectionResolver extends AbstractConnectionResolver
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public function get_query_args()
     {
+        $where_params = [];
         $query_args = [];
 
-        /**
-         * Prepare for later use
-         */
-        $last = ! empty($this->args['last']) ? $this->args['last'] : null;
-        $first = ! empty($this->args['first']) ? $this->args['first'] : null;
+        $query_args['limit'] = $this->getLimit();
 
-        /**
-         * Set limit the highest value of $first and $last, with a (filterable) max of 100
-         */
-        $query_args['limit'] = min(
-            max(absint($first), absint($last), 10),
-            $this->query_amount
-        ) + 1;
+        // Avoid multiple entries by join.
+        $query_args['group_by'] = 'VNU_ID';
+
+        $query_args['default_where_conditions'] = 'minimum';
 
         /**
          * Collect the input_fields and sanitize them to prepare them for sending to the Query
          */
         $input_fields = [];
         if (! empty($this->args['where'])) {
-            $input_fields = $this->sanitize_input_fields($this->args['where']);
+            $input_fields = $this->sanitizeInputFields($this->args['where']);
         }
 
         /**
@@ -94,10 +87,10 @@ class VenueConnectionResolver extends AbstractConnectionResolver
             switch (true) {
                 // Assumed to be an event
                 case $this->source instanceof Post:
-                    $query_args[] = ['Event.EVT_ID' => $this->source->ID];
+                    $where_params['Event.EVT_ID'] = $this->source->ID;
                     break;
                 case $this->source instanceof EE_Event:
-                    $query_args[] = ['Event.EVT_ID' => $this->source->ID()];
+                    $where_params['Event.EVT_ID'] = $this->source->ID();
                     break;
             }
         }
@@ -106,36 +99,45 @@ class VenueConnectionResolver extends AbstractConnectionResolver
          * Merge the input_fields with the default query_args
          */
         if (! empty($input_fields)) {
-            $query_args = array_merge($query_args, $input_fields);
+            $where_params = array_merge($where_params, $input_fields);
         }
+
+        list($query_args, $where_params) = $this->mapOrderbyInputArgs($query_args, $where_params, 'VNU_ID');
+
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__venue_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
+        $query_args[] = $where_params;
 
         /**
          * Return the $query_args
          */
-        return $query_args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__venue_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
     }
 
 
     /**
-     * This sets up the "allowed" args, and translates the GraphQL-friendly keys to WP_Query
-     * friendly keys. There's probably a cleaner/more dynamic way to approach this, but
-     * this was quick. I'd be down to explore more dynamic ways to map this, but for
-     * now this gets the job done.
+     * This sets up the "allowed" args, and translates the GraphQL-friendly keys to model
+     * friendly keys.
      *
-     * @param array $query_args
+     * @param array $where_args
      * @return array
      */
-    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function sanitize_input_fields(array $query_args)
+    public function sanitizeInputFields(array $where_args)
     {
-        $arg_mapping = [
-            'orderBy' => 'order_by',
-            'order'   => 'order',
-        ];
-
-        /**
-         * Return the Query Args
-         */
-        return ! empty($query_args) && is_array($query_args) ? $query_args : [];
+        return $this->sanitizeWhereArgsForInputFields(
+            $where_args,
+            [],
+            []
+        );
     }
 }

--- a/core/domain/services/graphql/connections/DatetimeTicketsConnection.php
+++ b/core/domain/services/graphql/connections/DatetimeTicketsConnection.php
@@ -74,29 +74,36 @@ class DatetimeTicketsConnection extends ConnectionBase
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function get_connection_args($args = [])
     {
-        return array_merge(
-            [
-                'orderby'      => [
-                    'type'        => ['list_of' => 'EspressoTicketsConnectionOrderbyInput'],
-                    'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
-                ],
-                'datetime' => [
-                    'type'        => 'ID',
-                    'description' => esc_html__('Globally unique datetime ID to get the tickets for.', 'event_espresso'),
-                ],
-                'datetimeIn' => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Globally unique datetime IDs to get the tickets for.', 'event_espresso'),
-                ],
-                'datetimeId' => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Datetime ID to get the tickets for.', 'event_espresso'),
-                ],
-                'datetimeIdIn' => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Datetime IDs to get the tickets for.', 'event_espresso'),
-                ],
+        $newArgs = [
+            'orderby'      => [
+                'type'        => ['list_of' => 'EspressoTicketsConnectionOrderbyInput'],
+                'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
             ],
+            'datetime' => [
+                'type'        => 'ID',
+                'description' => esc_html__('Globally unique datetime ID to get the tickets for.', 'event_espresso'),
+            ],
+            'datetimeIn' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Globally unique datetime IDs to get the tickets for.', 'event_espresso'),
+            ],
+            'datetimeId' => [
+                'type'        => 'Int',
+                'description' => esc_html__('Datetime ID to get the tickets for.', 'event_espresso'),
+            ],
+            'datetimeIdIn' => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Datetime IDs to get the tickets for.', 'event_espresso'),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__ticket_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
             $args
         );
     }

--- a/core/domain/services/graphql/connections/EventDatetimesConnection.php
+++ b/core/domain/services/graphql/connections/EventDatetimesConnection.php
@@ -75,57 +75,64 @@ class EventDatetimesConnection extends ConnectionBase
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function get_connection_args($args = [])
     {
-        return array_merge(
-            [
-                'orderby'      => [
-                    'type'        => ['list_of' => 'EspressoDatetimesConnectionOrderbyInput'],
-                    'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
-                ],
-                'event'  => [
-                    'type'        => 'ID',
-                    'description' => esc_html__('Globally unique event ID to get the datetimes for.', 'event_espresso'),
-                ],
-                'eventIn'  => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Globally unique event IDs to get the datetimes for.', 'event_espresso'),
-                ],
-                'eventId'  => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Event ID to get the datetimes for.', 'event_espresso'),
-                ],
-                'eventIdIn'  => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Event IDs to get the datetimes for.', 'event_espresso'),
-                ],
-                'ticket' => [
-                    'type'        => 'ID',
-                    'description' => esc_html__('Globally unique ticket ID to get the datetimes for.', 'event_espresso'),
-                ],
-                'ticketIn' => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Globally unique ticket IDs to get the datetimes for.', 'event_espresso'),
-                ],
-                'ticketId' => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Ticket ID to get the datetimes for.', 'event_espresso'),
-                ],
-                'ticketIdIn' => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Ticket IDs to get the datetimes for.', 'event_espresso'),
-                ],
-                'upcoming' => [
-                    'type'        => 'Boolean',
-                    'description' => esc_html__('Datetimes which are upcoming.', 'event_espresso'),
-                ],
-                'active'   => [
-                    'type'        => 'Boolean',
-                    'description' => esc_html__('Datetimes which are active.', 'event_espresso'),
-                ],
-                'expired'  => [
-                    'type'        => 'Boolean',
-                    'description' => esc_html__('Datetimes which are expired.', 'event_espresso'),
-                ],
+        $newArgs = [
+            'orderby'      => [
+                'type'        => ['list_of' => 'EspressoDatetimesConnectionOrderbyInput'],
+                'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
             ],
+            'event'  => [
+                'type'        => 'ID',
+                'description' => esc_html__('Globally unique event ID to get the datetimes for.', 'event_espresso'),
+            ],
+            'eventIn'  => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Globally unique event IDs to get the datetimes for.', 'event_espresso'),
+            ],
+            'eventId'  => [
+                'type'        => 'Int',
+                'description' => esc_html__('Event ID to get the datetimes for.', 'event_espresso'),
+            ],
+            'eventIdIn'  => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Event IDs to get the datetimes for.', 'event_espresso'),
+            ],
+            'ticket' => [
+                'type'        => 'ID',
+                'description' => esc_html__('Globally unique ticket ID to get the datetimes for.', 'event_espresso'),
+            ],
+            'ticketIn' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Globally unique ticket IDs to get the datetimes for.', 'event_espresso'),
+            ],
+            'ticketId' => [
+                'type'        => 'Int',
+                'description' => esc_html__('Ticket ID to get the datetimes for.', 'event_espresso'),
+            ],
+            'ticketIdIn' => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Ticket IDs to get the datetimes for.', 'event_espresso'),
+            ],
+            'upcoming' => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Datetimes which are upcoming.', 'event_espresso'),
+            ],
+            'active'   => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Datetimes which are active.', 'event_espresso'),
+            ],
+            'expired'  => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Datetimes which are expired.', 'event_espresso'),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__datetime_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
             $args
         );
     }

--- a/core/domain/services/graphql/connections/RootQueryAttendeesConnection.php
+++ b/core/domain/services/graphql/connections/RootQueryAttendeesConnection.php
@@ -72,67 +72,74 @@ class RootQueryAttendeesConnection extends AbstractRootQueryConnection
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function get_connection_args($args = [])
     {
-        return array_merge(
-            [
-                'datetime' => [
-                    'type'        => 'ID',
-                    'description' => esc_html__(
-                        'Globally unique datetime ID to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'datetimeIn' => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__(
-                        'Globally unique datetime IDs to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'event' => [
-                    'type'        => 'ID',
-                    'description' => esc_html__(
-                        'Globally unique event ID to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'eventIn' => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__(
-                        'Globally unique event IDs to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'orderby'      => [
-                    'type'        => ['list_of' => 'EspressoAttendeesConnectionOrderbyInput'],
-                    'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
-                ],
-                'regTicket' => [
-                    'type'        => 'ID',
-                    'description' => esc_html__(
-                        'Globally unique registration ticket ID to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'regTicketIn' => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__(
-                        'Globally unique registration ticket IDs to get the attendees for.',
-                        'event_espresso'
-                    ),
-                ],
-                'regTicketId' => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Registration ticket ID to get the attendees for.', 'event_espresso'),
-                ],
-                'regTicketIdIn' => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Registration ticket IDs to get the attendees for.', 'event_espresso'),
-                ],
-                'regStatus' => [
-                    'type'        => 'EspressoRegistrationStatusEnum',
-                    'description' => esc_html__('Limit attendees to registration status.', 'event_espresso'),
-                ],
+        $newArgs = [
+            'datetime' => [
+                'type'        => 'ID',
+                'description' => esc_html__(
+                    'Globally unique datetime ID to get the attendees for.',
+                    'event_espresso'
+                ),
             ],
+            'datetimeIn' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__(
+                    'Globally unique datetime IDs to get the attendees for.',
+                    'event_espresso'
+                ),
+            ],
+            'event' => [
+                'type'        => 'ID',
+                'description' => esc_html__(
+                    'Globally unique event ID to get the attendees for.',
+                    'event_espresso'
+                ),
+            ],
+            'eventIn' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__(
+                    'Globally unique event IDs to get the attendees for.',
+                    'event_espresso'
+                ),
+            ],
+            'orderby'      => [
+                'type'        => ['list_of' => 'EspressoAttendeesConnectionOrderbyInput'],
+                'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
+            ],
+            'regTicket' => [
+                'type'        => 'ID',
+                'description' => esc_html__(
+                    'Globally unique registration ticket ID to get the attendees for.',
+                    'event_espresso'
+                ),
+            ],
+            'regTicketIn' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__(
+                    'Globally unique registration ticket IDs to get the attendees for.',
+                    'event_espresso'
+                ),
+            ],
+            'regTicketId' => [
+                'type'        => 'Int',
+                'description' => esc_html__('Registration ticket ID to get the attendees for.', 'event_espresso'),
+            ],
+            'regTicketIdIn' => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Registration ticket IDs to get the attendees for.', 'event_espresso'),
+            ],
+            'regStatus' => [
+                'type'        => 'EspressoRegistrationStatusEnum',
+                'description' => esc_html__('Limit attendees to registration status.', 'event_espresso'),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__attendee_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
             $args
         );
     }

--- a/core/domain/services/graphql/connections/TicketPricesConnection.php
+++ b/core/domain/services/graphql/connections/TicketPricesConnection.php
@@ -73,61 +73,68 @@ class TicketPricesConnection extends ConnectionBase
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public static function get_connection_args($args = [])
     {
-        return array_merge(
-            [
-                'in'              => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Limit prices to the given globally unique IDs', 'event_espresso'),
-                ],
-                'idIn'            => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Limit prices to the given IDs', 'event_espresso'),
-                ],
-                'includeDefaultPrices'  => [
-                    'type'        => 'Boolean',
-                    'description' => esc_html__('Whether to add default prices to the list.', 'event_espresso'),
-                ],
-                'ticket'          => [
-                    'type'        => 'ID',
-                    'description' => esc_html__('Globally unique ticket ID to get the prices for.', 'event_espresso'),
-                ],
-                'ticketIn'        => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Globally unique ticket IDs to get the prices for.', 'event_espresso'),
-                ],
-                'ticketId'        => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Ticket ID to get the prices for.', 'event_espresso'),
-                ],
-                'ticketIdIn'      => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Ticket IDs to get the prices for.', 'event_espresso'),
-                ],
-                'priceType'       => [
-                    'type'        => 'ID',
-                    'description' => esc_html__('Globally unique price type ID to get the prices for.', 'event_espresso'),
-                ],
-                'priceTypeIn'     => [
-                    'type'        => ['list_of' => 'ID'],
-                    'description' => esc_html__('Globally unique price type IDs to get the prices for.', 'event_espresso'),
-                ],
-                'priceTypeId'     => [
-                    'type'        => 'Int',
-                    'description' => esc_html__('Price type ID to get the prices for.', 'event_espresso'),
-                ],
-                'priceTypeIdIn'   => [
-                    'type'        => ['list_of' => 'Int'],
-                    'description' => esc_html__('Price type IDs to get the prices for.', 'event_espresso'),
-                ],
-                'priceBaseType'   => [
-                    'type'        => 'PriceBaseTypeEnum',
-                    'description' => esc_html__('Price Base type.', 'event_espresso'),
-                ],
-                'priceBaseTypeIn' => [
-                    'type'        => ['list_of' => 'PriceBaseTypeEnum'],
-                    'description' => esc_html__('Price Base types.', 'event_espresso'),
-                ],
+        $newArgs = [
+            'in'              => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Limit prices to the given globally unique IDs', 'event_espresso'),
             ],
+            'idIn'            => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Limit prices to the given IDs', 'event_espresso'),
+            ],
+            'includeDefaultPrices'  => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Whether to add default prices to the list.', 'event_espresso'),
+            ],
+            'ticket'          => [
+                'type'        => 'ID',
+                'description' => esc_html__('Globally unique ticket ID to get the prices for.', 'event_espresso'),
+            ],
+            'ticketIn'        => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Globally unique ticket IDs to get the prices for.', 'event_espresso'),
+            ],
+            'ticketId'        => [
+                'type'        => 'Int',
+                'description' => esc_html__('Ticket ID to get the prices for.', 'event_espresso'),
+            ],
+            'ticketIdIn'      => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Ticket IDs to get the prices for.', 'event_espresso'),
+            ],
+            'priceType'       => [
+                'type'        => 'ID',
+                'description' => esc_html__('Globally unique price type ID to get the prices for.', 'event_espresso'),
+            ],
+            'priceTypeIn'     => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__('Globally unique price type IDs to get the prices for.', 'event_espresso'),
+            ],
+            'priceTypeId'     => [
+                'type'        => 'Int',
+                'description' => esc_html__('Price type ID to get the prices for.', 'event_espresso'),
+            ],
+            'priceTypeIdIn'   => [
+                'type'        => ['list_of' => 'Int'],
+                'description' => esc_html__('Price type IDs to get the prices for.', 'event_espresso'),
+            ],
+            'priceBaseType'   => [
+                'type'        => 'PriceBaseTypeEnum',
+                'description' => esc_html__('Price Base type.', 'event_espresso'),
+            ],
+            'priceBaseTypeIn' => [
+                'type'        => ['list_of' => 'PriceBaseTypeEnum'],
+                'description' => esc_html__('Price Base types.', 'event_espresso'),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__price_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
             $args
         );
     }

--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -88,7 +88,11 @@ class DatetimeMutation
             $args['tickets'] = array_map('sanitize_text_field', (array) $input['tickets']);
         }
 
-        return $args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_data__datetime_mutation_args',
+            $args,
+            $input
+        );
     }
 
 

--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -89,7 +89,7 @@ class DatetimeMutation
         }
 
         return apply_filters(
-            'FHEE__EventEspresso_core_domain_services_graphql_data__datetime_mutation_args',
+            'FHEE__EventEspresso_core_domain_services_graphql_data_mutations__datetime_args',
             $args,
             $input
         );

--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -87,7 +87,7 @@ class EventMutation
         }
 
         return apply_filters(
-            'FHEE__EventEspresso_core_domain_services_graphql_data__event_mutation_args',
+            'FHEE__EventEspresso_core_domain_services_graphql_data_mutations__event_args',
             $args,
             $input
         );

--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -86,6 +86,10 @@ class EventMutation
             $args['EVT_wp_user'] = absint($input['wpUser']);
         }
 
-        return $args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_data__event_mutation_args',
+            $args,
+            $input
+        );
     }
 }

--- a/core/domain/services/graphql/data/mutations/PriceMutation.php
+++ b/core/domain/services/graphql/data/mutations/PriceMutation.php
@@ -66,6 +66,10 @@ class PriceMutation
             $args['PRC_wp_user'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
         }
 
-        return $args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_data__price_mutation_args',
+            $args,
+            $input
+        );
     }
 }

--- a/core/domain/services/graphql/data/mutations/PriceMutation.php
+++ b/core/domain/services/graphql/data/mutations/PriceMutation.php
@@ -67,7 +67,7 @@ class PriceMutation
         }
 
         return apply_filters(
-            'FHEE__EventEspresso_core_domain_services_graphql_data__price_mutation_args',
+            'FHEE__EventEspresso_core_domain_services_graphql_data_mutations__price_args',
             $args,
             $input
         );

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -127,7 +127,11 @@ class TicketMutation
             $args['TKT_wp_user'] = (! empty($parts['id']) && is_int($parts['id'])) ? $parts['id'] : null;
         }
 
-        return $args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_data__ticket_mutation_args',
+            $args,
+            $input
+        );
     }
 
 

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -128,7 +128,7 @@ class TicketMutation
         }
 
         return apply_filters(
-            'FHEE__EventEspresso_core_domain_services_graphql_data__ticket_mutation_args',
+            'FHEE__EventEspresso_core_domain_services_graphql_data_mutations__ticket_args',
             $args,
             $input
         );

--- a/core/domain/services/graphql/data/mutations/VenueMutation.php
+++ b/core/domain/services/graphql/data/mutations/VenueMutation.php
@@ -37,6 +37,10 @@ class VenueMutation
 
         // Likewise the other fields...
 
-        return $args;
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_data__venue_mutation_args',
+            $args,
+            $input
+        );
     }
 }

--- a/core/domain/services/graphql/data/mutations/VenueMutation.php
+++ b/core/domain/services/graphql/data/mutations/VenueMutation.php
@@ -38,7 +38,7 @@ class VenueMutation
         // Likewise the other fields...
 
         return apply_filters(
-            'FHEE__EventEspresso_core_domain_services_graphql_data__venue_mutation_args',
+            'FHEE__EventEspresso_core_domain_services_graphql_data_mutations__venue_args',
             $args,
             $input
         );

--- a/core/domain/services/graphql/types/Attendee.php
+++ b/core/domain/services/graphql/types/Attendee.php
@@ -42,7 +42,7 @@ class Attendee extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -179,6 +179,13 @@ class Attendee extends TypeBase
                 ['ee_edit_contacts']
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__attendee_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 

--- a/core/domain/services/graphql/types/Country.php
+++ b/core/domain/services/graphql/types/Country.php
@@ -40,7 +40,7 @@ class Country extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -129,5 +129,12 @@ class Country extends TypeBase
                 esc_html__('Currency Thousands Separator', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__country_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 }

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -55,7 +55,7 @@ class Datetime extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -219,6 +219,13 @@ class Datetime extends TypeBase
                 )
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__datetime_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -41,7 +41,7 @@ class Event extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLOutputField(
                 'dbId',
                 ['non_null' => 'Int'],
@@ -202,6 +202,13 @@ class Event extends TypeBase
                 esc_html__('Flag indicating event is expired or not', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__event_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 

--- a/core/domain/services/graphql/types/Price.php
+++ b/core/domain/services/graphql/types/Price.php
@@ -46,7 +46,7 @@ class Price extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -168,6 +168,13 @@ class Price extends TypeBase
                 esc_html__('Price Creator ID', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__price_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 

--- a/core/domain/services/graphql/types/PriceType.php
+++ b/core/domain/services/graphql/types/PriceType.php
@@ -43,7 +43,7 @@ class PriceType extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -123,5 +123,12 @@ class PriceType extends TypeBase
                 esc_html__('Price Type Creator ID', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__priceType_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 }

--- a/core/domain/services/graphql/types/State.php
+++ b/core/domain/services/graphql/types/State.php
@@ -42,7 +42,7 @@ class State extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -92,5 +92,12 @@ class State extends TypeBase
                 esc_html__('Country ISO Code', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__state_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 }

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -54,7 +54,7 @@ class Ticket extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLField(
                 'id',
                 ['non_null' => 'ID'],
@@ -296,6 +296,13 @@ class Ticket extends TypeBase
                 esc_html__('Ticket Creator ID', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__ticket_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 

--- a/core/domain/services/graphql/types/Venue.php
+++ b/core/domain/services/graphql/types/Venue.php
@@ -41,7 +41,7 @@ class Venue extends TypeBase
      */
     public function getFields()
     {
-        return [
+        $fields = [
             new GraphQLOutputField(
                 'dbId',
                 ['non_null' => 'Int'],
@@ -194,6 +194,13 @@ class Venue extends TypeBase
                 esc_html__('Show Google Map?', 'event_espresso')
             ),
         ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__venue_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
     }
 
 


### PR DESCRIPTION
This PR adds action filters to allow addons modify/update the GQL schema. This way we won't need to modify core for any of the addons.