### PR TITLE
Allow multiple categories to be used in ESPRESSO_EVENTS

### DIFF
--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -544,7 +544,7 @@ class EEH_Event_Query
         if (! empty($event_category_slug) ) {
             $event_category_slugs_array = array_map('trim', explode(',', $event_category_slug));
             $event_category_slugs_prepare = implode( ', ', array_fill( 0, count( $event_category_slugs_array ), '%s' ));
-            return $wpdb->prepare(" AND {$wpdb->terms}.slug IN ($event_category_slugs_prepare) ", $event_category_slugs_array);
+            return $wpdb->prepare(" AND {$wpdb->terms}.slug IN ({$event_category_slugs_prepare}) ", $event_category_slugs_array);
         }
         return ''; 
     }

--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -541,9 +541,12 @@ class EEH_Event_Query
     public static function posts_where_sql_for_event_category_slug($event_category_slug = null)
     {
         global $wpdb;
-        return ! empty($event_category_slug)
-            ? $wpdb->prepare(" AND {$wpdb->terms}.slug = %s ", $event_category_slug)
-            : '';
+        if (! empty($event_category_slug) ) {
+            $event_category_slugs_array = array_map('trim', explode(',', $event_category_slug));
+            $event_category_slugs_prepare = implode( ', ', array_fill( 0, count( $event_category_slugs_array ), '%s' ));
+            return $wpdb->prepare(" AND {$wpdb->terms}.slug IN ($event_category_slugs_prepare) ", $event_category_slugs_array);
+        }
+        return ''; 
     }
 
 

--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -156,7 +156,7 @@ class EEH_Event_Query
      */
     private static function _event_category_slug($category = '')
     {
-        return sanitize_title_with_dashes(EE_Registry::instance()->REQ->get('event_query_category', $category));
+        return sanitize_text_field(EE_Registry::instance()->REQ->get('event_query_category', $category));
     }
 
 

--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -541,12 +541,12 @@ class EEH_Event_Query
     public static function posts_where_sql_for_event_category_slug($event_category_slug = null)
     {
         global $wpdb;
-        if (! empty($event_category_slug) ) {
+        if (! empty($event_category_slug)) {
             $event_category_slugs_array = array_map('trim', explode(',', $event_category_slug));
-            $event_category_slugs_prepare = implode( ', ', array_fill( 0, count( $event_category_slugs_array ), '%s' ));
+            $event_category_slugs_prepare = implode(', ', array_fill(0, count($event_category_slugs_array), '%s'));
             return $wpdb->prepare(" AND {$wpdb->terms}.slug IN ({$event_category_slugs_prepare}) ", $event_category_slugs_array);
         }
-        return ''; 
+        return '';
     }
 
 


### PR DESCRIPTION
See: https://eventespresso.com/topic/multiple-categories-in-shortcode-filter/

From the above request I start looking into do it via a support token, ended up finding:

https://events.codebasehq.com/projects/event-espresso/tickets/7323

## How has this been tested

Add something like `[ESPRESSO_EVENTS category_slug=cat-1]` to a page.

Confirm that events set to that category show up and not others.

Change is to `[ESPRESSO_EVENTS category_slug='cat-1']` (Note the single quotes, because people do it)..

Then change that to `[ESPRESSO_EVENTS category_slug=cat-1,cat-2]` 
(Note no quotes required as there isn't a space in the shortcode)

Now check that event from both cat-1 and cat-2 show up.

Then change that to `[ESPRESSO_EVENTS category_slug='cat-1, cat-2']` 
(single quotes required as there's a space this time)

Again confirm that the expected events show up.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
