### PR TITLE
Don't Load Bundled WPGraphQL if PHP < 7 closes #3135

### DIFF
--- a/core/domain/entities/routing/data_nodes/core/CurrentUser.php
+++ b/core/domain/entities/routing/data_nodes/core/CurrentUser.php
@@ -24,7 +24,7 @@ class CurrentUser extends JsonDataNode
      */
     public function __construct(JsonDataNodeValidator $validator)
     {
-        if (! class_exists('WPGraphQL')) {
+        if (PHP_VERSION_ID > 70000 && ! class_exists('WPGraphQL')) {
             require_once EE_THIRD_PARTY . 'wp-graphql/wp-graphql.php';
         }
         parent::__construct($validator);
@@ -41,7 +41,9 @@ class CurrentUser extends JsonDataNode
             $current_user = new WP_User();
         }
 
-        $this->addData('id', Relay::toGlobalId('user', $current_user->ID));
+        if (class_exists(Relay::class)) {
+            $this->addData('id', Relay::toGlobalId('user', $current_user->ID));
+        }
         $this->addData('databaseId', $current_user->ID);
         $this->addData('description', $current_user->description);
         $this->addData('email', $current_user->user_email);


### PR DESCRIPTION
see #3135

In the `\EventEspresso\core\domain\entities\routing\data_nodes\core\CurrentUser` class constructor, we were loading the bundled WPGraphQL plugin if it was not already active, but this causes errors if the PHP version is less than 7. This PR simply checks the PHP version before doing so.

Plz note that in `\EventEspresso\core\domain\entities\routing\handlers\shared\GQLRequests::requestHandler()` we also load the bundled WPGraphQL plugin, but that method is not called if the conditional in `matchesCurrentRequest()` returns false, and that conditional already performs a PHP version check.