### PR TITLE
Toolbar icon fix.

### DIFF
--- a/core/admin/assets/admin-menu-styles.css
+++ b/core/admin/assets/admin-menu-styles.css
@@ -473,43 +473,32 @@ div.TB-ee-frame a {
     color: var(--ee-status-color-purple);
 }
 
-.ee-icon-size-8,
 .ee-icon-size-8:before { font-size: 8px !important; }
 
-.ee-icon-size-12,
 .ee-icon-size-12:before { font-size: 12px !important; }
 
-.ee-icon-size-14,
 .ee-icon-size-14:before { font-size: 14px !important; }
 
-.ee-icon-size-16,
 .ee-icon-size-16:before {
 	font-size: 16px !important;
 	margin-right: -.002em;
 }
 
-.ee-icon-size-18,
 .ee-icon-size-18:before {
 	font-size: 18px !important;
 	margin-right:-0.05em;
 }
 
-.ee-icon-size-20,
 .ee-icon-size-20:before {
+        font-size: 20px !important;
 	margin-right: -0.1em;
 }
 
-.ee-icon-size-20:before {
-        font-size: 20px !important;
-}
-
-.ee-icon-size-22,
 .ee-icon-size-22:before {
 	font-size: 22px !important;
 	margin-right: -0.15em;
 }
 
-.ee-icon-size-24,
 .ee-icon-size-24:before {
 	font-size: 24px !important;
 	margin-right: -0.2em;
@@ -553,7 +542,6 @@ div.TB-ee-frame a {
 	font-size: 13px;
 
 }
-
 
 
 /**

--- a/core/admin/assets/admin-menu-styles.css
+++ b/core/admin/assets/admin-menu-styles.css
@@ -496,8 +496,11 @@ div.TB-ee-frame a {
 
 .ee-icon-size-20,
 .ee-icon-size-20:before {
-	font-size: 20px !important;
 	margin-right: -0.1em;
+}
+
+.ee-icon-size-20:before {
+        font-size: 20px !important;
 }
 
 .ee-icon-size-22,


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes the positioning of this element:

![image](https://user-images.githubusercontent.com/1477453/89266267-5d4f0e80-d63e-11ea-8c25-336381f593b1.png)

***
As seen in the screencast from below applying the font-size change on `ee-icon-size-20` has no effect on icon size, changes on icon size are taking place only when it is applied on `ee-icon-size-20:before`, but even that is overridden by `#wp-admin-bar-espresso-toolbar .ee-icon-ee-cup-thick:before` which has higher priority and is also using `important`

![Peek 2020-08-04 10-32](https://user-images.githubusercontent.com/1477453/89266304-6c35c100-d63e-11ea-95f7-e7a1b825a7ed.gif)


