### PR TITLE
Fix SPCO Copy Attendee Data Closes #3102

### DIFF
--- a/core/domain/entities/routing/handlers/shared/AssetRequests.php
+++ b/core/domain/entities/routing/handlers/shared/AssetRequests.php
@@ -3,6 +3,9 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
+use EventEspresso\core\domain\services\assets\CoreAssetManager;
+use EventEspresso\core\domain\services\assets\JqueryAssetManager;
+use EventEspresso\core\domain\services\assets\ReactAssetManager;
 use EventEspresso\core\services\assets\Barista;
 use EventEspresso\core\services\routing\Route;
 
@@ -42,12 +45,10 @@ class AssetRequests extends Route
             'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_new_object,
             'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
         ];
+        $this->dependency_map->registerDependencies(JqueryAssetManager::class, $default_dependencies);
+        $this->dependency_map->registerDependencies(ReactAssetManager::class, $default_dependencies);
         $this->dependency_map->registerDependencies(
-            'EventEspresso\core\domain\services\assets\ReactAssetManager',
-            $default_dependencies
-        );
-        $this->dependency_map->registerDependencies(
-            'EventEspresso\core\domain\services\assets\CoreAssetManager',
+            CoreAssetManager::class,
             [
                 'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_new_object,
                 'EE_Currency_Config'                                 => EE_Dependency_Map::load_from_cache,
@@ -117,7 +118,8 @@ class AssetRequests extends Route
             $barista->initialize();
             $this->loader->getShared('EventEspresso\core\services\assets\Registry');
         }
-        $this->loader->getShared('EventEspresso\core\domain\services\assets\CoreAssetManager');
+        $this->loader->getShared(JqueryAssetManager::class);
+        $this->loader->getShared(CoreAssetManager::class);
         if ($this->canLoadBlocks()) {
             $this->loader->getShared(
                 'EventEspresso\core\services\editor\BlockRegistrationManager'

--- a/core/domain/services/assets/CoreAssetManager.php
+++ b/core/domain/services/assets/CoreAssetManager.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\services\assets;
 
 use DomainException;
 use EE_Currency_Config;
+use EE_Registry;
 use EE_Template_Config;
 use EED_Core_Rest_Api;
 use EEH_DTT_Helper;
@@ -33,16 +34,16 @@ class CoreAssetManager extends AssetManager
     // WordPress core / Third party JS asset handles
     const JS_HANDLE_JS_CORE = 'eejs-core';
 
-    const JS_HANDLE_CORE = 'espresso_core';
+    const JS_HANDLE_CORE    = 'espresso_core';
 
-    const JS_HANDLE_I18N = 'eei18n';
+    const JS_HANDLE_I18N    = 'eei18n';
 
-    const JS_HANDLE_VENDOR = 'eventespresso-vendor';
+    const JS_HANDLE_VENDOR  = 'eventespresso-vendor';
 
     // EE CSS assets handles
     const CSS_HANDLE_DEFAULT = 'espresso_default';
 
-    const CSS_HANDLE_CUSTOM = 'espresso_custom_css';
+    const CSS_HANDLE_CUSTOM  = 'espresso_custom_css';
 
     /**
      * @var EE_Currency_Config $currency_config
@@ -78,13 +79,13 @@ class CoreAssetManager extends AssetManager
 
 
     /**
-     * @since 4.9.62.p
      * @throws DomainException
      * @throws DuplicateCollectionIdentifierException
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidEntityException
      * @throws InvalidInterfaceException
+     * @since 4.9.62.p
      */
     public function addAssets()
     {
@@ -94,13 +95,13 @@ class CoreAssetManager extends AssetManager
 
 
     /**
-     * @since 4.9.62.p
      * @throws DomainException
      * @throws DuplicateCollectionIdentifierException
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidEntityException
      * @throws InvalidInterfaceException
+     * @since 4.9.62.p
      */
     public function addJavascriptFiles()
     {
@@ -110,23 +111,23 @@ class CoreAssetManager extends AssetManager
         $this->registry->addData('eejs_api_nonce', wp_create_nonce('wp_rest'));
         $this->registry->addData(
             'paths',
-            array(
-                'base_rest_route' => rest_url(),
-                'rest_route' => rest_url('ee/v4.8.36/'),
+            [
+                'base_rest_route'      => rest_url(),
+                'rest_route'           => rest_url('ee/v4.8.36/'),
                 'collection_endpoints' => EED_Core_Rest_Api::getCollectionRoutesIndexedByModelName(),
-                'primary_keys' => EED_Core_Rest_Api::getPrimaryKeyNamesIndexedByModelName(),
-                'site_url' => site_url('/'),
-                'admin_url' => admin_url('/'),
-            )
+                'primary_keys'         => EED_Core_Rest_Api::getPrimaryKeyNamesIndexedByModelName(),
+                'site_url'             => site_url('/'),
+                'admin_url'            => admin_url('/'),
+            ]
         );
         // Event Espresso brand name
         $this->registry->addData('brandName', Domain::brandName());
         /** site formatting values **/
         $this->registry->addData(
             'site_formats',
-            array(
-                'date_formats' => EEH_DTT_Helper::convert_php_to_js_and_moment_date_formats()
-            )
+            [
+                'date_formats' => EEH_DTT_Helper::convert_php_to_js_and_moment_date_formats(),
+            ]
         );
         /** currency data **/
         $this->registry->addData(
@@ -136,25 +137,33 @@ class CoreAssetManager extends AssetManager
         /** site timezone */
         $this->registry->addData(
             'default_timezone',
-            array(
+            [
                 'pretty' => EEH_DTT_Helper::get_timezone_string_for_display(),
                 'string' => get_option('timezone_string'),
                 'offset' => EEH_DTT_Helper::get_site_timezone_gmt_offset(),
-            )
+            ]
         );
         /** site locale (user locale if user logged in) */
         $this->registry->addData(
             'locale',
-            array(
+            [
                 'user' => get_user_locale(),
-                'site' => get_locale()
-            )
+                'site' => get_locale(),
+            ]
         );
 
         $this->addJavascript(
             CoreAssetManager::JS_HANDLE_CORE,
             EE_GLOBAL_ASSETS_URL . 'scripts/espresso_core.js',
-            array(JqueryAssetManager::JS_HANDLE_JQUERY)
+            [JqueryAssetManager::JS_HANDLE_JQUERY]
+        )->setInlineDataCallback(
+            function() {
+                wp_localize_script(
+                    CoreAssetManager::JS_HANDLE_CORE,
+                    CoreAssetManager::JS_HANDLE_I18N,
+                    EE_Registry::$i18n_js_strings
+                );
+            }
         );
     }
 
@@ -174,38 +183,38 @@ class CoreAssetManager extends AssetManager
                 is_readable(EVENT_ESPRESSO_UPLOAD_DIR . 'css/espresso_default.css')
                     ? EVENT_ESPRESSO_UPLOAD_URL . 'css/espresso_default.css'
                     : EE_GLOBAL_ASSETS_URL . 'css/espresso_default.css',
-                array('dashicons')
+                ['dashicons']
             );
             //Load custom style sheet if available
             if ($this->template_config->custom_style_sheet !== null) {
                 $this->addStylesheet(
                     CoreAssetManager::CSS_HANDLE_CUSTOM,
                     EVENT_ESPRESSO_UPLOAD_URL . 'css/' . $this->template_config->custom_style_sheet,
-                    array(CoreAssetManager::CSS_HANDLE_DEFAULT)
+                    [CoreAssetManager::CSS_HANDLE_DEFAULT]
                 );
             }
         }
     }
 
 
-
     /**
      * Returns configuration data for the js Currency VO.
-     * @since 4.9.71.p
+     *
      * @return array
+     * @since 4.9.71.p
      */
     private function getCurrencySettings()
     {
-        return array(
-            'code' => $this->currency_config->code,
-            'singularLabel' => $this->currency_config->name,
-            'pluralLabel' => $this->currency_config->plural,
-            'sign' => $this->currency_config->sign,
-            'signB4' => $this->currency_config->sign_b4,
-            'decimalPlaces' => $this->currency_config->dec_plc,
-            'decimalMark' => $this->currency_config->dec_mrk,
+        return [
+            'code'               => $this->currency_config->code,
+            'singularLabel'      => $this->currency_config->name,
+            'pluralLabel'        => $this->currency_config->plural,
+            'sign'               => $this->currency_config->sign,
+            'signB4'             => $this->currency_config->sign_b4,
+            'decimalPlaces'      => $this->currency_config->dec_plc,
+            'decimalMark'        => $this->currency_config->dec_mrk,
             'thousandsSeparator' => $this->currency_config->thsnds,
-        );
+        ];
     }
 
 


### PR DESCRIPTION
see #3102 

This PR fixes the attendee data copy functionality on the single page checkout (SPCO) by:

- making sure that jQuery assets are always registered for all "asset" requests (HTTP web requests)

- localizes ee i18n strings for the `espresso_core` script

- auto formats the `CoreAssetManager`