### PR TITLE
If the user can read private events then include the private status when pulling upcoming events

### DIFF
--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -624,7 +624,13 @@ class EEM_Event extends EEM_CPT_Base
         }
         // let's add specific query_params for active_events
         // keep in mind this will override any sent status in the query AND any date queries.
-        $where_params['status'] = array('IN', array('publish', EEM_Event::sold_out));
+        // we need to pull events with a status of publish and sold_out
+        $event_status = array('publish', EEM_Event::sold_out);
+        // check if the user can read private events and if so add the 'private status to the were params'
+        if (EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_upcoming_events')) {
+            $event_status[] = 'private';
+        }
+        $where_params['status'] = array('IN', $event_status);
         // if there are already query_params matching DTT_EVT_start then we need to modify that to add them.
         if (isset($where_params['Datetime.DTT_EVT_start'])) {
             $where_params['Datetime.DTT_EVT_start*****'] = array(


### PR DESCRIPTION
Reported: https://eventespresso.com/topic/possible-bug-filter-by-category-shows-private-categoryupcoming-does-not/?view=all

To reproduce set an event to have a status of private and set a category on the event.

Then in the event list table (Event Espresso -> Events), filter the category.

You'll see your private event listed.

Now filter the status to show Upcoming events, the private event disappears.

Switch to this branch and repeat, it should not.

This just using a capability check that is used all over but if you want to confirm, remove `ee_read_private_events` from your user account and repeat.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
