### PR TITLE
Prep Barista and Asset Management for REM

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -741,7 +741,7 @@ class EE_Dependency_Map
                 'EventEspresso\core\services\routing\RouteHandler' => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\core\services\assets\AssetManifest' => [
-                'EventEspresso\core\domain\Domain'                 => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\Domain' => EE_Dependency_Map::load_from_cache,
             ],
         ];
     }
@@ -932,6 +932,7 @@ class EE_Dependency_Map
             'EventEspresso\core\services\request\ResponseInterface'                        => 'EventEspresso\core\services\request\Response',
             'EventEspresso\core\domain\DomainInterface'                                    => 'EventEspresso\core\domain\Domain',
             'Registration_Processor'                                                       => 'EE_Registration_Processor',
+            'EventEspresso\core\services\assets\AssetManifestInterface'                    => 'EventEspresso\core\services\assets\AssetManifest',
         ];
         foreach ($aliases as $alias => $fqn) {
             if (is_array($fqn)) {

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -743,6 +743,13 @@ class EE_Dependency_Map
             'EventEspresso\core\services\assets\AssetManifest' => [
                 'EventEspresso\core\domain\Domain' => EE_Dependency_Map::load_from_cache,
             ],
+            'EventEspresso\core\services\assets\AssetManifestFactory' => [
+                'EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache,
+            ],
+            'EventEspresso\core\services\assets\BaristaFactory' => [
+                'EventEspresso\core\services\assets\AssetManifestFactory' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache,
+            ],
         ];
     }
 

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -916,15 +916,7 @@ final class EE_System implements ResettableInterface
     private function _maybe_brew_regular()
     {
         /** @var Domain $domain */
-        $domain = DomainFactory::getShared(
-            new FullyQualifiedName(
-                'EventEspresso\core\domain\Domain'
-            ),
-            array(
-                new FilePath(EVENT_ESPRESSO_MAIN_FILE),
-                Version::fromString(espresso_version()),
-            )
-        );
+        $domain = DomainFactory::getEventEspressoCoreDomain();
         if ($domain->isCaffeinated()) {
             require_once EE_CAFF_PATH . 'brewing_regular.php';
         }

--- a/core/domain/DomainBase.php
+++ b/core/domain/DomainBase.php
@@ -59,6 +59,11 @@ abstract class DomainBase implements DomainInterface
      */
     private $assets_path;
 
+    /**
+     * @var bool
+     */
+    protected $initialized = false;
+
 
     /**
      * Initializes internal properties.
@@ -82,11 +87,14 @@ abstract class DomainBase implements DomainInterface
      */
     public function initialize($asset_namespace = 'eventespresso')
     {
-        $this->plugin_basename = plugin_basename($this->pluginFile());
-        $this->plugin_path     = plugin_dir_path($this->pluginFile());
-        $this->plugin_url      = plugin_dir_url($this->pluginFile());
-        $this->setAssetNamespace($asset_namespace);
-        $this->setDistributionAssetsPath();
+        if (! $this->initialized) {
+            $this->plugin_basename = plugin_basename($this->pluginFile());
+            $this->plugin_path     = plugin_dir_path($this->pluginFile());
+            $this->plugin_url      = plugin_dir_url($this->pluginFile());
+            $this->setAssetNamespace($asset_namespace);
+            $this->setDistributionAssetsPath();
+            $this->initialized = true;
+        }
     }
 
 

--- a/core/domain/DomainFactory.php
+++ b/core/domain/DomainFactory.php
@@ -67,6 +67,11 @@ class DomainFactory
     }
 
 
+    /**
+     * @param string $fqcn
+     * @param array  $arguments
+     * @return DomainInterface
+     */
     private static function getDomain($fqcn, array $arguments)
     {
         if (! isset(DomainFactory::$domains[ $fqcn ])) {

--- a/core/domain/DomainFactory.php
+++ b/core/domain/DomainFactory.php
@@ -6,7 +6,6 @@ use DomainException;
 use EventEspresso\core\domain\values\FilePath;
 use EventEspresso\core\domain\values\FullyQualifiedName;
 use EventEspresso\core\domain\values\Version;
-use EventEspresso\core\exceptions\InvalidClassException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidFilePathException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -30,13 +29,13 @@ class DomainFactory
 
 
     /**
-     * @param FullyQualifiedName $domain_fqcn   [required] Fully Qualified Class Name for the Domain class
-     * @param array $arguments                  [required] array of arguments to be passed to the Domain class
-     *                                          constructor. Must at least include the following two value objects:
-     *                                          array(
+     * @param FullyQualifiedName $domain_fqcn       [required] Fully Qualified Class Name for the Domain class
+     * @param array              $arguments         [required] array of arguments to be passed to the Domain class
+     *                                              constructor. Must at least include the following two value objects:
+     *                                              array(
      *                                              EventEspresso\core\domain\values\FilePath $plugin_file
      *                                              EventEspresso\core\domain\values\Version $version
-     *                                          )
+     *                                              )
      * @return DomainInterface
      * @throws DomainException
      * @throws InvalidArgumentException
@@ -61,16 +60,16 @@ class DomainFactory
     public static function getEventEspressoCoreDomain()
     {
         $fqcn = 'EventEspresso\core\domain\Domain';
-        if(! isset(DomainFactory::$domains[$fqcn])) {
+        if (! isset(DomainFactory::$domains[ $fqcn ])) {
             DomainFactory::getDomain($fqcn, [EVENT_ESPRESSO_MAIN_FILE, espresso_version()]);
         }
-        return DomainFactory::$domains[$fqcn];
+        return DomainFactory::$domains[ $fqcn ];
     }
 
 
     private static function getDomain($fqcn, array $arguments)
     {
-        if(! isset(DomainFactory::$domains[$fqcn])) {
+        if (! isset(DomainFactory::$domains[ $fqcn ])) {
             if (! isset($arguments[0], $arguments[1])) {
                 throw new InvalidArgumentException(
                     esc_html__(
@@ -80,8 +79,8 @@ class DomainFactory
                 );
             }
             $filepath = $arguments[0] instanceof FilePath ? $arguments[0] : new FilePath($arguments[0]);
-            $version = $arguments[1] instanceof Version ? $arguments[1] : Version::fromString($arguments[1]);
-            $domain = new $fqcn($filepath, $version);
+            $version  = $arguments[1] instanceof Version ? $arguments[1] : Version::fromString($arguments[1]);
+            $domain   = new $fqcn($filepath, $version);
             if (! $domain instanceof DomainBase || ! $domain instanceof $fqcn) {
                 throw new DomainException(
                     sprintf(

--- a/core/domain/DomainFactory.php
+++ b/core/domain/DomainFactory.php
@@ -23,6 +23,11 @@ use EventEspresso\core\services\loaders\LoaderFactory;
  */
 class DomainFactory
 {
+    /**
+     * @var DomainInterface[]
+     */
+    private static $domains = [];
+
 
     /**
      * @param FullyQualifiedName $domain_fqcn   [required] Fully Qualified Class Name for the Domain class
@@ -32,7 +37,7 @@ class DomainFactory
      *                                              EventEspresso\core\domain\values\FilePath $plugin_file
      *                                              EventEspresso\core\domain\values\Version $version
      *                                          )
-     * @return mixed
+     * @return DomainInterface
      * @throws DomainException
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -40,32 +45,13 @@ class DomainFactory
      */
     public static function getShared(FullyQualifiedName $domain_fqcn, array $arguments)
     {
-        if (! isset($arguments[0], $arguments[1])) {
-            throw new InvalidArgumentException(
-                esc_html__(
-                    'You need to pass at least two arguments, representing the addon plugin file and version, in order to generate a Domain class',
-                    'event_espresso'
-                )
-            );
-        }
-        $domain = LoaderFactory::getLoader()->getShared($domain_fqcn, $arguments);
-        if (! $domain instanceof $domain_fqcn && ! $domain instanceof DomainBase) {
-            throw new DomainException(
-                sprintf(
-                    esc_html__(
-                        'The requested Domain class "%1$s" could not be loaded.',
-                        'event_espresso'
-                    ),
-                    $domain_fqcn
-                )
-            );
-        }
-        return $domain;
+        $fqcn = $domain_fqcn->string();
+        return DomainFactory::getDomain($fqcn, $arguments);
     }
 
 
     /**
-     * @return Domain
+     * @return DomainInterface
      * @throws DomainException
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -74,11 +60,43 @@ class DomainFactory
      */
     public static function getEventEspressoCoreDomain()
     {
-        $domain = new Domain(
-            new FilePath(EVENT_ESPRESSO_MAIN_FILE),
-            Version::fromString(espresso_version())
-        );
-        LoaderFactory::getLoader()->share('EventEspresso\core\domain\Domain', $domain);
-        return $domain;
+        $fqcn = 'EventEspresso\core\domain\Domain';
+        if(! isset(DomainFactory::$domains[$fqcn])) {
+            DomainFactory::getDomain($fqcn, [EVENT_ESPRESSO_MAIN_FILE, espresso_version()]);
+        }
+        return DomainFactory::$domains[$fqcn];
+    }
+
+
+    private static function getDomain($fqcn, array $arguments)
+    {
+        if(! isset(DomainFactory::$domains[$fqcn])) {
+            if (! isset($arguments[0], $arguments[1])) {
+                throw new InvalidArgumentException(
+                    esc_html__(
+                        'You need to pass at least two arguments, representing the addon plugin file and version, in order to generate a Domain class',
+                        'event_espresso'
+                    )
+                );
+            }
+            $filepath = $arguments[0] instanceof FilePath ? $arguments[0] : new FilePath($arguments[0]);
+            $version = $arguments[1] instanceof Version ? $arguments[1] : Version::fromString($arguments[1]);
+            $domain = new $fqcn($filepath, $version);
+            if (! $domain instanceof DomainBase || ! $domain instanceof $fqcn) {
+                throw new DomainException(
+                    sprintf(
+                        esc_html__(
+                            'The requested Domain class "%1$s" could not be loaded.',
+                            'event_espresso'
+                        ),
+                        $fqcn
+                    )
+                );
+            }
+            DomainFactory::$domains[ $fqcn ] = $domain;
+            // we still need to share this with the core loader to facilitate automatic dependency injection
+            LoaderFactory::getLoader()->share($fqcn, $domain, [$filepath, $version, $domain->assetNamespace()]);
+        }
+        return DomainFactory::$domains[ $fqcn ];
     }
 }

--- a/core/domain/DomainFactory.php
+++ b/core/domain/DomainFactory.php
@@ -25,7 +25,7 @@ class DomainFactory
     /**
      * @var DomainInterface[]
      */
-    private static $domains = [];
+    protected static $domains = [];
 
 
     /**

--- a/core/domain/entities/routing/handlers/shared/AssetRequests.php
+++ b/core/domain/entities/routing/handlers/shared/AssetRequests.php
@@ -3,13 +3,13 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
-use EventEspresso\core\domain\Domain;
 use EventEspresso\core\domain\services\assets\CoreAssetManager;
 use EventEspresso\core\domain\services\assets\JqueryAssetManager;
 use EventEspresso\core\domain\services\assets\ReactAssetManager;
-use EventEspresso\core\services\assets\Barista;
 use EventEspresso\core\services\assets\BaristaFactory;
 use EventEspresso\core\services\assets\BaristaInterface;
+use EventEspresso\core\services\loaders\LoaderInterface;
+use EventEspresso\core\services\request\RequestInterface;
 use EventEspresso\core\services\routing\Route;
 
 /**
@@ -22,6 +22,31 @@ use EventEspresso\core\services\routing\Route;
  */
 class AssetRequests extends Route
 {
+
+    /**
+     * @var BaristaFactory $barista_factory
+     */
+    protected $barista_factory;
+
+
+    /**
+     * AssetRequests constructor.
+     *
+     * @param EE_Dependency_Map                $dependency_map
+     * @param LoaderInterface                  $loader
+     * @param RequestInterface                 $request
+     * @param BaristaFactory $barista_factory
+     */
+    public function __construct(
+        EE_Dependency_Map $dependency_map,
+        LoaderInterface $loader,
+        RequestInterface $request,
+        BaristaFactory $barista_factory
+    ) {
+        $this->barista_factory = $barista_factory;
+        parent::__construct($dependency_map, $loader, $request);
+    }
+
 
     /**
      * returns true if the current request matches this route
@@ -110,7 +135,7 @@ class AssetRequests extends Route
     protected function requestHandler()
     {
         if (apply_filters('FHEE__load_Barista', true)) {
-            $barista = BaristaFactory::create();
+            $barista = $this->barista_factory->create();
             if ($barista instanceof BaristaInterface) {
                 $barista->initialize();
                 $this->loader->getShared('EventEspresso\core\services\assets\Registry');

--- a/core/domain/entities/routing/handlers/shared/AssetRequests.php
+++ b/core/domain/entities/routing/handlers/shared/AssetRequests.php
@@ -3,10 +3,13 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
+use EventEspresso\core\domain\Domain;
 use EventEspresso\core\domain\services\assets\CoreAssetManager;
 use EventEspresso\core\domain\services\assets\JqueryAssetManager;
 use EventEspresso\core\domain\services\assets\ReactAssetManager;
 use EventEspresso\core\services\assets\Barista;
+use EventEspresso\core\services\assets\BaristaFactory;
+use EventEspresso\core\services\assets\BaristaInterface;
 use EventEspresso\core\services\routing\Route;
 
 /**
@@ -109,14 +112,12 @@ class AssetRequests extends Route
      */
     protected function requestHandler()
     {
-        if (apply_filters(
-            'FHEE__EventEspresso_core_domain_entities_routing_handlers_shared_AssetRequests__load_Barista',
-            true
-        )) {
-            /** @var Barista $barista */
-            $barista = $this->loader->getShared('EventEspresso\core\services\assets\Barista');
-            $barista->initialize();
-            $this->loader->getShared('EventEspresso\core\services\assets\Registry');
+        if (apply_filters('FHEE__load_Barista', true)) {
+            $barista = BaristaFactory::create(Domain::class);
+            if ($barista instanceof BaristaInterface) {
+                $barista->initialize();
+                $this->loader->getShared('EventEspresso\core\services\assets\Registry');
+            }
         }
         $this->loader->getShared(JqueryAssetManager::class);
         $this->loader->getShared(CoreAssetManager::class);

--- a/core/domain/entities/routing/handlers/shared/AssetRequests.php
+++ b/core/domain/entities/routing/handlers/shared/AssetRequests.php
@@ -92,10 +92,7 @@ class AssetRequests extends Route
                 'EventEspresso\core\domain\services\blocks\EventAttendeesBlockRenderer' => EE_Dependency_Map::load_from_cache,
             ]
         );
-        if (apply_filters(
-            'FHEE__EventEspresso_core_domain_entities_routing_handlers_shared_AssetRequests__load_Barista',
-            true
-        )) {
+        if (apply_filters('FHEE__load_Barista', true)) {
             $this->dependency_map->registerDependencies(
                 'EventEspresso\core\services\assets\Barista',
                 ['EventEspresso\core\services\assets\AssetManifest' => EE_Dependency_Map::load_from_cache]
@@ -113,7 +110,7 @@ class AssetRequests extends Route
     protected function requestHandler()
     {
         if (apply_filters('FHEE__load_Barista', true)) {
-            $barista = BaristaFactory::create(Domain::class);
+            $barista = BaristaFactory::create();
             if ($barista instanceof BaristaInterface) {
                 $barista->initialize();
                 $this->loader->getShared('EventEspresso\core\services\assets\Registry');

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
 use EventEspresso\core\services\assets\AssetManifest;
+use EventEspresso\core\services\assets\AssetManifestInterface;
 use EventEspresso\core\services\routing\Route;
 
 /**
@@ -192,7 +193,7 @@ class GQLRequests extends Route
             'EventEspresso\core\services\graphql\GraphQLManager'
         );
         $graphQL_manager->init();
-        /** @var AssetManifest $manifest */
+        /** @var AssetManifestInterface $manifest */
         $manifest = $this->loader->getShared('EventEspresso\core\services\assets\AssetManifest');
         $manifest->initialize();
         return true;

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -28,9 +28,9 @@ class GQLRequests extends Route
     /**
      * AssetRequests constructor.
      *
-     * @param EE_Dependency_Map                $dependency_map
-     * @param LoaderInterface                  $loader
-     * @param RequestInterface                 $request
+     * @param EE_Dependency_Map    $dependency_map
+     * @param LoaderInterface      $loader
+     * @param RequestInterface     $request
      * @param AssetManifestFactory $manifest_factory
      */
     public function __construct(
@@ -42,6 +42,7 @@ class GQLRequests extends Route
         $this->manifest_factory = $manifest_factory;
         parent::__construct($dependency_map, $loader, $request);
     }
+
 
     /**
      * returns true if the current request matches this route

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -3,8 +3,10 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
-use EventEspresso\core\services\assets\AssetManifest;
-use EventEspresso\core\services\assets\AssetManifestInterface;
+use EventEspresso\core\domain\DomainFactory;
+use EventEspresso\core\services\assets\AssetManifestFactory;
+use EventEspresso\core\services\loaders\LoaderInterface;
+use EventEspresso\core\services\request\RequestInterface;
 use EventEspresso\core\services\routing\Route;
 
 /**
@@ -17,6 +19,29 @@ use EventEspresso\core\services\routing\Route;
  */
 class GQLRequests extends Route
 {
+    /**
+     * @var AssetManifestFactory
+     */
+    private $manifest_factory;
+
+
+    /**
+     * AssetRequests constructor.
+     *
+     * @param EE_Dependency_Map                $dependency_map
+     * @param LoaderInterface                  $loader
+     * @param RequestInterface                 $request
+     * @param AssetManifestFactory $manifest_factory
+     */
+    public function __construct(
+        EE_Dependency_Map $dependency_map,
+        LoaderInterface $loader,
+        RequestInterface $request,
+        AssetManifestFactory $manifest_factory
+    ) {
+        $this->manifest_factory = $manifest_factory;
+        parent::__construct($dependency_map, $loader, $request);
+    }
 
     /**
      * returns true if the current request matches this route
@@ -193,8 +218,7 @@ class GQLRequests extends Route
             'EventEspresso\core\services\graphql\GraphQLManager'
         );
         $graphQL_manager->init();
-        /** @var AssetManifestInterface $manifest */
-        $manifest = $this->loader->getShared('EventEspresso\core\services\assets\AssetManifest');
+        $manifest = $this->manifest_factory->createFromDomainObject(DomainFactory::getEventEspressoCoreDomain());
         $manifest->initialize();
         return true;
     }

--- a/core/domain/entities/routing/handlers/shared/RegularRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RegularRequests.php
@@ -5,7 +5,6 @@ namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 use EE_Dependency_Map;
 use EventEspresso\core\services\routing\PrimaryRoute;
 use EventEspresso\core\services\routing\Route;
-use EventEspresso\core\services\routing\Router;
 
 /**
  * Class RoutingRequests
@@ -105,16 +104,22 @@ class RegularRequests extends PrimaryRoute
     {
         $admin = ['EE_Admin_Config' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
         $public = ['EE_Maintenance_Mode' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
+        $default_with_barista = [
+            'EventEspresso\core\services\assets\BaristaFactory' => EE_Dependency_Map::load_from_cache
+        ] + Route::$default_dependencies;
+        $default_with_manifest = [
+            'EventEspresso\core\services\assets\AssetManifestFactory' => EE_Dependency_Map::load_from_cache
+        ] + Route::$default_dependencies;
         $default_routes = [
             // default dependencies
             'EventEspresso\core\domain\entities\routing\handlers\admin\PueRequests'          => Route::$default_dependencies,
             'EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage' => Route::$default_dependencies,
             'EventEspresso\core\domain\entities\routing\handlers\frontend\ShortcodeRequests' => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\AssetRequests'       => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\GQLRequests'         => Route::$default_dependencies,
             'EventEspresso\core\domain\entities\routing\handlers\shared\RestApiRequests'     => Route::$default_dependencies,
             'EventEspresso\core\domain\entities\routing\handlers\shared\SessionRequests'     => Route::$default_dependencies,
             'EventEspresso\core\domain\entities\routing\handlers\shared\WordPressHeartbeat'  => Route::$default_dependencies,
+            'EventEspresso\core\domain\entities\routing\handlers\shared\AssetRequests'       => $default_with_barista,
+            'EventEspresso\core\domain\entities\routing\handlers\shared\GQLRequests'         => $default_with_manifest,
             // admin dependencies
             'EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute'           => $admin,
             'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin'  => $admin,

--- a/core/services/assets/AssetManifest.php
+++ b/core/services/assets/AssetManifest.php
@@ -91,6 +91,7 @@ class AssetManifest implements AssetManifestInterface
     public function __construct(DomainInterface $domain)
     {
         $this->domain = $domain;
+        $this->initialize();
     }
 
 
@@ -267,6 +268,15 @@ class AssetManifest implements AssetManifestInterface
     public function getAssetHandle($entry_point)
     {
         return $this->assets_namespace . '-' . $entry_point;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getAssetsPath()
+    {
+        return $this->assets_path;
     }
 
 

--- a/core/services/assets/AssetManifest.php
+++ b/core/services/assets/AssetManifest.php
@@ -11,7 +11,7 @@ use EventEspresso\core\domain\DomainInterface;
  * @author  Brent Christensen
  * @since   $VID:$
  */
-class AssetManifest
+class AssetManifest implements AssetManifestInterface
 {
 
     const ASSET_EXT_CSS      = '.css';

--- a/core/services/assets/AssetManifest.php
+++ b/core/services/assets/AssetManifest.php
@@ -120,7 +120,7 @@ class AssetManifest implements AssetManifestInterface
         if (! is_readable($manifest_path)) {
             throw new AssetManifestException(
                 $manifest_path,
-                AssetManifest::FILE_NAME,
+                '',
                 sprintf(
                     esc_html__(
                         'The "%1$s" file was not found or is not readable. Please verify that the file exists and has appropriate permissions.',
@@ -165,7 +165,7 @@ class AssetManifest implements AssetManifestInterface
         if (! $this->asset_files) {
             if (empty($this->manifest[ AssetManifest::KEY_FILES ])) {
                 if (WP_DEBUG) {
-                    throw new AssetManifestException(AssetManifest::KEY_FILES);
+                    throw new AssetManifestException(AssetManifest::KEY_FILES, $this->manifest_path);
                 }
                 return [];
             }
@@ -183,7 +183,7 @@ class AssetManifest implements AssetManifestInterface
         if (! $this->entry_points) {
             if (empty($this->manifest[ AssetManifest::KEY_ENTRY_POINTS ])) {
                 if (WP_DEBUG) {
-                    throw new AssetManifestException(AssetManifest::KEY_ENTRY_POINTS);
+                    throw new AssetManifestException(AssetManifest::KEY_ENTRY_POINTS, $this->manifest_path);
                 }
                 return [];
             }
@@ -252,7 +252,7 @@ class AssetManifest implements AssetManifestInterface
         $full_path = $this->assets_path . $file_name;
         if (! is_readable($full_path)) {
             if (WP_DEBUG) {
-                throw new AssetManifestException(AssetManifest::KEY_DEPENDENCIES);
+                throw new AssetManifestException(AssetManifest::KEY_DEPENDENCIES, $full_path);
             }
             return [];
         }

--- a/core/services/assets/AssetManifestException.php
+++ b/core/services/assets/AssetManifestException.php
@@ -17,38 +17,35 @@ class AssetManifestException extends DomainException
      * AssetManifestException constructor
      *
      * @param string    $entry
-     * @param string    $key
+     * @param string    $path
      * @param string    $message
      * @param int       $code
      * @param Exception $previous
      */
-    public function __construct($entry, $key = '', $message = '', $code = 0, Exception $previous = null)
+    public function __construct($entry, $path, $message = '', $code = 0, Exception $previous = null)
     {
         if (empty($message)) {
-            switch($key) {
+            switch($entry) {
                 case AssetManifest::KEY_DEPENDENCIES:
-                    $key = 'dependency';
-                    break;
-                case AssetManifest::KEY_FILES:
                     $key = 'file';
                     break;
                 case AssetManifest::KEY_VERSION:
                     $key = 'version';
                     break;
                 case AssetManifest::KEY_ENTRY_POINTS:
-                    $key = 'entry point';
-                    break;
+                case AssetManifest::KEY_FILES:
                 default:
                     $key = 'key';
             }
             $message =
                 sprintf(
                     esc_html__(
-                        'The "%1$s" %2$s was not found in the assets manifest file.',
+                        'The "%1$s" %2$s was not found in the assets manifest file at: %3$s',
                         'event_espresso'
                     ),
                     $entry,
-                    $key
+                    $key,
+                    $path
                 );
         }
         parent::__construct($message, $code, $previous);

--- a/core/services/assets/AssetManifestFactory.php
+++ b/core/services/assets/AssetManifestFactory.php
@@ -8,6 +8,12 @@ use EventEspresso\core\services\factory\FactoryInterface;
 use EventEspresso\core\services\loaders\LoaderInterface;
 use InvalidArgumentException;
 
+/**
+ * Class AssetManifestFactory
+ *
+ * @package EventEspresso\core\services\assets
+ * @since   $VID:$
+ */
 class AssetManifestFactory implements FactoryInterface
 {
     /**

--- a/core/services/assets/AssetManifestFactory.php
+++ b/core/services/assets/AssetManifestFactory.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace EventEspresso\core\services\assets;
+
+use DomainException;
+use EventEspresso\core\domain\DomainInterface;
+use EventEspresso\core\services\factory\FactoryInterface;
+use EventEspresso\core\services\loaders\LoaderInterface;
+use InvalidArgumentException;
+
+class AssetManifestFactory implements FactoryInterface
+{
+    /**
+     * @var AssetManifestInterface[]
+     */
+    private static $manifests = [];
+
+    /**
+     * @var LoaderInterface $loader
+     */
+    protected $loader;
+
+
+    /**
+     * AssetManifestFactory constructor.
+     *
+     * @param LoaderInterface $loader
+     */
+    public function __construct(LoaderInterface $loader)
+    {
+        $this->loader = $loader;
+    }
+
+
+    /**
+     * returns the applicable AssetManifest for the provided Domain
+     *
+     * @param DomainInterface $domain
+     * @return AssetManifestInterface
+     */
+    public function createFromDomainObject(DomainInterface $domain)
+    {
+        return $this->getAssetManifestForDomain(AssetManifest::class, $domain);
+    }
+
+
+    /**
+     * for creating an atypical AssetManifest for the Domain provided in the $arguments array
+     *
+     * @param string $fqcn      Fully Qualified Class Name
+     * @param array  $arguments [optional] array of data required for construction
+     * @return AssetManifestInterface
+     */
+    public function create($fqcn, array $arguments = [])
+    {
+        if (! isset($arguments[0]) || ! $arguments[0] instanceof DomainInterface) {
+            throw new InvalidArgumentException(
+                esc_html__(
+                    'In order to generate an AssetManifest class you need to supply an array where the first argument is an instance of DomainInterface.',
+                    'event_espresso'
+                )
+            );
+        }
+        return $this->getAssetManifestForDomain($fqcn, $arguments[0]);
+    }
+
+
+    /**
+     * @param string          $manifest_fqcn
+     * @param DomainInterface $domain
+     * @return AssetManifestInterface
+     */
+    private function getAssetManifestForDomain($manifest_fqcn, DomainInterface $domain)
+    {
+        $domain_fqcn = get_class($domain);
+        if (! isset(AssetManifestFactory::$manifests[ $domain_fqcn ])) {
+            $asset_manifest = new $manifest_fqcn($domain);
+            if (! $asset_manifest instanceof AssetManifestInterface || ! $asset_manifest instanceof $manifest_fqcn) {
+                throw new DomainException(
+                    sprintf(
+                        esc_html__(
+                            'The requested AssetManifest class "%1$s" could not be loaded.',
+                            'event_espresso'
+                        ),
+                        $manifest_fqcn
+                    )
+                );
+            }
+            // we still need to share this with the core loader to facilitate automatic dependency injection
+            $this->loader->share(AssetManifest::class, $asset_manifest, [$domain]);
+            AssetManifestFactory::$manifests[ $domain_fqcn ] = $asset_manifest;
+        }
+        return AssetManifestFactory::$manifests[ $domain_fqcn ];
+    }
+}

--- a/core/services/assets/AssetManifestInterface.php
+++ b/core/services/assets/AssetManifestInterface.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace EventEspresso\core\services\assets;
+
+
+/**
+ * Class for loading parsing and retrieving data from an asset manifest file
+ *
+ * @package EventEspresso\core\services\assets
+ * @author  Brent Christensen
+ * @since   $VID:$
+ */
+interface AssetManifestInterface
+{
+	/**
+	 * @return void
+	 */
+	public function initialize();
+
+
+	/**
+	 * @param string $manifest_path
+	 */
+	public function setManifestFilepath($manifest_path = '');
+
+
+	/**
+	 * @return array
+	 */
+	public function getAssetFiles();
+
+
+	/**
+	 * @return array
+	 */
+	public function getEntryPoints();
+
+
+	/**
+	 * @param string $entry_point
+	 * @param string $type
+	 * @return array
+	 */
+	public function getAssetDependencies($entry_point, $type = AssetManifest::ASSET_EXT_JS);
+
+
+	/**
+	 * @param string $entry_point
+	 * @return array
+	 */
+	public function getAssetDetails($entry_point);
+
+
+	/**
+	 * @param string $entry_point
+	 * @return string|int|false
+	 */
+	public function getAssetHandle($entry_point);
+
+
+	/**
+	 * @param string $entry_point
+	 * @param string $type
+	 * @return string
+	 */
+	public function getAssetPath($entry_point, $type = AssetManifest::ASSET_EXT_JS);
+
+
+	/**
+	 * @param string $entry_point
+	 * @param string $type
+	 * @return string
+	 */
+	public function getAssetUrl($entry_point, $type = AssetManifest::ASSET_EXT_JS);
+
+
+	/**
+	 * @param string $entry_point
+	 * @param string $type
+	 * @return string|int|false
+	 */
+	public function getAssetVersion($entry_point, $type = AssetManifest::ASSET_EXT_JS);
+
+
+	/**
+	 * @param string $entry_point
+	 * @param string $type
+	 * @return string
+	 */
+	public function hasAsset($entry_point, $type = AssetManifest::ASSET_EXT_JS);
+}

--- a/core/services/assets/Barista.php
+++ b/core/services/assets/Barista.php
@@ -2,6 +2,9 @@
 
 namespace EventEspresso\core\services\assets;
 
+use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
+use Exception;
+
 /**
  * @package EventEspresso\core\services\assets
  * @author  Manzoor Wani, Brent Christensen
@@ -55,18 +58,23 @@ class Barista implements BaristaInterface
      * `build/` location.
      *
      * @return void
+     * @throws Exception
      */
     public function registerScripts()
     {
-        $entry_points = $this->asset_manifest->getEntryPoints();
-        foreach ($entry_points as $entry_point) {
-            if ($this->asset_manifest->hasAsset($entry_point)) {
-                $handle = $this->asset_manifest->getAssetHandle($entry_point);
-                $source = $this->asset_manifest->getAssetUrl($entry_point);
-                $dependencies = $this->asset_manifest->getAssetDependencies($entry_point);
-                $version = $this->asset_manifest->getAssetVersion($entry_point);
-                wp_register_script($handle, $source, $dependencies, $version, true);
+        try {
+            $entry_points = $this->asset_manifest->getEntryPoints();
+            foreach ($entry_points as $entry_point) {
+                if ($this->asset_manifest->hasAsset($entry_point)) {
+                    $handle = $this->asset_manifest->getAssetHandle($entry_point);
+                    $source = $this->asset_manifest->getAssetUrl($entry_point);
+                    $dependencies = $this->asset_manifest->getAssetDependencies($entry_point);
+                    $version = $this->asset_manifest->getAssetVersion($entry_point);
+                    wp_register_script($handle, $source, $dependencies, $version, true);
+                }
             }
+        } catch (Exception $exception) {
+            wp_die(new ExceptionStackTraceDisplay($exception));
         }
     }
 
@@ -75,18 +83,23 @@ class Barista implements BaristaInterface
      * Registers all the packages and domain styles that are in the build folder.
      *
      * @return void
+     * @throws Exception
      */
     public function registerStyles()
     {
-        $entry_points = $this->asset_manifest->getEntryPoints();
-        foreach ($entry_points as $entry_point) {
-            if ($this->asset_manifest->hasAsset($entry_point, AssetManifest::ASSET_EXT_CSS)) {
-                $handle = $this->asset_manifest->getAssetHandle($entry_point);
-                $source = $this->asset_manifest->getAssetUrl($entry_point, AssetManifest::ASSET_EXT_CSS);
-                $dependencies = $this->asset_manifest->getAssetDependencies($entry_point, AssetManifest::ASSET_EXT_CSS);
-                $version = $this->asset_manifest->getAssetVersion($entry_point, AssetManifest::ASSET_EXT_CSS);
-                wp_register_style($handle, $source, $dependencies, $version, 'all');
+        try {
+            $entry_points = $this->asset_manifest->getEntryPoints();
+            foreach ($entry_points as $entry_point) {
+                if ($this->asset_manifest->hasAsset($entry_point, AssetManifest::ASSET_EXT_CSS)) {
+                    $handle = $this->asset_manifest->getAssetHandle($entry_point);
+                    $source = $this->asset_manifest->getAssetUrl($entry_point, AssetManifest::ASSET_EXT_CSS);
+                    $dependencies = $this->asset_manifest->getAssetDependencies($entry_point, AssetManifest::ASSET_EXT_CSS);
+                    $version = $this->asset_manifest->getAssetVersion($entry_point, AssetManifest::ASSET_EXT_CSS);
+                    wp_register_style($handle, $source, $dependencies, $version, 'all');
+                }
             }
+        } catch (Exception $exception) {
+            wp_die(new ExceptionStackTraceDisplay($exception));
         }
     }
 }

--- a/core/services/assets/Barista.php
+++ b/core/services/assets/Barista.php
@@ -7,14 +7,14 @@ namespace EventEspresso\core\services\assets;
  * @author  Manzoor Wani, Brent Christensen
  * @since   $VID:$
  */
-class Barista
+class Barista implements BaristaInterface
 {
 
     const DEPENDENCY_LIST_REGISTERED = 'registered';
 
 
     /**
-     * @var AssetManifest
+     * @var AssetManifestInterface
      */
     private $asset_manifest;
 
@@ -27,9 +27,9 @@ class Barista
     /**
      * Barista constructor.
      *
-     * @param AssetManifest   $asset_manifest
+     * @param AssetManifestInterface $asset_manifest
      */
-    public function __construct(AssetManifest $asset_manifest)
+    public function __construct(AssetManifestInterface $asset_manifest)
     {
         $this->asset_manifest = $asset_manifest;
     }
@@ -43,8 +43,8 @@ class Barista
         if (! $this->initialized) {
             add_action('wp_enqueue_scripts', [$this, 'registerScripts'], 0);
             add_action('admin_enqueue_scripts', [$this, 'registerScripts'], 0);
-            add_action('wp_enqueue_scripts', [$this, 'registerPackagesStyles'], 0);
-            add_action('admin_enqueue_scripts', [$this, 'registerPackagesStyles'], 0);
+            add_action('wp_enqueue_scripts', [$this, 'registerStyles'], 0);
+            add_action('admin_enqueue_scripts', [$this, 'registerStyles'], 0);
             $this->initialized = true;
         }
     }
@@ -76,7 +76,7 @@ class Barista
      *
      * @return void
      */
-    public function registerPackagesStyles()
+    public function registerStyles()
     {
         $entry_points = $this->asset_manifest->getEntryPoints();
         foreach ($entry_points as $entry_point) {

--- a/core/services/assets/Barista.php
+++ b/core/services/assets/Barista.php
@@ -44,6 +44,7 @@ class Barista implements BaristaInterface
     public function initialize()
     {
         if (! $this->initialized) {
+            $this->asset_manifest->initialize();
             add_action('wp_enqueue_scripts', [$this, 'registerScripts'], 0);
             add_action('admin_enqueue_scripts', [$this, 'registerScripts'], 0);
             add_action('wp_enqueue_scripts', [$this, 'registerStyles'], 0);

--- a/core/services/assets/BaristaFactory.php
+++ b/core/services/assets/BaristaFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace EventEspresso\core\services\assets;
+
+
+use DomainException;
+use EventEspresso\core\domain\DomainInterface;
+use EventEspresso\core\domain\services\factories\FactoryInterface;
+use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\loaders\LoaderInterface;
+
+class BaristaFactory implements FactoryInterface
+{
+    /**
+     * @param string $domain_fqcn Fully Qualified Class Name for the applicable DomainInterface class
+     * @return BaristaInterface
+     */
+    public static function create($domain_fqcn)
+    {
+        $loader = LoaderFactory::getLoader();
+        $domain = BaristaFactory::getDomain($loader, $domain_fqcn);
+        /** @var AssetManifestInterface $asset_manifest */
+        $asset_manifest = $loader->getShared(AssetManifest::class, [$domain]);
+        return $loader->getShared(Barista::class, [$asset_manifest]);
+    }
+
+
+    /**
+     * @param LoaderInterface $loader
+     * @param mixed $domain_fqcn Fully Qualified Class Name for the applicable DomainInterface class
+     * @return DomainInterface
+     */
+    private static function getDomain(LoaderInterface $loader, $domain_fqcn)
+    {
+        $domain = is_string($domain_fqcn) ? $loader->getShared($domain_fqcn) : null;
+        if ($domain instanceof DomainInterface) {
+            return $domain;
+        }
+        throw new DomainException(
+            sprintf(
+                esc_html__(
+                    'BaristaFactory::create() requires a fully qualified class name (FQCN) for the currently applicable Domain object.
+                    %1$sThe supplied FQCN ("%2$s") is either invalid or the class is missing.',
+                    'event_espresso'
+                ),
+                '<br />',
+                $domain_fqcn
+            )
+        );
+    }
+}

--- a/core/services/assets/BaristaFactory.php
+++ b/core/services/assets/BaristaFactory.php
@@ -16,9 +16,15 @@ class BaristaFactory implements FactoryInterface
      * @param string $domain_fqcn Fully Qualified Class Name for the applicable DomainInterface class
      * @return BaristaInterface
      */
-    public static function create($domain_fqcn)
+    public static function create($domain_fqcn = '')
     {
         $loader = LoaderFactory::getLoader();
+        // if no FQCN is supplied for the domain, then we are loading the defaults for core
+        // and can just request the Barista instance directly.
+        // add-ons will always have to supply their domain to retrieve their manifest
+        if ( empty($domain_fqcn)) {
+            return $loader->getShared(Barista::class);
+        }
         $domain = BaristaFactory::getDomain($loader, $domain_fqcn);
         /** @var AssetManifestInterface $asset_manifest */
         $asset_manifest = $loader->getShared(AssetManifest::class, [$domain]);

--- a/core/services/assets/BaristaInterface.php
+++ b/core/services/assets/BaristaInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EventEspresso\core\services\assets;
+
+
+/**
+ * @package EventEspresso\core\services\assets
+ * @author  Manzoor Wani, Brent Christensen
+ * @since   $VID:$
+ */
+interface BaristaInterface
+{
+	/**
+	 * @return void
+	 */
+	public function initialize();
+
+
+	/**
+	 * Registers all the WordPress packages scripts that are in the standardized
+	 * `build/` location.
+	 *
+	 * @return void
+	 */
+	public function registerScripts();
+
+
+	/**
+	 * Registers all the packages and domain styles that are in the build folder.
+	 *
+	 * @return void
+	 */
+	public function registerPackagesStyles();
+}

--- a/core/services/assets/BaristaInterface.php
+++ b/core/services/assets/BaristaInterface.php
@@ -30,5 +30,5 @@ interface BaristaInterface
 	 *
 	 * @return void
 	 */
-	public function registerPackagesStyles();
+	public function registerStyles();
 }

--- a/core/services/assets/Registry.php
+++ b/core/services/assets/Registry.php
@@ -32,7 +32,7 @@ class Registry
     protected $assets = [];
 
     /**
-     * @var AssetManifest
+     * @var AssetManifestInterface
      */
     private $asset_manifest;
 
@@ -61,14 +61,14 @@ class Registry
      * Registry constructor.
      * Hooking into WP actions for script registry.
      *
-     * @param AssetCollection      $assets
-     * @param AssetManifest $asset_manifest
-     * @param I18nRegistry         $i18n_registry
+     * @param AssetCollection        $assets
+     * @param AssetManifestInterface $asset_manifest
+     * @param I18nRegistry           $i18n_registry
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public function __construct(AssetCollection $assets, AssetManifest $asset_manifest, I18nRegistry $i18n_registry)
+    public function __construct(AssetCollection $assets, AssetManifestInterface $asset_manifest, I18nRegistry $i18n_registry)
     {
         $this->addAssetCollection($assets);
         $this->asset_manifest = $asset_manifest;
@@ -88,7 +88,7 @@ class Registry
      */
     public function addAssetCollection(AssetCollection $asset_collection)
     {
-        $id = spl_object_hash($asset_collection);
+        $id = $asset_collection->collectionIdentifier();
         if (! array_key_exists($id, $this->assets)) {
             $this->assets[ $id ] = $asset_collection;
         }

--- a/core/services/factory/Factory.php
+++ b/core/services/factory/Factory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EventEspresso\core\services\factories;
+namespace EventEspresso\core\services\factory;
 
 use EventEspresso\core\services\loaders\LoaderInterface;
 

--- a/core/services/factory/Factory.php
+++ b/core/services/factory/Factory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace EventEspresso\core\services\factories;
+
+use EventEspresso\core\services\loaders\LoaderInterface;
+
+abstract class Factory implements FactoryInterface
+{
+
+    /**
+     * @var LoaderInterface $loader
+     */
+    protected $loader;
+
+
+    /**
+     * RouteFactory constructor.
+     *
+     * @param LoaderInterface $loader
+     */
+    public function __construct(LoaderInterface $loader)
+    {
+        $this->loader = $loader;
+    }
+}

--- a/core/services/factory/FactoryInterface.php
+++ b/core/services/factory/FactoryInterface.php
@@ -7,6 +7,7 @@ namespace EventEspresso\core\services\factory;
  *
  * @package EventEspresso\core\domain\services\factories
  * @author  Brent Christensen
+ * @since   $VID:$
  */
 interface FactoryInterface
 {

--- a/core/services/factory/FactoryInterface.php
+++ b/core/services/factory/FactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EventEspresso\core\services\factories;
+namespace EventEspresso\core\services\factory;
 
 /**
  * Interface FactoryInterface

--- a/core/services/factory/FactoryInterface.php
+++ b/core/services/factory/FactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EventEspresso\core\services\factories;
+
+/**
+ * Interface FactoryInterface
+ *
+ * @package EventEspresso\core\domain\services\factories
+ * @author  Brent Christensen
+ */
+interface FactoryInterface
+{
+
+    /**
+     * @param string $fqcn      Fully Qualified Class Name
+     * @param array  $arguments [optional] array of data required for construction
+     * @return mixed
+     */
+    public function create($fqcn, array $arguments = []);
+}

--- a/core/services/factory/StaticFactoryInterface.php
+++ b/core/services/factory/StaticFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EventEspresso\core\services\factories;
+
+/**
+ * Interface FactoryInterface
+ *
+ * @package EventEspresso\core\domain\services\factories
+ * @author  Brent Christensen
+ */
+interface StaticFactoryInterface
+{
+
+    /**
+     * @param string $fqcn      Fully Qualified Class Name
+     * @param array  $arguments [optional] array of data required for construction
+     * @return mixed
+     */
+    public static function create($fqcn, array $arguments = []);
+}

--- a/core/services/factory/StaticFactoryInterface.php
+++ b/core/services/factory/StaticFactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EventEspresso\core\services\factories;
+namespace EventEspresso\core\services\factory;
 
 /**
  * Interface FactoryInterface

--- a/core/services/factory/StaticFactoryInterface.php
+++ b/core/services/factory/StaticFactoryInterface.php
@@ -7,6 +7,7 @@ namespace EventEspresso\core\services\factory;
  *
  * @package EventEspresso\core\domain\services\factories
  * @author  Brent Christensen
+ * @since   $VID:$
  */
 interface StaticFactoryInterface
 {

--- a/core/services/loaders/CachingLoaderDecoratorInterface.php
+++ b/core/services/loaders/CachingLoaderDecoratorInterface.php
@@ -14,8 +14,9 @@ interface CachingLoaderDecoratorInterface extends LoaderDecoratorInterface
     /**
      * @param string $fqcn
      * @param mixed  $object
+     * @param array  $arguments
      * @return bool
      * @throws InvalidArgumentException
      */
-    public function share($fqcn, $object);
+    public function share($fqcn, $object, array $arguments = []);
 }

--- a/core/services/loaders/Loader.php
+++ b/core/services/loaders/Loader.php
@@ -109,13 +109,14 @@ class Loader implements LoaderInterface
     /**
      * @param FullyQualifiedName|string $fqcn
      * @param mixed                     $object
+     * @param array                     $arguments
      * @return bool
      * @throws InvalidArgumentException
      */
-    public function share($fqcn, $object)
+    public function share($fqcn, $object, array $arguments = [])
     {
         $fqcn = $this->class_cache->getFqn($fqcn);
-        return $this->getSharedLoader()->share($fqcn, $object);
+        return $this->getSharedLoader()->share($fqcn, $object, $arguments);
     }
 
 

--- a/core/services/loaders/LoaderInterface.php
+++ b/core/services/loaders/LoaderInterface.php
@@ -17,7 +17,7 @@ interface LoaderInterface
      * @param bool                      $shared
      * @return mixed
      */
-    public function load($fqcn, array $arguments = array(), $shared = true);
+    public function load($fqcn, array $arguments = [], $shared = true);
 
 
     /**
@@ -27,7 +27,7 @@ interface LoaderInterface
      * @param array                     $arguments
      * @return mixed
      */
-    public function getNew($fqcn, array $arguments = array());
+    public function getNew($fqcn, array $arguments = []);
 
 
     /**
@@ -37,16 +37,17 @@ interface LoaderInterface
      * @param array                     $arguments
      * @return mixed
      */
-    public function getShared($fqcn, array $arguments = array());
+    public function getShared($fqcn, array $arguments = []);
 
 
     /**
      * @param FullyQualifiedName|string $fqcn
      * @param mixed                     $object
+     * @param array                     $arguments
      * @return bool
      * @throws InvalidArgumentException
      */
-    public function share($fqcn, $object);
+    public function share($fqcn, $object, array $arguments = []);
 
 
     /**

--- a/core/services/loaders/ObjectIdentifier.php
+++ b/core/services/loaders/ObjectIdentifier.php
@@ -89,6 +89,7 @@ class ObjectIdentifier
         )
             ? $this->getIdentifierForArguments($arguments)
             : '';
+        $fqcn = str_replace('\\', '_', $fqcn);
         if (! empty($identifier)) {
             $fqcn .= ObjectIdentifier::DELIMITER . md5($identifier);
         }

--- a/core/services/loaders/ObjectIdentifier.php
+++ b/core/services/loaders/ObjectIdentifier.php
@@ -68,6 +68,7 @@ class ObjectIdentifier
      */
     public function fqcnMatchesObjectIdentifier($fqcn, $object_identifier)
     {
+        $fqcn = str_replace('\\', '_', $fqcn);
         return $fqcn === $object_identifier
                || strpos($object_identifier, $fqcn . ObjectIdentifier::DELIMITER) === 0;
     }
@@ -89,10 +90,10 @@ class ObjectIdentifier
         )
             ? $this->getIdentifierForArguments($arguments)
             : '';
-        $fqcn = str_replace('\\', '_', $fqcn);
         if (! empty($identifier)) {
             $fqcn .= ObjectIdentifier::DELIMITER . md5($identifier);
         }
+        $fqcn = str_replace('\\', '_', $fqcn);
         return $fqcn;
     }
 

--- a/tests/mocks/core/domain/DomainFactoryMock.php
+++ b/tests/mocks/core/domain/DomainFactoryMock.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EventEspresso\tests\mocks\core\domain;
+
+use EventEspresso\core\domain\DomainFactory;
+
+class DomainFactoryMock extends DomainFactory
+{
+    public static function reset()
+    {
+        DomainFactory::$domains = [];
+    }
+}

--- a/tests/mocks/core/domain/entities/routing/handlers/shared/GQLRequestsMock.php
+++ b/tests/mocks/core/domain/entities/routing/handlers/shared/GQLRequestsMock.php
@@ -21,21 +21,25 @@ class GQLRequestsMock extends GQLRequests
         EE_Dependency_Map::instance()->registerDependencies(
             GQLRequestsMock::class,
             [
-                'EE_Dependency_Map'                                                                          => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\loaders\Loader'                                                 => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\request\Request'                                                => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\domain\entities\routing\specifications\RouteMatchSpecificationInterface' => EE_Dependency_Map::load_from_cache,
+                'EE_Dependency_Map'                                       => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\loaders\Loader'              => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'             => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\assets\AssetManifestFactory' => EE_Dependency_Map::load_from_cache,
             ]
         );
         $self = LoaderFactory::getLoader()->getShared(GQLRequestsMock::class);
         $self->registerDependencies();
     }
 
-    public function registerDependencies() {
+
+    public function registerDependencies()
+    {
         parent::registerDependencies();
     }
 
-    public function requestHandler() {
+
+    public function requestHandler()
+    {
         parent::requestHandler();
     }
 }

--- a/tests/testcases/core/domain/DomainFactoryTest.php
+++ b/tests/testcases/core/domain/DomainFactoryTest.php
@@ -3,13 +3,10 @@
 namespace EventEspresso\tests\testcases\core\domain;
 
 use EE_UnitTestCase;
-use EventEspresso\core\domain\DomainFactory;
-use EventEspresso\core\domain\values\FilePath;
 use EventEspresso\core\domain\values\FullyQualifiedName;
-use EventEspresso\core\domain\values\Version;
+use EventEspresso\tests\mocks\core\domain\DomainFactoryMock;
 
 defined('EVENT_ESPRESSO_VERSION') || exit;
-
 
 
 /**
@@ -23,28 +20,29 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  */
 class DomainFactoryTest extends EE_UnitTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        DomainFactoryMock::reset();
+    }
+
 
     public function test_getShared()
     {
         // $file_path = EE_TESTS_DIR . 'mocks/core/domain/DomainMock.php';
-        $file_path = EE_TESTS_DIR . 'mocks/core';
-        $version = '1.2.3.p';
-        $domain_mock = DomainFactory::getShared(
-            new FullyQualifiedName(
-                'EventEspresso\tests\mocks\core\domain\DomainMock'
-            ),
-            array(
-                new FilePath($file_path),
-                Version::fromString($version)
-            )
+        $file_path   = EE_TESTS_DIR . 'mocks/core';
+        $version     = '1.2.3.p';
+        $domain_mock = DomainFactoryMock::getShared(
+            new FullyQualifiedName('EventEspresso\tests\mocks\core\domain\DomainMock'),
+            [ $file_path, $version ]
         );
         $this->assertInstanceOf('EventEspresso\tests\mocks\core\domain\DomainMock', $domain_mock);
         $this->assertInstanceOf('EventEspresso\core\domain\DomainBase', $domain_mock);
         $this->assertEquals($file_path, $domain_mock->pluginFile());
         $this->assertEquals(plugin_basename($file_path), $domain_mock->pluginBasename());
-        $this->assertEquals(plugin_dir_path($file_path),$domain_mock->pluginPath());
-        $this->assertEquals(plugin_dir_url($file_path),$domain_mock->pluginUrl());
-        $this->assertEquals(plugin_dir_url($file_path),$domain_mock->pluginUrl());
+        $this->assertEquals(plugin_dir_path($file_path), $domain_mock->pluginPath());
+        $this->assertEquals(plugin_dir_url($file_path), $domain_mock->pluginUrl());
+        $this->assertEquals(plugin_dir_url($file_path), $domain_mock->pluginUrl());
         $this->assertEquals($version, $domain_mock->version());
         $this->assertEquals('Oh Yeah', $domain_mock->returnOhYeah());
     }
@@ -53,11 +51,11 @@ class DomainFactoryTest extends EE_UnitTestCase
     public function test_constructor_with_invalid_arguments()
     {
         $this->setExceptionExpected('InvalidArgumentException');
-        DomainFactory::getShared(
+        DomainFactoryMock::getShared(
             new FullyQualifiedName(
                 'EventEspresso\tests\mocks\core\domain\DomainMock'
             ),
-            array()
+            []
         );
     }
 
@@ -65,19 +63,19 @@ class DomainFactoryTest extends EE_UnitTestCase
     public function test_constructor_with_invalid_arguments_2()
     {
         $this->setExceptionExpected('InvalidArgumentException');
-        DomainFactory::getShared(
+        DomainFactoryMock::getShared(
             new FullyQualifiedName(
                 'EventEspresso\tests\mocks\core\domain\DomainMock'
             ),
-            array(new FilePath(EE_TESTS_DIR . 'mocks/core/domain/DomainMock.php'))
+            [EE_TESTS_DIR . 'mocks/core/domain/DomainMock.php']
         );
     }
 
 
     public function test_constructor_with_invalid_arguments_3()
     {
-        $this->setExceptionExpected('DomainException');
-        DomainFactory::getShared(
+        $this->setExceptionExpected('EventEspresso\core\exceptions\InvalidDataTypeException');
+        DomainFactoryMock::getShared(
             new FullyQualifiedName(
                 'EventEspresso\core\domain\values\FilePath'
             ),
@@ -89,4 +87,4 @@ class DomainFactoryTest extends EE_UnitTestCase
     }
 
 }
-// Location: DomainFactoryTest.php
+// Location: /tests/testcases/core/domain/DomainFactoryTest.php

--- a/tests/testcases/core/services/loaders/ObjectIdentifierTest.php
+++ b/tests/testcases/core/services/loaders/ObjectIdentifierTest.php
@@ -10,7 +10,6 @@ use stdClass;
 defined('EVENT_ESPRESSO_VERSION') || exit;
 
 
-
 /**
  * Class ObjectIdentifierTest
  * Description
@@ -45,6 +44,7 @@ class ObjectIdentifierTest extends EE_UnitTestCase
 
     /**
      * dataProvider for testGetIdentifier()
+     *
      * @return array[]
      */
     public function getIdentifierProvider()
@@ -53,36 +53,36 @@ class ObjectIdentifierTest extends EE_UnitTestCase
         $object1->prop1 = 1234;
         $object1->prop2 = 'mom\'s spaghetti';
         $object1hash = spl_object_hash($object1);
-        return array(
+        return [
             // $fqcn, $arguments, $expected
-            0 => array(
-                'fully/qualified/class/name/DoesNotNeedToBeReal',
-                array(),
-                'fully/qualified/class/name/DoesNotNeedToBeReal',
-            ),
-            1 => array(
-                'fully/qualified/class/name/DoesNotNeedToBeReal',
-                array(1, 2, 3, 4),
-                'fully/qualified/class/name/DoesNotNeedToBeReal' . ObjectIdentifier::DELIMITER . md5('1234'),
-            ),
-            2 => array(
-                'fully/qualified/class/name/DoesNotNeedToBeReal',
-                array($object1),
-                'fully/qualified/class/name/DoesNotNeedToBeReal' . ObjectIdentifier::DELIMITER . md5($object1hash),
-            ),
-            3 => array(
-                'fully/qualified/class/name/DoesNotNeedToBeReal',
-                array(1, 2, 3, 4, $object1),
-                'fully/qualified/class/name/DoesNotNeedToBeReal'
+            0 => [
+                'fully\qualified\class\name\DoesNotNeedToBeReal',
+                [],
+                'fully_qualified_class_name_DoesNotNeedToBeReal',
+            ],
+            1 => [
+                'fully\qualified\class\name\DoesNotNeedToBeReal',
+                [1, 2, 3, 4],
+                'fully_qualified_class_name_DoesNotNeedToBeReal' . ObjectIdentifier::DELIMITER . md5('1234'),
+            ],
+            2 => [
+                'fully\qualified\class\name\DoesNotNeedToBeReal',
+                [$object1],
+                'fully_qualified_class_name_DoesNotNeedToBeReal' . ObjectIdentifier::DELIMITER . md5($object1hash),
+            ],
+            3 => [
+                'fully\qualified\class\name\DoesNotNeedToBeReal',
+                [1, 2, 3, 4, $object1],
+                'fully_qualified_class_name_DoesNotNeedToBeReal'
                 . ObjectIdentifier::DELIMITER . md5('1234' . $object1hash),
-            ),
+            ],
             // test class that implements EventEspresso\core\interfaces\ReservedInstanceInterface
-            4 => array(
+            4 => [
                 'EventEspresso\core\services\request\Request',
-                array(array(1, 2, 3, 4), array(), array(), array()),
-                'EventEspresso\core\services\request\Request',
-            ),
-        );
+                [[1, 2, 3, 4], [], [], []],
+                'EventEspresso_core_services_request_Request',
+            ],
+        ];
     }
 
 
@@ -96,7 +96,7 @@ class ObjectIdentifierTest extends EE_UnitTestCase
     {
         $this->assertEquals(
             $expected,
-            $this->object_identifier->getIdentifier($fqcn,$arguments)
+            $this->object_identifier->getIdentifier($fqcn, $arguments)
         );
     }
 
@@ -108,10 +108,10 @@ class ObjectIdentifierTest extends EE_UnitTestCase
      */
     public function hasArgumentsProvider()
     {
-        return array(
-            array('fully/qualified/class/Name', false),
-            array('fully/qualified/class/Name' . ObjectIdentifier::DELIMITER . md5('1234'), true),
-        );
+        return [
+            ['fully/qualified/class/Name', false],
+            ['fully/qualified/class/Name' . ObjectIdentifier::DELIMITER . md5('1234'), true],
+        ];
     }
 
 
@@ -128,6 +128,7 @@ class ObjectIdentifierTest extends EE_UnitTestCase
         );
     }
 
+
     /**
      * dataProvider for testFqcnMatchesObjectIdentifier()
      *
@@ -135,12 +136,20 @@ class ObjectIdentifierTest extends EE_UnitTestCase
      */
     public function fqcnMatchesObjectIdentifierProvider()
     {
-        return array(
-            array('fully/qualified/class/Name', 'fully/qualified/class/Name', true),
-            array('fully/qualified/class/Name', 'fully/qualified/class/Name' . ObjectIdentifier::DELIMITER . md5('1234'), true),
-            array('fully/qualified/class/Name', 'fully/qualified/class/OtherName', false),
-            array('fully/qualified/class/Name', 'fully/qualified/class/OtherName' . ObjectIdentifier::DELIMITER . md5('1234'), false),
-        );
+        return [
+            ['fully/qualified/class/Name', 'fully/qualified/class/Name', true],
+            [
+                'fully/qualified/class/Name',
+                'fully/qualified/class/Name' . ObjectIdentifier::DELIMITER . md5('1234'),
+                true,
+            ],
+            ['fully/qualified/class/Name', 'fully/qualified/class/OtherName', false],
+            [
+                'fully/qualified/class/Name',
+                'fully/qualified/class/OtherName' . ObjectIdentifier::DELIMITER . md5('1234'),
+                false,
+            ],
+        ];
     }
 
 
@@ -148,7 +157,7 @@ class ObjectIdentifierTest extends EE_UnitTestCase
      * @dataProvider fqcnMatchesObjectIdentifierProvider
      * @param string $fqcn
      * @param string $object_identifier
-     * @param bool $matches
+     * @param bool   $matches
      */
     public function testFqcnMatchesObjectIdentifier($fqcn, $object_identifier, $matches)
     {


### PR DESCRIPTION
This PR does the following:

- creates and/or improves factory classes for:
    - AssetManifest
    - Barista
    - Domain

- fixes loading and caching so that multiple instances of Barista and AssetManifest can be created for multiple Domains (ie: one for core + one for each add-on)