### PR TITLE
Add session_write_close() directly after any time we call start_session()

### DIFF
--- a/core/services/session/SessionStartHandler.php
+++ b/core/services/session/SessionStartHandler.php
@@ -63,6 +63,7 @@ class SessionStartHandler
                 $this->checkCustomSessionSaveHandler();
             } else {
                 session_start();
+                session_write_close();
             }
         }
     }
@@ -95,6 +96,7 @@ class SessionStartHandler
         // on a previous request then just start the session
         if ($this->sessionSaveHandlerIsValid()) {
             session_start();
+            session_write_close();
             return;
         }
         // If not, then attempt to deal with any errors,
@@ -107,6 +109,7 @@ class SessionStartHandler
         $this->initializeSessionSaveHandlerStatus();
         // hold your breath, the custom session save handler might cause a fatal here...
         session_start();
+        session_write_close();
         // phew! we made it! the custom session handler is a-ok
         $this->setSessionSaveHandlerStatusToValid();
     }


### PR DESCRIPTION
See: https://core.trac.wordpress.org/ticket/47320

WP5.5 added a 'session check' to Site Health, users are asking why they are getting this notice now:

https://monosnap.com/file/GwlHOkbNUAc8851HLpfdr5pI7uvR66

As we don't actually write to the session and just use the ID I've just added `session_write_close()` directly after any session_start() call.

## How has this been tested
In master go to Tools -> Site Health.
With EE active you should see a notice about how an active PHP session has been detected.

Switch to this branch and confirm that no longer shows.

With this branch confirm that adding registrations on the front end and admin works, and using MER you can add various tickets to your cart from different events and then checkout without an issue.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
