### PR TITLE
Add hook to interrupt spco reg step(s)

### DIFF
--- a/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
+++ b/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
@@ -1326,7 +1326,9 @@ class EED_Single_Page_Checkout extends EED_Module
                     );
                     $process_reg_step = apply_filters(
                         "AHEE__Single_Page_Checkout__process_reg_step__{$this->checkout->current_step->slug()}__{$this->checkout->action}",
-                        $this->checkout->current_step
+                        true,
+                        $this->checkout->current_step,
+                        $this
                     );
                     // call action on current step
                     if ($process_reg_step && call_user_func([$this->checkout->current_step, $this->checkout->action])) {

--- a/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
+++ b/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
@@ -1324,8 +1324,12 @@ class EED_Single_Page_Checkout extends EED_Module
                         "AHEE__Single_Page_Checkout__before_{$this->checkout->current_step->slug()}__{$this->checkout->action}",
                         $this->checkout->current_step
                     );
+                    $process_reg_step = apply_filters(
+                        "AHEE__Single_Page_Checkout__process_reg_step__{$this->checkout->current_step->slug()}__{$this->checkout->action}",
+                        $this->checkout->current_step
+                    );
                     // call action on current step
-                    if (call_user_func(array($this->checkout->current_step, $this->checkout->action))) {
+                    if ($process_reg_step && call_user_func([$this->checkout->current_step, $this->checkout->action])) {
                         // good registrant, you get to proceed
                         if ($this->checkout->current_step->success_message() !== ''
                             && apply_filters(


### PR DESCRIPTION
This PR adds a hook into SPCO that can be used to interrupt any reg_step prior to it processing the data.

The current hooks allow you to hook in AFTER the forms have been processed, or hook into the processing of each individual registration (see [HERE](https://github.com/eventespresso/event-espresso-core/blob/19a9be9b07defa59a827608321a4348346e4d3b4/modules/single_page_checkout/reg_steps/attendee_information/EE_SPCO_Reg_Step_Attendee_Information.class.php#L1039)) this allows you to hook into the form submission and do any additional processing you need before the reg_step does.

@tn3rb you gave me a similar version of this but I switched it out to be more of a flag and passed the current reg_step and SPCO instance into it so that there's more data available in the callback.

Easier to see why I needed those with the use case I'm working currently so see this snippet:

https://gist.github.com/Pebblo/0b3b28c9d0c52d5425fa167da1f1a622

The idea behind the above is the user wants to hook into the submission and pull the values passed to a custom question, do some additional magic and halt processing if it's not a valid answer. My example just checks for 'stop' as the value to prevent submission, everything else should pass.

## How has this been tested
Have an event with a custom text question on your primary reg groups (doesn't match which group as long as its primary reg)

Add the first function from that snippet above to your site: https://gist.github.com/Pebblo/0b3b28c9d0c52d5425fa167da1f1a622#file-spco_hook_example-php-L3-L41

(The second one uses an existing hook to direct successful form submissions to google.com, up to you if you want to use that)

Set [Line 5](https://gist.github.com/Pebblo/0b3b28c9d0c52d5425fa167da1f1a622#file-spco_hook_example-php-L5) of that snippet to the ID of that question.

Register onto the event and enter 'stop' for the value of that question. When you submit you should see an error showing 'SPCO has been stopped before registrations have been processed'.

Change the value to anything else than the above and resubmit, this time it should process.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)