### PR TITLE
Convert WP PHP Date & Time Formats to Unicode for DOM Data

### DIFF
--- a/core/domain/entities/routing/data_nodes/core/GeneralSettings.php
+++ b/core/domain/entities/routing/data_nodes/core/GeneralSettings.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\domain\entities\routing\data_nodes\core;
 
+use EventEspresso\core\services\converters\date_time_formats\PhpToUnicode;
 use EventEspresso\core\services\json\JsonDataNode;
 use EventEspresso\core\services\json\JsonDataNodeValidator;
 
@@ -17,12 +18,19 @@ class GeneralSettings extends JsonDataNode
 
     const NODE_NAME = 'generalSettings';
 
+    /**
+     * @var PhpToUnicode $converter
+    */
+    private $converter;
+
 
     /**
      * @param JsonDataNodeValidator $validator
+     * @param PhpToUnicode $converter
      */
-    public function __construct(JsonDataNodeValidator $validator)
+    public function __construct(JsonDataNodeValidator $validator, PhpToUnicode $converter)
     {
+        $this->converter = $converter;
         parent::__construct($validator);
         $this->setNodeName(GeneralSettings::NODE_NAME);
     }
@@ -33,8 +41,12 @@ class GeneralSettings extends JsonDataNode
      */
     public function initialize()
     {
-        $this->addData('dateFormat', get_option('date_format'));
-        $this->addData('timeFormat', get_option('time_format'));
+        $wpDateFormat = get_option('date_format');
+        $wpTimeFormat = get_option('time_format');
+        $this->addData('wpDateFormat', $wpDateFormat);
+        $this->addData('wpTimeFormat', $wpTimeFormat);
+        $this->addData('dateFormat', $this->converter->convertDateFormat($wpDateFormat));
+        $this->addData('timeFormat', $this->converter->convertTimeFormat($wpTimeFormat));
         $this->addData('timezone', get_option('timezone_string'));
         $this->addData('__typename', 'GeneralSettings');
         $this->setInitialized(true);

--- a/core/domain/entities/routing/handlers/shared/RegularRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RegularRequests.php
@@ -29,7 +29,6 @@ class RegularRequests extends PrimaryRoute
         $basic_nodes = [
             'EventEspresso\core\domain\entities\routing\data_nodes\core\Api',
             'EventEspresso\core\domain\entities\routing\data_nodes\core\CurrentUser',
-            'EventEspresso\core\domain\entities\routing\data_nodes\core\GeneralSettings',
             'EventEspresso\core\domain\entities\routing\data_nodes\core\Locale',
             'EventEspresso\core\domain\entities\routing\data_nodes\core\SiteUrls',
         ];
@@ -39,6 +38,13 @@ class RegularRequests extends PrimaryRoute
                 ['EventEspresso\core\services\json\JsonDataNodeValidator' => EE_Dependency_Map::load_from_cache]
             );
         }
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\entities\routing\data_nodes\core\GeneralSettings',
+            [
+                'EventEspresso\core\services\json\JsonDataNodeValidator'                => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\converters\date_time_formats\PhpToUnicode' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\data_nodes\EventEspressoData',
             [

--- a/core/services/converters/date_time_formats/PhpToUnicode.php
+++ b/core/services/converters/date_time_formats/PhpToUnicode.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace EventEspresso\core\services\converters\date_time_formats;
+
+
+class PhpToUnicode
+{
+    /**
+     * array where keys are PHP date format parameters
+     * and values are Unicode Date Format substitutions
+     */
+    static $date_formats = [
+        // YEAR
+        'y' => 'YY',    // 00, 01, ..., 99
+        'Y' => 'YYYY',  // 2000, 2001, ..., 2099
+        'o' => 'GGGG',  // ISO "week-numbering year" 2000, 2001, ..., 2099
+        // MONTH
+        'n' => 'M',     // 1, 2, ..., 12
+        'm' => 'MM',    // 01, 02, ..., 12
+        'M' => 'MMM',   // Jan, Feb, ..., Dec
+        'F' => 'MMMM',  // January, February, ..., December
+        // DAY
+        'jS' => 'do',   // 1st, 2nd, ..., 31st
+        'j' => 'D',     // 1, 2, ..., 31
+        'd' => 'DD',    // 01, 02, ..., 31
+        'D' => 'ddd',   // Sun, Mon, ..., Sat
+        'l' => 'dddd',  // Sunday, Monday, ..., Saturday
+        'N' => 'E',     // Day of week 0, 1, ..., 6
+        'w' => 'd',     // ISO Day of week 1, 2, ..., 7
+        'z' => 'DDD',   // day of the year 0 - 365 to 1 - 366
+    ];
+
+
+    /**
+     * array where keys are PHP time format parameters
+     * and values are Unicode Time Format substitutions
+     */
+    static $time_formats = [
+        // HOUR
+        'g' => 'h',     // 1, 2, ..., 12
+        'h' => 'hh',    // 01, 02, ..., 12
+        'G' => 'H',     // 0, 1, ... 23
+        'H' => 'HH',    // 00, 01, ... 23
+        // MINUTES & SECONDS
+        'i' => 'mm',    // 00, 01, ..., 59
+        's' => 'ss',    // 00, 01, ..., 59
+        'v' => 'SSS',   // milliseconds 000, 001, ..., 999
+        'u' => 'SSS',   // microseconds (not in unicode) 000, 001, ..., 999
+    ];
+
+
+    /**
+     * array where keys are PHP timezone format parameters
+     * and values are Unicode Timezone Format substitutions
+     */
+    static $timezone_formats = [
+        'e' => 'Z',     // Timezone identifier UTC, GMT, Atlantic/Azores to -01:00, +00:00, ... +12:00
+        'T' => 'Z',     // Timezone abbreviation EST, MDT to -01:00, +00:00, ... +12:00
+        'P' => 'Z',     // -01:00, +00:00, ... +12:00
+        'O' => 'ZZ',    // -0100, +0000, ..., +1200
+        'Z' => 'ZZ',    // -0100, +0000, ..., +1200
+    ];
+
+
+    /**
+     * @param string $date_format
+     * @return string
+     */
+    public function convertDateFormat($date_format)
+    {
+        foreach (PhpToUnicode::$date_formats as $find => $replace) {
+            $date_format = (string) str_replace($find, $replace, $date_format);
+        }
+        return $date_format;
+    }
+
+
+    /**
+     * @param string $time_format
+     * @return string
+     */
+    public function convertTimeFormat($time_format)
+    {
+        foreach (PhpToUnicode::$time_formats as $find => $replace) {
+            $time_format = (string) str_replace($find, $replace, $time_format);
+        }
+        // and just in case the timezone has been added
+        foreach (PhpToUnicode::$timezone_formats as $find => $replace) {
+            $time_format = (string) str_replace($find, $replace, $time_format);
+        }
+        return $time_format;
+    }
+}


### PR DESCRIPTION
see https://github.com/eventespresso/barista/issues/197#issuecomment-676675829

does what the title says

resulting data schema looks something like this:

```
eventEspressoData.config.generalSettings = {
	dateFormat:		"MMMM ddd, YYYY"
	timeFormat: 	"hh:mm a"
	timezone: 		"America/Vancouver"
	wpDateFormat: 	"F j, Y"
	wpTimeFormat: 	"g:i a"
}
```

will work on unit tests for this on Friday