### PR TITLE
Don't Double Tax

### DIFF
--- a/core/db_classes/EE_Line_Item.class.php
+++ b/core/db_classes/EE_Line_Item.class.php
@@ -1236,8 +1236,7 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
             return 0;
         }
         // ensure all non-line items and non-sub-line-items have a quantity of 1 (except for Events)
-        if (! $this->is_line_item() && ! $this->is_sub_line_item() && ! $this->is_cancellation()
-        ) {
+        if (! $this->is_line_item() && ! $this->is_sub_line_item() && ! $this->is_cancellation()) {
             if ($this->OBJ_type() !== EEM_Line_Item::OBJ_TYPE_EVENT) {
                 $this->set_quantity(1);
             }
@@ -1290,7 +1289,11 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
         $subtotal_quantity = 0;
         // get the total of all its children
         foreach ($my_children as $child_line_item) {
-            if ($child_line_item instanceof EE_Line_Item && ! $child_line_item->is_cancellation()) {
+            if ($child_line_item instanceof EE_Line_Item) {
+                // skip line item if it is cancelled or is a tax
+                if ($child_line_item->is_cancellation() || $child_line_item->is_tax()) {
+                    continue;
+                }
                 // percentage line items are based on total so far
                 if ($child_line_item->is_percent()) {
                     // round as we go so that the line items add up ok
@@ -1351,7 +1354,11 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
         $quantity_for_total = 1;
         // get the total of all its children
         foreach ($my_children as $child_line_item) {
-            if ($child_line_item instanceof EE_Line_Item && ! $child_line_item->is_cancellation()) {
+            if ($child_line_item instanceof EE_Line_Item) {
+                // skip line item if it is cancelled or is a tax
+                if ($child_line_item->is_cancellation() || $child_line_item->is_tax()) {
+                    continue;
+                }
                 if ($child_line_item->is_percent()) {
                     // it should be the unit-price-so-far multiplied by teh percent multiplied by the quantity
                     // not total multiplied by percent, because that ignores rounding along-the-way

--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -266,12 +266,11 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
     public function date_range($date_format = '', $conjunction = ' - ')
     {
         $date_format = ! empty($date_format) ? $date_format : $this->_dt_frmt;
-        $first_date  = $this->first_datetime() instanceof EE_Datetime ? $this->first_datetime()
-                                                                            ->get_i18n_datetime('DTT_EVT_start',
-                                                                                                $date_format)
+        $first_date  = $this->first_datetime() instanceof EE_Datetime
+            ? $this->first_datetime()->get_i18n_datetime('DTT_EVT_start', $date_format)
             : '';
-        $last_date   = $this->last_datetime() instanceof EE_Datetime ? $this->last_datetime()
-                                                                           ->get_i18n_datetime('DTT_EVT_end', $date_format)
+        $last_date   = $this->last_datetime() instanceof EE_Datetime
+            ? $this->last_datetime()->get_i18n_datetime('DTT_EVT_end', $date_format)
             : '';
 
         return $first_date && $last_date ? $first_date . $conjunction . $last_date : '';
@@ -351,7 +350,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
                 if (empty($tickets_sold['datetime'])) {
                     return $total;
                 }
-                if (! empty($dtt_id) && ! isset($tickets_sold['datetime'][$dtt_id])) {
+                if (! empty($dtt_id) && ! isset($tickets_sold['datetime'][ $dtt_id ])) {
                     EE_Error::add_error(
                         __(
                             'You\'ve requested the amount of tickets sold for a given ticket and datetime, however there are no records for the datetime id you included.  Are you SURE that is a datetime related to this ticket?',
@@ -363,7 +362,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
                     );
                     return $total;
                 }
-                return empty($dtt_id) ? $tickets_sold['datetime'] : $tickets_sold['datetime'][$dtt_id];
+                return empty($dtt_id) ? $tickets_sold['datetime'] : $tickets_sold['datetime'][ $dtt_id ];
                 break;
             default:
                 return $total;
@@ -384,7 +383,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
         $tickets_sold = [];
         if (! empty($datetimes)) {
             foreach ($datetimes as $datetime) {
-                $tickets_sold['datetime'][$datetime->ID()] = $datetime->get('DTT_sold');
+                $tickets_sold['datetime'][ $datetime->ID() ] = $datetime->get('DTT_sold');
             }
         }
         // Tickets sold
@@ -581,7 +580,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
      */
     public function is_free()
     {
-        return $this->get_ticket_total_with_taxes() === (float)0;
+        return $this->get_ticket_total_with_taxes() === (float) 0;
     }
 
 
@@ -598,7 +597,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
         if ($this->_ticket_total_with_taxes === null || $no_cache) {
             $this->_ticket_total_with_taxes = $this->get_ticket_subtotal() + $this->get_ticket_taxes_total_for_admin();
         }
-        return (float)$this->_ticket_total_with_taxes;
+        return (float) $this->_ticket_total_with_taxes;
     }
 
 
@@ -975,7 +974,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
     public function set_reserved($reserved)
     {
         // reserved can not go below zero
-        $reserved = max(0, (int)$reserved);
+        $reserved = max(0, (int) $reserved);
         $this->set('TKT_reserved', $reserved);
     }
 

--- a/core/helpers/EEH_Line_Item.helper.php
+++ b/core/helpers/EEH_Line_Item.helper.php
@@ -309,13 +309,15 @@ class EEH_Line_Item
         $event = sprintf(_x('(For %1$s)', '(For Event Name)', 'event_espresso'), $first_datetime_name);
         // get event subtotal line
         $events_sub_total = self::get_event_line_item_for_ticket($total_line_item, $ticket);
+        $taxes = $ticket->tax_price_modifiers();
+        $is_taxable = empty($taxes) ? $ticket->taxable() : false;
         // add $ticket to cart
         $line_item = EE_Line_Item::new_instance(array(
             'LIN_name'       => $ticket->name(),
             'LIN_desc'       => $ticket->description() !== '' ? $ticket->description() . ' ' . $event : $event,
             'LIN_unit_price' => $ticket->price(),
             'LIN_quantity'   => $qty,
-            'LIN_is_taxable' => $ticket->taxable(),
+            'LIN_is_taxable' => $is_taxable,
             'LIN_order'      => count($events_sub_total->children()),
             'LIN_total'      => $ticket->price() * $qty,
             'LIN_type'       => EEM_Line_Item::type_line_item,


### PR DESCRIPTION
Previously, taxes were always applied globally by simply tagging a ticket as being taxable. During registration when line items were being generated this flag would be copied to the `LIN_is_taxable` field on the line item. Then when calculating totals, any ticket line item with that flag would have the global taxes calculated for it based on its unit price. 

In the new Event EDTR, taxes are added as price modifiers to tickets just like any other modifiers. This was done in order to facilitate reverse calculation where the ticket base price is calculated from the ticket total as opposed to the other way around. This also gives more control over taxes to users and solves the rare issue where some items are subject to some taxes and not others.

This PR solves the issue by only flagging ticket line items as taxable if:

- the ticket has NO price modifiers that are taxes

- is flagged as being taxable

this results in the "global" taxes only being applied where applicable.