### PR TITLE
Ensure WPGraphQL is Loaded Fixes #3024

### DIFF
--- a/core/domain/entities/routing/data_nodes/core/CurrentUser.php
+++ b/core/domain/entities/routing/data_nodes/core/CurrentUser.php
@@ -26,6 +26,9 @@ class CurrentUser extends JsonDataNode
      */
     public function __construct(JsonDataNodeValidator $validator)
     {
+        if (! class_exists('WPGraphQL')) {
+            require_once EE_THIRD_PARTY . 'wp-graphql/wp-graphql.php';
+        }
         parent::__construct($validator);
         $this->setNodeName(CurrentUser::NODE_NAME);
     }


### PR DESCRIPTION
see #3024

checks that WPGraphQL is loaded in constructor of `\EventEspresso\core\domain\entities\routing\data_nodes\core\CurrentUser`