### PR TITLE
Fix price update when ticket is made free

### DIFF
--- a/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
+++ b/assets/src/domain/eventEditor/ui/tickets/hooks/useRecalculateBasePrice.ts
@@ -20,6 +20,10 @@ const useRecalculateBasePrice = (ticketId: EntityId): Callback => {
 	return useCallback<Callback>(
 		(ticketPrice) => {
 			let tpcData = getDataState(null);
+			// Make sure the new ticket price is used
+			const updatedTicket = { ...tpcData?.ticket, price: ticketPrice };
+			tpcData = { ...tpcData, ticket: updatedTicket };
+
 			const exitingBasePrice = getBasePrice(tpcData?.prices);
 			// if the ticket does not have a base price,
 			// that means it was free and now a price has been added ¯\_(ツ)_/¯

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/editable/EditablePrice.tsx
@@ -14,8 +14,8 @@ interface EditablePriceProps extends TicketItemProps {
 const EditablePrice: React.FC<EditablePriceProps> = ({ entity: ticket, className }) => {
 	const recalculateBasePrice = useRecalculateBasePrice(ticket.id);
 	const onChangePrice = useCallback(
-		({ amount: price }: any): void => {
-			price = parseFloat(price);
+		({ amount }: any): void => {
+			const price = parseFloat(amount);
 			if (price !== ticket.price) {
 				recalculateBasePrice(price);
 			}

--- a/core/domain/services/graphql/data/mutations/PriceMutation.php
+++ b/core/domain/services/graphql/data/mutations/PriceMutation.php
@@ -23,11 +23,12 @@ class PriceMutation
     {
         $args = [];
 
-        if (! empty($input['amount'])) {
+        // amount can be 0
+        if (array_key_exists('amount', $input)) {
             $args['PRC_amount'] = (float) $input['amount'];
         }
 
-        if (! empty($input['description'])) {
+        if (isset($input['description'])) {
             $args['PRC_desc'] = sanitize_text_field($input['description']);
         }
 
@@ -39,7 +40,7 @@ class PriceMutation
             $args['PRC_deleted'] = (bool) $input['isTrashed'];
         }
 
-        if (! empty($input['name'])) {
+        if (isset($input['name'])) {
             $args['PRC_name'] = sanitize_text_field($input['name']);
         }
 


### PR DESCRIPTION
This PR fixes the issue of price not being set to `0` when ticket is made free and also fixes the issue of old ticket price being used to calculate base price when editing inline.