### PR TITLE
Date/Time picker API improvements

### DIFF
--- a/assets/src/application/ui/calendars/dateDisplay/EditDateRangeButton.tsx
+++ b/assets/src/application/ui/calendars/dateDisplay/EditDateRangeButton.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback } from 'react';
 import { useDisclosure } from '@chakra-ui/hooks';
 import { __ } from '@wordpress/i18n';
+import { parseISO } from 'date-fns';
 
+import { DateRange } from '@infraUI/inputs/dateTime';
+import { useMemoStringify, useTimeZoneTime } from '@application/services/hooks';
 import { DateTimeRangePicker } from '../../input';
 import { ButtonSize, ButtonType, IconButton } from '../../input';
 import { CalendarOutlined, Popover } from '../../display';
@@ -11,18 +14,21 @@ const EditDateRangeButton: React.FC<EditDateButtonProps> = ({ header, onEditHand
 	const { isOpen, onOpen, onClose } = useDisclosure();
 	const headerText = header ? header : __('Edit Start and End Dates and Times');
 	const onChange = useCallback(
-		(dates: string[]) => {
+		(dates: DateRange) => {
 			onEditHandler(dates);
 			onClose();
 		},
 		[onClose, onEditHandler]
 	);
+	const { utcToSiteTime } = useTimeZoneTime();
+
+	const value = useMemoStringify<DateRange>([utcToSiteTime(parseISO(startDate)), utcToSiteTime(parseISO(endDate))]);
 
 	return (
 		<Popover
 			className={'ee-edit-calendar-date-range'}
 			closeOnBlur={false}
-			content={<DateTimeRangePicker endDate={endDate} startDate={startDate} onChange={onChange} />}
+			content={<DateTimeRangePicker onChange={onChange} value={value} />}
 			header={<strong>{headerText}</strong>}
 			isOpen={isOpen}
 			onClose={onClose}

--- a/assets/src/application/ui/calendars/dateDisplay/types.ts
+++ b/assets/src/application/ui/calendars/dateDisplay/types.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { LabelPosition } from '@appDisplay/withLabel';
 import type { ButtonProps } from '../../input/Button';
+import { DateRange } from '@infraUI/inputs/dateTime';
 
 export interface CalendarDateProps {
 	className?: string;
@@ -16,7 +17,7 @@ export type keyPressHandler = (event: React.KeyboardEventHandler<HTMLButtonEleme
 export interface EditDateButtonProps extends ButtonProps {
 	endDate: string;
 	header?: string;
-	onEditHandler: (dates: string[]) => void;
+	onEditHandler: (dates: DateRange) => void;
 	startDate: string;
 	tooltip?: string;
 	tooltipPosition?: LabelPosition;

--- a/assets/src/application/ui/input/DateTimeRangePicker/index.tsx
+++ b/assets/src/application/ui/input/DateTimeRangePicker/index.tsx
@@ -8,13 +8,12 @@ import { Save } from '../../display/icons';
 
 const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 	className,
-	startDate,
-	endDate,
 	onChange,
 	onChangeValue,
+	value,
 	...props
 }) => {
-	const [dates, setDates] = useState([startDate, endDate]);
+	const [dates, setDates] = useState(value);
 
 	const onSave: VoidFunction = useCallback(() => {
 		if (typeof onChangeValue === 'function') {
@@ -33,11 +32,14 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 		'ee-input-base-wrapper'
 	);
 
-	const [start, end] = dates;
-
 	return (
 		<div className={htmlClass}>
-			<DateTimeRangePickerAdapter required onChange={setDates} startDate={start} endDate={end} {...props} />
+			<DateTimeRangePickerAdapter
+				required
+				onChange={setDates}
+				value={dates}
+				{...props}
+			/>
 			<IconButton
 				aria-label={__('save')}
 				buttonType={ButtonType.MINIMAL}

--- a/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
+++ b/assets/src/domain/eventEditor/ui/datetimes/datesList/cardView/DateCardSidebar.tsx
@@ -8,6 +8,7 @@ import { useDatesListFilterState } from '@edtrServices/filterState';
 import { useDatetimeMutator } from '@edtrServices/apollo/mutations';
 import { useTimeZoneTime } from '@appServices/hooks';
 import type { DateItemProps } from '../types';
+import { DateRange } from '@infraUI/inputs/dateTime';
 
 const DateCardSidebar: React.FC<DateItemProps> = ({ entity: date }) => {
 	const { displayStartOrEndDate } = useDatesListFilterState();
@@ -15,11 +16,10 @@ const DateCardSidebar: React.FC<DateItemProps> = ({ entity: date }) => {
 	const { siteTimeToUtc } = useTimeZoneTime();
 
 	const onEditHandler = useCallback(
-		(dates: string[]): void => {
-			const [start, end] = dates;
+		([start, end]: DateRange): void => {
 			// convert start & end dates to proper UTC "startDate" and "endDate"
-			const startDate = siteTimeToUtc(new Date(start)).toISOString();
-			const endDate = siteTimeToUtc(new Date(end)).toISOString();
+			const startDate = siteTimeToUtc(start).toISOString();
+			const endDate = siteTimeToUtc(end).toISOString();
 			updateEntity({ startDate, endDate });
 		},
 		[siteTimeToUtc, updateEntity]

--- a/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketsList/cardView/TicketCardSidebar.tsx
@@ -8,6 +8,7 @@ import { getPropsAreEqual } from '@appServices/utilities';
 import { useTicketMutator } from '@edtrServices/apollo/mutations';
 import { useTimeZoneTime } from '@appServices/hooks';
 import type { TicketItemProps } from '../types';
+import { DateRange } from '@infraUI/inputs/dateTime';
 
 const TicketCardSidebar: React.FC<TicketItemProps> = ({ entity: ticket }) => {
 	const { displayStartOrEndDate } = useTicketsListFilterState();
@@ -15,11 +16,10 @@ const TicketCardSidebar: React.FC<TicketItemProps> = ({ entity: ticket }) => {
 	const { siteTimeToUtc } = useTimeZoneTime();
 
 	const onEditHandler = useCallback(
-		(dates: string[]): void => {
-			const [start, end] = dates;
+		([start, end]: DateRange): void => {
 			// convert start & end dates to proper UTC "startDate" and "endDate"
-			const startDate = siteTimeToUtc(new Date(start)).toISOString();
-			const endDate = siteTimeToUtc(new Date(end)).toISOString();
+			const startDate = siteTimeToUtc(start).toISOString();
+			const endDate = siteTimeToUtc(end).toISOString();
 			updateEntity({ startDate, endDate });
 		},
 		[siteTimeToUtc, updateEntity]

--- a/assets/src/infrastructure/ui/inputs/dateTime/DatePicker/index.tsx
+++ b/assets/src/infrastructure/ui/inputs/dateTime/DatePicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { default as ReactDatepicker } from 'react-date-picker';
 
 import { DatePickerProps } from '../types';
@@ -9,7 +9,6 @@ import { convertWordPressDateFormat } from '../utilities';
 import '../style.scss';
 
 const DatePicker: React.FC<DatePickerProps> = ({ value, onChange, onChangeValue, ...props }) => {
-	const [date, setDate] = useState(value);
 	const {
 		dateTimeFormats: { dateFormat },
 		locale: { user },
@@ -17,20 +16,13 @@ const DatePicker: React.FC<DatePickerProps> = ({ value, onChange, onChangeValue,
 
 	const onChangeHandler: DatePickerProps['onChange'] = useCallback(
 		(newDate) => {
-			setDate(newDate);
-			if (!newDate || newDate === date) {
+			if (!newDate) {
 				return;
 			}
-
-			if (typeof onChangeValue === 'function') {
-				onChangeValue(newDate as Date);
-			}
-
-			if (typeof onChange === 'function') {
-				onChange(newDate);
-			}
+			onChangeValue?.(newDate);
+			onChange?.(newDate);
 		},
-		[date, onChange, onChangeValue]
+		[onChange, onChangeValue]
 	);
 
 	// convert date format to accepatble values for react-date-picker
@@ -44,7 +36,7 @@ const DatePicker: React.FC<DatePickerProps> = ({ value, onChange, onChangeValue,
 			clearIcon={<CloseOutlined />}
 			locale={user}
 			onChange={onChangeHandler}
-			value={date}
+			value={value}
 		/>
 	);
 };

--- a/assets/src/infrastructure/ui/inputs/dateTime/DateTimeRangePicker/index.tsx
+++ b/assets/src/infrastructure/ui/inputs/dateTime/DateTimeRangePicker/index.tsx
@@ -10,7 +10,7 @@ import { convertWordPressDateFormat, convertWordPressTimeFormat } from '../utili
 import '../style.scss';
 import './style.scss';
 
-const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({ endDate, onChange, startDate, ...props }) => {
+const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = (props) => {
 	const {
 		dateTimeFormats: { dateTimeFormat },
 		locale: { user },
@@ -28,9 +28,7 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({ endDate, onCh
 			disableClock
 			format={newDateTimeFormat}
 			locale={user}
-			onChange={onChange}
 			showLeadingZeros
-			value={[new Date(startDate), new Date(endDate)]}
 			{...props}
 		/>
 	);

--- a/assets/src/infrastructure/ui/inputs/dateTime/TimePicker/index.tsx
+++ b/assets/src/infrastructure/ui/inputs/dateTime/TimePicker/index.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from 'react';
-import { format, parse } from 'date-fns';
+import React, { useCallback } from 'react';
+import { parse } from 'date-fns';
 import { default as ReactTimePicker } from 'react-time-picker';
 
 import { CloseOutlined } from '@appDisplay/icons/svgs';
@@ -10,7 +10,6 @@ import { convertWordPressTimeFormat } from '../utilities';
 import '../style.scss';
 
 const TimePicker: React.FC<TimePickerProps> = ({ onChange, onChangeValue, value, ...props }) => {
-	const [time, setTime] = useState(format(value, 'HH:mm'));
 	const {
 		dateTimeFormats: { timeFormat },
 		locale: { user },
@@ -19,23 +18,19 @@ const TimePicker: React.FC<TimePickerProps> = ({ onChange, onChangeValue, value,
 	// convert date format to accepatble values for react-time-picker
 	const convertedTimeFormat = convertWordPressTimeFormat(timeFormat);
 
-	const onChangeHandler: TimePickerProps['onChange'] = useCallback(
-		(newTime) => {
+	const onChangeHandler = useCallback(
+		(newTime: string): void => {
 			// incoming value from timepicker is 24hr time like "17:00"
-			setTime(newTime);
-			if (!newTime || newTime === time) {
+			if (!newTime) {
 				return;
 			}
-			const newDate: Date = parse(newTime, 'HH:mm', value);
-			if (typeof onChangeValue === 'function') {
-				onChangeValue(newDate);
-			}
-
-			if (typeof onChange === 'function') {
-				onChange(newDate.toISOString());
-			}
+			// lets not assume that TimePicker will be controlled.
+			const referenceDate = value instanceof Date ? value : new Date();
+			const newDate = parse(newTime, 'HH:mm', referenceDate);
+			onChangeValue?.(newDate);
+			onChange?.(newDate);
 		},
-		[onChange, onChangeValue, time, value]
+		[onChange, onChangeValue, value]
 	);
 
 	return (
@@ -47,7 +42,7 @@ const TimePicker: React.FC<TimePickerProps> = ({ onChange, onChangeValue, value,
 			locale={user}
 			onChange={onChangeHandler}
 			required
-			value={time}
+			value={value}
 		/>
 	);
 };

--- a/assets/src/infrastructure/ui/inputs/dateTime/index.tsx
+++ b/assets/src/infrastructure/ui/inputs/dateTime/index.tsx
@@ -4,4 +4,4 @@ export { default as DateTimeRangePicker } from './DateTimeRangePicker';
 
 export { default as TimePicker } from './TimePicker';
 
-export type { DatePickerProps, DateTimeRangePickerProps, TimePickerProps } from './types';
+export * from './types';

--- a/assets/src/infrastructure/ui/inputs/dateTime/types.ts
+++ b/assets/src/infrastructure/ui/inputs/dateTime/types.ts
@@ -10,18 +10,19 @@ export interface DatePickerProps
 	value?: Date;
 }
 
+export type DateRange = [Date, Date];
+
 export interface DateTimeRangePickerProps
 	extends ReactDateTimeRangePickerProps,
-		CommonInputProps<HTMLInputElement, string[]> {
+		CommonInputProps<HTMLInputElement, DateRange> {
 	className?: string;
-	endDate: string;
-	onChange: (dates: string[]) => void;
-	startDate: string;
+	onChange: (dates: DateRange) => void;
+	value?: DateRange;
 }
 
 export interface TimePickerProps extends ReactTimePickerProps, CommonInputProps<HTMLInputElement, Date> {
 	className?: string;
-	onChange?: (time: string) => void;
+	onChange?: (time: Date) => void;
 	value?: Date;
 }
 


### PR DESCRIPTION
This PR improves Date and Time picker API and makes it consistent to use Date objects throughout.

See #3086 

Related [barista/pull/191](https://github.com/eventespresso/barista/pull/191)