### PR TITLE
Fix Query Errors in TableAnalysis::tableExists()

### DIFF
--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -439,7 +439,6 @@ final class EE_System implements ResettableInterface
         // check if db has been updated, or if its a brand-new installation
         $espresso_db_update = $this->fix_espresso_db_upgrade_option();
         $request_type = $this->detect_req_type($espresso_db_update);
-        // EEH_Debug_Tools::printr( $request_type, '$request_type', __FILE__, __LINE__ );
         switch ($request_type) {
             case EE_System::req_type_new_activation:
                 do_action('AHEE__EE_System__detect_if_activation_or_upgrade__new_activation');

--- a/core/db_classes/EE_Import.class.php
+++ b/core/db_classes/EE_Import.class.php
@@ -34,13 +34,13 @@ class EE_Import implements ResettableInterface
 
     private static $_columns_to_save     = [];
 
-    protected      $_total_inserts       = 0;
+    protected $_total_inserts       = 0;
 
-    protected      $_total_updates       = 0;
+    protected $_total_updates       = 0;
 
-    protected      $_total_insert_errors = 0;
+    protected $_total_insert_errors = 0;
 
-    protected      $_total_update_errors = 0;
+    protected $_total_update_errors = 0;
 
 
     /**

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -1328,7 +1328,8 @@ class EEH_Activation implements ResettableInterface
                 // if already active or has already been activated before we skip
                 // (otherwise we might reactivate something user's intentionally deactivated.)
                 // we also skip if the message type is not installed.
-                if ($message_resource_manager->has_message_type_been_activated_for_messenger(
+                if (! isset($installed_message_types[ $default_message_type_name_for_messenger ])
+                    || $message_resource_manager->has_message_type_been_activated_for_messenger(
                         $default_message_type_name_for_messenger,
                         $active_messenger->name
                     )
@@ -1336,7 +1337,6 @@ class EEH_Activation implements ResettableInterface
                         $active_messenger->name,
                         $default_message_type_name_for_messenger
                     )
-                    || ! isset($installed_message_types[ $default_message_type_name_for_messenger ])
                 ) {
                     continue;
                 }

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -4,6 +4,8 @@ use EventEspresso\core\domain\entities\notifications\PersistentAdminNotice;
 use EventEspresso\core\domain\services\custom_post_types\RewriteRules;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\interfaces\ResettableInterface;
+use EventEspresso\core\services\database\TableAnalysis;
+use EventEspresso\core\services\database\TableManager;
 
 /**
  * EEH_Activation Helper
@@ -39,35 +41,39 @@ class EEH_Activation implements ResettableInterface
     protected static $_initialized_db_content_already_in_this_request = false;
 
     /**
-     * @var \EventEspresso\core\services\database\TableAnalysis $table_analysis
+     * @var TableAnalysis $table_analysis
      */
     private static $table_analysis;
 
     /**
-     * @var \EventEspresso\core\services\database\TableManager $table_manager
+     * @var TableManager $table_manager
      */
     private static $table_manager;
 
 
     /**
-     * @return \EventEspresso\core\services\database\TableAnalysis
+     * @return TableAnalysis
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function getTableAnalysis()
     {
-        if (! self::$table_analysis instanceof \EventEspresso\core\services\database\TableAnalysis) {
-            self::$table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
+        if (! self::$table_analysis instanceof TableAnalysis) {
+            self::$table_analysis = EE_Registry::instance()->create('TableAnalysis', [], true);
         }
         return self::$table_analysis;
     }
 
 
     /**
-     * @return \EventEspresso\core\services\database\TableManager
+     * @return TableManager
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function getTableManager()
     {
-        if (! self::$table_manager instanceof \EventEspresso\core\services\database\TableManager) {
-            self::$table_manager = EE_Registry::instance()->create('TableManager', array(), true);
+        if (! self::$table_manager instanceof TableManager) {
+            self::$table_manager = EE_Registry::instance()->create('TableManager', [], true);
         }
         return self::$table_manager;
     }
@@ -76,15 +82,17 @@ class EEH_Activation implements ResettableInterface
     /**
      *    _ensure_table_name_has_prefix
      *
+     * @param $table_name
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      * @deprecated instead use TableAnalysis::ensureTableNameHasPrefix()
      * @access     public
      * @static
-     * @param $table_name
-     * @return string
      */
     public static function ensure_table_name_has_prefix($table_name)
     {
-        return \EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix($table_name);
+        return EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix($table_name);
     }
 
 
@@ -110,7 +118,8 @@ class EEH_Activation implements ResettableInterface
      * be called on plugin activation and reactivation
      *
      * @return boolean success, whether the database and folders are setup properly
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function initialize_db_and_folders()
     {
@@ -124,7 +133,8 @@ class EEH_Activation implements ResettableInterface
      * upon activation of a new plugin, reactivation, and at the end
      * of running migration scripts
      *
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function initialize_db_content()
     {
@@ -164,19 +174,21 @@ class EEH_Activation implements ResettableInterface
      * @param string $which_to_include can be 'current' (ones that are currently in use),
      *                                 'old' (only returns ones that should no longer be used),or 'all',
      * @return array
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public static function get_cron_tasks($which_to_include)
     {
         $cron_tasks = apply_filters(
             'FHEE__EEH_Activation__get_cron_tasks',
-            array(
+            [
                 'AHEE__EE_Cron_Tasks__clean_up_junk_transactions'      => 'hourly',
-            //              'AHEE__EE_Cron_Tasks__finalize_abandoned_transactions' => EEH_Activation::cron_task_no_longer_in_use, actually this is still in use
+                // 'AHEE__EE_Cron_Tasks__finalize_abandoned_transactions' =>
+                // EEH_Activation::cron_task_no_longer_in_use, actually this is still in use
                 'AHEE__EE_Cron_Tasks__update_transaction_with_payment' => EEH_Activation::cron_task_no_longer_in_use,
-                // there may have been a bug which prevented from these cron tasks from getting unscheduled, so we might want to remove these for a few updates
+                // there may have been a bug which prevented these cron tasks from getting unscheduled,
+                // so we might want to remove these for a few updates
                 'AHEE_EE_Cron_Tasks__clean_out_old_gateway_logs'       => 'daily',
-            )
+            ]
         );
         if ($which_to_include === 'old') {
             $cron_tasks = array_filter(
@@ -205,7 +217,7 @@ class EEH_Activation implements ResettableInterface
     /**
      * Ensure cron tasks are setup (the removal of crons should be done by remove_crons())
      *
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public static function create_cron_tasks()
     {
@@ -220,7 +232,7 @@ class EEH_Activation implements ResettableInterface
                     && isset($frequency[0], $frequency[1])
                 ) {
                     $start_timestamp = $frequency[0];
-                    $frequency = $frequency[1];
+                    $frequency       = $frequency[1];
                 } else {
                     $start_timestamp = time();
                 }
@@ -234,13 +246,13 @@ class EEH_Activation implements ResettableInterface
      * Remove the currently-existing and now-removed cron tasks.
      *
      * @param boolean $remove_all whether to only remove the old ones, or remove absolutely ALL the EE ones
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public static function remove_cron_tasks($remove_all = true)
     {
         $cron_tasks_to_remove = $remove_all ? 'all' : 'old';
         $crons                = _get_cron_array();
-        $crons                = is_array($crons) ? $crons : array();
+        $crons                = is_array($crons) ? $crons : [];
         /* reminder of what $crons look like:
          * Top-level keys are timestamps, and their values are arrays.
          * The 2nd level arrays have keys with each of the cron task hook names to run at that time
@@ -285,6 +297,8 @@ class EEH_Activation implements ResettableInterface
      * @access public
      * @static
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function CPT_initialization()
     {
@@ -292,7 +306,6 @@ class EEH_Activation implements ResettableInterface
         EE_Registry::instance()->load_core('Register_CPTs');
         flush_rewrite_rules();
     }
-
 
 
     /**
@@ -307,10 +320,10 @@ class EEH_Activation implements ResettableInterface
      */
     public static function reset_and_update_config()
     {
-        do_action('AHEE__EE_Config___load_core_config__start', array('EEH_Activation', 'load_calendar_config'));
+        do_action('AHEE__EE_Config___load_core_config__start', ['EEH_Activation', 'load_calendar_config']);
         add_filter(
             'FHEE__EE_Config___load_core_config__config_settings',
-            array('EEH_Activation', 'migrate_old_config_data'),
+            ['EEH_Activation', 'migrate_old_config_data'],
             10,
             3
         );
@@ -357,24 +370,23 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
      *    _migrate_old_config_data
      *
      * @access    public
      * @param array|stdClass $settings
      * @param string         $config
-     * @param \EE_Config     $EE_Config
-     * @return \stdClass
+     * @param EE_Config      $EE_Config
+     * @return stdClass
      */
-    public static function migrate_old_config_data($settings = array(), $config = '', EE_Config $EE_Config)
+    public static function migrate_old_config_data($settings = [], $config = '', EE_Config $EE_Config)
     {
-        $convert_from_array = array('addons');
+        $convert_from_array = ['addons'];
         // in case old settings were saved as an array
         if (is_array($settings) && in_array($config, $convert_from_array)) {
             // convert existing settings to an object
             $config_array = $settings;
-            $settings = new stdClass();
+            $settings     = new stdClass();
             foreach ($config_array as $key => $value) {
                 if ($key === 'calendar' && class_exists('EE_Calendar_Config')) {
                     $EE_Config->set_config('addons', 'EE_Calendar', 'EE_Calendar_Config', $value);
@@ -404,7 +416,6 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
      * verify_default_pages_exist
      *
@@ -416,33 +427,33 @@ class EEH_Activation implements ResettableInterface
     public static function verify_default_pages_exist()
     {
         $critical_page_problem = false;
-        $critical_pages = array(
-            array(
+        $critical_pages        = [
+            [
                 'id'   => 'reg_page_id',
                 'name' => __('Registration Checkout', 'event_espresso'),
                 'post' => null,
                 'code' => 'ESPRESSO_CHECKOUT',
-            ),
-            array(
+            ],
+            [
                 'id'   => 'txn_page_id',
                 'name' => __('Transactions', 'event_espresso'),
                 'post' => null,
                 'code' => 'ESPRESSO_TXN_PAGE',
-            ),
-            array(
+            ],
+            [
                 'id'   => 'thank_you_page_id',
                 'name' => __('Thank You', 'event_espresso'),
                 'post' => null,
                 'code' => 'ESPRESSO_THANK_YOU',
-            ),
-            array(
+            ],
+            [
                 'id'   => 'cancel_page_id',
                 'name' => __('Registration Cancelled', 'event_espresso'),
                 'post' => null,
                 'code' => 'ESPRESSO_CANCELLED',
-            ),
-        );
-        $EE_Core_Config = EE_Registry::instance()->CFG->core;
+            ],
+        ];
+        $EE_Core_Config        = EE_Registry::instance()->CFG->core;
         foreach ($critical_pages as $critical_page) {
             // is critical page ID set in config ?
             if ($EE_Core_Config->{$critical_page['id']} !== false) {
@@ -508,7 +519,6 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
      * Returns the first post which uses the specified shortcode
      *
@@ -523,7 +533,10 @@ class EEH_Activation implements ResettableInterface
     {
         global $wpdb;
         $shortcode_and_opening_bracket = '[' . $ee_shortcode;
-        $post_id = $wpdb->get_var("SELECT ID FROM {$wpdb->posts} WHERE post_content LIKE '%$shortcode_and_opening_bracket%' LIMIT 1");
+        $post_id                       =
+            $wpdb->get_var(
+                "SELECT ID FROM {$wpdb->posts} WHERE post_content LIKE '%$shortcode_and_opening_bracket%' LIMIT 1"
+            );
         if ($post_id) {
             return get_post($post_id);
         } else {
@@ -543,13 +556,13 @@ class EEH_Activation implements ResettableInterface
     public static function create_critical_page($critical_page)
     {
 
-        $post_args = array(
+        $post_args = [
             'post_title'     => $critical_page['name'],
             'post_status'    => 'publish',
             'post_type'      => 'page',
             'comment_status' => 'closed',
             'post_content'   => '[' . $critical_page['code'] . ']',
-        );
+        ];
 
         $post_id = wp_insert_post($post_args);
         if (! $post_id) {
@@ -573,15 +586,15 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
-
     /**
      * Tries to find the oldest admin for this site.  If there are no admins for this site then return NULL.
      * The role being used to check is filterable.
      *
+     * @return mixed null|int WP_user ID or NULL
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since  4.6.0
      * @global WPDB $wpdb
-     * @return mixed null|int WP_user ID or NULL
      */
     public static function get_default_creator_id()
     {
@@ -599,13 +612,13 @@ class EEH_Activation implements ResettableInterface
         if ($pre_filtered_id !== false) {
             return (int) $pre_filtered_id;
         }
-        $capabilities_key = \EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('capabilities');
-        $query = $wpdb->prepare(
+        $capabilities_key = EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('capabilities');
+        $query            = $wpdb->prepare(
             "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '$capabilities_key' AND meta_value LIKE %s ORDER BY user_id ASC LIMIT 0,1",
             '%' . $role_to_check . '%'
         );
-        $user_id = $wpdb->get_var($query);
-        $user_id = apply_filters('FHEE__EEH_Activation_Helper__get_default_creator_id__user_id', $user_id);
+        $user_id          = $wpdb->get_var($query);
+        $user_id          = apply_filters('FHEE__EEH_Activation_Helper__get_default_creator_id__user_id', $user_id);
         if ($user_id && (int) $user_id) {
             self::$_default_creator_id = (int) $user_id;
             return self::$_default_creator_id;
@@ -613,7 +626,6 @@ class EEH_Activation implements ResettableInterface
             return null;
         }
     }
-
 
 
     /**
@@ -634,6 +646,7 @@ class EEH_Activation implements ResettableInterface
      *                                         (and if it HAS data in it you want to leave it be)
      * @return void
      * @throws EE_Error if there are database errors
+     * @throws ReflectionException
      */
     public static function create_table($table_name, $sql, $engine = 'ENGINE=MyISAM ', $drop_pre_existing_table = false)
     {
@@ -644,7 +657,7 @@ class EEH_Activation implements ResettableInterface
         if (! function_exists('dbDelta')) {
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
         }
-        $tableAnalysis = \EEH_Activation::getTableAnalysis();
+        $tableAnalysis = EEH_Activation::getTableAnalysis();
         $wp_table_name = $tableAnalysis->ensureTableNameHasPrefix($table_name);
         // do we need to first delete an existing version of this table ?
         if ($drop_pre_existing_table && $tableAnalysis->tableExists($wp_table_name)) {
@@ -652,7 +665,7 @@ class EEH_Activation implements ResettableInterface
             $deleted_safely = EEH_Activation::delete_db_table_if_empty($wp_table_name);
             // table is NOT empty, are you SURE you want to delete this table ???
             if (! $deleted_safely && defined('EE_DROP_BAD_TABLES') && EE_DROP_BAD_TABLES) {
-                \EEH_Activation::getTableManager()->dropTable($wp_table_name);
+                EEH_Activation::getTableManager()->dropTable($wp_table_name);
             } elseif (! $deleted_safely) {
                 // so we should be more cautious rather than just dropping tables so easily
                 error_log(
@@ -669,30 +682,31 @@ class EEH_Activation implements ResettableInterface
             }
         }
         $engine = str_replace('ENGINE=', '', $engine);
-        \EEH_Activation::getTableManager()->createTable($table_name, $sql, $engine);
+        EEH_Activation::getTableManager()->createTable($table_name, $sql, $engine);
     }
 
 
-
     /**
-     *    add_column_if_it_doesn't_exist
+     *    add_column_if_it_doesnt_exist
      *    Checks if this column already exists on the specified table. Handy for addons which want to add a column
      *
      * @access     public
      * @static
-     * @deprecated instead use TableManager::addColumn()
      * @param string $table_name  (without "wp_", eg "esp_attendee"
      * @param string $column_name
      * @param string $column_info if your SQL were 'ALTER TABLE table_name ADD price VARCHAR(10)', this would be
      *                            'VARCHAR(10)'
      * @return bool|int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @deprecated instead use TableManager::addColumn()
      */
     public static function add_column_if_it_doesnt_exist(
         $table_name,
         $column_name,
         $column_info = 'INT UNSIGNED NOT NULL'
     ) {
-        return \EEH_Activation::getTableManager()->addColumn($table_name, $column_name, $column_info);
+        return EEH_Activation::getTableManager()->addColumn($table_name, $column_name, $column_info);
     }
 
 
@@ -701,14 +715,16 @@ class EEH_Activation implements ResettableInterface
      * Gets all the fields on the database table.
      *
      * @access     public
-     * @deprecated instead use TableManager::getTableColumns()
-     * @static
      * @param string $table_name , without prefixed $wpdb->prefix
      * @return array of database column names
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @deprecated instead use TableManager::getTableColumns()
+     * @static
      */
     public static function get_fields_on_table($table_name = null)
     {
-        return \EEH_Activation::getTableManager()->getTableColumns($table_name);
+        return EEH_Activation::getTableManager()->getTableColumns($table_name);
     }
 
 
@@ -716,14 +732,16 @@ class EEH_Activation implements ResettableInterface
      * db_table_is_empty
      *
      * @access     public\
-     * @deprecated instead use TableAnalysis::tableIsEmpty()
-     * @static
      * @param string $table_name
      * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @deprecated instead use TableAnalysis::tableIsEmpty()
+     * @static
      */
     public static function db_table_is_empty($table_name)
     {
-        return \EEH_Activation::getTableAnalysis()->tableIsEmpty($table_name);
+        return EEH_Activation::getTableAnalysis()->tableIsEmpty($table_name);
     }
 
 
@@ -734,11 +752,13 @@ class EEH_Activation implements ResettableInterface
      * @static
      * @param string $table_name
      * @return bool | int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function delete_db_table_if_empty($table_name)
     {
-        if (\EEH_Activation::getTableAnalysis()->tableIsEmpty($table_name)) {
-            return \EEH_Activation::getTableManager()->dropTable($table_name);
+        if (EEH_Activation::getTableAnalysis()->tableIsEmpty($table_name)) {
+            return EEH_Activation::getTableManager()->dropTable($table_name);
         }
         return false;
     }
@@ -749,13 +769,15 @@ class EEH_Activation implements ResettableInterface
      *
      * @access     public
      * @static
-     * @deprecated instead use TableManager::dropTable()
      * @param string $table_name
      * @return bool | int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @deprecated instead use TableManager::dropTable()
      */
     public static function delete_unused_db_table($table_name)
     {
-        return \EEH_Activation::getTableManager()->dropTable($table_name);
+        return EEH_Activation::getTableManager()->dropTable($table_name);
     }
 
 
@@ -764,16 +786,17 @@ class EEH_Activation implements ResettableInterface
      *
      * @access     public
      * @static
-     * @deprecated instead use TableManager::dropIndex()
      * @param string $table_name
      * @param string $index_name
      * @return bool | int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @deprecated instead use TableManager::dropIndex()
      */
     public static function drop_index($table_name, $index_name)
     {
-        return \EEH_Activation::getTableManager()->dropIndex($table_name, $index_name);
+        return EEH_Activation::getTableManager()->dropIndex($table_name, $index_name);
     }
-
 
 
     /**
@@ -781,8 +804,9 @@ class EEH_Activation implements ResettableInterface
      *
      * @access public
      * @static
-     * @throws EE_Error
      * @return boolean success (whether database is setup properly or not)
+     * @throws ReflectionException
+     * @throws EE_Error
      */
     public static function create_database_tables()
     {
@@ -802,7 +826,7 @@ class EEH_Activation implements ResettableInterface
                 } else {
                     EE_Error::add_error(
                         __(
-                            'There were errors creating the Event Espresso database tables and Event Espresso has been 
+                            'There were errors creating the Event Espresso database tables and Event Espresso has been
                             deactivated. To view the errors, please enable WP_DEBUG in your wp-config.php file.',
                             'event_espresso'
                         )
@@ -828,36 +852,37 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
      * initialize_system_questions
      *
      * @access public
      * @static
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function initialize_system_questions()
     {
         // QUESTION GROUPS
         global $wpdb;
-        $table_name = \EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question_group');
-        $SQL = "SELECT QSG_system FROM $table_name WHERE QSG_system != 0";
+        $table_name = EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question_group');
+        $SQL        = "SELECT QSG_system FROM $table_name WHERE QSG_system != 0";
         // what we have
         $question_groups = $wpdb->get_col($SQL);
         // check the response
-        $question_groups = is_array($question_groups) ? $question_groups : array();
+        $question_groups = is_array($question_groups) ? $question_groups : [];
         // what we should have
-        $QSG_systems = array(1, 2);
+        $QSG_systems = [1, 2];
         // loop thru what we should have and compare to what we have
         foreach ($QSG_systems as $QSG_system) {
             // reset values array
-            $QSG_values = array();
+            $QSG_values = [];
             // if we don't have what we should have (but use $QST_system as as string because that's what we got from the db)
             if (! in_array("$QSG_system", $question_groups)) {
                 // add it
                 switch ($QSG_system) {
                     case 1:
-                        $QSG_values = array(
+                        $QSG_values = [
                             'QSG_name'            => __('Personal Information', 'event_espresso'),
                             'QSG_identifier'      => 'personal-information-' . time(),
                             'QSG_desc'            => '',
@@ -866,10 +891,10 @@ class EEH_Activation implements ResettableInterface
                             'QSG_show_group_desc' => 1,
                             'QSG_system'          => EEM_Question_Group::system_personal,
                             'QSG_deleted'         => 0,
-                        );
+                        ];
                         break;
                     case 2:
-                        $QSG_values = array(
+                        $QSG_values = [
                             'QSG_name'            => __('Address Information', 'event_espresso'),
                             'QSG_identifier'      => 'address-information-' . time(),
                             'QSG_desc'            => '',
@@ -878,7 +903,7 @@ class EEH_Activation implements ResettableInterface
                             'QSG_show_group_desc' => 1,
                             'QSG_system'          => EEM_Question_Group::system_address,
                             'QSG_deleted'         => 0,
-                        );
+                        ];
                         break;
                 }
                 // make sure we have some values before inserting them
@@ -887,7 +912,7 @@ class EEH_Activation implements ResettableInterface
                     $wpdb->insert(
                         $table_name,
                         $QSG_values,
-                        array('%s', '%s', '%s', '%d', '%d', '%d', '%d', '%d')
+                        ['%s', '%s', '%s', '%d', '%d', '%d', '%d', '%d']
                     );
                     $QSG_IDs[ $QSG_system ] = $wpdb->insert_id;
                 }
@@ -895,16 +920,16 @@ class EEH_Activation implements ResettableInterface
         }
         // QUESTIONS
         global $wpdb;
-        $table_name = \EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question');
-        $SQL = "SELECT QST_system FROM $table_name WHERE QST_system != ''";
+        $table_name = EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question');
+        $SQL        = "SELECT QST_system FROM $table_name WHERE QST_system != ''";
         // what we have
         $questions = $wpdb->get_col($SQL);
         // all system questions
         $personal_system_group_questions = ['fname', 'lname', 'email'];
-        $address_system_group_questions = ['address', 'address2', 'city', 'country', 'state', 'zip', 'phone'];
-        $system_questions_not_in_group = ['email_confirm'];
+        $address_system_group_questions  = ['address', 'address2', 'city', 'country', 'state', 'zip', 'phone'];
+        $system_questions_not_in_group   = ['email_confirm'];
         // merge all of the system questions we should have
-        $QST_systems = array_merge(
+        $QST_systems       = array_merge(
             $personal_system_group_questions,
             $address_system_group_questions,
             $system_questions_not_in_group
@@ -914,13 +939,13 @@ class EEH_Activation implements ResettableInterface
         // loop thru what we should have and compare to what we have
         foreach ($QST_systems as $QST_system) {
             // reset values array
-            $QST_values = array();
+            $QST_values = [];
             // if we don't have what we should have
             if (! in_array($QST_system, $questions)) {
                 // add it
                 switch ($QST_system) {
                     case 'fname':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('First Name', 'event_espresso'),
                             'QST_admin_label'   => __('First Name - System Question', 'event_espresso'),
                             'QST_system'        => 'fname',
@@ -929,13 +954,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 1,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'lname':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Last Name', 'event_espresso'),
                             'QST_admin_label'   => __('Last Name - System Question', 'event_espresso'),
                             'QST_system'        => 'lname',
@@ -944,13 +971,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 2,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'email':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Email Address', 'event_espresso'),
                             'QST_admin_label'   => __('Email Address - System Question', 'event_espresso'),
                             'QST_system'        => 'email',
@@ -959,13 +988,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 3,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'email_confirm':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Confirm Email Address', 'event_espresso'),
                             'QST_admin_label'   => __('Confirm Email Address - System Question', 'event_espresso'),
                             'QST_system'        => 'email_confirm',
@@ -974,13 +1005,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 4,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'address':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Address', 'event_espresso'),
                             'QST_admin_label'   => __('Address - System Question', 'event_espresso'),
                             'QST_system'        => 'address',
@@ -989,13 +1022,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 5,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'address2':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Address2', 'event_espresso'),
                             'QST_admin_label'   => __('Address2 - System Question', 'event_espresso'),
                             'QST_system'        => 'address2',
@@ -1004,13 +1039,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 6,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'city':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('City', 'event_espresso'),
                             'QST_admin_label'   => __('City - System Question', 'event_espresso'),
                             'QST_system'        => 'city',
@@ -1019,13 +1056,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 7,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'country':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Country', 'event_espresso'),
                             'QST_admin_label'   => __('Country - System Question', 'event_espresso'),
                             'QST_system'        => 'country',
@@ -1036,10 +1075,10 @@ class EEH_Activation implements ResettableInterface
                             'QST_admin_only'    => 0,
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'state':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('State/Province', 'event_espresso'),
                             'QST_admin_label'   => __('State/Province - System Question', 'event_espresso'),
                             'QST_system'        => 'state',
@@ -1050,10 +1089,10 @@ class EEH_Activation implements ResettableInterface
                             'QST_admin_only'    => 0,
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'zip':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Zip/Postal Code', 'event_espresso'),
                             'QST_admin_label'   => __('Zip/Postal Code - System Question', 'event_espresso'),
                             'QST_system'        => 'zip',
@@ -1062,13 +1101,15 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 10,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                     case 'phone':
-                        $QST_values = array(
+                        $QST_values = [
                             'QST_display_text'  => __('Phone Number', 'event_espresso'),
                             'QST_admin_label'   => __('Phone Number - System Question', 'event_espresso'),
                             'QST_system'        => 'phone',
@@ -1077,10 +1118,12 @@ class EEH_Activation implements ResettableInterface
                             'QST_required_text' => __('This field is required', 'event_espresso'),
                             'QST_order'         => 11,
                             'QST_admin_only'    => 0,
-                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question($QST_system),
+                            'QST_max'           => EEM_Question::instance()->absolute_max_for_system_question(
+                                $QST_system
+                            ),
                             'QST_wp_user'       => self::get_default_creator_id(),
                             'QST_deleted'       => 0,
-                        );
+                        ];
                         break;
                 }
                 if (! empty($QST_values)) {
@@ -1088,7 +1131,7 @@ class EEH_Activation implements ResettableInterface
                     $wpdb->insert(
                         $table_name,
                         $QST_values,
-                        array('%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d', '%d')
+                        ['%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d', '%d']
                     );
                     $QST_ID = $wpdb->insert_id;
 
@@ -1105,7 +1148,7 @@ class EEH_Activation implements ResettableInterface
                         $QSG_ID = $QSG_IDs[ $system_question_we_want ];
                     } else {
                         $id_col = EEM_Question_Group::instance()
-                                                    ->get_col(array(array('QSG_system' => $system_question_we_want)));
+                                                    ->get_col([['QSG_system' => $system_question_we_want]]);
                         if (is_array($id_col)) {
                             $QSG_ID = reset($id_col);
                         } else {
@@ -1128,13 +1171,13 @@ class EEH_Activation implements ResettableInterface
                     }
                     // add system questions to groups
                     $wpdb->insert(
-                        \EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question_group_question'),
-                        array(
+                        EEH_Activation::getTableAnalysis()->ensureTableNameHasPrefix('esp_question_group_question'),
+                        [
                             'QSG_ID'    => $QSG_ID,
                             'QST_ID'    => $QST_ID,
                             'QGQ_order' => ($QSG_ID === 1) ? $order_for_group_1++ : $order_for_group_2++,
-                        ),
-                        array('%d', '%d', '%d')
+                        ],
+                        ['%d', '%d', '%d']
                     );
                 }
             }
@@ -1146,7 +1189,8 @@ class EEH_Activation implements ResettableInterface
      * Makes sure the default payment method (Invoice) is active.
      * This used to be done automatically as part of constructing the old gateways config
      *
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function insert_default_payment_methods()
     {
@@ -1158,22 +1202,26 @@ class EEH_Activation implements ResettableInterface
         }
     }
 
+
     /**
      * insert_default_status_codes
      *
      * @access public
      * @static
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function insert_default_status_codes()
     {
 
         global $wpdb;
 
-        if (\EEH_Activation::getTableAnalysis()->tableExists(EEM_Status::instance()->table())) {
+        if (EEH_Activation::getTableAnalysis()->tableExists(EEM_Status::instance()->table())) {
             $table_name = EEM_Status::instance()->table();
 
-            $SQL = "DELETE FROM $table_name WHERE STS_ID IN ( 'ACT', 'NAC', 'NOP', 'OPN', 'CLS', 'PND', 'ONG', 'SEC', 'DRF', 'DEL', 'DEN', 'EXP', 'RPP', 'RCN', 'RDC', 'RAP', 'RNA', 'RWL', 'TAB', 'TIN', 'TFL', 'TCM', 'TOP', 'PAP', 'PCN', 'PFL', 'PDC', 'EDR', 'ESN', 'PPN', 'RIC', 'MSN', 'MFL', 'MID', 'MRS', 'MIC', 'MDO', 'MEX' );";
+            $SQL =
+                "DELETE FROM $table_name WHERE STS_ID IN ( 'ACT', 'NAC', 'NOP', 'OPN', 'CLS', 'PND', 'ONG', 'SEC', 'DRF', 'DEL', 'DEN', 'EXP', 'RPP', 'RCN', 'RDC', 'RAP', 'RNA', 'RWL', 'TAB', 'TIN', 'TFL', 'TCM', 'TOP', 'PAP', 'PCN', 'PFL', 'PDC', 'EDR', 'ESN', 'PPN', 'RIC', 'MSN', 'MFL', 'MID', 'MRS', 'MIC', 'MDO', 'MEX' );";
             $wpdb->query($SQL);
 
             $SQL = "INSERT INTO $table_name
@@ -1225,11 +1273,12 @@ class EEH_Activation implements ResettableInterface
      * generate_default_message_templates
      *
      * @static
-     * @throws EE_Error
      * @return bool     true means new templates were created.
      *                  false means no templates were created.
      *                  This is NOT an error flag. To check for errors you will want
      *                  to use either EE_Error or a try catch for an EE_Error exception.
+     * @throws ReflectionException
+     * @throws EE_Error
      */
     public static function generate_default_message_templates()
     {
@@ -1246,9 +1295,10 @@ class EEH_Activation implements ResettableInterface
          * This method is verifying there are no NEW default message types
          * for ACTIVE messengers that need activated (and corresponding templates setup).
          */
-        $new_templates_created_for_message_type = self::_activate_new_message_types_for_active_messengers_and_generate_default_templates(
-            $message_resource_manager
-        );
+        $new_templates_created_for_message_type =
+            self::_activate_new_message_types_for_active_messengers_and_generate_default_templates(
+                $message_resource_manager
+            );
         // after all is done, let's persist these changes to the db.
         $message_resource_manager->update_has_activated_messengers_option();
         $message_resource_manager->update_active_messengers_option();
@@ -1257,22 +1307,21 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
-     * @param \EE_Message_Resource_Manager $message_resource_manager
+     * @param EE_Message_Resource_Manager $message_resource_manager
      * @return array|bool
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     protected static function _activate_new_message_types_for_active_messengers_and_generate_default_templates(
         EE_Message_Resource_Manager $message_resource_manager
     ) {
         /** @type EE_messenger[] $active_messengers */
-        $active_messengers = $message_resource_manager->active_messengers();
+        $active_messengers       = $message_resource_manager->active_messengers();
         $installed_message_types = $message_resource_manager->installed_message_types();
-        $templates_created = false;
+        $templates_created       = false;
         foreach ($active_messengers as $active_messenger) {
             $default_message_type_names_for_messenger = $active_messenger->get_default_message_types();
-            $default_message_type_names_to_activate = array();
+            $default_message_type_names_to_activate   = [];
             // looping through each default message type reported by the messenger
             // and setup the actual message types to activate.
             foreach ($default_message_type_names_for_messenger as $default_message_type_name_for_messenger) {
@@ -1280,9 +1329,9 @@ class EEH_Activation implements ResettableInterface
                 // (otherwise we might reactivate something user's intentionally deactivated.)
                 // we also skip if the message type is not installed.
                 if ($message_resource_manager->has_message_type_been_activated_for_messenger(
-                    $default_message_type_name_for_messenger,
-                    $active_messenger->name
-                )
+                        $default_message_type_name_for_messenger,
+                        $active_messenger->name
+                    )
                     || $message_resource_manager->is_message_type_active_for_messenger(
                         $active_messenger->name,
                         $default_message_type_name_for_messenger
@@ -1313,7 +1362,6 @@ class EEH_Activation implements ResettableInterface
     }
 
 
-
     /**
      * This will activate and generate default messengers and default message types for those messengers.
      *
@@ -1327,9 +1375,9 @@ class EEH_Activation implements ResettableInterface
         EE_Message_Resource_Manager $message_resource_manager
     ) {
         /** @type EE_messenger[] $messengers_to_generate */
-        $messengers_to_generate = self::_get_default_messengers_to_generate_on_activation($message_resource_manager);
+        $messengers_to_generate  = self::_get_default_messengers_to_generate_on_activation($message_resource_manager);
         $installed_message_types = $message_resource_manager->installed_message_types();
-        $templates_generated = false;
+        $templates_generated     = false;
         foreach ($messengers_to_generate as $messenger_to_generate) {
             $default_message_type_names_for_messenger = $messenger_to_generate->get_default_message_types();
             // verify the default message types match an installed message type.
@@ -1374,7 +1422,7 @@ class EEH_Activation implements ResettableInterface
      * - whether a messenger has been made active at any time in the past.
      *
      * @static
-     * @param  EE_Message_Resource_Manager $message_resource_manager
+     * @param EE_Message_Resource_Manager $message_resource_manager
      * @return EE_messenger[]
      */
     protected static function _get_default_messengers_to_generate_on_activation(
@@ -1384,7 +1432,7 @@ class EEH_Activation implements ResettableInterface
         $installed_messengers = $message_resource_manager->installed_messengers();
         $has_activated        = $message_resource_manager->get_has_activated_messengers_option();
 
-        $messengers_to_generate = array();
+        $messengers_to_generate = [];
         foreach ($installed_messengers as $installed_messenger) {
             // if installed messenger is a messenger that should be activated on install
             // and is not already active
@@ -1409,8 +1457,10 @@ class EEH_Activation implements ResettableInterface
      * EE_Messenger_Resource_Manager is constructed.  Message Types are a bit more resource heavy for validation so they
      * are still handled in here.
      *
-     * @since 4.3.1
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.3.1
      */
     public static function validate_messages_system()
     {
@@ -1434,7 +1484,7 @@ class EEH_Activation implements ResettableInterface
         // this allows us to warn admins of the situation so that it can be corrected
         $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', false);
         if (! $espresso_no_ticket_prices) {
-            add_option('ee_no_ticket_prices', array(), '', false);
+            add_option('ee_no_ticket_prices', [], '', false);
         }
     }
 
@@ -1455,17 +1505,17 @@ class EEH_Activation implements ResettableInterface
      * Finds all our EE4 custom post types, and deletes them and their associated data
      * (like post meta or term relations)
      *
+     * @throws EE_Error
      * @global wpdb $wpdb
-     * @throws \EE_Error
      */
     public static function delete_all_espresso_cpt_data()
     {
         global $wpdb;
         // get all the CPT post_types
-        $ee_post_types = array();
+        $ee_post_types = [];
         foreach (EE_Registry::instance()->non_abstract_db_models as $model_name) {
             if (method_exists($model_name, 'instance')) {
-                $model_obj = call_user_func(array($model_name, 'instance'));
+                $model_obj = call_user_func([$model_name, 'instance']);
                 if ($model_obj instanceof EEM_CPT_Base) {
                     $ee_post_types[] = $wpdb->prepare("%s", $model_obj->post_type());
                 }
@@ -1480,23 +1530,25 @@ class EEH_Activation implements ResettableInterface
         }
     }
 
+
     /**
      * Deletes all EE custom tables
      *
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function drop_espresso_tables()
     {
-        $tables = array();
+        $tables = [];
         // load registry
         foreach (EE_Registry::instance()->non_abstract_db_models as $model_name) {
             if (method_exists($model_name, 'instance')) {
-                $model_obj = call_user_func(array($model_name, 'instance'));
+                $model_obj = call_user_func([$model_name, 'instance']);
                 if ($model_obj instanceof EEM_Base) {
                     foreach ($model_obj->get_tables() as $table) {
                         if (strpos($table->get_table_name(), 'esp_')
-                            &&
-                            (
+                            && (
                                 is_main_site()// main site? nuke them all
                                 || ! $table->is_global()// not main site,but not global either. nuke it
                             )
@@ -1510,19 +1562,18 @@ class EEH_Activation implements ResettableInterface
 
         // there are some tables whose models were removed.
         // they should be removed when removing all EE core's data
-        $tables_without_models = array(
+        $tables_without_models = [
             'esp_promotion',
             'esp_promotion_applied',
             'esp_promotion_object',
             'esp_promotion_rule',
             'esp_rule',
-        );
+        ];
         foreach ($tables_without_models as $table) {
             $tables[ $table ] = $table;
         }
-        return \EEH_Activation::getTableManager()->dropTables($tables);
+        return EEH_Activation::getTableManager()->dropTables($tables);
     }
-
 
 
     /**
@@ -1530,16 +1581,17 @@ class EEH_Activation implements ResettableInterface
      * each table name provided has a wpdb prefix attached, and that it exists.
      * Returns the list actually deleted
      *
-     * @deprecated in 4.9.13. Instead use TableManager::dropTables()
-     * @global WPDB $wpdb
      * @param array $table_names
      * @return array of table names which we deleted
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global WPDB $wpdb
+     * @deprecated in 4.9.13. Instead use TableManager::dropTables()
      */
     public static function drop_tables($table_names)
     {
-        return \EEH_Activation::getTableManager()->dropTables($table_names);
+        return EEH_Activation::getTableManager()->dropTables($table_names);
     }
-
 
 
     /**
@@ -1549,57 +1601,60 @@ class EEH_Activation implements ResettableInterface
      * @static
      * @param bool $remove_all
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function delete_all_espresso_tables_and_data($remove_all = true)
     {
         global $wpdb;
         self::drop_espresso_tables();
-        $wp_options_to_delete = array(
-            'ee_no_ticket_prices'                => true,
-            'ee_active_messengers'               => true,
-            'ee_has_activated_messenger'         => true,
+        $wp_options_to_delete = [
+            'ee_no_ticket_prices'                        => true,
+            'ee_active_messengers'                       => true,
+            'ee_has_activated_messenger'                 => true,
             RewriteRules::OPTION_KEY_FLUSH_REWRITE_RULES => true,
-            'ee_config'                          => false,
-            'ee_data_migration_current_db_state' => true,
-            'ee_data_migration_mapping_'         => false,
-            'ee_data_migration_script_'          => false,
-            'ee_data_migrations'                 => true,
-            'ee_dms_map'                         => false,
-            'ee_notices'                         => true,
-            'lang_file_check_'                   => false,
-            'ee_maintenance_mode'                => true,
-            'ee_ueip_optin'                      => true,
-            'ee_ueip_has_notified'               => true,
-            'ee_plugin_activation_errors'        => true,
-            'ee_id_mapping_from'                 => false,
-            'espresso_persistent_admin_notices'  => true,
-            'ee_encryption_key'                  => true,
-            'pue_force_upgrade_'                 => false,
-            'pue_json_error_'                    => false,
-            'pue_install_key_'                   => false,
-            'pue_verification_error_'            => false,
-            'pu_dismissed_upgrade_'              => false,
-            'external_updates-'                  => false,
-            'ee_extra_data'                      => true,
-            'ee_ssn_'                            => false,
-            'ee_rss_'                            => false,
-            'ee_rte_n_tx_'                       => false,
-            'ee_pers_admin_notices'              => true,
-            'ee_job_parameters_'                 => false,
-            'ee_upload_directories_incomplete'   => true,
-            'ee_verified_db_collations'          => true,
-        );
+            'ee_config'                                  => false,
+            'ee_data_migration_current_db_state'         => true,
+            'ee_data_migration_mapping_'                 => false,
+            'ee_data_migration_script_'                  => false,
+            'ee_data_migrations'                         => true,
+            'ee_dms_map'                                 => false,
+            'ee_notices'                                 => true,
+            'lang_file_check_'                           => false,
+            'ee_maintenance_mode'                        => true,
+            'ee_ueip_optin'                              => true,
+            'ee_ueip_has_notified'                       => true,
+            'ee_plugin_activation_errors'                => true,
+            'ee_id_mapping_from'                         => false,
+            'espresso_persistent_admin_notices'          => true,
+            'ee_encryption_key'                          => true,
+            'pue_force_upgrade_'                         => false,
+            'pue_json_error_'                            => false,
+            'pue_install_key_'                           => false,
+            'pue_verification_error_'                    => false,
+            'pu_dismissed_upgrade_'                      => false,
+            'external_updates-'                          => false,
+            'ee_extra_data'                              => true,
+            'ee_ssn_'                                    => false,
+            'ee_rss_'                                    => false,
+            'ee_rte_n_tx_'                               => false,
+            'ee_pers_admin_notices'                      => true,
+            'ee_job_parameters_'                         => false,
+            'ee_upload_directories_incomplete'           => true,
+            'ee_verified_db_collations'                  => true,
+        ];
         if (is_main_site()) {
             $wp_options_to_delete['ee_network_config'] = true;
         }
-        $undeleted_options = array();
+        $undeleted_options = [];
         foreach ($wp_options_to_delete as $option_name => $no_wildcard) {
             if ($no_wildcard) {
                 if (! delete_option($option_name)) {
                     $undeleted_options[] = $option_name;
                 }
             } else {
-                $option_names_to_delete_from_wildcard = $wpdb->get_col("SELECT option_name FROM $wpdb->options WHERE option_name LIKE '%$option_name%'");
+                $option_names_to_delete_from_wildcard =
+                    $wpdb->get_col("SELECT option_name FROM $wpdb->options WHERE option_name LIKE '%$option_name%'");
                 foreach ($option_names_to_delete_from_wildcard as $option_name_from_wildcard) {
                     if (! delete_option($option_name_from_wildcard)) {
                         $undeleted_options[] = $option_name_from_wildcard;
@@ -1608,9 +1663,9 @@ class EEH_Activation implements ResettableInterface
             }
         }
         // also, let's make sure the "ee_config_option_names" wp option stays out by removing the action that adds it
-        remove_action('shutdown', array(EE_Config::instance(), 'shutdown'), 10);
+        remove_action('shutdown', [EE_Config::instance(), 'shutdown'], 10);
         if ($remove_all && $espresso_db_update = get_option('espresso_db_update')) {
-            $db_update_sans_ee4 = array();
+            $db_update_sans_ee4 = [];
             foreach ($espresso_db_update as $version => $times_activated) {
                 if ((string) $version[0] === '3') {// if its NON EE4
                     $db_update_sans_ee4[ $version ] = $times_activated;
@@ -1631,6 +1686,7 @@ class EEH_Activation implements ResettableInterface
         }
     }
 
+
     /**
      * Gets the mysql error code from the last used query by wpdb
      *
@@ -1648,18 +1704,22 @@ class EEH_Activation implements ResettableInterface
         // phpcs:enable
     }
 
+
     /**
      * Checks that the database table exists. Also works on temporary tables (for unit tests mostly).
      *
-     * @global wpdb  $wpdb
-     * @deprecated instead use TableAnalysis::tableExists()
      * @param string $table_name with or without $wpdb->prefix
      * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global wpdb  $wpdb
+     * @deprecated instead use TableAnalysis::tableExists()
      */
     public static function table_exists($table_name)
     {
-        return \EEH_Activation::getTableAnalysis()->tableExists($table_name);
+        return EEH_Activation::getTableAnalysis()->tableExists($table_name);
     }
+
 
     /**
      * Resets the cache on EEH_Activation
@@ -1670,9 +1730,12 @@ class EEH_Activation implements ResettableInterface
         self::$_initialized_db_content_already_in_this_request = false;
     }
 
+
     /**
      * Removes 'email_confirm' from the Address info question group on activation
+     *
      * @return void
+     * @throws EE_Error
      */
     public static function removeEmailConfirmFromAddressGroup()
     {
@@ -1683,12 +1746,12 @@ class EEH_Activation implements ResettableInterface
         );
         // Remove the email_confirm question group from the address group questions.
         EEM_Question_Group_Question::instance()->delete(
-            array(
-                array(
-                    'QST_ID' => $email_confirm_question_id,
+            [
+                [
+                    'QST_ID'                    => $email_confirm_question_id,
                     'Question_Group.QSG_system' => EEM_Question_Group::system_address,
-                ),
-            )
+                ],
+            ]
         );
     }
 }

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -670,9 +670,7 @@ class EE_Register_Addon implements EEI_Plugin_API
             // Note: the presence of pue_options in the addon registration options will initialize the $_settings
             // property for the add-on, but the add-on is only partially initialized.  Hence, the additional check.
             if (! isset(self::$_settings[ $addon_name ])
-                || (isset(self::$_settings[ $addon_name ])
-                    && ! isset(self::$_settings[ $addon_name ]['class_name'])
-                )
+                || (isset(self::$_settings[ $addon_name ]) && ! isset(self::$_settings[ $addon_name ]['class_name']))
             ) {
                 self::$_settings[ $addon_name ] = $addon_settings;
                 $addon = self::_load_and_init_addon_class($addon_name);
@@ -1005,21 +1003,23 @@ class EE_Register_Addon implements EEI_Plugin_API
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
+     * @throws DomainException
      */
     private static function _load_and_init_addon_class($addon_name)
     {
-        $addon = LoaderFactory::getLoader()->getShared(
-            self::$_settings[ $addon_name ]['class_name'],
-            array('EE_Registry::create(addon)' => true)
-        );
-        if (! $addon instanceof EE_Addon) {
+        $addon_class = self::$_settings[ $addon_name ]['class_name'];
+        $addon = LoaderFactory::getLoader()->getShared($addon_class, ['EE_Registry::create(addon)' => true]);
+        // verify addon has been instantiated correctly
+        if (! $addon instanceof $addon_class) {
             throw new DomainException(
                 sprintf(
-                    esc_html__(
-                        'Failed to instantiate the %1$s class. PLease check that the class exists.',
+                    __(
+                        'An attempt to register an EE_Addon named "%1$s" has failed because the "%2$s" class is either missing or invalid. The following was created instead: %3$s',
                         'event_espresso'
                     ),
-                    $addon_name
+                    $addon_name,
+                    $addon_class,
+                    print_r($addon, true)
                 )
             );
         }

--- a/core/services/database/TableAnalysis.php
+++ b/core/services/database/TableAnalysis.php
@@ -2,6 +2,9 @@
 
 namespace EventEspresso\core\services\database;
 
+use EE_Base;
+use wpdb;
+
 /**
  * Class TableAnalysis
  * For analyzing database tables; should not perform any manipulation, or have
@@ -11,7 +14,7 @@ namespace EventEspresso\core\services\database;
  * @subpackage
  * @author                Mike Nelson
  */
-class TableAnalysis extends \EE_Base
+class TableAnalysis extends EE_Base
 {
 
     /**
@@ -25,7 +28,7 @@ class TableAnalysis extends \EE_Base
      * except if it currently has the wpdb->base_prefix on the front, in which case
      * it will have the wpdb->base_prefix on it
      *
-     * @global \wpdb $wpdb
+     * @global wpdb $wpdb
      * @param string $table_name
      * @return string $tableName, having ensured it has the wpdb prefix on the front
      */
@@ -40,7 +43,7 @@ class TableAnalysis extends \EE_Base
      * Indicates whether or not the table has any entries. $table_name can
      * optionally start with $wpdb->prefix or not
      *
-     * @global \wpdb $wpdb
+     * @global wpdb $wpdb
      * @param string $table_name
      * @return bool
      */
@@ -50,7 +53,7 @@ class TableAnalysis extends \EE_Base
         $table_name = $this->ensureTableNameHasPrefix($table_name);
         if ($this->tableExists($table_name)) {
             $count = $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
-            return absint($count) === 0 ? true : false;
+            return absint($count) === 0;
         }
         return false;
     }
@@ -60,63 +63,22 @@ class TableAnalysis extends \EE_Base
      * Indicates whether or not the table exists. $table_name can optionally
      * have the $wpdb->prefix on the beginning, or not.
      *
-     * @global \wpdb $wpdb
-     * @global array EZSQL_Error
-     * @param        $table_name
+     * @global wpdb $wpdb
+     * @param string $table_name
      * @return bool
      */
     public function tableExists($table_name)
     {
-        global $wpdb, $EZSQL_ERROR;
+        global $wpdb;
         $table_name = $this->ensureTableNameHasPrefix($table_name);
-        // ignore if this causes an sql error
-        $old_error = $wpdb->last_error;
-        $old_suppress_errors = $wpdb->suppress_errors();
-        $old_show_errors_value = $wpdb->show_errors(false);
-        $ezsql_error_cache = $EZSQL_ERROR;
-        $wpdb->get_results("SELECT * from $table_name LIMIT 1");
-        $wpdb->show_errors($old_show_errors_value);
-        $wpdb->suppress_errors($old_suppress_errors);
-        $new_error = $wpdb->last_error;
-        $wpdb->last_error = $old_error;
-        $EZSQL_ERROR = $ezsql_error_cache;
-        // if there was a table doesn't exist error
-        if (! empty($new_error)) {
-            if (in_array(
-                \EEH_Activation::last_wpdb_error_code(),
-                array(
-                    1051, // bad table
-                    1109, // unknown table
-                    117, // no such table
-                )
-            )
-                ||
-                preg_match(
-                    '~^Table .* doesn\'t exist~',
-                    $new_error
-                ) // in case not using mysql and error codes aren't reliable, just check for this error string
-            ) {
-                return false;
-            } else {
-                // log this because that's weird. Just use the normal PHP error log
-                error_log(
-                    sprintf(
-                        __(
-                            'Event Espresso error detected when checking if table existed: %1$s (it wasn\'t just that the table didn\'t exist either)',
-                            'event_espresso'
-                        ),
-                        $new_error
-                    )
-                );
-            }
-        }
-        return true;
+        $query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table_name ) );
+        return $wpdb->get_var( $query ) === $table_name;
     }
 
 
     /**
-     * @param $table_name
-     * @param $index_name
+     * @param string $table_name
+     * @param string $index_name
      * @return array of columns used on that index, Each entry is an object with the following properties {
      * @type string Table
      * @type string Non_unique "0" or "1"

--- a/core/services/database/TableAnalysis.php
+++ b/core/services/database/TableAnalysis.php
@@ -71,8 +71,8 @@ class TableAnalysis extends EE_Base
     {
         global $wpdb;
         $table_name = $this->ensureTableNameHasPrefix($table_name);
-        $query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table_name ) );
-        return $wpdb->get_var( $query ) === $table_name;
+        $query = $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table_name));
+        return $wpdb->get_var($query) === $table_name;
     }
 
 

--- a/core/services/database/TableManager.php
+++ b/core/services/database/TableManager.php
@@ -60,7 +60,6 @@ class TableManager extends \EE_Base
      * @param string $column_info
      * @return bool|false|int
      * @throws EE_Error
-     * @throws EE_Error
      */
     public function addColumn($table_name, $column_name, $column_info = 'INT UNSIGNED NOT NULL')
     {
@@ -84,7 +83,6 @@ class TableManager extends \EE_Base
      *
      * @param string $table_name
      * @return array
-     * @throws EE_Error
      * @throws EE_Error
      * @global wpdb $wpdb
      */
@@ -112,7 +110,6 @@ class TableManager extends \EE_Base
      * @param string $table_name
      * @return int
      * @throws EE_Error
-     * @throws EE_Error
      * @global wpdb $wpdb
      */
     public function dropTable($table_name)
@@ -133,7 +130,6 @@ class TableManager extends \EE_Base
      *
      * @param array $table_names
      * @return array of table names which we deleted
-     * @throws EE_Error
      * @throws EE_Error
      * @global WPDB $wpdb
      */

--- a/core/services/database/TableManager.php
+++ b/core/services/database/TableManager.php
@@ -220,12 +220,7 @@ class TableManager extends \EE_Base
         $table_name = $this->getTableAnalysis()->ensureTableNameHasPrefix($table_name);
         global $wpdb;
         $collation = $wpdb->get_charset_collate();
-        $SQL = "
-CREATE TABLE {$table_name} (
-{$create_sql}
-) ENGINE={$engine}
-{$collation}
-";
+        $SQL = "CREATE TABLE {$table_name} ({$create_sql}) ENGINE={$engine} {$collation}";
         // get $wpdb to echo errors, but buffer them. This way at least WE know an error
         // happened. And then we can choose to tell the end user
         $old_show_errors_policy = $wpdb->show_errors(true);

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -11,9 +11,9 @@ use EventEspresso\core\services\loaders\LoaderFactory;
  * This is used to override any existing WP_UnitTestCase methods that need specific handling in EE.  We
  * can also add additional methods in here for EE tests (that are used frequently)
  *
- * @since        4.3.0
+ * @since          4.3.0
  * @package        Event Espresso
- * @subpackage    tests
+ * @subpackage     tests
  */
 class EE_UnitTestCase extends WP_UnitTestCase
 {
@@ -22,11 +22,13 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Should be used to store the global $wp_actions during a test
      * so that it can be restored afterwards to keep tests from interfere with each other
+     *
      * @var array
      */
-    protected $wp_filters_saved = NULL;
+    protected $wp_filters_saved = null;
 
-    protected $_cached_SERVER_NAME = NULL;
+    protected $_cached_SERVER_NAME = null;
+
     /**
      *
      * @var WP_User
@@ -36,9 +38,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Boolean indicating we've already noted an accidental txn commit and we don't need to
      * keep checking or warning the test runner about it
+     *
      * @var boolean
      */
-    public static $accidental_txn_commit_noted = FALSE;
+    public static $accidental_txn_commit_noted = false;
 
     /**
      * Holds an array of default DateTime objects for testing with.
@@ -86,7 +89,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     //  * but the test name is not being reported anywhere.
     //  * Just uncomment this method as well as the first line of setUp() below.
     //  *
-    //  * @throws \EE_Error
+    //  * @throws EE_Error
     //  */
     // public static function setUpBeforeClass() {
     //     echo "\n\n\n" . get_called_class() . "\n\n";
@@ -101,6 +104,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
     // }
 
 
+    /**
+     * @throws EE_Error
+     */
     public function setUp()
     {
         global $EE_TEST_RUN;
@@ -109,23 +115,23 @@ class EE_UnitTestCase extends WP_UnitTestCase
         //save the hooks state before WP_UnitTestCase actually gets its hands on it...
         //as it immediately adds a few hooks we might not want to backup
         global $auto_made_thing_seed, $wp_filter, $wp_actions, $merged_filters, $wp_current_filter, $wpdb, $current_user;
-        $this->wp_filters_saved = array(
-            'wp_filter' => $wp_filter,
-            'wp_actions' => $wp_actions,
-            'merged_filters' => $merged_filters,
-            'wp_current_filter' => $wp_current_filter
-        );
+        $this->wp_filters_saved   = [
+            'wp_filter'         => $wp_filter,
+            'wp_actions'        => $wp_actions,
+            'merged_filters'    => $merged_filters,
+            'wp_current_filter' => $wp_current_filter,
+        ];
         $this->_orig_current_user = $current_user instanceof WP_User ? clone $current_user : new WP_User(1);
         parent::setUp();
         $auto_made_thing_seed = 1;
         //reset wpdb's list of queries executed so it only stores those from the current test
-        $wpdb->queries = array();
+        $wpdb->queries = [];
         //the accidental txn commit indicator option shouldn't be set from the previous test
-        update_option('accidental_txn_commit_indicator', TRUE);
+        update_option('accidental_txn_commit_indicator', true);
 
         // Fake WP mail globals, to avoid errors
-        add_filter('wp_mail', array($this, 'setUp_wp_mail'));
-        add_filter('wp_mail_from', array($this, 'tearDown_wp_mail'));
+        add_filter('wp_mail', [$this, 'setUp_wp_mail']);
+        add_filter('wp_mail_from', [$this, 'tearDown_wp_mail']);
         add_filter('FHEE__EEH_Activation__create_table__short_circuit', '__return_true');
         add_filter('FHEE__EEH_Activation__add_column_if_it_doesnt_exist__short_circuit', '__return_true');
         add_filter('FHEE__EEH_Activation__drop_index__short_circuit', '__return_true');
@@ -139,14 +145,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // 'user_has_cap' filter to do this
         $_wp_test_version = getenv('WP_VERSION');
         if ($_wp_test_version && $_wp_test_version === '4.1') {
-            add_filter('user_has_cap', function ($all_caps, $caps, $args, WP_User $WP_User) {
-                $WP_User->get_role_caps();
+            add_filter(
+                'user_has_cap',
+                function ($all_caps, $caps, $args, WP_User $WP_User) {
+                    $WP_User->get_role_caps();
 
-                return $WP_User->allcaps;
-            }, 10, 4);
+                    return $WP_User->allcaps;
+                },
+                10,
+                4
+            );
         }
         //tell EE_Registry to do a hard reset
-        add_filter( 'FHEE__EE_Registry__reset__hard', '__return_true');
+        add_filter('FHEE__EE_Registry__reset__hard', '__return_true');
         do_action('AHEE__EventEspresso_core_services_loaders_CachingLoader__resetCache');
         // turn off caching for any loaders in use during tests
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_true');
@@ -154,35 +165,38 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
 
     /**
-     * @param bool $short_circuit
+     * @param bool   $short_circuit
      * @param string $table_name
      * @param string $sql
      * @return bool
      */
-    public function _short_circuit_db_implicit_commits($short_circuit = FALSE, $table_name, $sql)
+    public function _short_circuit_db_implicit_commits($short_circuit = false, $table_name, $sql)
     {
-        $whitelisted_tables = apply_filters('FHEE__EE_UnitTestCase__short_circuit_db_implicit_commits__whitelisted_tables', array());
-        if (in_array($table_name, $whitelisted_tables, true)) {
-            //it's not altering. it's ok
-            return FALSE;
-        } else {
-            return TRUE;
-        }
+        $whitelisted_tables = apply_filters(
+			'FHEE__EE_UnitTestCase__short_circuit_db_implicit_commits__whitelisted_tables',
+			[]
+		);
+		// if it's not altering. it's ok
+		return in_array($table_name, $whitelisted_tables, true);
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     public function tearDown()
     {
         parent::tearDown();
         global $wp_filter, $wp_actions, $merged_filters, $wp_current_filter, $current_user;
-        $wp_filter = $this->wp_filters_saved['wp_filter'];
-        $wp_actions = $this->wp_filters_saved['wp_actions'];
-        $merged_filters = $this->wp_filters_saved['merged_filters'];
+        $wp_filter         = $this->wp_filters_saved['wp_filter'];
+        $wp_actions        = $this->wp_filters_saved['wp_actions'];
+        $merged_filters    = $this->wp_filters_saved['merged_filters'];
         $wp_current_filter = $this->wp_filters_saved['wp_current_filter'];
-        $current_user = $this->_orig_current_user;
+        $current_user      = $this->_orig_current_user;
         $this->_detect_accidental_txn_commit();
         $notices = EE_Error::get_notices(false, false, true);
         EE_Error::reset_notices();
-        if (!empty($notices['errors'])) {
+        if (! empty($notices['errors'])) {
             $error_message = sprintf(
                 'The following error(s) occurred during test "%1$s" : %2$s',
                 get_called_class() . '::' . $this->getName() . '()',
@@ -199,6 +213,55 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $EE_TEST_RUN = false;
     }
 
+
+    /**
+     * @param string $request_type_slug
+     * @throws Exception
+     * @since $VID:$
+     */
+    protected function setupRequest($request_type_slug = RequestTypeContext::ADMIN)
+    {
+        $request_type_context = new RequestTypeContext($request_type_slug, 'mock request type');
+        $request_type_context->setIsUnitTesting(true);
+        $this->request->setRequestTypeContextChecker(new RequestTypeContextChecker($request_type_context));
+        EE_Dependency_Map::register_dependencies(
+            'EventEspresso\tests\mocks\core\services\routing\RouterMock',
+            [
+                'EE_Dependency_Map'                                => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\loaders\Loader'       => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\routing\RouteHandler' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        /** @var EventEspresso\tests\mocks\core\services\routing\RouterMock $router */
+        $router = $this->loader->getShared('EventEspresso\tests\mocks\core\services\routing\RouterMock');
+        $router->loadPrimaryRoutes();
+        switch($request_type_slug) {
+            case RequestTypeContext::ADMIN:
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventEditor');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage');
+                // $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\PueRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\WordPressHeartbeat');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\GQLRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\RestApiRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\AssetRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\SessionRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\PersonalDataRequests');
+                break;
+            case RequestTypeContext::FRONTEND:
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\frontend\FrontendRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\frontend\ShortcodeRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\WordPressHeartbeat');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\RestApiRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\AssetRequests');
+                $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\shared\SessionRequests');
+                break;
+        }
+        $router->handleRoutesForCurrentRequest();
+    }
+
+
     protected function loadTestScenarios()
     {
         // load scenarios
@@ -206,14 +269,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $this->scenarios = new EE_Test_Scenario_Factory($this);
     }
 
+
     /**
      * Detects whether or not a MYSQL query was issued which caused an implicit commit
      * (or an explicit one). Basically, we can't do a commit mid-test because it messes
      * up the test's state (which means the database state at the time of the commit will
      * become the new starting state for all future tests, which will likely cause hard-to-find
      * bugs, and makes test results dependent on order of execution)
-     * @global WPDB $wpdb
+     *
      * @throws EE_Error
+     * @global WPDB $wpdb
      */
     protected function _detect_accidental_txn_commit()
     {
@@ -221,10 +286,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
         //we prefer to do it now so that we can check for implicit commits
         $this->clean_up_global_scope();
         //now we can check if there was an accidental implicit commit
-        if (!self::$accidental_txn_commit_noted && get_option('accidental_txn_commit_indicator', FALSE)) {
+        if (! self::$accidental_txn_commit_noted && get_option('accidental_txn_commit_indicator', false)) {
             global $wpdb;
-            self::$accidental_txn_commit_noted = TRUE;
-            throw new EE_Error(sprintf(__("Accidental MySQL Commit was issued sometime during the previous test. This means we couldn't properly restore database to its pre-test state. If this doesnt create problems now it probably will later! Read up on MySQL commits, especially Implicit Commits. Queries executed were: \r\n%s. \r\nThis accidental commit happened during %s", 'event_espresso'), print_r($wpdb->queries, TRUE), $this->getName()));
+            self::$accidental_txn_commit_noted = true;
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "Accidental MySQL Commit was issued sometime during the previous test. This means we couldn't properly restore database to its pre-test state. If this doesnt create problems now it probably will later! Read up on MySQL commits, especially Implicit Commits. Queries executed were: \r\n%s. \r\nThis accidental commit happened during %s",
+                        'event_espresso'
+                    ),
+                    print_r($wpdb->queries, true),
+                    $this->getName()
+                )
+            );
         }
     }
 
@@ -234,7 +308,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *  that they are fresh between tests.
      *
      * @todo this of course means we need an easy way to reset our singletons...
-     * @see parent::cleanup_global_scope();
+     * @see  parent::cleanup_global_scope();
      */
     public function clean_up_global_scope()
     {
@@ -263,7 +337,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function tearDown_wp_mail($args)
     {
-        if (!empty($this->_cached_SERVER_NAME)) {
+        if (! empty($this->_cached_SERVER_NAME)) {
             $_SERVER['SERVER_NAME'] = $this->_cached_SERVER_NAME;
             unset($this->_cached_SERVER_NAME);
         } else {
@@ -279,6 +353,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Helper method for setting the maintenance mode of EE to given maintenance mode
      *
      * @param int $level use to indicate which maintenance mode to set.
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.3.0
      */
     public function setMaintenanceMode($level = 0)
@@ -306,6 +382,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Helper method for just setting the core config and net config on EE_Registry, so
      * configuration tests can be run.
      *
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.3.0
      */
     public function setCoreConfig()
@@ -322,18 +400,18 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function resetCoreConfig()
     {
-        EE_Registry::instance()->CFG = NULL;
-        EE_Registry::instance()->NET_CFG = NULL;
+        EE_Registry::instance()->CFG     = null;
+        EE_Registry::instance()->NET_CFG = null;
     }
 
 
     /**
      * Method that accepts an array of filter refs to clear all filters from.
      *
+     * @param array $filters array of filter refs to clear. (be careful about core wp filters).
      * @since 4.3.0
-     * @param  array $filters array of filter refs to clear. (be careful about core wp filters).
      */
-    public function clearAllFilters($filters = array())
+    public function clearAllFilters(array $filters = [])
     {
         foreach ($filters as $filter) {
             remove_all_filters($filter);
@@ -344,10 +422,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Method that accepts an array of action refs to clear all actions from.
      *
+     * @param array $actions array of action refs to clear. (be careful about core wp actions).
      * @since 4.3.0
-     * @param  array $actions array of action refs to clear. (be careful about core wp actions).
      */
-    public function clearAllActions($actions = array())
+    public function clearAllActions(array $actions = [])
     {
         foreach ($actions as $action) {
             remove_all_actions($action);
@@ -356,14 +434,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
 
     /**
-     * This defines EE_Admin_Constants to point to the admin mocks * folder instead of the default admin folder.  Note, you will need
-     * to be careful of using this.
+     * This defines EE_Admin_Constants to point to the admin mocks * folder instead of the default admin folder.  Note,
+     * you will need to be careful of using this.
      *
      * @since 4.3.0
      */
     public function defineAdminConstants()
     {
-        if (!defined('EE_ADMIN_PAGES')){
+        if (! defined('EE_ADMIN_PAGES')) {
             define('EE_ADMIN_PAGES', EE_TESTS_DIR . 'mocks/admin');
         }
     }
@@ -385,9 +463,11 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     /**
      * This loads the various admin page mock files required for tests.
-     * Note these pages should be loaded on demand, because constants will be defined that will interfere with other Admin Page loading tests.
-     * @since 4.6.0
+     * Note these pages should be loaded on demand, because constants will be defined that will interfere with other
+     * Admin Page loading tests.
+     *
      * @param string $page
+     * @since 4.6.0
      */
     public function delayedAdminPageMocks($page = '')
     {
@@ -420,7 +500,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModelsMocks array of Model class names like "EEM_Event"
      */
-    public function loadModelsMocks($ModelsMocks = array())
+    public function loadModelsMocks($ModelsMocks = [])
     {
         foreach ($ModelsMocks as $ModelsMock) {
             require_once EE_TESTS_DIR . 'mocks/core/db_models/' . $ModelsMock . '_Mock.php';
@@ -431,7 +511,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModelFieldMocks array of Model Field class names like "EE_Datetime_Field"
      */
-    public function loadModelFieldMocks($ModelFieldMocks = array())
+    public function loadModelFieldMocks($ModelFieldMocks = [])
     {
         foreach ($ModelFieldMocks as $ModelFieldMock) {
             require_once EE_TESTS_DIR . 'mocks/core/db_models/fields/' . $ModelFieldMock . '_Mock.php';
@@ -442,7 +522,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModuleMocks array of Module class names like "EED_Single_Page_Checkout"
      */
-    public function loadModuleMocks($ModuleMocks = array())
+    public function loadModuleMocks($ModuleMocks = [])
     {
         foreach ($ModuleMocks as $ModuleMock) {
             require_once EE_TESTS_DIR . 'mocks/modules/' . $ModuleMock . '_Mock.php';
@@ -457,8 +537,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function date_formats_to_test()
     {
-        return array(
-            'date' => array(
+        return [
+            'date' => [
                 'F j, Y',
                 'Y-m-d',
                 'm/d/Y',
@@ -467,16 +547,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 'd-m-Y',
                 'm-d-Y',
                 'd-m Y',
-                '\D\a\t\e\: Y-m-d'
-            ),
-            'time' => array(
+                '\D\a\t\e\: Y-m-d',
+            ],
+            'time' => [
                 'g:i a',
                 'g:i A',
                 'H: i',
                 'h:i:s a',
-                '\T\i\m\e\: g:i a'
-            )
-        );
+                '\T\i\m\e\: g:i a',
+            ],
+        ];
     }
 
 
@@ -484,16 +564,18 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * This sets a bunch of default dates for common data properties using dates for testing.
      *
      * @param string $timezone Timezone string to initialize the times in.
+     * @throws Exception
+     * @throws Exception
      */
     protected function _set_default_dates($timezone = 'America/Vancouver')
     {
-        $tz = new DateTimeZone($timezone);
-        $this->_default_dates = array(
+        $tz                   = new DateTimeZone($timezone);
+        $this->_default_dates = [
             'DTT_start' => new DateTime('2015-02-20 11:30 am', $tz),
-            'DTT_end' => new DateTime('2015-02-20 2:00 pm', $tz),
+            'DTT_end'   => new DateTime('2015-02-20 2:00 pm', $tz),
             'TKT_start' => new DateTime('2015-01-30 8:00 am', $tz),
-            'TKT_end' => new DateTime('2015-02-20 8:00 am', $tz)
-        );
+            'TKT_end'   => new DateTime('2015-02-20 8:00 am', $tz),
+        ];
     }
 
 
@@ -523,23 +605,23 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * will result in a date remaining in March.
      * see http://php.net/manual/en/datetime.sub.php#example-2469
      *
-     * @param \DateTime $now
-     * @param bool $adding_interval
+     * @param DateTime $now
+     * @param bool     $adding_interval
      * @return string
      */
     protected function _get_one_month_period_offset_in_days(DateTime $now, $adding_interval = true)
     {
-        $year = (int)$now->format('Y');
-        $month = (int)$now->format('n');
-        $day = (int)$now->format('j');
+        $year  = (int) $now->format('Y');
+        $month = (int) $now->format('n');
+        $day   = (int) $now->format('j');
         // determine how to increment or decrement the year and month
         if ($adding_interval && $month === 12) {
             // adding a month to december?
             $year++;
             $month = 1;
-        } else if ($adding_interval) {
+        } elseif ($adding_interval) {
             $month++;
-        } else if ($month === 1) {
+        } elseif ($month === 1) {
             $year--;
             $month = 12;
         } else {
@@ -548,9 +630,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // create a date for the first day in the offset month (actual day doesn't really matter)
         $offset_month = new DateTime("{$year}-{$month}-01");
         // get the number of days in the offset month
-        $days_in_offset_month = (int)$offset_month->format('t');
+        $days_in_offset_month = (int) $offset_month->format('t');
         // get the number of days in the original passed month
-        $days_in_month = (int)$now->format('t');
+        $days_in_month = (int) $now->format('t');
         // now figure out what period to actually return
         // by looking at whether we are adding or subtract a time period
         // and also comparing the days in each month,
@@ -561,12 +643,12 @@ class EE_UnitTestCase extends WP_UnitTestCase
             // so just add the number of days in February
             //echo "\n add days_in_offset_month : " . $days_in_offset_month;
             return "P{$days_in_offset_month}D";
-        } else if ($adding_interval) {
+        } elseif ($adding_interval) {
             // all other additions can safely just use the number of days in the current month
             // ie: Jan 27 can add 31 days
             //echo "\n add days_in_month : " . $days_in_month;
             return "P{$days_in_month}D";
-        } else if ($day > $days_in_offset_month) {
+        } elseif ($day > $days_in_offset_month) {
             // subtract 1 month from March 28, but wait...
             // subtracting 31 days could take us to Feb 25 !!!
             // so just subtract the day of the month we are on
@@ -586,8 +668,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *
      * correctly calculates a date that is slightly more than one month in the past from passed date
      *
-     * @param \DateTime $now
-     * @return \DateTime
+     * @param DateTime $now
+     * @return DateTime
+     * @throws Exception
+     * @throws Exception
      */
     protected function _get_date_one_month_ago(DateTime $now)
     {
@@ -605,8 +689,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *
      * correctly calculates a date that is slightly more than one month in the future from passed date
      *
-     * @param \DateTime $now
-     * @return \DateTime
+     * @param DateTime $now
+     * @return DateTime
+     * @throws Exception
+     * @throws Exception
      */
     protected function _get_date_one_month_from_now(DateTime $now)
     {
@@ -621,27 +707,27 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     /**
      * @param string $expected_date The expected date string in the given full_format date string format.
-     * @param string $actual_date The actual date string in the given full_format date string format.
-     * @param        $full_format
+     * @param string $actual_date   The actual date string in the given full_format date string format.
+     * @param string $full_format
      * @param string $custom_error_message
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function assertDateWithinOneMinute($expected_date, $actual_date, $full_format, $custom_error_message = '')
     {
         //take the incoming date strings convert to datetime objects and verify they are within one minute of each other
-        $expected_date_obj = date_create_from_format($full_format, $expected_date);
-        $actual_date_obj = date_create_from_format($full_format, $actual_date);
+        $expected_date_obj  = date_create_from_format($full_format, $expected_date);
+        $actual_date_obj    = date_create_from_format($full_format, $actual_date);
         $date_parsing_error = '';
-        if (!$expected_date_obj instanceof DateTime) {
+        if (! $expected_date_obj instanceof DateTime) {
             $date_parsing_error = sprintf(
-                __('Expected date %1$s could not be parsed into format %2$s', 'event_espresso'),
+                esc_html__('Expected date %1$s could not be parsed into format %2$s', 'event_espresso'),
                 print_r($expected_date, true),
                 $full_format
             );
         }
-        if (!$actual_date_obj instanceof DateTime) {
+        if (! $actual_date_obj instanceof DateTime) {
             $date_parsing_error = sprintf(
-                __('Actual date %1$s could not be parsed into format %2$s', 'event_espresso'),
+                esc_html__('Actual date %1$s could not be parsed into format %2$s', 'event_espresso'),
                 print_r($actual_date, true),
                 $full_format
             );
@@ -649,11 +735,11 @@ class EE_UnitTestCase extends WP_UnitTestCase
         if ($date_parsing_error) {
             throw new EE_Error($date_parsing_error);
         }
-        $difference = $actual_date_obj->format('U') - $expected_date_obj->format('U');
-        $custom_error_message = !empty($custom_error_message)
+        $difference           = $actual_date_obj->format('U') - $expected_date_obj->format('U');
+        $custom_error_message = ! empty($custom_error_message)
             ? $custom_error_message
             : sprintf(
-                __(
+                esc_html__(
                     'The expected date "%1$s" differs from the actual date "%2$s" by more than one minute',
                     'event_espresso'
                 ),
@@ -667,91 +753,98 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * This sets up some save data for use in testing updates and saves via the event editor.
      *
-     * @todo Add extra event data for testing event creation/save.
-     * @param string $format The format used for incoming date strings.
-     * @param string $prefix A string to prefix the fields being assembled.  Used as a way of
+     * @param string $format          The format used for incoming date strings.
+     * @param string $prefix          A string to prefix the fields being assembled.  Used as a way of
      *                                differentiating between multiple calls.
-     * @param string $row Equals the value we want to give for row.
-     * @param string $timezone Timezone string to add to the timezone data point.  Remember that
+     * @param string $row             Equals the value we want to give for row.
+     * @param string $timezone        Timezone string to add to the timezone data point.  Remember that
      *                                $this->_default_date() datetime objects are used for the default dates, so if
      *                                you include a string here make sure it matches what you set used for setting
      *                                _default_dates unless you are intentionally testing timezone mismatches.
      *
      * @return array of data in post format from the save action.
+     * @todo Add extra event data for testing event creation/save.
      */
-    protected function _get_save_data($format = 'Y-m-d h:i a', $prefix = '', $row = '1', $timezone = 'America/Vancouver')
-    {
-        $data = array(
-            'starting_ticket_datetime_rows' => array(
-                $row => ''
-            ),
-            'ticket_datetime_rows' => array(
-                $row => '1'
-            ),
-            'datetime_IDs' => '',
-            'edit_event_datetimes' => array(
-                $row => array(
-                    'DTT_EVT_end' => $this->_default_dates['DTT_end']->format($format),
-                    'DTT_EVT_start' => $this->_default_dates['DTT_start']->format($format),
-                    'DTT_ID' => '0',
-                    'DTT_name' => $prefix . ' Datetime A',
+    protected function _get_save_data(
+        $format = 'Y-m-d h:i a',
+        $prefix = '',
+        $row = '1',
+        $timezone = 'America/Vancouver'
+    ) {
+        $data = [
+            'starting_ticket_datetime_rows' => [
+                $row => '',
+            ],
+            'ticket_datetime_rows'          => [
+                $row => '1',
+            ],
+            'datetime_IDs'                  => '',
+            'edit_event_datetimes'          => [
+                $row => [
+                    'DTT_EVT_end'     => $this->_default_dates['DTT_end']->format($format),
+                    'DTT_EVT_start'   => $this->_default_dates['DTT_start']->format($format),
+                    'DTT_ID'          => '0',
+                    'DTT_name'        => $prefix . ' Datetime A',
                     'DTT_description' => $prefix . ' Lorem Ipsum Emitetad',
-                    'DTT_reg_limit' => '',
-                    'DTT_order' => $row
-                )
-            ),
-            'edit_tickets' => array(
-                $row => array(
-                    'TKT_ID' => '0',
-                    'TKT_base_price' => '0',
+                    'DTT_reg_limit'   => '',
+                    'DTT_order'       => $row,
+                ],
+            ],
+            'edit_tickets'                  => [
+                $row => [
+                    'TKT_ID'            => '0',
+                    'TKT_base_price'    => '0',
                     'TKT_base_price_ID' => '1',
-                    'TTM_ID' => '0',
-                    'TKT_name' => $prefix . ' Ticket A',
-                    'TKT_description' => $prefix . ' Lorem Ipsum Tekcit',
-                    'TKT_start_date' => $this->_default_dates['TKT_start']->format($format),
-                    'TKT_end_date' => $this->_default_dates['TKT_end']->format($format),
-                    'TKT_qty' => '',
-                    'TKT_uses' => '',
-                    'TKT_min' => '',
-                    'TKT_max' => '',
-                    'TKT_row' => '',
-                    'TKT_order' => $row,
-                    'TKT_taxable' => '0',
-                    'TKT_required' => '0',
-                    'TKT_price' => '0',
-                    'TKT_is_default' => '0'
-                )
-            ),
-            'edit_prices' => array(
-                $row => array(
-                    'PRT_ID' => '1',
-                    'PRC_ID' => '0',
-                    'PRC_amount' => '0',
-                    'PRC_name' => $prefix . ' Price A',
-                    'PRC_desc' => $prefix . ' Lorem Ipsum Ecirp',
+                    'TTM_ID'            => '0',
+                    'TKT_name'          => $prefix . ' Ticket A',
+                    'TKT_description'   => $prefix . ' Lorem Ipsum Tekcit',
+                    'TKT_start_date'    => $this->_default_dates['TKT_start']->format($format),
+                    'TKT_end_date'      => $this->_default_dates['TKT_end']->format($format),
+                    'TKT_qty'           => '',
+                    'TKT_uses'          => '',
+                    'TKT_min'           => '',
+                    'TKT_max'           => '',
+                    'TKT_row'           => '',
+                    'TKT_order'         => $row,
+                    'TKT_taxable'       => '0',
+                    'TKT_required'      => '0',
+                    'TKT_price'         => '0',
+                    'TKT_is_default'    => '0',
+                ],
+            ],
+            'edit_prices'                   => [
+                $row => [
+                    'PRT_ID'         => '1',
+                    'PRC_ID'         => '0',
+                    'PRC_amount'     => '0',
+                    'PRC_name'       => $prefix . ' Price A',
+                    'PRC_desc'       => $prefix . ' Lorem Ipsum Ecirp',
                     'PRC_is_default' => '1',
-                    'PRC_order' => $row
-                )
-            ),
-            'timezone_string' => $timezone
-        );
+                    'PRC_order'      => $row,
+                ],
+            ],
+            'timezone_string'               => $timezone,
+        ];
         return $data;
     }
 
 
     /**
      * IT would be better to add a constraint and do this properly at some point
+     *
      * @param mixed $item
      * @param       $haystack
      */
     public function assertArrayContains($item, $haystack)
     {
-        $in_there = in_array($item, $haystack, true);
-        if ($in_there) {
-            $this->assertTrue(true);
-        } else {
-            $this->assertTrue($in_there, sprintf(__('Array %1$s does not contain %2$s', 'event_espresso'), print_r($haystack, true), print_r($item, true)));
-        }
+        $this->assertTrue(
+            in_array($item, $haystack, true),
+            sprintf(
+                esc_html__('Array %1$s does not contain %2$s', 'event_espresso'),
+                print_r($haystack, true),
+                print_r($item, true)
+            )
+        );
     }
 
 
@@ -761,13 +854,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function assertArrayDoesNotContain($item, $haystack)
     {
-        $not_in_there = !in_array($item, $haystack, true);
-        if ($not_in_there) {
-            $this->assertTrue($not_in_there);
-        } else {
-            $this->assertTrue($not_in_there, sprintf(__('Array %1$s DOES contain %2$s when it shouldn\'t', 'event_espresso'), print_r($haystack, true), print_r($item, true)));
-        }
+        $this->assertFalse(
+            in_array($item, $haystack, true),
+            sprintf(
+                esc_html__('Array %1$s DOES contain %2$s when it shouldn\'t', 'event_espresso'),
+                print_r($haystack, true),
+                print_r($item, true)
+            )
+        );
     }
+
 
     /**
      *
@@ -775,12 +871,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function assertWPOptionExists($option_name)
     {
-        $option = get_option($option_name, NULL);
-        if ($option) {
-            $this->assertTrue(true);
-        } else {
-            $this->assertNotNull($option, sprintf(__('The WP Option "%s" does not exist but should', 'event_espresso'), $option_name));
-        }
+        $option = get_option($option_name, null);
+        $this->assertNotNull(
+            $option,
+            sprintf(
+                esc_html__('The WP Option "%s" does not exist but should', 'event_espresso'),
+                $option_name
+            )
+        );
     }
 
 
@@ -789,23 +887,22 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function assertWPOptionDoesNotExist($option_name)
     {
-        $option = get_option($option_name, NULL);
-        if ($option) {
-            $this->assertNull($option, sprintf(__('The WP Option "%s" exists but shouldn\'t', 'event_espresso'), $option_name));
-        } else {
-            $this->assertTrue(true);
-        }
+        $option = get_option($option_name, null);
+        $this->assertNull(
+            $option,
+            sprintf(__('The WP Option "%s" exists but shouldn\'t', 'event_espresso'), $option_name)
+        );
     }
 
 
-
     /**
-     * Compares two EE model objects by just looking at their field's values. If you want strict comparison just use ordinary '==='.
-     * If you pass it two arrays of EE objects, that works too
+     * Compares two EE model objects by just looking at their field's values. If you want strict comparison just use
+     * ordinary '==='. If you pass it two arrays of EE objects, that works too
      *
      * @param EE_Base_Class|EE_Base_Class[] $expected_object
      * @param EE_Base_Class|EE_Base_Class[] $actual_object
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function assertEEModelObjectsEquals($expected_object, $actual_object)
     {
@@ -823,7 +920,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 if ($expected_value !== $actual_value) {
                     $this->fail(
                         sprintf(
-                            __('EE objects for the field %4$s of class "%1$s" did not match. They were: %2$s and %3$s.  The values for the field were %5$s and %6$s', 'event_espresso'),
+                            esc_html__(
+                                'EE objects for the field %4$s of class "%1$s" did not match. They were: %2$s and %3$s.  The values for the field were %5$s and %6$s',
+                                'event_espresso'
+                            ),
                             get_class($expected_object),
                             print_r($expected_object->model_field_array(), true),
                             print_r($actual_object->model_field_array(), true),
@@ -837,6 +937,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
     }
 
+
     /**
      * Compares HTML, ignoring whitespace differences; also tries to make differences
      * more obvious for comparison in PHPUnit results.
@@ -844,6 +945,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Eg, ignore case differences,unnecessary whitespace differences (eg '< br >' vs '<br>'),
      * attribute order differences, so this would only fail when there would be a noticeable
      * difference. The true ideal would be system testing using something codeception or something
+     *
      * @param string $expected
      * @param string $actual
      * @param string $error_message
@@ -852,24 +954,26 @@ class EE_UnitTestCase extends WP_UnitTestCase
     public function assertHTMLEquals($expected, $actual, $error_message = '')
     {
         $expected_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $expected);
-        $actual_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $actual);
+        $actual_standardized_whitespace   = preg_replace('~(\\s)+~', PHP_EOL, $actual);
         $this->assertEquals($expected_standardized_whitespace, $actual_standardized_whitespace, $error_message);
     }
 
 
     /**
      *Creates a model object and its required dependencies
-     * @param string $model_name
-     * @param array $args array of arguments to supply when constructing the model object
+     *
+     * @param string  $model_name
+     * @param array   $args array of arguments to supply when constructing the model object
      * @param boolean $save
-     * @throws EE_Error
-     * @global int $auto_made_thing_seed
      * @return EE_Base_Class
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global int    $auto_made_thing_seed
      */
-    public function new_model_obj_with_dependencies($model_name, $args = array(), $save = true)
+    public function new_model_obj_with_dependencies($model_name, $args = [], $save = true)
     {
         global $auto_made_thing_seed;
-        if ($auto_made_thing_seed === NULL) {
+        if ($auto_made_thing_seed === null) {
             $auto_made_thing_seed = 1;
         }
         $model = EE_Registry::instance()->load_model($model_name);
@@ -880,9 +984,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 continue;
             } elseif ($related_model_name === 'WP_User' && get_current_user_id()) {
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (! isset($args[$fk->get_name()])) {
-                    $obj = \EEM_WP_User::instance()->get_one_by_ID(get_current_user_id());
-                    $args[$fk->get_name()] = $obj->ID();
+                if (! isset($args[ $fk->get_name() ])) {
+                    $obj                     = EEM_WP_User::instance()->get_one_by_ID(get_current_user_id());
+                    $args[ $fk->get_name() ] = $obj->ID();
                 }
             } elseif ($related_model_name === 'Country' && ! isset($args['CNT_ISO'])) {
                 //we already have lots of countries. lets not make any more
@@ -892,68 +996,68 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 $args['CNT_ISO'] = 'US';
             } elseif ($related_model_name === 'Status') {
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (!isset($args[$fk->get_name()])) {
+                if (! isset($args[ $fk->get_name() ])) {
                     //only set the default if they haven't specified anything
-                    $args[$fk->get_name()] = $fk->get_default_value();
+                    $args[ $fk->get_name() ] = $fk->get_default_value();
                 }
             } elseif ($relation instanceof EE_Belongs_To_Relation) {
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (!isset($args[$fk->get_name()])) {
-                    $obj = $this->new_model_obj_with_dependencies($related_model_name);
-                    $args[$fk->get_name()] = $obj->ID();
+                if (! isset($args[ $fk->get_name() ])) {
+                    $obj                     = $this->new_model_obj_with_dependencies($related_model_name);
+                    $args[ $fk->get_name() ] = $obj->ID();
                 }
             }
         }
         //set any other fields which haven't yet been set
         foreach ($model->field_settings() as $field_name => $field) {
-            $value = NULL;
+            $value = null;
             if (
-                in_array(
-                    $field_name,
-                    array(
-                        'EVT_timezone_string',
-                        'PAY_redirect_url',
-                        'PAY_redirect_args',
-                        'TKT_reserved',
-                        'DTT_reserved',
-                        'parent',
-                        //don't make system questions etc
-                        'QST_system',
-                        'QSG_system',
-                        'QSO_system',
-                        'password'
-                    ),
-                    true
-                )
+            in_array(
+                $field_name,
+                [
+                    'EVT_timezone_string',
+                    'PAY_redirect_url',
+                    'PAY_redirect_args',
+                    'TKT_reserved',
+                    'DTT_reserved',
+                    'parent',
+                    //don't make system questions etc
+                    'QST_system',
+                    'QSG_system',
+                    'QSO_system',
+                    'password',
+                ],
+                true
+            )
             ) {
-                $value = NULL;
+                $value = null;
             } elseif (
-                $field_name === 'TKT_start_date' ||
-                $field_name === 'DTT_EVT_start'
+                $field_name === 'TKT_start_date' || $field_name === 'DTT_EVT_start'
             ) {
                 $value = time() + MONTH_IN_SECONDS;
             } elseif (
-                $field_name === 'TKT_end_date' ||
-                $field_name === 'DTT_EVT_end'
+                $field_name === 'TKT_end_date' || $field_name === 'DTT_EVT_end'
             ) {
                 $value = time() + MONTH_IN_SECONDS + DAY_IN_SECONDS;
             } elseif (
-                $field instanceof EE_Enum_Integer_Field ||
-                $field instanceof EE_Enum_Text_Field ||
-                $field instanceof EE_Boolean_Field ||
-                $field_name === 'PMD_type' ||
-                $field_name === 'CNT_cur_dec_mrk' ||
-                $field_name === 'CNT_cur_thsnds' ||
-                $field_name === 'CNT_tel_code'
+                $field instanceof EE_Enum_Integer_Field || $field instanceof EE_Enum_Text_Field
+                || $field
+                   instanceof
+                   EE_Boolean_Field
+                || $field_name === 'PMD_type'
+                || $field_name === 'CNT_cur_dec_mrk'
+                || $field_name === 'CNT_cur_thsnds'
+                || $field_name === 'CNT_tel_code'
             ) {
                 $value = $field->get_default_value();
             } elseif (
-                $field instanceof EE_Integer_Field ||
-                $field instanceof EE_Float_Field ||
-                $field instanceof EE_Foreign_Key_Field_Base ||
-                $field_name === 'STA_abbrev' ||
-                $field_name === 'CNT_ISO3' ||
-                $field_name === 'CNT_cur_code'
+                $field instanceof EE_Integer_Field || $field instanceof EE_Float_Field
+                || $field
+                   instanceof
+                   EE_Foreign_Key_Field_Base
+                || $field_name === 'STA_abbrev'
+                || $field_name === 'CNT_ISO3'
+                || $field_name === 'CNT_cur_code'
             ) {
                 $value = $auto_made_thing_seed;
             } elseif ($field instanceof EE_Primary_Key_String_Field) {
@@ -963,20 +1067,21 @@ class EE_UnitTestCase extends WP_UnitTestCase
             } elseif ($field instanceof EE_Text_Field_Base) {
                 $value = $auto_made_thing_seed . "_" . $field_name;
             }
-            if (!array_key_exists($field_name, $args) && $value !== NULL) {
-                $args[$field_name] = $value;
+            if (! array_key_exists($field_name, $args) && $value !== null) {
+                $args[ $field_name ] = $value;
             }
         }
-        //and finally make the model obj
+        // and finally make the model obj
+        /** @var EE_Base_Class $classname */
         $classname = 'EE_' . $model_name;
         $model_obj = $classname::new_instance($args);
         if ($save) {
             $success = $model_obj->save();
-            if (!$success) {
+            if (! $success) {
                 global $wpdb;
                 throw new EE_Error(
                     sprintf(
-                        __('Could not save %1$s using %2$s. Error was %3$s', 'event_espresso'),
+                        esc_html__('Could not save %1$s using %2$s. Error was %3$s', 'event_espresso'),
                         $model_name,
                         wp_json_encode($args),
                         $wpdb->last_error
@@ -999,7 +1104,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     protected function initTableAnalysis()
     {
         if (! $this->table_analysis instanceof TableAnalysis) {
-            $this->table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
+            $this->table_analysis = EE_Registry::instance()->create('TableAnalysis', [], true);
         }
         return $this->table_analysis;
     }
@@ -1069,7 +1174,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
         if ($this->table_analysis->tableExists($table_name)) {
             $this->fail(
                 sprintf(
-                    esc_html__('Table like %1$s SHOULD NOT exist. It was apparently defined on the model "%2$s"', 'event_espresso'),
+                    esc_html__(
+                        'Table like %1$s SHOULD NOT exist. It was apparently defined on the model "%2$s"',
+                        'event_espresso'
+                    ),
                     $table_name,
                     $model_name
                 )
@@ -1082,6 +1190,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Modifies the $wp_actions global to make it look like certain actions were and weren't
      * performed, so that EE_Register_Addon is deceived into thinking it's the right
      * time to register an addon etc
+     *
      * @global array $wp_actions
      */
     protected function _pretend_addon_hook_time()
@@ -1096,90 +1205,94 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $wp_actions['AHEE__EE_System__load_espresso_addons'] = 1;
     }
 
+
     /**
-     * Restores the $wp_actions global to how ti should have been before we
+     * Restores the $wp_actions global to how it should have been before we
      * started pretending we hooked in at the right time etc
+     *
      * @global array $wp_actions
      */
     protected function _stop_pretending_addon_hook_time()
     {
         global $wp_actions;
         $wp_actions['AHEE__EE_System___detect_if_activation_or_upgrade__begin'] = 1;
-        $wp_actions['FHEE__EE_System__parse_model_names'] = 1;
-        $wp_actions['FHEE__EE_System__parse_implemented_model_names'] = 1;
+        $wp_actions['FHEE__EE_System__parse_model_names']                       = 1;
+        $wp_actions['FHEE__EE_System__parse_implemented_model_names']           = 1;
         unset($wp_actions['AHEE__EE_System__load_espresso_addons']);
     }
-
 
 
     /**
      * Makes a complete transaction record with all associated data (ie, its line items,
      * registrations, tickets, datetimes, events, attendees, questions, answers, etc).
      *
-     * @param array $options         {
-     * 	@type int    $ticket_types/$tickets    the number of different ticket types in this transaction. Default 1
-     * 	@type int    $taxable_tickets how many of those ticket types should be taxable. Default EE_INF
-     * @type int fixed_ticket_price_modifiers the number of fixed ticket price modifiers to use on the tickets. Defaults to 1.
-     * @type string $reg_status the status of the transaction's registration. Defaults to "RAP"
-     * @type boolean $setup_reg whether to add a registration or not onto the transaction. Defaults to true
-     * @type int $tkt_qty the number of tickest available for purchase that the transaction is for
+     * @param array  $options         {
+     * @type int     $ticket_types    /$tickets    the number of different ticket types in this transaction. Default 1
+     * @type int     $taxable_tickets how many of those ticket types should be taxable. Default EE_INF
+     * @type int fixed_ticket_price_modifiers the number of fixed ticket price modifiers to use on the tickets.
+     *                                Defaults to 1.
+     * @type string  $reg_status      the status of the transaction's registration. Defaults to "RAP"
+     * @type boolean $setup_reg       whether to add a registration or not onto the transaction. Defaults to true
+     * @type int     $tkt_qty         the number of tickest available for purchase that the transaction is for
      * @type string/int/Datetime $timestamp to use on the transaction and registration and payments etc
-     * }
+     *                                }
      * @return EE_Transaction
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function new_typical_transaction($options = array())
+    protected function new_typical_transaction($options = [])
     {
-        $ticket_types = isset($options['ticket_types'])
+        $ticket_types                 = isset($options['ticket_types'])
             ? $options['ticket_types']
             : $ticket_types = 1;
-        $taxable_tickets = isset($options['taxable_tickets'])
+        $taxable_tickets              = isset($options['taxable_tickets'])
             ? $options['taxable_tickets']
             : $taxable_tickets = EE_INF;
         $fixed_ticket_price_modifiers = isset($options['fixed_ticket_price_modifiers'])
             ? $options['fixed_ticket_price_modifiers']
             : $fixed_ticket_price_modifiers = 1;
-        $reg_status = isset($options['reg_status'])
+        $reg_status                   = isset($options['reg_status'])
             ? $options['reg_status']
             : EEM_Registration::status_id_approved;
-        $setup_reg = isset($options['setup_reg'])
+        $setup_reg                    = isset($options['setup_reg'])
             ? $options['setup_reg']
             : true;
-        $tkt_qty = isset($options['tkt_qty'])
+        $tkt_qty                      = isset($options['tkt_qty'])
             ? $options['tkt_qty']
             : 1;
-        $ticket_types = isset($options['tickets'])
+        $ticket_types                 = isset($options['tickets'])
             ? count($options['tickets'])
             : $ticket_types;
-        $timestamp = isset($options['timestamp'])
+        $timestamp                    = isset($options['timestamp'])
             ? $options['timestamp']
             : current_time('timestamp');
         /** @var EE_Transaction $txn */
-        $txn = $this->new_model_obj_with_dependencies(
+        $txn             = $this->new_model_obj_with_dependencies(
             'Transaction',
-            array(
-                'TXN_paid' => 0,
-                'TXN_timestamp' => $timestamp
-            )
+            [
+                'TXN_paid'      => 0,
+                'TXN_timestamp' => $timestamp,
+            ]
         );
         $total_line_item = EEH_Line_Item::create_total_line_item($txn->ID());
         $total_line_item->save_this_and_descendants_to_txn($txn->ID());
         $taxes = EEM_Price::instance()->get_all_prices_that_are_taxes();
         for ($i = 1; $i <= $ticket_types; $i++) {
             /** @var EE_Ticket $ticket */
-            if(isset($options['tickets'], $options['tickets'][$i])){
-                $ticket = $options['tickets'][$i];
+            if (isset($options['tickets'], $options['tickets'][ $i ])) {
+                $ticket          = $options['tickets'][ $i ];
                 $reg_final_price = $ticket->price();
-                $datetime = $ticket->first_datetime();
+                $datetime        = $ticket->first_datetime();
             } else {
 
-                $ticket = $this->new_model_obj_with_dependencies(
+                $ticket            = $this->new_model_obj_with_dependencies(
                     'Ticket',
-                    array(
-                        'TKT_price' => $i * 10,
-                        'TKT_taxable' => $taxable_tickets-- > 0 ? true : false,
-                        'TKT_reserved' => $setup_reg && $reg_status === EEM_Registration::status_id_pending_payment ? 1 : 0
-                    )
+                    [
+                        'TKT_price'    => $i * 10,
+                        'TKT_taxable'  => $taxable_tickets-- > 0 ? true : false,
+                        'TKT_reserved' => $setup_reg && $reg_status === EEM_Registration::status_id_pending_payment ? 1
+                            : 0,
+                    ]
                 );
                 $sum_of_sub_prices = 0;
                 for ($j = 1; $j <= $fixed_ticket_price_modifiers; $j++) {
@@ -1189,9 +1302,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
                         $price_amount = $i * 10 / $fixed_ticket_price_modifiers;
                     }
                     /** @var EE_Price $price */
-                    $price = $this->new_model_obj_with_dependencies(
+                    $price             = $this->new_model_obj_with_dependencies(
                         'Price',
-                        array('PRC_amount' => $price_amount, 'PRC_order' => $j)
+                        ['PRC_amount' => $price_amount, 'PRC_order' => $j]
                     );
                     $sum_of_sub_prices += $price->amount();
                     $ticket->_add_relation_to($price, 'Price');
@@ -1215,7 +1328,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
             if ($setup_reg) {
                 $this->new_model_obj_with_dependencies(
                     'Registration',
-                    array(
+                    [
                         'TXN_ID'          => $txn->ID(),
                         'TKT_ID'          => $ticket->ID(),
                         'STS_ID'          => $reg_status,
@@ -1223,8 +1336,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
                         'REG_count'       => 1,
                         'REG_group_size'  => 1,
                         'REG_final_price' => $reg_final_price,
-                        'REG_date' => $timestamp
-                    )
+                        'REG_date'        => $timestamp,
+                    ]
                 );
             }
         }
@@ -1235,22 +1348,23 @@ class EE_UnitTestCase extends WP_UnitTestCase
     }
 
 
-
     /**
      * Creates an interesting ticket, with a base price, dollar surcharge, and a percent surcharge,
      * which is for 2 different datetimes.
      *
      * @param array $options           {
      * @type int    $dollar_surcharge  the dollar surcharge to add to this ticket
-     * @type int    $percent_surcharge teh percent surcharge to add to this ticket (value in percent, not in decimal. Eg if it's a 10% surcharge, enter 10.00, not 0.10
+     * @type int    $percent_surcharge teh percent surcharge to add to this ticket (value in percent, not in decimal.
+     *                                 Eg if it's a 10% surcharge, enter 10.00, not 0.10
      * @type int    $datetimes         the number of datetimes for this ticket,
      * @type int    $TKT_price         set the TKT_price to this value.
      * @type int    $TKT_taxable       set the TKT_taxable to this value.
      *                                 }
      * @return EE_Ticket
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function new_ticket($options = array())
+    public function new_ticket($options = [])
     {
         // copy incoming options to use for ticket args
         $ticket_args = $options;
@@ -1266,63 +1380,81 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $ticket_args['TKT_start_date'] = isset($options['TKT_start_date'])
             ? $options['TKT_start_date']
             : time() + MONTH_IN_SECONDS;
-        $ticket_args['TKT_end_date'] = isset($options['TKT_end_date'])
+        $ticket_args['TKT_end_date']   = isset($options['TKT_end_date'])
             ? $options['TKT_end_date']
             : time() + MONTH_IN_SECONDS + DAY_IN_SECONDS;
         // now dump any other elements that came from the incoming options that are not ticket properties
         $ticket_args = array_intersect_key(
             $ticket_args,
-            array(
-                'TTM_ID' => 1,
-                'TKT_name' => 1,
+            [
+                'TTM_ID'          => 1,
+                'TKT_name'        => 1,
                 'TKT_description' => 1,
-                'TKT_start_date' => 1,
-                'TKT_end_date' => 1,
-                'TKT_min' => 1,
-                'TKT_max' => 1,
-                'TKT_price' => 1,
-                'TKT_sold' => 1,
-                'TKT_qty' => 1,
-                'TKT_reserved' => 1,
-                'TKT_uses' => 1,
-                'TKT_required' => 1,
-                'TKT_taxable' => 1,
-                'TKT_is_default' => 1,
-                'TKT_order' => 1,
-                'TKT_row' => 1,
-                'TKT_deleted' => 1,
-                'TKT_wp_user' => 1,
-                'TKT_parent' => 1,
-            )
+                'TKT_start_date'  => 1,
+                'TKT_end_date'    => 1,
+                'TKT_min'         => 1,
+                'TKT_max'         => 1,
+                'TKT_price'       => 1,
+                'TKT_sold'        => 1,
+                'TKT_qty'         => 1,
+                'TKT_reserved'    => 1,
+                'TKT_uses'        => 1,
+                'TKT_required'    => 1,
+                'TKT_taxable'     => 1,
+                'TKT_is_default'  => 1,
+                'TKT_order'       => 1,
+                'TKT_row'         => 1,
+                'TKT_deleted'     => 1,
+                'TKT_wp_user'     => 1,
+                'TKT_parent'      => 1,
+            ]
         );
         /** @type EE_Ticket $ticket */
-        $ticket = $this->new_model_obj_with_dependencies('Ticket',$ticket_args);
-        $base_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Base Price')));
+        $ticket          = $this->new_model_obj_with_dependencies('Ticket', $ticket_args);
+        $base_price_type = EEM_Price_Type::instance()->get_one([['PRT_name' => 'Base Price']]);
         $this->assertInstanceOf('EE_Price_Type', $base_price_type);
 
         //only associate on the tickets if TKT_price is not included
-        if (!isset($options['TKT_price'])) {
-            $base_price = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => 10, 'PRT_ID' => $base_price_type->ID()));
+        if (! isset($options['TKT_price'])) {
+            $base_price =
+                $this->new_model_obj_with_dependencies(
+                    'Price',
+                    ['PRC_amount' => 10, 'PRT_ID' => $base_price_type->ID()]
+                );
             $ticket->_add_relation_to($base_price, 'Price');
             $this->assertArrayContains($base_price, $ticket->prices());
             if (isset($options['dollar_surcharge'])) {
-                $dollar_surcharge_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Dollar Surcharge')));
+                $dollar_surcharge_price_type =
+                    EEM_Price_Type::instance()->get_one([['PRT_name' => 'Dollar Surcharge']]);
                 $this->assertInstanceOf('EE_Price_Type', $dollar_surcharge_price_type);
-                $dollar_surcharge = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['dollar_surcharge'], 'PRT_ID' => $dollar_surcharge_price_type->ID()));
+                $dollar_surcharge =
+                    $this->new_model_obj_with_dependencies(
+                        'Price',
+                        ['PRC_amount' => $options['dollar_surcharge'], 'PRT_ID' => $dollar_surcharge_price_type->ID()]
+                    );
                 $ticket->_add_relation_to($dollar_surcharge, 'Price');
                 $this->assertArrayContains($dollar_surcharge, $ticket->prices());
             }
             if (isset($options['percent_surcharge'])) {
-                $percent_surcharge_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Percent Surcharge')));
+                $percent_surcharge_price_type =
+                    EEM_Price_Type::instance()->get_one([['PRT_name' => 'Percent Surcharge']]);
                 $this->assertInstanceOf('EE_Price_Type', $percent_surcharge_price_type);
-                $percent_surcharge = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['percent_surcharge'], 'PRT_ID' => $percent_surcharge_price_type->ID()));
+                $percent_surcharge =
+                    $this->new_model_obj_with_dependencies(
+                        'Price',
+                        ['PRC_amount' => $options['percent_surcharge'], 'PRT_ID' => $percent_surcharge_price_type->ID()]
+                    );
                 $ticket->_add_relation_to($percent_surcharge, 'Price');
                 $this->assertArrayContains($percent_surcharge, $ticket->prices());
             }
         } else {
             $ticket->set('TKT_price', $options['TKT_price']);
             //set the base price
-            $base_price = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['TKT_price'], 'PRT_ID' => $base_price_type->ID()));
+            $base_price =
+                $this->new_model_obj_with_dependencies(
+                    'Price',
+                    ['PRC_amount' => $options['TKT_price'], 'PRT_ID' => $base_price_type->ID()]
+                );
             $ticket->_add_relation_to($base_price, 'Price');
             $this->assertArrayContains($base_price, $ticket->prices());
         }
@@ -1332,7 +1464,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
 
         // were datetimes (and their related events) already setup?
-        if(!empty($options['datetime_objects']) && is_array($options['datetime_objects'])) {
+        if (! empty($options['datetime_objects']) && is_array($options['datetime_objects'])) {
             foreach ($options['datetime_objects'] as $datetime_object) {
                 $ticket->_add_relation_to($datetime_object, 'Datetime');
             }
@@ -1344,15 +1476,15 @@ class EE_UnitTestCase extends WP_UnitTestCase
             global $current_user;
             // create new datetimes, default = 1
             $datetimes = isset($options['datetimes']) ? $options['datetimes'] : 1;
-            $event = $this->new_model_obj_with_dependencies('Event', array('EVT_wp_user' => $current_user->ID));
+            $event     = $this->new_model_obj_with_dependencies('Event', ['EVT_wp_user' => $current_user->ID]);
             for ($i = 0; $i <= $datetimes; $i++) {
                 $ddt = $this->new_model_obj_with_dependencies(
                     'Datetime',
-                    array(
-                        'EVT_ID' => $event->ID(),
+                    [
+                        'EVT_ID'        => $event->ID(),
                         'DTT_EVT_start' => time() + MONTH_IN_SECONDS,
                         'DTT_EVT_end'   => time() + MONTH_IN_SECONDS + DAY_IN_SECONDS,
-                    )
+                    ]
                 );
                 $ticket->_add_relation_to($ddt, 'Datetime');
                 $this->assertArrayContains($ddt, $ticket->datetimes());
@@ -1372,7 +1504,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @return WP_User
      * @throws EE_Error
      */
-    public function wp_admin_with_ee_caps($ee_capabilities = array())
+    public function wp_admin_with_ee_caps($ee_capabilities = [])
     {
         //if caps were provided then just add the caps to a default user role (non admin user).
         if ($ee_capabilities) {
@@ -1384,16 +1516,18 @@ class EE_UnitTestCase extends WP_UnitTestCase
             return $user;
         }
         /** @type WP_User $user */
-        $user = $this->factory->user->create_and_get(array('role' => 'administrator'));
+        $user = $this->factory->user->create_and_get(['role' => 'administrator']);
         return $user;
     }
 
 
     /**
      * increments the ticket and datetime sold values
-     * @param \EE_ticket $ticket
-     * @param int $qty
-     * @throws \EE_Error
+     *
+     * @param EE_ticket $ticket
+     * @param int       $qty
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function simulate_x_number_ticket_sales(EE_ticket $ticket, $qty = 1)
     {
@@ -1403,9 +1537,11 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     /**
      * decrements the ticket and datetime sold values
-     * @param \EE_ticket $ticket
-     * @param int $qty
-     * @throws \EE_Error
+     *
+     * @param EE_ticket $ticket
+     * @param int       $qty
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function reverse_x_number_ticket_sales(EE_ticket $ticket, $qty = 1)
     {
@@ -1413,9 +1549,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
     }
 
 
-
     /**
      * Calls the WordPress version specific method for refreshing user roles during tests
+     *
      * @param WP_User $user
      */
     protected function refreshRolesForUser(WP_User $user)
@@ -1455,10 +1591,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // load, register, and add shortcodes the new way
         LoaderFactory::getLoader()->getShared(
             'EventEspresso\core\services\shortcodes\ShortcodesManager',
-            array(
+            [
                 // and the old way, but we'll put it under control of the new system
-                EE_Config::getLegacyShortcodesManager()
-            )
+                EE_Config::getLegacyShortcodesManager(),
+            ]
         );
         do_action('AHEE__EE_System__register_shortcodes_modules_and_widgets');
         do_action('AHEE__EE_System__core_loaded_and_ready');
@@ -1478,7 +1614,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     protected function assertHookIsSet($hook_name, callable $callback, $equals, $is_action = true)
     {
         $has_hook = $is_action ? 'has_action' : 'has_filter';
-        $actual = $has_hook($hook_name, $callback);
+        $actual   = $has_hook($hook_name, $callback);
         if ($actual === false) {
             // produces error message like:
             // The `EE_Admin::filter_plugin_actions()` callback is NOT registered to the "plugin_action_links" action when it should be.

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -141,6 +141,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // load factories
         EEH_Autoloader::register_autoloaders_for_each_file_in_folder(EE_TESTS_DIR . 'includes/factories');
         $this->factory = new EE_UnitTest_Factory();
+        $this->loader = LoaderFactory::getLoader();
 
         //IF we detect we're running tests on WP4.1, then we need to make sure current_user_can tests pass by implementing
         //updating all_caps when `WP_User::add_cap` is run (which is fixed in later wp versions).  So we hook into the

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -5,6 +5,8 @@ use EventEspresso\core\domain\services\contexts\RequestTypeContextChecker;
 use EventEspresso\core\services\database\TableAnalysis;
 use EventEspresso\core\services\database\TableManager;
 use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\loaders\LoaderInterface;
+use EventEspresso\core\services\request\RequestInterface;
 
 /**
  * EE's extension of WP_UnitTestCase for writing all EE_Tests

--- a/tests/mocks/addons/eea-new-addon/core/data_migration_scripts/EE_DMS_New_Addon_1_0_0.dms.php
+++ b/tests/mocks/addons/eea-new-addon/core/data_migration_scripts/EE_DMS_New_Addon_1_0_0.dms.php
@@ -1,88 +1,96 @@
 <?php
 
-if (!defined('EVENT_ESPRESSO_VERSION'))
-	exit('No direct script access allowed');
-
 /**
  *
  * EE_DMS_New_Addon_0_0_1
  *
- * @package			Event Espresso
+ * @package               Event Espresso
  * @subpackage
- * @author				Mike Nelson
+ * @author                Mike Nelson
  *
  */
-class EE_DMS_New_Addon_1_0_0 extends EE_Data_Migration_Script_Base{
+class EE_DMS_New_Addon_1_0_0 extends EE_Data_Migration_Script_Base
+{
 
-	public function __construct() {
-		$this->_pretty_name = __("Data Migration to New Addon 0.0.2", "event_espresso");
-		$this->_migration_stages = array(
-			/*
-			 * add children of EE_Data_Migration_Script_Stage or EE_Data_Migration_Script_Stage_Table
-			 * it's easiest to add these classes onto this same file, or use EEH_Autoloader to autoload them
-			 * BEFORE declaring this class' name (because on some requests only THIS file is auto-loaded
-			 * and the class is unserialized from the DB- ie used but NOT constructed)
-			 */
-		);
-		parent::__construct();
-	}
-	/**
-	 * Indicates whether or not this data migration script should migrate data or not
-	 * @param array $current_database_state_of keys are EE plugin slugs like
-	 *				'Core', 'Calendar', 'Mailchimp',etc, Your addon's slug can be retrieved
-	 *				using $this->slug(). Your addon's entry database state is located
-	 *				at $current_database_state_of[ $this->slug() ] if it was previously
-	 *				intalled; if it wasn't previously installed its NOT in the array
-	 * @return boolean
-	 */
-	public function can_migrate_from_version($current_database_state_of) {
-		/* NOTE: if this is your addon's only DMS and your addon will NOT be migrating data from pre-event-espresso-4,
-		 * then this should just return FALSE. Eg, if there is NO EQUIVALENT EE3 addon,
-		 * then return FALSE. If there was, and this DMS will be migrating data from it,
-		 * then we should return TRUE if we know the old data exists in this system, otherwise FALSE.
-		 */
-		if( isset( $current_database_state_of[ $this->slug() ] ) ) {
-			if( version_compare( '1.0.0.dev.000', $current_database_state_of[ $this->slug() ], '>')) {
-				//db state is old. this applies
-				return TRUE;
-			} else {
-				//db state is at 1.0.0.dev.000 or higher. this doesnt apply
-				return FALSE;
+    public function __construct()
+    {
+        $this->_pretty_name      = esc_html__("Data Migration to New Addon 0.0.2", "event_espresso");
+        $this->_migration_stages = [
+            /*
+             * add children of EE_Data_Migration_Script_Stage or EE_Data_Migration_Script_Stage_Table
+             * it's easiest to add these classes onto this same file, or use EEH_Autoloader to autoload them
+             * BEFORE declaring this class' name (because on some requests only THIS file is auto-loaded
+             * and the class is unserialized from the DB- ie used but NOT constructed)
+             */
+        ];
+        parent::__construct();
+    }
 
-			}
-		} else {
-			/* apparently this EE4 addon was never installed previously.
-			 * If there was an EE3 equivalent, you could use \EventEspresso\core\services\database\TableAnalysis::tableExists(),
-			 * and EE_Data_Migration_Manager::get_migration_ran() to see if the old
-			 * EE3 tables exist and if the core DMS migrated core data from EE3.
-			 * If so, you probably want to migrate (return TRUE).
-			 * If there was NO EE3 equivalent addon, return FALSE (indicating you don't want
-			 * to migrate. Normal activation processes will take care of calling the most
-			 * up-to-date DMS's schema_changes_before_migration() and schema_changes_after_migration()
-			 * for your addon to setup your database.)
-			 */
-			return FALSE;
-		}
-	}
 
-	public function schema_changes_after_migration() {
+    /**
+     * Indicates whether or not this data migration script should migrate data or not
+     *
+     * @param array $current_database_state_of keys are EE plugin slugs like
+     *                                         'Core', 'Calendar', 'Mailchimp',etc, Your addon's slug can be retrieved
+     *                                         using $this->slug(). Your addon's entry database state is located
+     *                                         at $current_database_state_of[ $this->slug() ] if it was previously
+     *                                         installed; if it wasn't previously installed its NOT in the array
+     * @return boolean
+     */
+    public function can_migrate_from_version($current_database_state_of)
+    {
+        /* NOTE: if this is your addon's only DMS and your addon will NOT be migrating data from pre-event-espresso-4,
+         * then this should just return FALSE. Eg, if there is NO EQUIVALENT EE3 addon,
+         * then return FALSE. If there was, and this DMS will be migrating data from it,
+         * then we should return TRUE if we know the old data exists in this system, otherwise FALSE.
+         */
+        if (isset($current_database_state_of[ $this->slug() ])) {
+            if (version_compare('1.0.0.dev.000', $current_database_state_of[ $this->slug() ], '>')) {
+                //db state is old. this applies
+                return true;
+            }
+            //db state is at 1.0.0.dev.000 or higher. this doesnt apply
+            return false;
+        }
+        /* apparently this EE4 addon was never installed previously.
+         * If there was an EE3 equivalent, you could use \EventEspresso\core\services\database\TableAnalysis::tableExists(),
+         * and EE_Data_Migration_Manager::get_migration_ran() to see if the old
+         * EE3 tables exist and if the core DMS migrated core data from EE3.
+         * If so, you probably want to migrate (return TRUE).
+         * If there was NO EE3 equivalent addon, return FALSE (indicating you don't want
+         * to migrate. Normal activation processes will take care of calling the most
+         * up-to-date DMS's schema_changes_before_migration() and schema_changes_after_migration()
+         * for your addon to setup your database.)
+         */
+        return false;
+    }
 
-	}
 
-	public function schema_changes_before_migration() {
-		$this->_table_is_new_in_this_version('esp_new_addon_thing', '
+    public function schema_changes_before_migration()
+    {
+        $this->_table_is_new_in_this_version(
+            'esp_new_addon_thing',
+            '
 			NEW_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 			NEW_name VARCHAR(10) NOT NULL,
 			NEW_wp_user bigint unsigned NOT NULL,
 			PRIMARY KEY  (NEW_ID)'
-				);
-		$this->_table_is_new_in_this_version('esp_new_addon_attendee_meta', '
+        );
+        $this->_table_is_new_in_this_version(
+            'esp_new_addon_attendee_meta',
+            '
 			NATT_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 			ATT_ID int(10) unsigned NOT NULL,
 			ATT_foobar int(10) unsigned NOT NULL,
 			PRIMARY KEY  (NATT_ID)'
-				);
-	}
+        );
+    }
+
+
+    public function schema_changes_after_migration()
+    {
+        return true;
+    }
 }
 
 // End of file EE_DMS_New_Addon_0_0_1.dms.php

--- a/tests/mocks/addons/eea-new-addon/core/db_classes/EE_New_Addon_Thing.class.php
+++ b/tests/mocks/addons/eea-new-addon/core/db_classes/EE_New_Addon_Thing.class.php
@@ -1,33 +1,38 @@
 <?php
 
-if (!defined('EVENT_ESPRESSO_VERSION'))
-	exit('No direct script access allowed');
-
 /**
- *
  * EE_Mock
  *
- * @package			Event Espresso
+ * @package               Event Espresso
  * @subpackage
- * @author				Mike Nelson
+ * @author                Mike Nelson
  *
  */
-class EE_New_Addon_Thing extends EE_Base_Class{
-	/**
-	 *
-	 * @param type $props_n_values
-	 * @return EE_Attendee
-	 */
-	public static function new_instance( $props_n_values = array() ) {
-		$classname = __CLASS__;
-		$has_object = parent::_check_for_object( $props_n_values, $classname );
-		return $has_object ? $has_object : new self( $props_n_values );
-	}
+class EE_New_Addon_Thing extends EE_Base_Class
+{
+    /**
+     *
+     * @param array $props_n_values
+     * @return EE_New_Addon_Thing
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public static function new_instance(array $props_n_values = [])
+    {
+        $classname  = __CLASS__;
+        $has_object = parent::_check_for_object($props_n_values, $classname);
+        return $has_object ? $has_object : new self($props_n_values);
+    }
 
 
-	public static function new_instance_from_db ( $props_n_values = array() ) {
-		return new self( $props_n_values, TRUE );
-	}
+    /**
+     * @param array $props_n_values
+     * @return EE_New_Addon_Thing
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public static function new_instance_from_db(array $props_n_values = [])
+    {
+        return new self($props_n_values, true);
+    }
 }
-
-// End of file EE_Base_Class_Mock.class.php

--- a/tests/testcases/core/EE_Addon_Test.php
+++ b/tests/testcases/core/EE_Addon_Test.php
@@ -31,17 +31,18 @@ class EE_Addon_Test extends EE_UnitTestCase{
      * @var array
      */
     protected $_temp_tables_added_by_addon = array( 'esp_new_addon_thing', 'esp_new_addon_attendee_meta' );
+
 	public function __construct($name = NULL, array $data = array(), $dataName = '') {
 		$this->_main_file_path = EE_TESTS_DIR . 'mocks/addons/eea-new-addon/eea-new-addon.php';
 		require_once $this->_main_file_path;
 		//loading that file adds a hook, but we want to control when it hooks in
 		remove_action( 'AHEE__EE_System__load_espresso_addons', 'load_espresso_new_addon' );
-        $this->_table_analysis = new \EventEspresso\core\services\database\TableAnalysis();
-        $this->_table_manager = new \EventEspresso\core\services\database\TableManager( $this->_table_analysis );
 		parent::__construct($name, $data, $dataName);
 	}
+
 	public function setUp(){
 		parent::setUp();
+        $this->initTableManager();
 		//let's just make a generic addon, but not bother registering it
         $loader = EventEspresso\core\services\loaders\LoaderFactory::getLoader();
         require_once dirname($this->_main_file_path) . '/EE_New_Addon.class.php';
@@ -62,7 +63,7 @@ class EE_Addon_Test extends EE_UnitTestCase{
 
 	public function tearDown(){
         //drop all the temporary tables we created during this test, because each subsequent test expects them to be gone
-        $this->_table_manager->dropTables( $this->_temp_tables_added_by_addon );
+        $this->table_manager->dropTables( $this->_temp_tables_added_by_addon );
         parent::tearDown();
     }
 
@@ -77,16 +78,11 @@ class EE_Addon_Test extends EE_UnitTestCase{
 	 * @return boolean
 	 */
 	public function dont_short_circuit_new_addon_table( $short_circuit = false, $table_name = '', $create_sql = '' ){
-		if (
-			in_array( $table_name, $this->_temp_tables_added_by_addon )
-		) {
-//			echo "\r\n\r\nDONT short circuit $sql";
-			//it's not altering. it's ok to allow this
+		if (in_array( $table_name, $this->_temp_tables_added_by_addon )) {
+			// it's not altering. it's ok to allow this
 			return false;
-		}else{
-//			echo "3\r\n\r\n short circuit:$sql";
-			return $short_circuit;
 		}
+        return $short_circuit;
 	}
 
 	public function test_update_list_of_installed_versions(){

--- a/tests/testcases/core/Psr4AutoloaderTest.php
+++ b/tests/testcases/core/Psr4AutoloaderTest.php
@@ -6,17 +6,16 @@ use EventEspresso\Tests\Mocks\Core\Psr4AutoloaderMock;
 class Psr4AutoloaderTest extends \EE_UnitTestCase {
 
 	/**
-	 * @type Psr4AutoloaderMock $loader
+	 * @type Psr4AutoloaderMock $autoloader
 	 */
-	protected $loader;
-
+	protected $autoloader;
 
 
 	public function setUp() {
 		parent::setUp();
 		require_once( EE_TESTS_DIR . 'mocks/core/Psr4AutoloaderMock.php' );
-		$this->loader = new Psr4AutoloaderMock;
-		$this->loader->setFiles( array(
+		$this->autoloader = new Psr4AutoloaderMock;
+		$this->autoloader->setFiles( array(
 			'/vendor/foo.bar/src/ClassName.php',
 			'/vendor/foo.bar/src/DoomClassName.php',
 			'/vendor/foo.bar/tests/ClassNameTest.php',
@@ -24,23 +23,23 @@ class Psr4AutoloaderTest extends \EE_UnitTestCase {
 			'/vendor/foo.bar.baz.dib/src/ClassName.php',
 			'/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php',
 		) );
-		$this->loader->addNamespace(
+		$this->autoloader->addNamespace(
 			'Foo\Bar',
 			'/vendor/foo.bar/src'
 		);
-		$this->loader->addNamespace(
+		$this->autoloader->addNamespace(
 			'Foo\Bar',
 			'/vendor/foo.bar/tests'
 		);
-		$this->loader->addNamespace(
+		$this->autoloader->addNamespace(
 			'Foo\BarDoom',
 			'/vendor/foo.bardoom/src'
 		);
-		$this->loader->addNamespace(
+		$this->autoloader->addNamespace(
 			'Foo\Bar\Baz\Dib',
 			'/vendor/foo.bar.baz.dib/src'
 		);
-		$this->loader->addNamespace(
+		$this->autoloader->addNamespace(
 			'Foo\Bar\Baz\Dib\Zim\Gir',
 			'/vendor/foo.bar.baz.dib.zim.gir/src'
 		);
@@ -49,10 +48,10 @@ class Psr4AutoloaderTest extends \EE_UnitTestCase {
 
 
 	public function testExistingFile() {
-		$actual = $this->loader->loadClass( 'Foo\Bar\ClassName' );
+		$actual = $this->autoloader->loadClass( 'Foo\Bar\ClassName' );
 		$expect = '/vendor/foo.bar/src/ClassName.php';
 		$this->assertSame( $expect, $actual );
-		$actual = $this->loader->loadClass( 'Foo\Bar\ClassNameTest' );
+		$actual = $this->autoloader->loadClass( 'Foo\Bar\ClassNameTest' );
 		$expect = '/vendor/foo.bar/tests/ClassNameTest.php';
 		$this->assertSame( $expect, $actual );
 	}
@@ -60,14 +59,14 @@ class Psr4AutoloaderTest extends \EE_UnitTestCase {
 
 
 	public function testMissingFile() {
-		$actual = $this->loader->loadClass( 'No_Vendor\No_Package\NoClass' );
+		$actual = $this->autoloader->loadClass( 'No_Vendor\No_Package\NoClass' );
 		$this->assertFalse( $actual );
 	}
 
 
 
 	public function testDeepFile() {
-		$actual = $this->loader->loadClass( 'Foo\Bar\Baz\Dib\Zim\Gir\ClassName' );
+		$actual = $this->autoloader->loadClass( 'Foo\Bar\Baz\Dib\Zim\Gir\ClassName' );
 		$expect = '/vendor/foo.bar.baz.dib.zim.gir/src/ClassName.php';
 		$this->assertSame( $expect, $actual );
 	}
@@ -75,10 +74,10 @@ class Psr4AutoloaderTest extends \EE_UnitTestCase {
 
 
 	public function testConfusion() {
-		$actual = $this->loader->loadClass( 'Foo\Bar\DoomClassName' );
+		$actual = $this->autoloader->loadClass( 'Foo\Bar\DoomClassName' );
 		$expect = '/vendor/foo.bar/src/DoomClassName.php';
 		$this->assertSame( $expect, $actual );
-		$actual = $this->loader->loadClass( 'Foo\BarDoom\ClassName' );
+		$actual = $this->autoloader->loadClass( 'Foo\BarDoom\ClassName' );
 		$expect = '/vendor/foo.bardoom/src/ClassName.php';
 		$this->assertSame( $expect, $actual );
 	}

--- a/tests/testcases/core/db_models/EEM_Base_Using_Mock_Model_Test.php
+++ b/tests/testcases/core/db_models/EEM_Base_Using_Mock_Model_Test.php
@@ -46,26 +46,24 @@ class EEM_Base_Using_Mock_Model_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
      *
      * @param bool   $short_circuit
      * @param string $table_name
      * @param string $create_sql
-     * @return array
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function dont_short_circuit_mock_table($short_circuit = false, $table_name = '', $create_sql = '')
     {
-        $table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
-        if ($table_name == 'esp_mock' && ! $table_analysis->tableExists($table_name)) {
-            //			echo "\r\n\r\nDONT short circuit $sql";
-            //it's not altering. it's ok to allow this
+        $this->initTableAnalysis();
+        if ($table_name === 'esp_mock' && ! $this->table_analysis->tableExists($table_name)) {
+            // it's not altering. it's ok to allow this
             return false;
-        } else {
-            //			echo "3\r\n\r\n short circuit:$sql";
-            return $short_circuit;
         }
+        return $short_circuit;
     }
 
 
@@ -81,7 +79,7 @@ class EEM_Base_Using_Mock_Model_Test extends EE_UnitTestCase
                 'MCK_value' => 'foobar',
             )
         );
-        $id = $mock_thing->save();
+        $mock_thing->save();
         $found_mock_thing = EEM_Mock::instance()->get_one();
         $this->assertEquals($mock_thing, $found_mock_thing);
     }

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
@@ -1,19 +1,17 @@
 <?php
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
+
 /**
  * EE_Register_Addon_Test
  *
- * @package 	Event Espresso
+ * @package       Event Espresso
  * @subpackage
- * @author 		Mike Nelson
+ * @author        Mike Nelson
  *
- * @group 		core/libraries/plugin_api
- * @group 		core
- * @group 		agg
- * @group 		addons
- * @group 		caps
+ * @group         core/libraries/plugin_api
+ * @group         core
+ * @group         agg
+ * @group         addons
+ * @group         caps
  */
 class EE_Register_Addon_Test extends EE_UnitTestCase
 {
@@ -25,18 +23,17 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     private $_addon_name;
 
 
-
     /**
      * Constructs a test case with the given name.
      *
-     * @param string $name
-     * @param array  $data
-     * @param string $dataName
+     * @param string|null $name
+     * @param array       $data
+     * @param string      $dataName
      */
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         $this->_mock_addon_path = EE_MOCKS_DIR . 'addons/eea-new-addon/';
-        $this->_reg_args = array(
+        $this->_reg_args        = [
             'version'               => '1.0.0',
             'min_core_version'      => '4.0.0',
             'main_file_path'        => $this->_mock_addon_path . 'eea-new-addon.php',
@@ -45,11 +42,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
             'class_paths'           => $this->_mock_addon_path . 'core/db_classes',
             'class_extension_paths' => $this->_mock_addon_path . 'core/db_class_extensions',
             'model_extension_paths' => $this->_mock_addon_path . 'core/db_model_extensions',
-        );
-        $this->_addon_name = 'New_Addon';
+        ];
+        $this->_addon_name      = 'New_Addon';
         parent::__construct($name, $data, $dataName);
     }
-
 
 
     public function setUp()
@@ -57,7 +53,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         parent::setUp();
         add_filter(
             'FHEE__EEH_Activation__create_table__short_circuit',
-            array($this, 'dont_short_circuit_new_addon_table'),
+            [$this, 'dont_short_circuit_new_addon_table'],
             20,
             3
         );
@@ -65,7 +61,8 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
 
 
     /**
-     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
+     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this
+     * same hook
      *
      * @param bool   $short_circuit
      * @param string $table_name
@@ -77,7 +74,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     public function dont_short_circuit_new_addon_table($short_circuit = false, $table_name = '', $create_sql = '')
     {
         $this->initTableAnalysis();
-        if (in_array($table_name, array('esp_new_addon_thing', 'esp_new_addon_attendee_meta'), true)
+        if (in_array($table_name, ['esp_new_addon_thing', 'esp_new_addon_attendee_meta'], true)
             && ! $this->table_analysis->tableExists($table_name)
         ) {
             // it's not altering. it's ok to allow this
@@ -87,8 +84,12 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
-    //test registering a bare minimum addon, and then de-registering it
+    /**
+     * test registering a bare minimum addon, and then de-registering it
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function test_register_mock_addon_fail()
     {
         // echo "\n\n " . __LINE__ . ") " . __METHOD__ . "()";
@@ -110,7 +111,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function test_register_mock_addon_fail__bad_parameters()
     {
         //we're registering the addon with the wrong parameters
@@ -121,11 +125,11 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         try {
             EE_Register_Addon::register(
                 $this->_addon_name,
-                array(
-                	'version'          => '1.0.0',
-                	'min_core_version' => '4.0.0',
-                	'dms_paths'        => $this->_mock_addon_path . 'core/data_migration_scripts',
-            	)
+                [
+                    'version'          => '1.0.0',
+                    'min_core_version' => '4.0.0',
+                    'dms_paths'        => $this->_mock_addon_path . 'core/data_migration_scripts',
+                ]
             );
             $this->fail(
                 'We should have received a warning that the "main_file_path" is a required argument when registering an addon'
@@ -138,12 +142,15 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         //check DMSs weren't setup either
         $DMSs_available = EE_Data_Migration_Manager::reset()->get_all_data_migration_scripts_available();
         $this->assertArrayNotHasKey('EE_DMS_New_Addon_1_0_0', $DMSs_available);
-        //check that we didn't register the addon's de-activaiton hook either
+        //check that we didn't register the addon's de-activation hook either
         $this->assertFalse(has_action('deactivate_' . plugin_basename($this->_reg_args['main_file_path'])));
     }
 
 
-
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function test_register_mock_addon_success()
     {
         //ensure model and class extensions weren't setup beforehand
@@ -190,13 +197,13 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         //check that the caps maps were registered properly too
         $this->_pretend_capabilities_registered();
         $current_user = $this->factory->user->create_and_get();
-        $other_user = $this->factory->user->create_and_get();
+        $other_user   = $this->factory->user->create_and_get();
         //give user administrator role for test!
         $current_user->add_role('administrator');
-        $a_thing = $this->new_model_obj_with_dependencies('New_Addon_Thing', array('NEW_wp_user' => $current_user->ID));
+        $a_thing      = $this->new_model_obj_with_dependencies('New_Addon_Thing', ['NEW_wp_user' => $current_user->ID]);
         $others_thing = $this->new_model_obj_with_dependencies(
-        	'New_Addon_Thing',
-        	array('NEW_wp_user' => $other_user->ID)
+            'New_Addon_Thing',
+            ['NEW_wp_user' => $other_user->ID]
         );
         $this->assertTrue(
             EE_Capabilities::instance()->user_can($current_user, 'edit_thing', 'testing_edit', $a_thing->ID())
@@ -207,12 +214,13 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * Utility function to just setup valid capabilities for tests in this suite.
      *
-     * @since 1.0.0
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 1.0.0
      */
     private function _pretend_capabilities_registered()
     {
@@ -224,7 +232,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         //verify new caps are in the role
         $role = get_role('administrator');
         $this->assertContains(
-            array('edit_thing', 'edit_things', 'edit_others_things', 'edit_private_things'),
+            ['edit_thing', 'edit_things', 'edit_others_things', 'edit_private_things'],
             $role->capabilities
         );
     }
@@ -270,12 +278,15 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     //		$this->assertTrue( $this->_class_has_been_extended( TRUE ) );
     //		$this->assertTrue( $this->_model_has_been_extended( TRUE ) );
     //	}
+
+
     /**
      * check that when we register an addon and then another after the 'activate_plugin'
      * action fired, that there are no errors and the 2nd addon's activation indicator
      * was set properly
      *
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_register_mock_addon__activation()
     {
@@ -295,13 +306,13 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * registers an addon as usual, but then calls 'activate_plugin', as if a different
      * addon had been activated. Because the register method is called twice, this has the potential
      * for problems
      *
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_register_addon_called_twice_on_activation()
     {
@@ -327,14 +338,17 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function tearDown()
     {
         if (isset($this->_addon_name, EE_Registry::instance()->addons->EE_New_Addon)) {
             $main_file_path_before_deregistration = EE_Registry::instance()
-            										->addons
-            										->EE_New_Addon
-            										->get_main_plugin_file_basename();
+                ->addons
+                ->EE_New_Addon
+                ->get_main_plugin_file_basename();
             EE_Register_Addon::deregister($this->_addon_name);
             $this->assertArrayNotHasKey('EE_New_Addon', EE_Registry::instance()->addons);
             //verify the de-activation hook was removed
@@ -378,12 +392,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     protected function _pretend_after_plugin_activation()
     {
         do_action('activate_plugin');
     }
-
 
 
     protected function _pretend_addon_hook_time()
@@ -397,7 +409,6 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         );
         parent::_pretend_addon_hook_time();
     }
-
 
 
     /**
@@ -422,7 +433,6 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * Determines if the Attendee model has been extended by the mock extension
      *
@@ -442,7 +452,8 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
                             __(
                                 'The field ATT_foobar is not on EEM_Attendee, but the extension should have added it. fields are: %s',
                                 'event_espresso'
-                            ), implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
                         )
                     );
                 }
@@ -455,7 +466,8 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
                             __(
                                 'The relation of type New_Addon_Thing on EEM_Attendee, but the extension should have added it. fields are: %s',
                                 'event_espresso'
-                            ), implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
                         )
                     );
                 }
@@ -472,7 +484,6 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     public function test_effective_version()
     {
         //use reflection to test this protected method
@@ -482,7 +493,6 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         $this->assertEquals('4.3.0.p.000', $method->invoke(null, '4.3.0.p'));
         $this->assertEquals('4.3.0.rc.123', $method->invoke(null, '4.3.0.rc.123'));
     }
-
 
 
     public function test_meets_min_core_version_requirement()

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
@@ -64,7 +64,6 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
      *
@@ -72,19 +71,18 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
      * @param string $table_name
      * @param string $create_sql
      * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function dont_short_circuit_new_addon_table($short_circuit = false, $table_name = '', $create_sql = '')
     {
-        $table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
-        if (
-            in_array($table_name, array('esp_new_addon_thing', 'esp_new_addon_attendee_meta'), true)
-            && ! $table_analysis->tableExists($table_name)
+        $this->initTableAnalysis();
+        if (in_array($table_name, array('esp_new_addon_thing', 'esp_new_addon_attendee_meta'), true)
+            && ! $this->table_analysis->tableExists($table_name)
         ) {
-            // echo "\r\n\r\nDONT short circuit $sql";
             // it's not altering. it's ok to allow this
             return false;
         }
-        // echo "3\r\n\r\n short circuit:$sql";
         return $short_circuit;
     }
 

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
@@ -1,171 +1,225 @@
 <?php
 
-if (!defined('EVENT_ESPRESSO_VERSION')) {
-	exit('No direct script access allowed');
-}
-
 /**
  *
  * EE_Register_Model_Test
  *
- * @package			Event Espresso
+ * @package               Event Espresso
  * @subpackage
- * @author				Mike Nelson
- *
- */
-/**
+ * @author                Mike Nelson
  * @group core/libraries/plugin_api
  * @group agg
  * @group addons
  * @group problem
  */
-class EE_Register_Model_Extensions_Test extends EE_UnitTestCase{
-	private $_reg_args;
-	private $_model_group;
-	public function __construct($name = NULL, array $data = array(), $dataName = '') {
-		$this->_reg_args = array(
-			'model_extension_paths' => array( EE_MOCKS_DIR . 'core/db_model_extensions/' ),
-			'class_extension_paths' => array( EE_MOCKS_DIR . 'core/db_class_extensions/' )
-		);
-		$this->_model_group = 'Mock';
-		parent::__construct($name, $data, $dataName);
-	}
-	/**
-	 * Determines if the attendee class has been extended by teh mock extension
-	 * @return boolean
-	 */
-	private function _class_has_been_extended( $throw_error = FALSE){
-		try{
-			$a = EE_Attendee::new_instance();
-			$a->foobar();
-			return TRUE;
-		}catch(EE_Error $e){
-			if( $throw_error ){
-				throw $e;
-			}
-			return FALSE;
-		}
-	}
+class EE_Register_Model_Extensions_Test extends EE_UnitTestCase
+{
+    private $_reg_args;
+
+    private $_model_group;
 
 
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        $this->_reg_args    = [
+            'model_extension_paths' => [EE_MOCKS_DIR . 'core/db_model_extensions/'],
+            'class_extension_paths' => [EE_MOCKS_DIR . 'core/db_class_extensions/'],
+        ];
+        $this->_model_group = 'Mock';
+        parent::__construct($name, $data, $dataName);
+    }
 
-	/**
-	 * Determines if the Attendee model has been extended by the mock extension
-	 *
-	 * @param bool $throw_error
-	 * @return bool
-	 * @throws \EE_Error
-	 */
-	private function _model_has_been_extended( $throw_error = FALSE){
-		try{
-			$att = EE_Registry::instance()->load_model('Attendee');
-			$att->reset()->foobar();
-			if( ! $att->has_field('ATT_foobar')){
-				if( $throw_error ){
-					throw new EE_Error(sprintf( __( 'The field ATT_foobar is not on EEM_Attendee, but the extension should have added it. fields are: %s', 'event_espresso' ), implode(",",array_keys(EEM_Attendee::instance()->field_settings()))));
-				}
-				return FALSE;
-			}
-			if( ! $att->has_relation('Transaction')){
-				if( $throw_error ){
-					throw new EE_Error(sprintf( __( 'The relation of type Transaction on EEM_Attendee, but the extension should have added it. fields are: %s', 'event_espresso' ), implode(",",array_keys(EEM_Attendee::instance()->field_settings()))));
-				}
-				return FALSE;
-			}
-			return TRUE;
-		}catch(EE_Error $e){
-			if( $throw_error ){
-				throw $e;
-			}
-			return FALSE;
-		}
-	}
 
-	//test registering a bare minimum addon, and then deregistering it
-	function test_register_mock_model_fail(){
-		//we're registering the addon WAAAY after EE_System has set thing up, so
-		//registering this first time should throw an E_USER_NOTICE
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-		try{
-			EE_Register_Model_Extensions::register($this->_model_group, $this->_reg_args);
-			$this->fail('We should have had a warning saying that we are setting up the ee addon at the wrong time');
-		}catch(EE_Error $e){
-			$this->assertTrue(True);
-		}
-		//verify they still haven't been extended
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-	}
+    /**
+     * Determines if the attendee class has been extended by teh mock extension
+     *
+     * @return boolean
+     * @throws EE_Error
+     */
+    private function _class_has_been_extended($throw_error = false)
+    {
+        try {
+            $a = EE_Attendee::new_instance();
+            $a->foobar();
+            return true;
+        } catch (EE_Error $e) {
+            if ($throw_error) {
+                throw $e;
+            }
+            return false;
+        }
+    }
 
-	function test_register_mock_model_extension_fail__bad_parameters(){
-		//we're registering the addon with the wrong parameters
-		$this->_pretend_addon_hook_time();
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-		try{
-			EE_Register_Model_Extensions::register($this->_model_group, array('foo' => 'bar'));
-			$this->fail('We should have had a warning saying that we are setting up the ee addon at the wrong time');
-		}catch(EE_Error $e){
-			$this->assertTrue(True);
-		}
-		//verify they still haven't been extended
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-	}
 
-	protected function _pretend_addon_hook_time() {
-		global $wp_actions;
-		unset( $wp_actions['AHEE__EEM_Attendee__construct__end'] );
-		parent::_pretend_addon_hook_time();
-	}
+    /**
+     * Determines if the Attendee model has been extended by the mock extension
+     *
+     * @param bool $throw_error
+     * @return bool
+     * @throws \EE_Error
+     * @throws ReflectionException
+     */
+    private function _model_has_been_extended($throw_error = false)
+    {
+        try {
+            $att = EE_Registry::instance()->load_model('Attendee');
+            $att->reset()->foobar();
+            if (! $att->has_field('ATT_foobar')) {
+                if ($throw_error) {
+                    throw new EE_Error(
+                        sprintf(
+                            __(
+                                'The field ATT_foobar is not on EEM_Attendee, but the extension should have added it. fields are: %s',
+                                'event_espresso'
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                        )
+                    );
+                }
+                return false;
+            }
+            if (! $att->has_relation('Transaction')) {
+                if ($throw_error) {
+                    throw new EE_Error(
+                        sprintf(
+                            __(
+                                'The relation of type Transaction on EEM_Attendee, but the extension should have added it. fields are: %s',
+                                'event_espresso'
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                        )
+                    );
+                }
+                return false;
+            }
+            return true;
+        } catch (EE_Error $e) {
+            if ($throw_error) {
+                throw $e;
+            }
+            return false;
+        }
+    }
 
-	function test_register_mock_addon_success(){
 
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-		$this->_pretend_addon_hook_time();
+    /**
+     * test registering a bare minimum addon, and then de-registering it
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    function test_register_mock_model_fail()
+    {
+        // we're registering the addon WAAAY after EE_System has set thing up, so
+        // registering this first time should throw an E_USER_NOTICE
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+        try {
+            EE_Register_Model_Extensions::register($this->_model_group, $this->_reg_args);
+            $this->fail('We should have had a warning saying that we are setting up the ee addon at the wrong time');
+        } catch (EE_Error $e) {
+            $this->assertTrue(true);
+        }
+        // verify they still haven't been extended
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+    }
 
-		EE_Register_Model_Extensions::register($this->_model_group, $this->_reg_args);
-		EEM_Attendee::instance()->reset();
-		//verify they still haven't been extended
-		$this->assertTrue( $this->_class_has_been_extended( TRUE ) );
-		$this->assertTrue( $this->_model_has_been_extended( TRUE ) );
-		//and that we can still use EEM_Attendee
-		EE_Attendee::new_instance();
-		EEM_Attendee::instance()->get_all();
-		EE_Registry::instance()->load_model('Attendee')->get_all();
 
-		//now deregister it
-		EE_Register_Model_Extensions::deregister($this->_model_group);
-		$this->assertFalse( $this->_class_has_been_extended() );
-		$this->assertFalse( $this->_model_has_been_extended() );
-		EEM_Attendee::instance()->reset();
-		//and EEM_Attendee still works right? both ways of instantiating it?
-		EE_Attendee::new_instance();
-		EEM_Attendee::instance()->get_all();
-		EE_Registry::instance()->load_model('Attendee')->get_all();
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    function test_register_mock_model_extension_fail__bad_parameters()
+    {
+        // we're registering the addon with the wrong parameters
+        $this->_pretend_addon_hook_time();
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+        try {
+            EE_Register_Model_Extensions::register($this->_model_group, ['foo' => 'bar']);
+            $this->fail('We should have had a warning saying that we are setting up the ee addon at the wrong time');
+        } catch (EE_Error $e) {
+            $this->assertTrue(true);
+        }
+        // verify they still haven't been extended
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+    }
 
-	}
-	public function setUp(){
-		parent::setUp();
-		//whitelist the table we're about to add
-		add_filter( 'FHEE__EEH_Activation__create_table__short_circuit', array($this, 'dont_short_circuit_mock_table' ), 25, 3 );
-		//add table from related DMS
-		EEH_Activation::create_table('esp_mock_attendee_meta', '
+
+    protected function _pretend_addon_hook_time()
+    {
+        global $wp_actions;
+        unset($wp_actions['AHEE__EEM_Attendee__construct__end']);
+        parent::_pretend_addon_hook_time();
+    }
+
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    function test_register_mock_addon_success()
+    {
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+        $this->_pretend_addon_hook_time();
+
+        EE_Register_Model_Extensions::register($this->_model_group, $this->_reg_args);
+        EEM_Attendee::instance()->reset();
+        // verify they still haven't been extended
+        $this->assertTrue($this->_class_has_been_extended(true));
+        $this->assertTrue($this->_model_has_been_extended(true));
+        // and that we can still use EEM_Attendee
+        EE_Attendee::new_instance();
+        EEM_Attendee::instance()->get_all();
+        EE_Registry::instance()->load_model('Attendee')->get_all();
+
+        // now deregister it
+        EE_Register_Model_Extensions::deregister($this->_model_group);
+        $this->assertFalse($this->_class_has_been_extended());
+        $this->assertFalse($this->_model_has_been_extended());
+        EEM_Attendee::instance()->reset();
+        // and EEM_Attendee still works right? both ways of instantiating it?
+        EE_Attendee::new_instance();
+        EEM_Attendee::instance()->get_all();
+        EE_Registry::instance()->load_model('Attendee')->get_all();
+
+    }
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        // whitelist the table we're about to add
+        add_filter(
+            'FHEE__EEH_Activation__create_table__short_circuit',
+            [$this, 'dont_short_circuit_mock_table'],
+            25,
+            3
+        );
+        // add table from related DMS
+        EEH_Activation::create_table(
+            'esp_mock_attendee_meta',
+            '
 			MATTM_ID int(10) unsigned NOT NULL AUTO_INCREMENT,
 			ATT_ID int(10) unsigned NOT NULL,
 			ATT_foobar int(10) unsigned NOT NULL,
 			PRIMARY KEY  (MATTM_ID)'
-				);
-		$this->assertTableExists( 'esp_mock_attendee_meta' );
+        );
+        $this->assertTableExists('esp_mock_attendee_meta');
 
-		EE_Register_Model_Extensions::deregister( $this->_model_group );
-	}
+        EE_Register_Model_Extensions::deregister($this->_model_group);
+    }
 
 
     /**
-     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
+     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this
+     * same hook
      *
      * @param bool   $short_circuit
      * @param string $table_name
@@ -174,22 +228,27 @@ class EE_Register_Model_Extensions_Test extends EE_UnitTestCase{
      * @throws EE_Error
      * @throws ReflectionException
      */
-	public function dont_short_circuit_mock_table( $short_circuit = false, $table_name = '', $create_sql = '' ){
+    public function dont_short_circuit_mock_table($short_circuit = false, $table_name = '', $create_sql = '')
+    {
         $this->initTableAnalysis();
-		if( $table_name == 'esp_mock_attendee_meta' && ! $this->table_analysis->tableExists( $table_name) ){
-			//it's not altering. it's ok to allow this
-			return false;
-		}
+        if ($table_name == 'esp_mock_attendee_meta' && ! $this->table_analysis->tableExists($table_name)) {
+            // it's not altering. it's ok to allow this
+            return false;
+        }
         return $short_circuit;
-	}
+    }
 
 
-	public function tearDown(){
-		//ensure the models aren't still registered. they should have either been
-		//deregistered during the test, or not been registered at all
-		$this->_stop_pretending_addon_hook_time();
-		parent::tearDown();
-	}
+    /**
+     * @throws EE_Error
+     */
+    public function tearDown()
+    {
+        // ensure the models aren't still registered. they should have either been
+        // deregistered during the test, or not been registered at all
+        $this->_stop_pretending_addon_hook_time();
+        parent::tearDown();
+    }
 }
 
 // End of file EE_Register_Model_Test.php

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
@@ -164,28 +164,28 @@ class EE_Register_Model_Extensions_Test extends EE_UnitTestCase{
 	}
 
 
-
-	/**
-	 * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
-	 *
-	 * @param bool   $short_circuit
-	 * @param string $table_name
-	 * @param string $create_sql
-	 * @return array
-	 */
+    /**
+     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
+     *
+     * @param bool   $short_circuit
+     * @param string $table_name
+     * @param string $create_sql
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
 	public function dont_short_circuit_mock_table( $short_circuit = false, $table_name = '', $create_sql = '' ){
-		$table_analysis = EE_Registry::instance()->create( 'TableAnalysis', array(), true );
-		if( $table_name == 'esp_mock_attendee_meta' && ! $table_analysis->tableExists( $table_name) ){
-//			echo "\r\n\r\nDONT short circuit $sql";
+        $this->initTableAnalysis();
+		if( $table_name == 'esp_mock_attendee_meta' && ! $this->table_analysis->tableExists( $table_name) ){
 			//it's not altering. it's ok to allow this
 			return false;
-		}else{
-//			echo "3\r\n\r\n short circuit:$sql";
-			return $short_circuit;
 		}
+        return $short_circuit;
 	}
+
+
 	public function tearDown(){
-		//ensure the models aren't stil registered. they should have either been
+		//ensure the models aren't still registered. they should have either been
 		//deregistered during the test, or not been registered at all
 		$this->_stop_pretending_addon_hook_time();
 		parent::tearDown();

--- a/tests/testcases/core/services/loaders/CachingLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CachingLoaderTest.php
@@ -24,11 +24,10 @@ use PHPUnit\Framework\Exception;
 class CachingLoaderTest extends EE_UnitTestCase
 {
 
-
     /**
-     * @var CachingLoaderMock $loader
+     * @var CachingLoaderMock $loader_mock
      */
-    private static $loader;
+    private static $loader_mock;
 
 
     /**
@@ -41,8 +40,8 @@ class CachingLoaderTest extends EE_UnitTestCase
     {
         //caching is turned off by default in the parent test case.  For tests in here where we're doing a number of
         //different persistence tests
-        if (! self::$loader instanceof LoaderDecorator) {
-            self::$loader = new CachingLoaderMock(
+        if (! CachingLoaderTest::$loader_mock instanceof LoaderDecorator) {
+            CachingLoaderTest::$loader_mock = new CachingLoaderMock(
                 new CoreLoader(EE_Registry::instance()),
                 new LooseCollection(''),
                 new ObjectIdentifier(new ClassInterfaceCache())
@@ -65,7 +64,7 @@ class CachingLoaderTest extends EE_UnitTestCase
      */
     public function testLoadCachingOff()
     {
-        $object = self::$loader->load($this->getFqcnForTest());
+        $object = CachingLoaderTest::$loader_mock->load($this->getFqcnForTest());
         $this->assertInstanceOf(
             $this->getFqcnForTest(),
             $object,
@@ -77,14 +76,14 @@ class CachingLoaderTest extends EE_UnitTestCase
         );
         $obj1ID = spl_object_hash($object);
         // none of these objects are getting cached because it is turned off for unit testing
-        $object2 = self::$loader->load($this->getFqcnForTest());
+        $object2 = CachingLoaderTest::$loader_mock->load($this->getFqcnForTest());
         $obj2ID = spl_object_hash($object2);
         $this->assertNotEquals($obj1ID, $obj2ID);
 
         //this time let's load the object with caching turned on so it gets in the cache and we'll send that objects
         //hash along for the persistence test.
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false', 10);
-        return spl_object_hash(self::$loader->load($this->getFqcnForTest()));
+        return spl_object_hash(CachingLoaderTest::$loader_mock->load($this->getFqcnForTest()));
     }
 
 
@@ -97,8 +96,8 @@ class CachingLoaderTest extends EE_UnitTestCase
         //turn caching on.
         remove_all_filters('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache');
         $this->assertEquals(
-            spl_object_hash(self::$loader->load($this->getFqcnForTest())),
-            spl_object_hash(self::$loader->load($this->getFqcnForTest()))
+            spl_object_hash(CachingLoaderTest::$loader_mock->load($this->getFqcnForTest())),
+            spl_object_hash(CachingLoaderTest::$loader_mock->load($this->getFqcnForTest()))
         );
     }
 
@@ -114,25 +113,25 @@ class CachingLoaderTest extends EE_UnitTestCase
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false', 10);
         // add a few different objects this time, but confirm that they are getting cached
         $fqcn7 = '\EventEspresso\core\services\address\formatters\AddressFormatter';
-        $object7 = self::$loader->load($fqcn7);
+        $object7 = CachingLoaderTest::$loader_mock->load($fqcn7);
         $this->assertInstanceOf($fqcn7, $object7);
-        $this->assertEquals(spl_object_hash($object7), spl_object_hash(self::$loader->load($fqcn7)));
+        $this->assertEquals(spl_object_hash($object7), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn7)));
         $fqcn8 = '\EventEspresso\core\services\address\formatters\InlineAddressFormatter';
-        $object8 = self::$loader->load($fqcn8);
+        $object8 = CachingLoaderTest::$loader_mock->load($fqcn8);
         $this->assertInstanceOf($fqcn8, $object8);
-        $this->assertEquals(spl_object_hash($object8), spl_object_hash(self::$loader->load($fqcn8)));
+        $this->assertEquals(spl_object_hash($object8), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn8)));
         $fqcn9 = '\EventEspresso\core\services\address\formatters\MultiLineAddressFormatter';
-        $object9 = self::$loader->load($fqcn9);
+        $object9 = CachingLoaderTest::$loader_mock->load($fqcn9);
         $this->assertInstanceOf($fqcn9, $object9);
-        $this->assertEquals(spl_object_hash($object9), spl_object_hash(self::$loader->load($fqcn9)));
-        $this->assertCount(3, self::$loader->getCache());
+        $this->assertEquals(spl_object_hash($object9), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn9)));
+        $this->assertCount(3, CachingLoaderTest::$loader_mock->getCache());
         // now reset the cache using the do_action()
         do_action('AHEE__EventEspresso_core_services_loaders_CachingLoader__resetCache');
-        $this->assertCount(0, self::$loader->getCache());
+        $this->assertCount(0, CachingLoaderTest::$loader_mock->getCache());
         // confirm that reloading the same FCQNs as above results in new objects
-        $this->assertNotEquals(spl_object_hash($object7), spl_object_hash(self::$loader->load($fqcn7)));
-        $this->assertNotEquals(spl_object_hash($object8), spl_object_hash(self::$loader->load($fqcn8)));
-        $this->assertNotEquals(spl_object_hash($object9), spl_object_hash(self::$loader->load($fqcn9)));
+        $this->assertNotEquals(spl_object_hash($object7), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn7)));
+        $this->assertNotEquals(spl_object_hash($object8), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn8)));
+        $this->assertNotEquals(spl_object_hash($object9), spl_object_hash(CachingLoaderTest::$loader_mock->load($fqcn9)));
     }
 
     /**
@@ -151,9 +150,9 @@ class CachingLoaderTest extends EE_UnitTestCase
             'we are testing the share method'
         );
         // share it but don't pass any arguments
-        $added = self::$loader->share('EventEspresso\core\domain\entities\contexts\Context', $context1);
+        $added = CachingLoaderTest::$loader_mock->share('EventEspresso\core\domain\entities\contexts\Context', $context1);
         $this->assertTrue($added);
-        $object1 = self::$loader->load('EventEspresso\core\domain\entities\contexts\Context');
+        $object1 = CachingLoaderTest::$loader_mock->load('EventEspresso\core\domain\entities\contexts\Context');
         $this->assertEquals(spl_object_hash($object1), spl_object_hash($context1));
         // create another context object
         $context2 = new EventEspresso\core\domain\entities\contexts\Context(
@@ -161,19 +160,19 @@ class CachingLoaderTest extends EE_UnitTestCase
             'we are testing the share method again'
         );
         // share it but pass an array of its arguments
-        $added2 = self::$loader->share(
+        $added2 = CachingLoaderTest::$loader_mock->share(
             'EventEspresso\core\domain\entities\contexts\Context',
             $context2,
             array('testShare2', 'we are testing the share method again')
         );
         $this->assertTrue($added2);
         // just load using FQCN... should match object 1
-        $not_object2 = self::$loader->load('EventEspresso\core\domain\entities\contexts\Context');
+        $not_object2 = CachingLoaderTest::$loader_mock->load('EventEspresso\core\domain\entities\contexts\Context');
         $this->assertNotEquals(spl_object_hash($not_object2), spl_object_hash($context2));
         // because it's context 1
         $this->assertEquals(spl_object_hash($not_object2), spl_object_hash($context1));
         // now load using arguments
-        $object2 = self::$loader->load(
+        $object2 = CachingLoaderTest::$loader_mock->load(
             'EventEspresso\core\domain\entities\contexts\Context',
             array('testShare2', 'we are testing the share method again')
         );

--- a/tests/testcases/core/services/loaders/CoreLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CoreLoaderTest.php
@@ -16,18 +16,17 @@ use EventEspresso\core\services\loaders\LoaderInterface;
 class CoreLoaderTest extends EE_UnitTestCase
 {
 
-
     /**
-     * @var LoaderInterface $loader
+     * @var LoaderInterface $loader_mock
      */
-    private $loader;
+    private $loader_mock;
 
 
 
     public function setUp()
     {
         parent::setUp();
-        $this->loader = new CoreLoader(EE_Registry::instance());
+        $this->loader_mock = new CoreLoader(EE_Registry::instance());
     }
 
 
@@ -38,7 +37,7 @@ class CoreLoaderTest extends EE_UnitTestCase
     public function testBadConstruct()
     {
         try {
-            $this->loader = new CoreLoader(new stdClass());
+            $this->loader_mock = new CoreLoader(new stdClass());
             $this->fail('EventEspresso\core\services\loaders\CoreLoader should have thrown an InvalidArgumentException');
         } catch (Exception $e) {
             $this->assertTrue(true);
@@ -52,8 +51,8 @@ class CoreLoaderTest extends EE_UnitTestCase
      */
     public function testLoad()
     {
-        $fqcn = '\EventEspresso\core\services\address\formatters\AddressFormatter';
-        $formatter = $this->loader->load($fqcn);
+        $fqcn = 'EventEspresso\core\services\address\formatters\AddressFormatter';
+        $formatter = $this->loader_mock->load($fqcn);
         $this->assertInstanceOf(
             $fqcn,
             $formatter,

--- a/tests/testcases/core/services/loaders/LoaderTest.php
+++ b/tests/testcases/core/services/loaders/LoaderTest.php
@@ -1,10 +1,7 @@
 <?php
 
-use EventEspresso\core\services\loaders\LoaderInterface;
-use EventEspresso\core\services\loaders\LoaderFactory;
-
-defined('EVENT_ESPRESSO_VERSION') || exit;
-
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Exception;
 
 /**
  * Class LoaderTest
@@ -18,29 +15,10 @@ class LoaderTest extends EE_UnitTestCase
 {
 
     /**
-     * @var LoaderInterface $loader
-     */
-    private static $loader;
-
-
-    /**
-     * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     */
-    public function setUp()
-    {
-        self::$loader = LoaderFactory::getLoader();
-        parent::setUp();
-    }
-
-
-    /**
      * testNewLoader
      *
-     * @throws \PHPUnit\Framework\AssertionFailedError
-     * @throws \PHPUnit\Framework\Exception
+     * @throws AssertionFailedError
+     * @throws Exception
      */
     public function testNewLoader()
     {
@@ -48,7 +26,7 @@ class LoaderTest extends EE_UnitTestCase
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false');
         $fqcn = 'EventEspresso\tests\mocks\core\services\loaders\NewClassToLoad';
         /** @var EventEspresso\tests\mocks\core\services\loaders\NewClassToLoad $object */
-        $object = self::$loader->load($fqcn, array(), false);
+        $object = $this->loader->load($fqcn, array(), false);
         $this->assertInstanceOf(
             $fqcn,
             $object,
@@ -59,7 +37,7 @@ class LoaderTest extends EE_UnitTestCase
             )
         );
         // none of these objects are getting cached because it is turned off for unit testing
-        $object2 = self::$loader->load($fqcn, array(), false);
+        $object2 = $this->loader->load($fqcn, array(), false);
         $this->assertFalse($object->sameInstance($object2));
     }
 
@@ -67,8 +45,8 @@ class LoaderTest extends EE_UnitTestCase
     /**
      * testSharedLoader
      *
-     * @throws \PHPUnit\Framework\AssertionFailedError
-     * @throws \PHPUnit\Framework\Exception
+     * @throws AssertionFailedError
+     * @throws Exception
      */
     public function testSharedLoader()
     {
@@ -76,7 +54,7 @@ class LoaderTest extends EE_UnitTestCase
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_false');
         $fqcn = 'EventEspresso\tests\mocks\core\services\loaders\SharedClassToLoad';
         /** @var EventEspresso\tests\mocks\core\services\loaders\SharedClassToLoad $object */
-        $object = self::$loader->load($fqcn);
+        $object = $this->loader->load($fqcn);
         $this->assertInstanceOf(
             $fqcn,
             $object,
@@ -87,7 +65,7 @@ class LoaderTest extends EE_UnitTestCase
             )
         );
         // caching is on and we want a shared instance, so we should get the same object again
-        $object2 = self::$loader->load($fqcn);
+        $object2 = $this->loader->load($fqcn);
         $this->assertTrue($object->sameInstance($object2));
     }
 
@@ -96,8 +74,8 @@ class LoaderTest extends EE_UnitTestCase
      * testSharedLoader
      *
      * @group loaderArgs
-     * @throws \PHPUnit\Framework\AssertionFailedError
-     * @throws \PHPUnit\Framework\Exception
+     * @throws AssertionFailedError
+     * @throws Exception
      */
     public function testSharedLoaderWithArgs()
     {
@@ -106,7 +84,7 @@ class LoaderTest extends EE_UnitTestCase
         $fqcn = 'EventEspresso\tests\mocks\core\services\loaders\SharedClassToLoad';
         $original_args = array(1, 2, 3);
         /** @var EventEspresso\tests\mocks\core\services\loaders\SharedClassToLoad $object */
-        $object = self::$loader->load($fqcn, array($original_args));
+        $object = $this->loader->load($fqcn, array($original_args));
         $this->assertInstanceOf(
             $fqcn,
             $object,
@@ -119,11 +97,11 @@ class LoaderTest extends EE_UnitTestCase
         $this->assertEquals($original_args, $object->args());
         // caching is on and we want a shared instance,
         // but we are passing new args, so we should get a new object
-        $object2 = self::$loader->load($fqcn, array(array(4, 5, 6)));
+        $object2 = $this->loader->load($fqcn, array(array(4, 5, 6)));
         $this->assertFalse($object->sameInstance($object2));
         $this->assertNotEquals($original_args, $object2->args());
         // now let's request another instance but  with no args, which *should* return the first instance
-        $object3 = self::$loader->load($fqcn);
+        $object3 = $this->loader->load($fqcn);
         $this->assertTrue($object->sameInstance($object3));
         $this->assertEquals($original_args, $object3->args());
     }

--- a/tests/testcases/core/services/request/RequestStackBuilderTest.php
+++ b/tests/testcases/core/services/request/RequestStackBuilderTest.php
@@ -4,20 +4,20 @@ namespace EventEspresso\tests\testcases\core\services\request;
 
 use EE_Error;
 use EE_UnitTestCase;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\loaders\LoaderInterface;
+use EventEspresso\core\services\request\InvalidRequestStackMiddlewareException;
 use EventEspresso\core\services\request\Request;
 use EventEspresso\core\services\request\Response;
 use EventEspresso\tests\mocks\core\services\request\RequestStackBuilderMock;
 use EventEspresso\tests\mocks\core\services\request\RequestStackCoreAppMock;
+use Exception;
+use InvalidArgumentException;
 
 class RequestStackBuilderTest extends EE_UnitTestCase
 {
-
-    /**
-     * @type LoaderInterface $loader
-     */
-    private $loader;
 
     /**
      * @var RequestStackBuilderMock $request_stack_builder
@@ -36,15 +36,14 @@ class RequestStackBuilderTest extends EE_UnitTestCase
 
 
     /**
-     * @throws \EE_Error
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \InvalidArgumentException
+     * @throws EE_Error
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws InvalidArgumentException
      */
     public function setUp()
     {
         parent::setUp();
-        $this->loader = LoaderFactory::getLoader();
         $this->request_stack_builder = $this->loader->getShared(
             'EventEspresso\tests\mocks\core\services\request\RequestStackBuilderMock',
             array($this->loader)
@@ -182,7 +181,7 @@ class RequestStackBuilderTest extends EE_UnitTestCase
      * @param array  $middleware_app
      * @param bool   $recurse
      * @param string $expected
-     * @throws \EventEspresso\core\services\request\InvalidRequestStackMiddlewareException
+     * @throws InvalidRequestStackMiddlewareException
      */
     public function testValidateMiddlewareAppDetails(array $middleware_app, $recurse, $expected)
     {
@@ -209,7 +208,7 @@ class RequestStackBuilderTest extends EE_UnitTestCase
 
     /**
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function testRequestStackBuilderResolve()
     {
@@ -219,7 +218,7 @@ class RequestStackBuilderTest extends EE_UnitTestCase
 
     /**
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function testRequestStackBuilderResolveWithLegacyMiddleware()
     {
@@ -230,7 +229,7 @@ class RequestStackBuilderTest extends EE_UnitTestCase
 
     /**
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function TheBattleOfUtapau()
     {


### PR DESCRIPTION
While activating a bunch of add-ons on https://barista.eventespresso.com/ I noticed there were a bunch of db errors that occurred:

![ScreenShot_20201013130401](https://user-images.githubusercontent.com/1751030/95910379-d496d200-0d54-11eb-84fc-9755767db26d.png)

which all originated from the `TableAnalysis::tableExists()` method.

That method was essentially running a query to return a value from the desired table and then checking for wpdb errors to determine if the table exists or not. ie: no table === missing table error

This PR replaces the logic in `tableExists()` with essentially the same code that WP core uses in their [maybe_create_table() function](https://developer.wordpress.org/reference/functions/maybe_create_table/#source)  which does not result in any errors because it is not intentionally relying on errors to determine if a table exists or not.