### PR TITLE
Add a check for missing message queue crons when running the message queue cleanup.

### DIFF
--- a/core/libraries/messages/EE_Messages_Scheduler.lib.php
+++ b/core/libraries/messages/EE_Messages_Scheduler.lib.php
@@ -196,7 +196,7 @@ class EE_Messages_Scheduler extends EE_Base
             'AHEE__EE_Messages_Scheduler__sending'    => 'ee_message_cron',
         );
         foreach ($message_crons_to_check as $hook_name => $frequency) {
-            if(! wp_next_scheduled($hook_name)) {
+            if (! wp_next_scheduled($hook_name)) {
                 wp_schedule_event(time(), $frequency, $hook_name);
             }
         }

--- a/core/libraries/messages/EE_Messages_Scheduler.lib.php
+++ b/core/libraries/messages/EE_Messages_Scheduler.lib.php
@@ -189,7 +189,19 @@ class EE_Messages_Scheduler extends EE_Base
      */
     public static function cleanup()
     {
-        // first check if user has cleanup turned on or if we're in maintenance mode.  If in maintenance mode we'll wait
+        // First, confirm that the generation and sending EE_Messages_Scheduler crons are
+        // set and reschedule them if they are not.
+        $message_crons_to_check = array(
+            'AHEE__EE_Messages_Scheduler__generation' => 'ee_message_cron',
+            'AHEE__EE_Messages_Scheduler__sending'    => 'ee_message_cron',
+        );
+        foreach($message_crons_to_check as $hook_name => $frequency ){
+            if(! wp_next_scheduled($hook_name)) {
+                wp_schedule_event(time(), $frequency, $hook_name);
+            }
+        }
+
+        // check if user has cleanup turned on or if we're in maintenance mode.  If in maintenance mode we'll wait
         // until the next scheduled event.
         if (! EE_Registry::instance()->CFG->messages->delete_threshold
             || ! EE_Maintenance_Mode::instance()->models_can_query()

--- a/core/libraries/messages/EE_Messages_Scheduler.lib.php
+++ b/core/libraries/messages/EE_Messages_Scheduler.lib.php
@@ -195,7 +195,7 @@ class EE_Messages_Scheduler extends EE_Base
             'AHEE__EE_Messages_Scheduler__generation' => 'ee_message_cron',
             'AHEE__EE_Messages_Scheduler__sending'    => 'ee_message_cron',
         );
-        foreach($message_crons_to_check as $hook_name => $frequency ){
+        foreach ($message_crons_to_check as $hook_name => $frequency) {
             if(! wp_next_scheduled($hook_name)) {
                 wp_schedule_event(time(), $frequency, $hook_name);
             }


### PR DESCRIPTION
So, I'm not thrilled with this but I think its better than what is happening now.

@tn3rb I've intentionally set this check to run regardless of what 'delete_threshold' is set to and if MM is set as I want to make sure these crons are set regardless.

Context:
For a while we've had the odd few sites report that their messaging queue would just randomly stop working and we tracked it down to be missing cron events

It has happened over a long period and I'd say we've had less than 10 reports from when the message system was introduced but we couldn't find any connection between them.

I started doing some digging and it looks like this is a common WP core issue:
https://wordpress.org/support/topic/php-cron-job-disappering/
https://wordpress.stackexchange.com/questions/158303/scheduled-events-disappear-from-events-queue

---

The message system add 3 crons:

```
AHEE__EE_Messages_Scheduler__generation => 5 mins
AHEE__EE_Messages_Scheduler__sending => 5 mins
AHEE__EE_Messages_Scheduler__cleanup => hourly
```

I'm sure you can guess by their names what they do.

The first 2 randomly disappear and that apparently can site unnoticed for a while until the user updates EE, the update runs through EEH_Activation and the crons are recreated. Problem is the user can now have a queue of messages spanning from MONTHS ago which start generating and sending.

The reports we've had all seem to be delayed emails (sat waiting to generate/send) rather than duplicates but some users are convinced they are dupes.


## Problem this Pull Request solves
This just added a check to the `AHEE__EE_Messages_Scheduler__cleanup` callback to check specifically for the 2 crons missing for the message queue, I had initially used `register_scheduled_tasks()` to pull all of them (its only an additional cron, the one thats calling this) but seemed weird this specific callback checking for its own callback again so switch to this.

## How has this been tested
Use wp_crontol and go to Tools -> Cron events.

Delete the `AHEE__EE_Messages_Scheduler__generation` and `AHEE__EE_Messages_Scheduler__sending` crons.

Refresh and confirm they don't just re-appear on their own.

Find `AHEE__EE_Messages_Scheduler__cleanup` and force it to run.

After a few seconds, refresh and you should see the above crons rescheduled.
Note that you may see `AHEE__EE_Messages_Scheduler__cleanup` get scheduled twice on the first refresh (depends how quick you are) then on the next the 2 above will be set. That is normal.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
