### PR TITLE
Don't update the Transaction/Registrations within the cron check when the primary registrant is Not Approved

### DIFF
--- a/core/EE_Cron_Tasks.core.php
+++ b/core/EE_Cron_Tasks.core.php
@@ -420,7 +420,7 @@ class EE_Cron_Tasks extends EE_Base
                     // Completed TXNs
                     case EEM_Transaction::complete_status_code:
                         // Don't update the transaction/registrations if the Primary Registration is Not Approved.
-                        $transaction->primary_registration();
+                        $primary_registration = $transaction->primary_registration();
                         if ($primary_registration instanceof EE_Registration
                             && $primary_registration->status_ID() == EEM_Registration::status_id_not_approved
                         ) {

--- a/core/EE_Cron_Tasks.core.php
+++ b/core/EE_Cron_Tasks.core.php
@@ -419,16 +419,22 @@ class EE_Cron_Tasks extends EE_Base
                 switch ($transaction->status_ID()) {
                     // Completed TXNs
                     case EEM_Transaction::complete_status_code:
-                        /** @type EE_Transaction_Processor $transaction_processor */
-                        $transaction_processor = EE_Registry::instance()->load_class('Transaction_Processor');
-                        $transaction_processor->update_transaction_and_registrations_after_checkout_or_payment(
-                            $transaction,
-                            $transaction->last_payment()
-                        );
-                        do_action(
-                            'AHEE__EE_Cron_Tasks__process_expired_transactions__completed_transaction',
-                            $transaction
-                        );
+                        // Don't update the transaction/registrations if the Primary Registration is Not Approved.
+                        $transaction->primary_registration();
+                        if ($primary_registration instanceof EE_Registration
+                            && $primary_registration->status_ID() == EEM_Registration::status_id_not_approved
+                        ) {
+                            /** @type EE_Transaction_Processor $transaction_processor */
+                            $transaction_processor = EE_Registry::instance()->load_class('Transaction_Processor');
+                            $transaction_processor->update_transaction_and_registrations_after_checkout_or_payment(
+                                $transaction,
+                                $transaction->last_payment()
+                            );
+                            do_action(
+                                'AHEE__EE_Cron_Tasks__process_expired_transactions__completed_transaction',
+                                $transaction
+                            );
+                        }
                         break;
                     // Overpaid TXNs
                     case EEM_Transaction::overpaid_status_code:

--- a/core/EE_Cron_Tasks.core.php
+++ b/core/EE_Cron_Tasks.core.php
@@ -422,7 +422,7 @@ class EE_Cron_Tasks extends EE_Base
                         // Don't update the transaction/registrations if the Primary Registration is Not Approved.
                         $primary_registration = $transaction->primary_registration();
                         if ($primary_registration instanceof EE_Registration
-                            && $primary_registration->status_ID() == EEM_Registration::status_id_not_approved
+                            && $primary_registration->status_ID() !== EEM_Registration::status_id_not_approved
                         ) {
                             /** @type EE_Transaction_Processor $transaction_processor */
                             $transaction_processor = EE_Registry::instance()->load_class('Transaction_Processor');


### PR DESCRIPTION
....they most likely finalized using a free ticket.

Messages can be triggered multiple times if you use a DRS of Not Approved and register onto a free ticket.

This branch simply checks that the Primary Registration is NOT set to Not Approved when a Transaction status is 'Complete' and the expired transaction cron runs.

To reproduce set up an event to use a DRS of 'Not Approved' and set it to have a free ticket.

Register onto that ticket.

EE will trigger the 'Not Approved' message.

Now us [WP Crontol](https://en-gb.wordpress.org/plugins/wp-crontrol/) (or whatever else you prefer, to run the `AHEE__EE_Cron_Tasks__expired_transaction_check` job 

(note that function is passed the TXN ID in the additional params for the cron, make sure you are running the cron that matches the TXN ID for the above registration)

Each time it runs it will retrigger the Not Approved message so it means that all Not Approved messaged registrations on free tickets will trigger 2 messages (once when they select and finalize and another when the session expires and the above cron runs, by default an hour late).

This branch should prevent that.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
