### PR TITLE
Rename wpUser field to manager on event object

### DIFF
--- a/core/domain/entities/admin/GraphQLData/Event.php
+++ b/core/domain/entities/admin/GraphQLData/Event.php
@@ -40,7 +40,7 @@ class Event extends GraphQLData
                 status
                 timezoneString
                 visibleOn
-                wpUser {
+                manager {
                     id
                     name
                 }

--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\services\graphql\data\mutations;
 
 use DateTime;
 use Exception;
+use GraphQLRelay\Relay;
 
 /**
  * Class EventMutation
@@ -82,8 +83,9 @@ class EventMutation
             $args['EVT_visible_on'] = new DateTime(sanitize_text_field($input['visibleOn']));
         }
 
-        if (! empty($input['wpUser'])) {
-            $args['EVT_wp_user'] = absint($input['wpUser']);
+        if (! empty($input['manager'])) {
+            $parts = Relay::fromGlobalId(sanitize_text_field($input['manager']));
+            $args['EVT_wp_user'] = ! empty($parts['id']) ? $parts['id'] : null;
         }
 
         return apply_filters(

--- a/core/domain/services/graphql/resolvers/FieldResolver.php
+++ b/core/domain/services/graphql/resolvers/FieldResolver.php
@@ -111,6 +111,7 @@ class FieldResolver extends ResolverBase
                 case 'event':
                     return $this->resolveEvent($source, $args, $context);
                 case 'wpUser':
+                case 'manager':
                     return $this->resolveWpUser($source, $args, $context);
                 case 'state': // Venue
                     return $this->resolveState($source);

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -79,16 +79,16 @@ class Event extends TypeBase
                 esc_html__('Date/Time Event Created', 'event_espresso')
             ),
             new GraphQLOutputField(
-                'wpUser',
+                'manager',
                 'User',
                 null,
-                esc_html__('Event Creator', 'event_espresso')
+                esc_html__('Event Manager', 'event_espresso')
             ),
             new GraphQLInputField(
-                'wpUser',
-                'Int',
+                'manager',
+                'String',
                 null,
-                esc_html__('Event Creator ID', 'event_espresso')
+                esc_html__('Event manager GUID', 'event_espresso')
             ),
             new GraphQLField(
                 'order',

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -88,7 +88,7 @@ class Event extends TypeBase
                 'manager',
                 'String',
                 null,
-                esc_html__('Event manager GUID', 'event_espresso')
+                esc_html__('Globally unique event ID the event manager', 'event_espresso')
             ),
             new GraphQLField(
                 'order',


### PR DESCRIPTION
This PR fixes event manager mutation and renames `wpUser` field to `manager` on event object

See #3179 