### PR TITLE
Change Default Values for Start and End Dates

### DIFF
--- a/assets/src/application/services/utilities/date/misc.ts
+++ b/assets/src/application/services/utilities/date/misc.ts
@@ -19,3 +19,12 @@ export const setDateToToday = (date: Date): Date => {
         setYear(today.getFullYear()
     ))(date);
 };
+
+/**
+ * Sets the default time for a date based on `type`
+ * Default time: 'start' => 8 am, 'end' => 5 pm
+ */
+export const setDefaultTime = (date: Date, type: 'start' | 'end' = 'start'): Date => {
+	const hours = type === 'start' ? 8 : 17;
+	return pipe(setHours(hours), setMinutes(0), setSeconds(0))(date);
+};

--- a/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/index.tsx
+++ b/assets/src/application/ui/calendars/dateDisplay/CalendarDateSwitcher/index.tsx
@@ -5,13 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { BiggieCalendarDate, CalendarDateRange } from '../';
 import { CalendarDateSwitcherProps } from './types';
 import { DisplayStartOrEndDate } from '@sharedServices/filterState';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@sharedConstants/defaultDates';
 import { switchTenseForDate } from '@appServices/utilities/date';
+import { useMemoStringify } from '@application/services/hooks';
 
 const CalendarDateSwitcher: React.FC<CalendarDateSwitcherProps> = React.memo(
 	({ className, displayDate = DisplayStartOrEndDate.start, labels, ...props }) => {
-		const startDate = parseISO(props.startDate) || PLUS_ONE_MONTH;
-		const endDate = parseISO(props.endDate) || PLUS_TWO_MONTHS;
+		const startDate = useMemoStringify(parseISO(props.startDate), [props.startDate]);
+		const endDate = useMemoStringify(parseISO(props.endDate), [props.endDate]);
 
 		let headerText = '';
 		let footerText = '';

--- a/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
+++ b/assets/src/domain/eventEditor/ui/datetimes/dateForm/useDateFormConfig.ts
@@ -10,147 +10,161 @@ import { EntityId } from '@dataServices/types';
 import { processDateAndTime } from '@sharedServices/utils/dateAndTime';
 import { validate } from './formValidation';
 import { DateFormShape } from './types';
-import { useTimeZoneTime } from '@appServices/hooks';
+import { useTimeZoneTime, useMemoStringify } from '@appServices/hooks';
 import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@sharedConstants/defaultDates';
-import { setDateToToday, setTimeToZeroHour } from '@appServices/utilities/date';
+import { setDateToToday, setTimeToZeroHour, setDefaultTime } from '@appServices/utilities/date';
+import { useMemo, useCallback } from 'react';
 
 type DateFormConfig = EspressoFormProps<DateFormShape>;
 
 const FIELD_NAMES: Array<keyof Datetime> = ['id', 'name', 'description', 'capacity', 'isTrashed'];
 
 const useDateFormConfig = (id: EntityId, config?: EspressoFormProps): DateFormConfig => {
-	const { startDate: start, endDate: end, ...restProps } = useDatetimeItem({ id }) || {};
+	const datetime = useDatetimeItem({ id });
 
 	const { siteTimeToUtc, utcToSiteTime } = useTimeZoneTime();
 
-	const startDate = start ? utcToSiteTime(parseISO(start)) : PLUS_ONE_MONTH;
-	const endDate = end ? utcToSiteTime(parseISO(end)) : PLUS_TWO_MONTHS;
+	const startDate = useMemoStringify(
+		datetime?.startDate ? utcToSiteTime(parseISO(datetime?.startDate)) : setDefaultTime(PLUS_ONE_MONTH, 'start')
+	);
+	const endDate = useMemoStringify(
+		datetime?.endDate ? utcToSiteTime(parseISO(datetime?.endDate)) : setDefaultTime(PLUS_ONE_MONTH, 'end')
+	);
 
 	const { onSubmit } = config;
 
-	const onSubmitFrom: DateFormConfig['onSubmit'] = ({ dateTime, ...rest }, form, ...restParams) => {
-		// convert "dateTime" object to proper UTC "startDate" and "endDate"
-		const { startDate, endDate } = processDateAndTime(dateTime, siteTimeToUtc);
+	const onSubmitFrom: DateFormConfig['onSubmit'] = useCallback(
+		({ dateTime, ...rest }, form, ...restParams) => {
+			// convert "dateTime" object to proper UTC "startDate" and "endDate"
+			const { startDate, endDate } = processDateAndTime(dateTime, siteTimeToUtc);
 
-		const values = { ...rest, startDate, endDate };
+			const values = { ...rest, startDate, endDate };
 
-		return onSubmit(values, form, ...restParams);
-	};
-
-	const initialValues: DateFormShape = {
-		...pick<Partial<Datetime>, keyof Datetime>(FIELD_NAMES, restProps),
-		dateTime: {
-			/**
-			 * for validations, we need to make
-			 * - time same for dates
-			 * - date same for times
-			 * ¯\_(ツ)_/¯
-			 */
-			startDate: setTimeToZeroHour(startDate),
-			startTime: setDateToToday(startDate),
-			endDate: setTimeToZeroHour(endDate),
-			endTime: setDateToToday(endDate),
+			return onSubmit(values, form, ...restParams);
 		},
-	};
+		[onSubmit, siteTimeToUtc]
+	);
 
-	const adjacentFormItemProps = {
+	const initialValues: DateFormShape = useMemo(
+		() => ({
+			...pick<Partial<Datetime>, keyof Datetime>(FIELD_NAMES, datetime || {}),
+			dateTime: {
+				/**
+				 * for validations, we need to make
+				 * - time same for dates
+				 * - date same for times
+				 * ¯\_(ツ)_/¯
+				 */
+				startDate: setTimeToZeroHour(startDate),
+				startTime: setDateToToday(startDate),
+				endDate: setTimeToZeroHour(endDate),
+				endTime: setDateToToday(endDate),
+			},
+		}),
+		[datetime, endDate, startDate]
+	);
+
+	const adjacentFormItemProps = useMemoStringify({
 		className: 'ee-form-item-pair',
-	};
+	});
 
-	return {
-		...config,
-		onSubmit: onSubmitFrom,
-		initialValues,
-		validate,
-		layout: 'horizontal',
-		debugFields: ['values', 'errors'],
-		sections: [
-			{
-				name: 'basics',
-				icon: ProfileOutlined,
-				title: __('Basics'),
-				fields: [
-					{
-						name: 'name',
-						label: __('Name'),
-						fieldType: 'text',
-						required: true,
-						min: 3,
-					},
-					{
-						name: 'description',
-						label: __('Description'),
-						fieldType: 'textarea',
-					},
-				],
-			},
-			{
-				name: 'dateTime',
-				icon: CalendarOutlined,
-				title: __('Date & Time'),
-				fields: [
-					{
-						name: 'dateTime',
-						label: '',
-						fieldType: 'group',
-						subFields: [
-							{
-								name: 'startDate',
-								label: __('Start Date'),
-								fieldType: 'datepicker',
-								required: true,
-							},
-							{
-								name: 'startTime',
-								label: __('Start Time'),
-								fieldType: 'timepicker',
-								required: true,
-							},
-							{
-								name: 'endDate',
-								label: __('End Date'),
-								fieldType: 'datepicker',
-								required: true,
-							},
-							{
-								name: 'endTime',
-								label: __('End Time'),
-								fieldType: 'timepicker',
-								required: true,
-							},
-						],
-					},
-				],
-			},
-			{
-				name: 'details',
-				icon: ControlOutlined,
-				title: __('Details'),
-				fields: [
-					{
-						name: 'capacity',
-						label: __('Capacity'),
-						fieldType: 'number',
-						parseAsInfinity: true,
-						min: -1,
-						info: sprintf(
-							__(
-								'The maximum number of registrants that can attend the event at this particular date.%sSet to 0 to close registration or leave blank for no limit.'
+	return useMemo(
+		() => ({
+			...config,
+			onSubmit: onSubmitFrom,
+			initialValues,
+			validate,
+			layout: 'horizontal',
+			debugFields: ['values', 'errors'],
+			sections: [
+				{
+					name: 'basics',
+					icon: ProfileOutlined,
+					title: __('Basics'),
+					fields: [
+						{
+							name: 'name',
+							label: __('Name'),
+							fieldType: 'text',
+							required: true,
+							min: 3,
+						},
+						{
+							name: 'description',
+							label: __('Description'),
+							fieldType: 'textarea',
+						},
+					],
+				},
+				{
+					name: 'dateTime',
+					icon: CalendarOutlined,
+					title: __('Date & Time'),
+					fields: [
+						{
+							name: 'dateTime',
+							label: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'startDate',
+									label: __('Start Date'),
+									fieldType: 'datepicker',
+									required: true,
+								},
+								{
+									name: 'startTime',
+									label: __('Start Time'),
+									fieldType: 'timepicker',
+									required: true,
+								},
+								{
+									name: 'endDate',
+									label: __('End Date'),
+									fieldType: 'datepicker',
+									required: true,
+								},
+								{
+									name: 'endTime',
+									label: __('End Time'),
+									fieldType: 'timepicker',
+									required: true,
+								},
+							],
+						},
+					],
+				},
+				{
+					name: 'details',
+					icon: ControlOutlined,
+					title: __('Details'),
+					fields: [
+						{
+							name: 'capacity',
+							label: __('Capacity'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							min: -1,
+							info: sprintf(
+								__(
+									'The maximum number of registrants that can attend the event at this particular date.%sSet to 0 to close registration or leave blank for no limit.'
+								),
+								'\n'
 							),
-							'\n'
-						),
-						formControlProps: adjacentFormItemProps,
-					},
-					{
-						name: 'isTrashed',
-						label: __('Trash'),
-						fieldType: 'switch',
-						formControlProps: adjacentFormItemProps,
-					},
-				],
-			},
-		],
-	};
+							formControlProps: adjacentFormItemProps,
+						},
+						{
+							name: 'isTrashed',
+							label: __('Trash'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
+						},
+					],
+				},
+			],
+		}),
+		[adjacentFormItemProps, config, initialValues, onSubmitFrom]
+	);
 };
 
 export default useDateFormConfig;

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -9,11 +9,11 @@ import useTicketItem from '@edtrServices/apollo/queries/tickets/useTicketItem';
 import { Ticket } from '@edtrServices/apollo/types';
 import { EntityId } from '@dataServices/types';
 import { processDateAndTime } from '@sharedServices/utils/dateAndTime';
-import { validate } from './formValidation';
-import { TicketFormShape } from './types';
 import { useTimeZoneTime, useMemoStringify } from '@appServices/hooks';
 import { PLUS_ONE_MONTH } from '@sharedConstants/defaultDates';
 import { setDateToToday, setTimeToZeroHour, setDefaultTime } from '@appServices/utilities/date';
+import { validate } from './formValidation';
+import { TicketFormShape } from './types';
 
 type TicketFormConfig = EspressoFormProps<TicketFormShape>;
 

--- a/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
+++ b/assets/src/domain/eventEditor/ui/tickets/ticketForm/useTicketFormConfig.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { pick } from 'ramda';
 import { parseISO } from 'date-fns';
@@ -9,12 +9,11 @@ import useTicketItem from '@edtrServices/apollo/queries/tickets/useTicketItem';
 import { Ticket } from '@edtrServices/apollo/types';
 import { EntityId } from '@dataServices/types';
 import { processDateAndTime } from '@sharedServices/utils/dateAndTime';
-import TicketPriceCalculatorButton from '../ticketPriceCalculator/buttons/TicketPriceCalculatorButton';
 import { validate } from './formValidation';
 import { TicketFormShape } from './types';
 import { useTimeZoneTime, useMemoStringify } from '@appServices/hooks';
-import { PLUS_ONE_MONTH, PLUS_TWO_MONTHS } from '@sharedConstants/defaultDates';
-import { setDateToToday, setTimeToZeroHour } from '@appServices/utilities/date';
+import { PLUS_ONE_MONTH } from '@sharedConstants/defaultDates';
+import { setDateToToday, setTimeToZeroHour, setDefaultTime } from '@appServices/utilities/date';
 
 type TicketFormConfig = EspressoFormProps<TicketFormShape>;
 
@@ -34,193 +33,206 @@ const FIELD_NAMES: Array<keyof Ticket> = [
 ];
 
 const useTicketFormConfig = (id: EntityId, config?: EspressoFormProps): TicketFormConfig => {
-	const { startDate: start, endDate: end, ...restProps } = useTicketItem({ id }) || {};
+	const ticket = useTicketItem({ id });
 
 	const { siteTimeToUtc, utcToSiteTime } = useTimeZoneTime();
 
-	const startDate = start ? utcToSiteTime(parseISO(start)) : PLUS_ONE_MONTH;
-	const endDate = end ? utcToSiteTime(parseISO(end)) : PLUS_TWO_MONTHS;
+	const startDate = useMemoStringify(
+		ticket?.startDate ? utcToSiteTime(parseISO(ticket?.startDate)) : setDefaultTime(PLUS_ONE_MONTH, 'start')
+	);
+	const endDate = useMemoStringify(
+		ticket?.endDate ? utcToSiteTime(parseISO(ticket?.endDate)) : setDefaultTime(PLUS_ONE_MONTH, 'end')
+	);
 
 	const { onSubmit } = config;
 
-	const onSubmitFrom: TicketFormConfig['onSubmit'] = ({ dateTime, ...rest }, form, ...restParams) => {
-		// convert "dateTime" object to proper UTC "startDate" and "endDate"
-		const { startDate, endDate } = processDateAndTime(dateTime, siteTimeToUtc);
+	const onSubmitFrom: TicketFormConfig['onSubmit'] = useCallback(
+		({ dateTime, ...rest }, form, ...restParams) => {
+			// convert "dateTime" object to proper UTC "startDate" and "endDate"
+			const { startDate, endDate } = processDateAndTime(dateTime, siteTimeToUtc);
 
-		const values = { ...rest, startDate, endDate };
+			const values = { ...rest, startDate, endDate };
 
-		return onSubmit(values, form, ...restParams);
-	};
+			return onSubmit(values, form, ...restParams);
+		},
+		[onSubmit, siteTimeToUtc]
+	);
 
 	const adjacentFormItemProps = useMemoStringify({
 		className: 'ee-form-item-pair',
 	});
 
-	const initialValues: TicketFormShape = {
-		...pick<Omit<Partial<Ticket>, 'prices'>, keyof Ticket>(FIELD_NAMES, restProps),
-		dateTime: {
-			/**
-			 * for validations, we need to make
-			 * - time same for dates
-			 * - date same for times
-			 * ¯\_(ツ)_/¯
-			 */
-			startDate: setTimeToZeroHour(startDate),
-			startTime: setDateToToday(startDate),
-			endDate: setTimeToZeroHour(endDate),
-			endTime: setDateToToday(endDate),
-		},
-	};
+	const initialValues: TicketFormShape = useMemo(
+		() => ({
+			...pick<Omit<Partial<Ticket>, 'prices'>, keyof Ticket>(FIELD_NAMES, ticket || {}),
+			dateTime: {
+				/**
+				 * for validations, we need to make
+				 * - time same for dates
+				 * - date same for times
+				 * ¯\_(ツ)_/¯
+				 */
+				startDate: setTimeToZeroHour(startDate),
+				startTime: setDateToToday(startDate),
+				endDate: setTimeToZeroHour(endDate),
+				endTime: setDateToToday(endDate),
+			},
+		}),
+		[endDate, startDate, ticket]
+	);
 
-	return {
-		...config,
-		onSubmit: onSubmitFrom,
-		initialValues,
-		validate,
-		layout: 'horizontal',
-		debugFields: ['values', 'errors'],
-		sections: [
-			{
-				name: 'basics',
-				icon: ProfileOutlined,
-				title: __('Basics'),
-				fields: [
-					{
-						name: 'name',
-						label: __('Name'),
-						fieldType: 'text',
-						min: 3,
-						required: true,
-					},
-					{
-						name: 'description',
-						label: __('Description'),
-						fieldType: 'textarea',
-					},
-				],
-			},
-			{
-				name: 'sales',
-				icon: CalendarOutlined,
-				title: __('Ticket Sales'),
-				fields: [
-					{
-						name: 'dateTime',
-						label: '',
-						fieldType: 'group',
-						subFields: [
-							{
-								name: 'startDate',
-								label: __('Start Date'),
-								fieldType: 'datepicker',
-								required: true,
-							},
-							{
-								name: 'startTime',
-								label: __('Start Time'),
-								fieldType: 'timepicker',
-								required: true,
-							},
-							{
-								name: 'endDate',
-								label: __('End Date'),
-								fieldType: 'datepicker',
-								required: true,
-							},
-							{
-								name: 'endTime',
-								label: __('End Time'),
-								fieldType: 'timepicker',
-								required: true,
-							},
-						],
-					},
-				],
-			},
-			{
-				name: 'details',
-				icon: ControlOutlined,
-				title: __('Details'),
-				fields: [
-					{
-						name: 'quantity',
-						label: __('Quantity For Sale'),
-						fieldType: 'number',
-						formControlProps: adjacentFormItemProps,
-						parseAsInfinity: true,
-						min: -1,
-						info: sprintf(
-							__(
-								'The maximum number of this ticket available for sale.%sSet to 0 to stop sales, or leave blank for no limit.'
+	return useMemo(
+		() => ({
+			...config,
+			onSubmit: onSubmitFrom,
+			initialValues,
+			validate,
+			layout: 'horizontal',
+			debugFields: ['values', 'errors'],
+			sections: [
+				{
+					name: 'basics',
+					icon: ProfileOutlined,
+					title: __('Basics'),
+					fields: [
+						{
+							name: 'name',
+							label: __('Name'),
+							fieldType: 'text',
+							min: 3,
+							required: true,
+						},
+						{
+							name: 'description',
+							label: __('Description'),
+							fieldType: 'textarea',
+						},
+					],
+				},
+				{
+					name: 'sales',
+					icon: CalendarOutlined,
+					title: __('Ticket Sales'),
+					fields: [
+						{
+							name: 'dateTime',
+							label: '',
+							fieldType: 'group',
+							subFields: [
+								{
+									name: 'startDate',
+									label: __('Start Date'),
+									fieldType: 'datepicker',
+									required: true,
+								},
+								{
+									name: 'startTime',
+									label: __('Start Time'),
+									fieldType: 'timepicker',
+									required: true,
+								},
+								{
+									name: 'endDate',
+									label: __('End Date'),
+									fieldType: 'datepicker',
+									required: true,
+								},
+								{
+									name: 'endTime',
+									label: __('End Time'),
+									fieldType: 'timepicker',
+									required: true,
+								},
+							],
+						},
+					],
+				},
+				{
+					name: 'details',
+					icon: ControlOutlined,
+					title: __('Details'),
+					fields: [
+						{
+							name: 'quantity',
+							label: __('Quantity For Sale'),
+							fieldType: 'number',
+							formControlProps: adjacentFormItemProps,
+							parseAsInfinity: true,
+							min: -1,
+							info: sprintf(
+								__(
+									'The maximum number of this ticket available for sale.%sSet to 0 to stop sales, or leave blank for no limit.'
+								),
+								'\n'
 							),
-							'\n'
-						),
-					},
-					{
-						name: 'uses',
-						label: __('Number of Uses'),
-						fieldType: 'number',
-						parseAsInfinity: true,
-						formControlProps: adjacentFormItemProps,
-						min: 0,
-						info: sprintf(
-							__(
-								'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.%sExample: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
+						},
+						{
+							name: 'uses',
+							label: __('Number of Uses'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							formControlProps: adjacentFormItemProps,
+							min: 0,
+							info: sprintf(
+								__(
+									'Controls the total number of times this ticket can be used, regardless of the number of dates it is assigned to.%sExample: A ticket might have access to 4 different dates, but setting this field to 2 would mean that the ticket could only be used twice. Leave blank for no limit.'
+								),
+								'\n'
 							),
-							'\n'
-						),
-					},
-					{
-						name: 'min',
-						label: __('Minimum Quantity'),
-						fieldType: 'number',
-						formControlProps: adjacentFormItemProps,
-						min: 0,
-						info: sprintf(
-							__(
-								'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sLeave blank for no minimum.'
+						},
+						{
+							name: 'min',
+							label: __('Minimum Quantity'),
+							fieldType: 'number',
+							formControlProps: adjacentFormItemProps,
+							min: 0,
+							info: sprintf(
+								__(
+									'The minimum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sLeave blank for no minimum.'
+								),
+								'\n'
 							),
-							'\n'
-						),
-					},
-					{
-						name: 'max',
-						label: __('Maximum Quantity'),
-						fieldType: 'number',
-						parseAsInfinity: true,
-						formControlProps: adjacentFormItemProps,
-						min: -1,
-						info: sprintf(
-							__(
-								'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sLeave blank for no maximum.'
+						},
+						{
+							name: 'max',
+							label: __('Maximum Quantity'),
+							fieldType: 'number',
+							parseAsInfinity: true,
+							formControlProps: adjacentFormItemProps,
+							min: -1,
+							info: sprintf(
+								__(
+									'The maximum quantity that can be selected for this ticket. Use this to create ticket bundles or graduated pricing.%sLeave blank for no maximum.'
+								),
+								'\n'
 							),
-							'\n'
-						),
-					},
-					{
-						name: 'isRequired',
-						label: __('Required Ticket'),
-						fieldType: 'switch',
-						formControlProps: adjacentFormItemProps,
-						info: __('If enabled, the ticket will appear first in frontend ticket lists.'),
-					},
-					{
-						name: 'isDefault',
-						label: __('Default Ticket'),
-						fieldType: 'switch',
-						formControlProps: adjacentFormItemProps,
-						info: __('If enabled, the ticket will appear on all new events.'),
-					},
-					{
-						name: 'isTrashed',
-						label: __('Trash'),
-						fieldType: 'switch',
-						formControlProps: adjacentFormItemProps,
-					},
-				],
-			},
-		],
-	};
+						},
+						{
+							name: 'isRequired',
+							label: __('Required Ticket'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
+							info: __('If enabled, the ticket will appear first in frontend ticket lists.'),
+						},
+						{
+							name: 'isDefault',
+							label: __('Default Ticket'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
+							info: __('If enabled, the ticket will appear on all new events.'),
+						},
+						{
+							name: 'isTrashed',
+							label: __('Trash'),
+							fieldType: 'switch',
+							formControlProps: adjacentFormItemProps,
+						},
+					],
+				},
+			],
+		}),
+		[adjacentFormItemProps, config, initialValues, onSubmitFrom]
+	);
 };
 
 export default useTicketFormConfig;


### PR DESCRIPTION
This PR changes the default values for start and end dates for dates and tickets

- Start date: One month from now `@8am`
- End date: One month from now `@5pm`

This PR also adds memoization to form config hooks

Closes #3089