### PR TITLE
Don't Load Legacy "Event Registration Options" or "Author" Meta Boxes in EDTR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ before_script:
   - phpenv config-rm xdebug.ini
 
 script:
-  - ./vendor/bin/phpunit tests --configuration tests/phpunit.xml
+  - vendor/bin/phpunit --version
+  - vendor/bin/phpunit tests --configuration tests/phpunit.xml
 
 jobs:
   allow_failures:
@@ -41,23 +42,15 @@ jobs:
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       script:
         - composer config-eventespressocs || exit 1
-        - ./vendor/bin/phpcs -n || exit 1
+        - vendor/bin/phpcs -n || exit 1
 
     - name: "php 7.1 test"
       php: 7.1
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
-      script:
-        - phpunit --version
-        - vendor/bin/phpunit --version
-        - ./vendor/bin/phpunit --version
 
     - name: "php 7.2 test"
       php: 7.2
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
-      script:
-        - phpunit --version
-        - vendor/bin/phpunit --version
-        - ./vendor/bin/phpunit --version
 
     - name: "php 7.3 test"
       php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ install:
       else
         composer require phpunit/phpunit ^6;
       fi
+  - composer --version
 
 script:
-  - ./vendor/bin/phpunit tests --configuration tests/phpunit.xml
+  - phpunit tests --configuration tests/phpunit.xml
 
 jobs:
   allow_failures:
@@ -34,7 +35,7 @@ jobs:
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       script:
         - composer config-eventespressocs || exit 1
-        - ./vendor/bin/phpcs -n || exit 1
+        - vendor/bin/phpcs -n || exit 1
 
     - name: "php 7.1 test"
       php: 7.1
@@ -47,14 +48,14 @@ jobs:
     - name: "php 7.3 test"
       php: 7.3
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
-      # multisite
 
+      # multisite
     - name: "php 7.2 multisite test"
       php: 7.2
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       env: WP_MULTISITE=1
-      # allowed to fail
 
+      # allowed to fail
     - name: "php nightly test"
       php: nightly
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,80 +7,54 @@ language: php
 services:
   - mysql
 
-cache:
-  apt: true
-  directories:
-    - $HOME/.composer/cache
-
 env:
   global:
     - WP_VERSION=latest WP_MULTISITE=0
 
-before_install:
-  - |
-    if [[ "$SKIP_XDEBUG_REMOVE" != "true" ]]; then
-      cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp
-      phpenv config-rm xdebug.ini
-      echo "xdebug removed";
-    fi
-before_script:
-  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - |
-    # Install the specified version of PHPUnit depending on the PHP version:
-    if [[ -n "$TRAVIS_PHP_VERSION" ]]; then
-      case "$TRAVIS_PHP_VERSION" in
-        nightly)
-          echo "Using PHPUnit 9"
-          composer global require "phpunit/phpunit=9.*"
-          ;;
-        7.1|7.2|7.3|7.4)
-          # when wp tests support phpunit 7 we'll update this.
-          echo "Using PHPUnit 6"
-          composer global require "phpunit/phpunit=6.5.*"
-          ;;
-        *)
-          echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
-          exit 1
-          ;;
-      esac
-    fi
-  - mysql --version
-  - phpunit --version
-  - phpenv versions
+install:
+  - composer install || exit 1
+  - if [[ $TRAVIS_PHP_VERSION == nightly ]]; then
+        composer require phpunit/phpunit ^9;
+      else
+        composer require phpunit/phpunit ^6;
+      fi
 
-script: phpunit tests --configuration tests/phpunit.xml
+script:
+  - ./vendor/bin/phpunit tests --configuration tests/phpunit.xml
 
 jobs:
   allow_failures:
     - php: nightly
+
   fast_finish: true
+
   include:
     - name: "php lint"
       php: 7.3
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
-      env:
-        - PHP_LINT=1
-        - PHP_LINT_WITH_WARNINGS=no
       script:
-        - composer install || exit 1
         - composer config-eventespressocs || exit 1
-        - vendor/bin/phpcs -n || exit 1
+        - ./vendor/bin/phpcs -n || exit 1
+
     - name: "php 7.1 test"
       php: 7.1
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
+
     - name: "php 7.2 test"
       php: 7.2
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
+
     - name: "php 7.3 test"
       php: 7.3
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       # multisite
+
     - name: "php 7.2 multisite test"
       php: 7.2
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       env: WP_MULTISITE=1
       # allowed to fail
+
     - name: "php nightly test"
       php: nightly
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 env:
   global:
     - WP_VERSION=latest WP_MULTISITE=0
-    - EE_TESTS_DIR=${HOME}/build/eventespresso/event-espresso-core/tests
 
 install:
   - composer install || exit 1
@@ -33,7 +32,7 @@ before_script:
 
 script:
   - vendor/bin/phpunit --version
-  - vendor/bin/phpunit ${EE_TESTS_DIR} --configuration ${EE_TESTS_DIR}/phpunit.xml
+  - vendor/bin/phpunit --configuration phpunit.xml
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ install:
       else
         composer require phpunit/phpunit ^6;
       fi
-  - phpunit --version
-  - vendor/bin/phpunit --version
-  - ./vendor/bin/phpunit --version
+
+before_script:
+  - phpenv config-rm xdebug.ini
 
 script:
   - ./vendor/bin/phpunit tests --configuration tests/phpunit.xml
@@ -46,10 +46,18 @@ jobs:
     - name: "php 7.1 test"
       php: 7.1
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
+      script:
+        - phpunit --version
+        - vendor/bin/phpunit --version
+        - ./vendor/bin/phpunit --version
 
     - name: "php 7.2 test"
       php: 7.2
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
+      script:
+        - phpunit --version
+        - vendor/bin/phpunit --version
+        - ./vendor/bin/phpunit --version
 
     - name: "php 7.3 test"
       php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ os: linux
 
 language: php
 
-services:
-  - mysql
+services: mysql
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache
 
 env:
   global:
@@ -18,10 +22,12 @@ install:
       else
         composer require phpunit/phpunit ^6;
       fi
-  - composer --version
+  - phpunit --version
+  - vendor/bin/phpunit --version
+  - ./vendor/bin/phpunit --version
 
 script:
-  - vendor/bin/phpunit tests --configuration tests/phpunit.xml
+  - ./vendor/bin/phpunit tests --configuration tests/phpunit.xml
 
 jobs:
   allow_failures:
@@ -35,7 +41,7 @@ jobs:
       if: NOT commit_message =~ js_only AND NOT commit_message =~ dependabot AND NOT sender =~ dependabot
       script:
         - composer config-eventespressocs || exit 1
-        - vendor/bin/phpcs -n || exit 1
+        - ./vendor/bin/phpcs -n || exit 1
 
     - name: "php 7.1 test"
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: php
 
 services: mysql
 
+git:
+  quiet: true
+
 cache:
   apt: true
   directories:
@@ -14,6 +17,7 @@ cache:
 env:
   global:
     - WP_VERSION=latest WP_MULTISITE=0
+    - EE_TESTS_DIR=${HOME}/build/eventespresso/event-espresso-core/tests
 
 install:
   - composer install || exit 1
@@ -25,10 +29,11 @@ install:
 
 before_script:
   - phpenv config-rm xdebug.ini
+  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script:
   - vendor/bin/phpunit --version
-  - vendor/bin/phpunit tests --configuration tests/phpunit.xml
+  - vendor/bin/phpunit ${EE_TESTS_DIR} --configuration ${EE_TESTS_DIR}/phpunit.xml
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - composer --version
 
 script:
-  - phpunit tests --configuration tests/phpunit.xml
+  - vendor/bin/phpunit tests --configuration tests/phpunit.xml
 
 jobs:
   allow_failures:

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -562,19 +562,22 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         wp_register_style(
             'events-admin-css',
             EVENTS_ASSETS_URL . 'events-admin-page.css',
-            array(),
+            [],
             EVENT_ESPRESSO_VERSION
         );
-        wp_register_style('ee-cat-admin', EVENTS_ASSETS_URL . 'ee-cat-admin.css', array(), EVENT_ESPRESSO_VERSION);
+        wp_register_style(
+            'ee-cat-admin',
+            EVENTS_ASSETS_URL . 'ee-cat-admin.css',
+            [],
+            EVENT_ESPRESSO_VERSION
+        );
         wp_enqueue_style('events-admin-css');
         wp_enqueue_style('ee-cat-admin');
-        // todo note: we also need to load_scripts_styles per view (i.e. default/view_report/event_details
-        // registers for all views
         // scripts
         wp_register_script(
             'event_editor_js',
             EVENTS_ASSETS_URL . 'event_editor.js',
-            array('ee_admin_js', 'jquery-ui-slider', 'jquery-ui-timepicker-addon'),
+            ['ee_admin_js', 'jquery-ui-slider', 'jquery-ui-timepicker-addon'],
             EVENT_ESPRESSO_VERSION,
             true
         );
@@ -600,18 +603,20 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         wp_register_style(
             'event-editor-css',
             EVENTS_ASSETS_URL . 'event-editor.css',
-            array('ee-admin-css'),
+            ['ee-admin-css'],
             EVENT_ESPRESSO_VERSION
         );
         wp_enqueue_style('event-editor-css');
         // scripts
-        wp_register_script(
-            'event-datetime-metabox',
-            EVENTS_ASSETS_URL . 'event-datetime-metabox.js',
-            array('event_editor_js', 'ee-datepicker'),
-            EVENT_ESPRESSO_VERSION
-        );
-        wp_enqueue_script('event-datetime-metabox');
+        if (! $this->admin_config->useAdvancedEditor()) {
+            wp_register_script(
+                'event-datetime-metabox',
+                EVENTS_ASSETS_URL . 'event-datetime-metabox.js',
+                ['event_editor_js', 'ee-datepicker'],
+                EVENT_ESPRESSO_VERSION
+            );
+            wp_enqueue_script('event-datetime-metabox');
+        }
     }
 
 
@@ -1177,7 +1182,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _default_tickets_update(EE_Event $evtobj, $data)
     {
-        if (EE_Registry::instance()->CFG->admin->useAdvancedEditor()) {
+        if ($this->admin_config->useAdvancedEditor()) {
             return [];
         }
         $success = true;
@@ -1569,7 +1574,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _register_event_editor_meta_boxes()
     {
         $this->verify_cpt_object();
-        if (EE_Registry::instance()->CFG->admin->useAdvancedEditor()) {
+        if ($this->admin_config->useAdvancedEditor()) {
             add_action(
                 'add_meta_boxes_espresso_events',
                 function () {

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1579,7 +1579,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 'add_meta_boxes_espresso_events',
                 function () {
                     global $current_screen;
-                    remove_meta_box( 'authordiv' , $current_screen , 'normal' );
+                    remove_meta_box('authordiv', $current_screen, 'normal');
                 },
                 99
             );

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1569,16 +1569,25 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _register_event_editor_meta_boxes()
     {
         $this->verify_cpt_object();
-        if (! EE_Registry::instance()->CFG->admin->useAdvancedEditor()) {
-            add_meta_box(
-                'espresso_event_editor_tickets',
-                esc_html__('Event Datetime & Ticket', 'event_espresso'),
-                [$this, 'ticket_metabox'],
-                $this->page_slug,
-                'normal',
-                'high'
+        if (EE_Registry::instance()->CFG->admin->useAdvancedEditor()) {
+            add_action(
+                'add_meta_boxes_espresso_events',
+                function () {
+                    global $current_screen;
+                    remove_meta_box( 'authordiv' , $current_screen , 'normal' );
+                },
+                99
             );
+            return;
         }
+        add_meta_box(
+            'espresso_event_editor_tickets',
+            esc_html__('Event Datetime & Ticket', 'event_espresso'),
+            [$this, 'ticket_metabox'],
+            $this->page_slug,
+            'normal',
+            'high'
+        );
         add_meta_box(
             'espresso_event_editor_event_options',
             esc_html__('Event Registration Options', 'event_espresso'),

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -73,45 +73,6 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 'obj_id'     => $evt_id,
                 'noheader'   => true,
             ),
-            'ticket_list_table'        => array(
-                'func'       => '_tickets_overview_list_table',
-                'capability' => 'ee_read_default_tickets',
-            ),
-            'trash_ticket'             => array(
-                'func'       => '_trash_or_restore_ticket',
-                'capability' => 'ee_delete_default_ticket',
-                'obj_id'     => $tkt_id,
-                'noheader'   => true,
-                'args'       => array('trash' => true),
-            ),
-            'trash_tickets'            => array(
-                'func'       => '_trash_or_restore_ticket',
-                'capability' => 'ee_delete_default_tickets',
-                'noheader'   => true,
-                'args'       => array('trash' => true),
-            ),
-            'restore_ticket'           => array(
-                'func'       => '_trash_or_restore_ticket',
-                'capability' => 'ee_delete_default_ticket',
-                'obj_id'     => $tkt_id,
-                'noheader'   => true,
-            ),
-            'restore_tickets'          => array(
-                'func'       => '_trash_or_restore_ticket',
-                'capability' => 'ee_delete_default_tickets',
-                'noheader'   => true,
-            ),
-            'delete_ticket'            => array(
-                'func'       => '_delete_ticket',
-                'capability' => 'ee_delete_default_ticket',
-                'obj_id'     => $tkt_id,
-                'noheader'   => true,
-            ),
-            'delete_tickets'           => array(
-                'func'       => '_delete_ticket',
-                'capability' => 'ee_delete_default_tickets',
-                'noheader'   => true,
-            ),
             'import_page'              => array(
                 'func'       => '_import_page',
                 'capability' => 'import',
@@ -146,17 +107,60 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ),
-        );
+        );        // don't load these meta boxes if using the advanced editor
+        if (! $this->admin_config->useAdvancedEditor()) {
+            $this->_page_config['create_new']['metaboxes'][] = '_premium_event_editor_meta_boxes';
+            $this->_page_config['edit']['metaboxes'][] = '_premium_event_editor_meta_boxes';
+            $this->_page_config['create_new']['qtips'][] = 'EE_Event_Editor_Tips';
+            $this->_page_config['edit']['qtips'][] = 'EE_Event_Editor_Tips';
+
+            $legacy_editor_page_routes = [
+                'ticket_list_table' => [
+                    'func'       => '_tickets_overview_list_table',
+                    'capability' => 'ee_read_default_tickets',
+                ],
+                'trash_ticket'      => [
+                    'func'       => '_trash_or_restore_ticket',
+                    'capability' => 'ee_delete_default_ticket',
+                    'obj_id'     => $tkt_id,
+                    'noheader'   => true,
+                    'args'       => ['trash' => true],
+                ],
+                'trash_tickets'     => [
+                    'func'       => '_trash_or_restore_ticket',
+                    'capability' => 'ee_delete_default_tickets',
+                    'noheader'   => true,
+                    'args'       => ['trash' => true],
+                ],
+                'restore_ticket'    => [
+                    'func'       => '_trash_or_restore_ticket',
+                    'capability' => 'ee_delete_default_ticket',
+                    'obj_id'     => $tkt_id,
+                    'noheader'   => true,
+                ],
+                'restore_tickets'   => [
+                    'func'       => '_trash_or_restore_ticket',
+                    'capability' => 'ee_delete_default_tickets',
+                    'noheader'   => true,
+                ],
+                'delete_ticket'     => [
+                    'func'       => '_delete_ticket',
+                    'capability' => 'ee_delete_default_ticket',
+                    'obj_id'     => $tkt_id,
+                    'noheader'   => true,
+                ],
+                'delete_tickets'    => [
+                    'func'       => '_delete_ticket',
+                    'capability' => 'ee_delete_default_tickets',
+                    'noheader'   => true,
+                ],
+            ];
+            $new_page_routes = array_merge($new_page_routes, $legacy_editor_page_routes);
+        }
+
         $this->_page_routes = array_merge($this->_page_routes, $new_page_routes);
         // partial route/config override
         $this->_page_config['import_events']['metaboxes'] = $this->_default_espresso_metaboxes;
-        $this->_page_config['create_new']['metaboxes'][] = '_premium_event_editor_meta_boxes';
-        // don't load qTips if using the advanced editor
-        if (! $this->admin_config->useAdvancedEditor()) {
-            $this->_page_config['create_new']['qtips'][] = 'EE_Event_Editor_Tips';
-            $this->_page_config['edit']['qtips'][] = 'EE_Event_Editor_Tips';
-        }
-        $this->_page_config['edit']['metaboxes'][] = '_premium_event_editor_meta_boxes';
         $this->_page_config['default']['list_table'] = 'Extend_Events_Admin_List_Table';
         // add tickets tab but only if there are more than one default ticket!
         $tkt_count = EEM_Ticket::instance()->count_deleted_and_undeleted(

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -352,18 +352,20 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
      */
     public function load_scripts_styles_edit()
     {
-        wp_register_script(
-            'ee-event-editor-heartbeat',
-            EVENTS_CAF_ASSETS_URL . 'event-editor-heartbeat.js',
-            array('ee_admin_js', 'heartbeat'),
-            EVENT_ESPRESSO_VERSION,
-            true
-        );
-        wp_enqueue_script('ee-accounting');
+        if (! $this->admin_config->useAdvancedEditor()) {
+            wp_register_script(
+                'ee-event-editor-heartbeat',
+                EVENTS_CAF_ASSETS_URL . 'event-editor-heartbeat.js',
+                ['ee_admin_js', 'heartbeat'],
+                EVENT_ESPRESSO_VERSION,
+                true
+            );
+            wp_enqueue_script('ee-accounting');
+            wp_enqueue_script('ee-event-editor-heartbeat');
+        }
+        wp_enqueue_script('event_editor_js');
         // styles
         wp_enqueue_style('espresso-ui-theme');
-        wp_enqueue_script('event_editor_js');
-        wp_enqueue_script('ee-event-editor-heartbeat');
     }
 
 

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -18,6 +18,10 @@ use EventEspresso\core\services\loaders\LoaderInterface;
  */
 abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
 {
+    /**
+     * @var EE_Admin_Config
+     */
+    protected $admin_config;
 
     /**
      * @var LoaderInterface $loader
@@ -187,6 +191,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
     public function __construct($routing = true)
     {
         $this->loader = LoaderFactory::getLoader();
+        $this->admin_config = $this->loader->getShared('EE_Admin_Config');
         if (strpos($this->_get_dir(), 'caffeinated') !== false) {
             $this->_is_caf = true;
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,23 +8,23 @@
 	>
     <filter>
         <whitelist>
-            <directory>../</directory>
+            <directory>./tests/</directory>
             <exclude>
-                <directory>../assets</directory>
-                <directory>../bin</directory>
-                <directory>../core/third_party_libs</directory>
-                <directory>../docs</directory>
-                <directory>../languages</directory>
-                <directory>../public</directory>
-                <directory>../tests</directory>
-                <directory>../vendor</directory>
-                <directory>../wp-assets</directory>
+                <directory>./assets</directory>
+                <directory>./bin</directory>
+                <directory>./core/third_party_libs</directory>
+                <directory>./docs</directory>
+                <directory>./languages</directory>
+                <directory>./public</directory>
+                <directory>./tests</directory>
+                <directory>./vendor</directory>
+                <directory>./wp-assets</directory>
             </exclude>
         </whitelist>
     </filter>
 	<testsuites>
 		<testsuite name="default">
-			<directory suffix=".php">/testcases</directory>
+			<directory suffix=".php">./tests/testcases</directory>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <phpunit
-	bootstrap="bootstrap.php"
+	bootstrap="./tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
@@ -35,7 +35,7 @@
         </exclude>
     </groups>
 	<listeners>
-        <listener class="SpeedTrapListener" file="includes/listener-loader.php">
+        <listener class="SpeedTrapListener" file="./tests/includes/listener-loader.php">
             <arguments>
 				<array>
 					<element key="slowThreshold">


### PR DESCRIPTION
This PR simply skips loading the "Event Registration Options" and "Author" meta boxes when the advanced editor option is selected. It also avoids loading some other resources that are only relevant to the legacy dates and tickets section of the event editor.