### PR TITLE
Only load .php files when dynamically loading classes

### DIFF
--- a/core/helpers/EEH_File.helper.php
+++ b/core/helpers/EEH_File.helper.php
@@ -587,7 +587,7 @@ class EEH_File extends EEH_Base implements EEHI_File
         foreach ($folder_paths as $folder_path) {
             $folder_path = self::standardise_and_end_with_directory_separator($folder_path);
             // load WP_Filesystem and set file permissions
-            $files_in_folder = glob($folder_path . '*');
+            $files_in_folder = glob($folder_path . '*.php');
             $class_to_folder_path = array();
             if ($files_in_folder) {
                 foreach ($files_in_folder as $file_path) {


### PR DESCRIPTION
## Problem this Pull Request solves
This branch prevents fatal errors when `error_log` or `.{something}` files (basically any file that isn't .PHP) are added to EE's/Add-ons directories.

We've had a few instances of `error_log` files being created in every directory of EE, notably on GoDaddy servers but it really could be any I guess. (It looks like its from some kind of scan happening on every file but rather than logging them in a single location they throw them local to the file itself, yay)

## How has this been tested
Annoyingly the error isn't thrown for me locally when I test this but if I add an error_log file to one of my test sites in `/eea-promotions/core/db_class_extensions/` or `/db_models/` just loading /wp-admin gives me fatal errors.

So add an error_log to the promotions add-on in /eea-promotions/core/db_class_extensions/ with master. You should get a fatal error on /wp-admin/

Now switch to this branch and confirm the error is no longer thrown.

@tn3rb can you think of anything specific to test with this? I'm guessing if this broke it would be pretty obvious, right?

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
