### PR TITLE
Deployment to RC and barista sites

### DIFF
--- a/.github/workflows/deploy-to-barista.yml
+++ b/.github/workflows/deploy-to-barista.yml
@@ -1,16 +1,18 @@
-name: Deploy to NK site
+name: Deploy to barista site
 
 on:
   push:
     branches: [barista-prod]
+
 jobs:
-  deploy-to-nk-site:
+  deploy-to-barista-site:
     runs-on: ubuntu-latest
     steps:
-      - name: deploy via ssh
+      - name: Deploy via ssh
         uses: garygrossgarten/github-action-ssh@release
         with:
-          command: source deploy-from-gh-actions-to-nk.sh "event-espresso-core"
+          # the command is supposed to run in home directory of deploy user
+          command: source deploy-to-barista.sh "event-espresso-core"
           host: ${{ secrets.SERVER_EE_DEVBOX_SITES_HOST }}
           username: ${{ secrets.SERVER_EE_DEVBOX_SITES_USERNAME }}
           passphrase: ${{ secrets.SERVER_EE_DEVBOX_SITES_PASSPHRASE }}

--- a/.github/workflows/deploy-to-rc.yml
+++ b/.github/workflows/deploy-to-rc.yml
@@ -1,0 +1,20 @@
+name: Deploy to RC site
+
+on:
+  push:
+    branches:
+      # If the branch name starts with "rc-"
+      - "rc-**"
+jobs:
+  deploy-to-rc-site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via ssh
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          # the command is supposed to run in home directory of deploy user
+          command: source deploy-to-rc.sh "event-espresso-core" ${{ github.ref }}
+          host: ${{ secrets.SERVER_EE_DEVBOX_SITES_HOST }}
+          username: ${{ secrets.SERVER_EE_DEVBOX_SITES_USERNAME }}
+          passphrase: ${{ secrets.SERVER_EE_DEVBOX_SITES_PASSPHRASE }}
+          privateKey: ${{ secrets.SERVER_EE_DEVBOX_SITES_PRIVATE_KEY}}

--- a/.github/workflows/deploy-to-rc.yml
+++ b/.github/workflows/deploy-to-rc.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # If the branch name starts with "rc-"
-      - "rc-**"
+      - rc-**
 jobs:
   deploy-to-rc-site:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds GH actions workflows to deploy `barista-prod` to `barista.eventespresso.com` and `rc-*` to `rc.eventespresso.com`

You can see that this branch has already been deployed because it starts with `rc-` 😄 