### PR TITLE
Add DOM Data for Gutenberg Blocks closes #3027

### DIFF
--- a/assets/src/domain/index.ts
+++ b/assets/src/domain/index.ts
@@ -4,14 +4,18 @@ import './shared/services/publicPath';
 const eventEspressoData: EventEspressoData = window?.eventEspressoData;
 const domain = eventEspressoData?.domain;
 
-if (!domain) {
-	console.error('No domain supplied');
-} else if (domain !== 'blocks') {
-	// todo remove this at some point in the future
-	console.log(`%c importing: /domain/${domain}/entryPoint.ts`, 'color: SkyBlue;');
+if (domain) {
+	// todo remove console.log at some point in the future
+	console.log(
+		`%c importing: /domain/${domain}/entryPoint.ts with eventEspressoData: `,
+		'color: SkyBlue;',
+		eventEspressoData
+	);
 	import(
 		/* webpackExclude: /(shared|blocks)/ */
 		/* webpackChunkName: "[request]" */
 		`./${domain}/entryPoint.ts`
 	).catch(console.error);
+} else {
+	console.error('No domain supplied');
 }

--- a/assets/src/domain/index.ts
+++ b/assets/src/domain/index.ts
@@ -4,7 +4,9 @@ import './shared/services/publicPath';
 const eventEspressoData: EventEspressoData = window?.eventEspressoData;
 const domain = eventEspressoData?.domain;
 
-if (domain) {
+if (!domain) {
+	console.error('No domain supplied');
+} else if (domain !== 'blocks') {
 	// todo remove this at some point in the future
 	console.log(`%c importing: /domain/${domain}/entryPoint.ts`, 'color: SkyBlue;');
 	import(
@@ -12,6 +14,4 @@ if (domain) {
 		/* webpackChunkName: "[request]" */
 		`./${domain}/entryPoint.ts`
 	).catch(console.error);
-} else {
-	console.error('No domain supplied');
 }

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1145,6 +1145,7 @@ final class EE_System implements ResettableInterface
         $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin');
         $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin');
         $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventEditor');
+        $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\GutenbergEditor');
         $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage');
         $this->router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\WordPressHeartbeat');
         do_action('AHEE__EE_System__load_controllers__complete');

--- a/core/domain/entities/editor/CoreBlocksAssetManager.php
+++ b/core/domain/entities/editor/CoreBlocksAssetManager.php
@@ -2,7 +2,13 @@
 
 namespace EventEspresso\core\domain\entities\editor;
 
+use DomainException;
+use EventEspresso\core\domain\services\assets\CoreAssetManager;
+use EventEspresso\core\domain\services\assets\ReactAssetManager;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\assets\BlockAssetManager;
+use EventEspresso\core\services\collections\DuplicateCollectionIdentifierException;
 
 /**
  * Class CoreBlocksAssetManager
@@ -14,7 +20,6 @@ use EventEspresso\core\services\assets\BlockAssetManager;
  */
 class CoreBlocksAssetManager extends BlockAssetManager
 {
-    const JS_HANDLE_CORE_BLOCKS_EDITOR = 'eventespresso-blocks';
     const JS_HANDLE_CORE_BLOCKS = 'eventespresso-blocks';
 
 
@@ -23,7 +28,45 @@ class CoreBlocksAssetManager extends BlockAssetManager
      */
     public function setAssetHandles()
     {
-        $this->setEditorScriptHandle(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS_EDITOR);
+        $this->setEditorScriptHandle(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS);
         $this->setScriptHandle(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS);
+    }
+
+
+    /**
+     * @throws InvalidDataTypeException
+     * @throws InvalidEntityException
+     * @throws DuplicateCollectionIdentifierException
+     * @throws DomainException
+     */
+    public function addAssets()
+    {
+        parent::addAssets();
+        $this->registerJavascript();
+    }
+
+
+    /**
+     * Register javascript assets
+     *
+     * @throws InvalidDataTypeException
+     * @throws InvalidEntityException
+     * @throws DuplicateCollectionIdentifierException
+     * @throws DomainException
+     */
+    private function registerJavascript()
+    {
+        $this->addJs(
+            CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS,
+            [
+                ReactAssetManager::JS_HANDLE_REACT,
+                ReactAssetManager::JS_HANDLE_REACT_DOM,
+                CoreAssetManager::JS_HANDLE_JS_CORE,
+                'wp-components',
+                'wp-i18n',
+                'wp-keycodes',
+                'wp-url',
+            ]
+        )->setRequiresTranslation();
     }
 }

--- a/core/domain/entities/routing/data_nodes/EventEspressoData.php
+++ b/core/domain/entities/routing/data_nodes/EventEspressoData.php
@@ -54,7 +54,6 @@ class EventEspressoData extends PrimaryJsonDataNode
         $this->config = $config;
         $this->jed_locale = $jed_locale;
         $this->setNodeName(EventEspressoData::NODE_NAME);
-        $this->setTargetScript(EspressoCoreAppAssetManager::JS_HANDLE_EDITOR);
     }
 
 

--- a/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
+++ b/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
@@ -23,7 +23,8 @@ class GutenbergEditorData extends JsonDataNode
      *
      * @param JsonDataNodeValidator $validator
      */
-    public function __construct(JsonDataNodeValidator $validator) {
+    public function __construct(JsonDataNodeValidator $validator)
+    {
         parent::__construct($validator);
         $this->setDomain(GutenbergEditorData::NODE_NAME);
         $this->setNodeName(GutenbergEditorData::NODE_NAME);

--- a/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
+++ b/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
@@ -35,6 +35,6 @@ class GutenbergEditorData extends JsonDataNode
      */
     public function initialize()
     {
-        // $this->addData('block-name', []);
+        $this->addData('BlockName', []);
     }
 }

--- a/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
+++ b/core/domain/entities/routing/data_nodes/domains/GutenbergEditorData.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\data_nodes\domains;
+
+use EventEspresso\core\services\json\JsonDataNode;
+use EventEspresso\core\services\json\JsonDataNodeValidator;
+
+/**
+ * Class GutenbergEditorData
+ *
+ * @package EventEspresso\core\domain\entities\routing\data_nodes\domains
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class GutenbergEditorData extends JsonDataNode
+{
+
+    const NODE_NAME = 'blocks';
+
+
+    /**
+     * WordPressPluginsPageData JsonDataNode constructor.
+     *
+     * @param JsonDataNodeValidator $validator
+     */
+    public function __construct(JsonDataNodeValidator $validator) {
+        parent::__construct($validator);
+        $this->setDomain(GutenbergEditorData::NODE_NAME);
+        $this->setNodeName(GutenbergEditorData::NODE_NAME);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize()
+    {
+        // $this->addData('block-name', []);
+    }
+}

--- a/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
+++ b/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
@@ -4,6 +4,8 @@ namespace EventEspresso\core\domain\entities\routing\handlers\admin;
 
 use EE_Dependency_Map;
 use EventEspresso\core\domain\entities\routing\data_nodes\domains\EventEditor;
+use EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData;
+use EventEspresso\core\domain\services\assets\EspressoCoreAppAssetManager;
 use EventEspresso\core\services\graphql\GraphQLManager;
 
 /**
@@ -103,8 +105,15 @@ class EspressoEventEditor extends EspressoEventsAdmin
                 'EventEspresso\core\services\json\JsonDataNodeValidator'                        => EE_Dependency_Map::load_from_cache,
             ]
         );
+        /** @var EventEspressoData $primary_data_node */
+        $primary_data_node = $this->loader->getShared(
+            'EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData'
+        );
+        $primary_data_node->setTargetScript(EspressoCoreAppAssetManager::JS_HANDLE_EDITOR);
         /** @var EventEditor $data_node */
-        $data_node = $this->loader->getShared('EventEspresso\core\domain\entities\routing\data_nodes\domains\EventEditor');
+        $data_node = $this->loader->getShared(
+            'EventEspresso\core\domain\entities\routing\data_nodes\domains\EventEditor'
+        );
         $this->setDataNode($data_node);
     }
 

--- a/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
+++ b/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\routing\handlers\admin;
+
+use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\data_nodes\domains\EventEditor;
+
+/**
+ * Class GutenbergEditor
+ * detects and executes logic for the WP Gutenberg Editor
+ *
+ * @package EventEspresso\core\domain\entities\routing\admin
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+class GutenbergEditor extends AdminRoute
+{
+
+    /**
+     * returns true if the current request matches this route
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    public function matchesCurrentRequest()
+    {
+        global $pagenow;
+        return parent::matchesCurrentRequest()
+               && $pagenow
+               && (
+                   $pagenow === 'post-new.php'
+                   || (
+                       $pagenow === 'post.php'
+                       && $this->request->getRequestParam('action') === 'edit'
+                   )
+               );
+    }
+
+
+    /**
+     * @since $VID:$
+     */
+    protected function registerDependencies()
+    {
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\routing\data_nodes\domains\GutenbergEditorData',
+            [
+                'EventEspresso\core\services\json\JsonDataNodeValidator' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        /** @var EventEditor $data_node */
+        $data_node = $this->loader->getShared(
+            'EventEspresso\core\domain\entities\routing\data_nodes\domains\GutenbergEditorData'
+        );
+        $this->setDataNode($data_node);
+    }
+
+
+    /**
+     * implements logic required to run during request
+     *
+     * @return bool
+     * @since   $VID:$
+     */
+    protected function requestHandler()
+    {
+        $this->asset_manager = $this->loader->getShared(
+            'EventEspresso\core\domain\services\assets\EspressoCoreAppAssetManager'
+        );
+        add_action('admin_enqueue_scripts', [$this->asset_manager, 'enqueueBrowserAssets'], 100);
+        return true;
+    }
+}

--- a/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
+++ b/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
@@ -3,7 +3,10 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\admin;
 
 use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\editor\CoreBlocksAssetManager;
 use EventEspresso\core\domain\entities\routing\data_nodes\domains\EventEditor;
+use EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData;
+use EventEspresso\core\domain\services\assets\EspressoCoreAppAssetManager;
 
 /**
  * Class GutenbergEditor
@@ -48,6 +51,19 @@ class GutenbergEditor extends AdminRoute
                 'EventEspresso\core\services\json\JsonDataNodeValidator' => EE_Dependency_Map::load_from_cache,
             ]
         );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\editor\CoreBlocksAssetManager',
+            [
+                'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        /** @var EventEspressoData $primary_data_node */
+        $primary_data_node = $this->loader->getShared(
+            'EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData'
+        );
+        $primary_data_node->setTargetScript(CoreBlocksAssetManager::JS_HANDLE_CORE_BLOCKS);
         /** @var EventEditor $data_node */
         $data_node = $this->loader->getShared(
             'EventEspresso\core\domain\entities\routing\data_nodes\domains\GutenbergEditorData'
@@ -65,7 +81,7 @@ class GutenbergEditor extends AdminRoute
     protected function requestHandler()
     {
         $this->asset_manager = $this->loader->getShared(
-            'EventEspresso\core\domain\services\assets\EspressoCoreAppAssetManager'
+            'EventEspresso\core\domain\entities\editor\CoreBlocksAssetManager'
         );
         add_action('admin_enqueue_scripts', [$this->asset_manager, 'enqueueBrowserAssets'], 100);
         return true;

--- a/core/domain/entities/routing/handlers/admin/WordPressPluginsPage.php
+++ b/core/domain/entities/routing/handlers/admin/WordPressPluginsPage.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\entities\routing\handlers\admin;
 
 use DomainException;
 use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData;
 use EventEspresso\core\domain\services\assets\EspressoCoreAppAssetManager;
 use EventEspresso\core\domain\values\assets\JavascriptAsset;
 use EventEspresso\core\services\assets\AssetCollection;
@@ -56,6 +57,11 @@ class WordPressPluginsPage extends Route
             ['EventEspresso\core\domain\Domain' => EE_Dependency_Map::load_from_cache]
         );
 
+        /** @var EventEspressoData $primary_data_node */
+        $primary_data_node = $this->loader->getShared(
+            'EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData'
+        );
+        $primary_data_node->setTargetScript(EspressoCoreAppAssetManager::JS_HANDLE_EDITOR);
         /** @var WordPressPluginsPageData $data_node */
         $data_node = $this->loader->getShared(
             'EventEspresso\core\domain\entities\routing\data_nodes\domains\WordPressPluginsPageData'

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -24,6 +24,7 @@ class GQLRequests extends Route
      */
     public function matchesCurrentRequest()
     {
+        global $pagenow;
         return PHP_VERSION_ID > 70000
                && (
                    $this->request->isGQL()
@@ -34,6 +35,16 @@ class GQLRequests extends Route
                        && (
                            $this->request->getRequestParam('action') === 'create_new'
                            || $this->request->getRequestParam('action') === 'edit'
+                       )
+                   )
+                   || (
+                       $pagenow
+                       && (
+                           $pagenow === 'post-new.php'
+                           || (
+                               $pagenow === 'post.php'
+                               && $this->request->getRequestParam('action') === 'edit'
+                           )
                        )
                    )
                );

--- a/core/domain/entities/routing/handlers/shared/RoutingRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RoutingRequests.php
@@ -117,6 +117,7 @@ class RoutingRequests extends Route
             'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin'  => $admin,
             'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventEditor'  => $admin,
             'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin'  => $admin,
+            'EventEspresso\core\domain\entities\routing\handlers\admin\GutenbergEditor'  => $admin,
             // public dependencies
             'EventEspresso\core\domain\entities\routing\handlers\admin\PersonalDataRequests' => $public,
             'EventEspresso\core\domain\entities\routing\handlers\frontend\FrontendRequests'  => $public,

--- a/core/services/assets/BlockAssetManager.php
+++ b/core/services/assets/BlockAssetManager.php
@@ -21,9 +21,6 @@ use EventEspresso\core\services\collections\DuplicateCollectionIdentifierExcepti
  */
 abstract class BlockAssetManager extends AssetManager implements BlockAssetManagerInterface
 {
-
-    const JS_HANDLE_EDITOR = 'eventespresso-blocks';
-
     /**
      * @var string $editor_script_handle
      */

--- a/core/services/json/PrimaryJsonDataNode.php
+++ b/core/services/json/PrimaryJsonDataNode.php
@@ -32,7 +32,7 @@ abstract class PrimaryJsonDataNode extends JsonDataNode
      * @param string $target_script
      * @throws DomainException
      */
-    protected function setTargetScript($target_script)
+    public function setTargetScript($target_script)
     {
         if ($this->target_script !== null) {
             $this->validator->overwriteError($target_script, 'target script');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,6 @@
 		"strict": false,
 		"target": "es5"
 	},
-	"exclude": ["node_modules", "assets/dist", "assets/ZZZ"],
+	"exclude": ["node_modules", "assets/dist"],
 	"include": ["assets/src"]
 }


### PR DESCRIPTION
see: #3027 

adds a route and data node for the Gutenberg editor


![ScreenShot_20200707113137](https://user-images.githubusercontent.com/1751030/86826346-77003480-c045-11ea-85d6-a91e5fd94c95.png)
