### PR TITLE
add EventManagers DOM data class to EDTR

### DIFF
--- a/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
+++ b/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
@@ -49,6 +49,7 @@ class EspressoEventEditor extends EspressoEventsAdmin
                 'EventEspresso\core\domain\entities\admin\GraphQLData\PriceTypes'                => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\domain\entities\admin\GraphQLData\Tickets'                   => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\domain\services\admin\events\editor\NewEventDefaultEntities' => EE_Dependency_Map::load_from_cache,
+                '\EventEspresso\core\domain\services\admin\events\editor\EventManagers'          => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\domain\services\admin\events\editor\EventEntityRelations'    => EE_Dependency_Map::load_from_cache,
             ]
         );
@@ -109,6 +110,12 @@ class EspressoEventEditor extends EspressoEventsAdmin
                 'EventEspresso\core\domain\Domain'                   => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\assets\AssetCollection' => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\admin\events\editor\EventManagers',
+            [
+                'EventEspresso\core\domain\services\graphql\Utilities' => EE_Dependency_Map::load_from_cache,
             ]
         );
         $this->loader->getShared(

--- a/core/domain/services/admin/events/editor/EventEditorGraphQLData.php
+++ b/core/domain/services/admin/events/editor/EventEditorGraphQLData.php
@@ -52,6 +52,11 @@ class EventEditorGraphQLData
     protected $relations;
 
     /**
+     * @var EventManagers $managers
+     */
+    protected $managers;
+
+    /**
      * @var NewEventDefaultEntities $default_entities
      */
     protected $default_entities;
@@ -66,6 +71,7 @@ class EventEditorGraphQLData
      * @param PriceTypes              $price_types
      * @param Tickets                 $tickets
      * @param EventEntityRelations    $relations
+     * @param EventManagers           $managers
      * @param NewEventDefaultEntities $default_entities
      */
     public function __construct(
@@ -75,13 +81,15 @@ class EventEditorGraphQLData
         PriceTypes $price_types,
         Tickets $tickets,
         EventEntityRelations $relations,
+        EventManagers $managers,
         NewEventDefaultEntities $default_entities
     ) {
         $this->datetimes        = $datetimes;
-        $this->event           = $event;
+        $this->event            = $event;
         $this->default_entities = $default_entities;
         $this->prices           = $prices;
         $this->price_types      = $price_types;
+        $this->managers         = $managers;
         $this->relations        = $relations;
         $this->tickets          = $tickets;
     }
@@ -98,6 +106,7 @@ class EventEditorGraphQLData
     {
         $event = $this->event->getData(['id' => $eventId]);
         $datetimes = $this->datetimes->getData(['eventId' => $eventId]);
+        $eventManagers = $this->managers ->getData($eventId);
 
         // Avoid undefined variable warning in PHP >= 7.3
         $tickets = null;
@@ -131,7 +140,14 @@ class EventEditorGraphQLData
 
         $relations = $this->relations->getData($eventId);
 
-
-        return compact('event', 'datetimes', 'tickets', 'prices', 'priceTypes', 'relations');
+        return compact(
+            'datetimes',
+            'event',
+            'eventManagers',
+            'prices',
+            'priceTypes',
+            'relations',
+            'tickets'
+        );
     }
 }

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -57,7 +57,7 @@ class EventManagers implements EventEditorDataInterface
 
 
     /**
-     * Returns a list of WP_Role names that have "event manager" capabilities
+     * Returns a list of WP_Role that have "event manager" capabilities
      * The list of "event manager" capabilities is filtered but defaults to:
      *      - 'ee_edit_events'
      *      - 'ee_edit_event'
@@ -98,18 +98,21 @@ class EventManagers implements EventEditorDataInterface
     private function getEventManagerUsers(array $event_manager_roles)
     {
         global $wpdb;
+        // no roles ?!!? then nothing to query for
         if (empty($event_manager_roles)) {
             return [];
         }
-        // now begin to build our
+        // begin to build our query
         $SQL = "SELECT u1.ID, u1.display_name FROM {$wpdb->users} AS u1 "
              . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
              . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
              . 'WHERE';
         $operator = '';
         foreach ($event_manager_roles as $role) {
+            // for each role, add a WHERE clause
             if ($role instanceof WP_Role) {
                 $SQL     .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
+                // subsequent clauses will use OR so that any role is accepted
                 $operator = 'OR';
             }
         }

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace EventEspresso\core\domain\services\admin\events\editor;
+
+use EventEspresso\core\domain\services\graphql\Utilities;
+
+/**
+ * Class EventManagers
+ *
+ * @author  Brent Christensen
+ * @package EventEspresso\core\domain\services\admin\events\editor
+ * @since   $VID:$
+ */
+class EventManagers implements EventEditorDataInterface
+{
+
+    /**
+     * @var Utilities
+     */
+    private $utilities;
+
+
+    /**
+     * EventManagers constructor.
+     *
+     * @param Utilities $utilities
+     */
+    public function __construct(Utilities $utilities)
+    {
+        $this->utilities = $utilities;
+    }
+
+
+    /**
+     * @param int $eventId
+     * @return array
+     */
+    public function getData(int $eventId)
+    {
+        global $wpdb, $wp_roles;
+        $roles = $wp_roles->role_objects;
+        $capabilities = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_admin_events_editor_EventManagers__getData__capability',
+            ['ee_edit_events', 'ee_edit_event'],
+            $roles
+        );
+        $SQL = "SELECT u1.ID, u1.display_name FROM {$wpdb->users} AS u1 "
+               . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
+               . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
+               . 'WHERE';
+        $operator = '';
+        foreach ($roles as $role) {
+            foreach ($capabilities as $capability) {
+                if($role->has_cap($capability)) {
+                    $SQL .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
+                    $operator = 'OR';
+                }
+            }
+        }
+        $SQL .= "ORDER BY user_id ASC";
+        $users = $wpdb->get_results($SQL);
+        $event_managers = [];
+        foreach ($users as $user) {
+            $event_managers[] = [
+                'id' => $this->utilities->convertToGlobalId('User', $user->ID),
+                'name' => $user->display_name,
+            ];
+        }
+        return $event_managers;
+    }
+}

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -46,9 +46,9 @@ class EventManagers implements EventEditorDataInterface
         // now convert to a format that's usable by GQL
         $event_managers = [];
         foreach ($event_manager_users as $user) {
-            $GUID = $this->utilities->convertToGlobalId('User', $user->ID);
-            $event_managers[ $GUID ] = [
-                'id' => $GUID,
+            $GUID                  = $this->utilities->convertToGlobalId('User', $user->ID);
+            $event_managers[$GUID] = [
+                'id'   => $GUID,
                 'name' => $user->display_name,
             ];
         }
@@ -70,7 +70,7 @@ class EventManagers implements EventEditorDataInterface
         // first let's grab all of the WP_Role objects
         $roles = $wp_roles->role_objects;
         // then filter a list of capabilities we want to use to define an event manager
-        $capabilities = apply_filters(
+        $capabilities = (array) apply_filters(
             'FHEE__EventEspresso_core_domain_services_admin_events_editor_EventManagers__getData__capabilities',
             ['ee_edit_events', 'ee_edit_event'],
             $roles
@@ -80,8 +80,8 @@ class EventManagers implements EventEditorDataInterface
         foreach ($roles as $role) {
             foreach ($capabilities as $capability) {
                 // we're using the role name as the array index to prevent duplicates
-                if(! isset($event_manager_roles[ $role->name ]) && $role->has_cap($capability)) {
-                    $event_manager_roles[ $role->name ] = $role;
+                if (! isset($event_manager_roles[$role->name]) && $role->has_cap($capability)) {
+                    $event_manager_roles[$role->name] = $role;
                 }
             }
         }
@@ -92,25 +92,28 @@ class EventManagers implements EventEditorDataInterface
     /**
      * Returns a list of users that have any of the supplied roles
      *
-     * @param array $event_manager_roles
+     * @param WP_Role[] $event_manager_roles
      * @return stdClass[]
      */
     private function getEventManagerUsers(array $event_manager_roles)
     {
         global $wpdb;
+        if (empty($event_manager_roles)) {
+            return [];
+        }
         // now begin to build our
         $SQL = "SELECT u1.ID, u1.display_name FROM {$wpdb->users} AS u1 "
-               . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
-               . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
-               . 'WHERE';
+             . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
+             . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
+             . 'WHERE';
         $operator = '';
         foreach ($event_manager_roles as $role) {
             if ($role instanceof WP_Role) {
-                $SQL .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
+                $SQL     .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
                 $operator = 'OR';
             }
         }
-        $SQL .= "ORDER BY user_id ASC";
+        $SQL  .= "ORDER BY user_id ASC";
         $users = $wpdb->get_results($SQL);
         return ! empty($users) ? $users : [];
     }

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -47,7 +47,7 @@ class EventManagers implements EventEditorDataInterface
         $event_managers = [];
         foreach ($event_manager_users as $user) {
             $GUID                  = $this->utilities->convertToGlobalId('User', $user->ID);
-            $event_managers[$GUID] = [
+            $event_managers[ $GUID ] = [
                 'id'   => $GUID,
                 'name' => $user->display_name,
             ];
@@ -80,8 +80,8 @@ class EventManagers implements EventEditorDataInterface
         foreach ($roles as $role) {
             foreach ($capabilities as $capability) {
                 // we're using the role name as the array index to prevent duplicates
-                if (! isset($event_manager_roles[$role->name]) && $role->has_cap($capability)) {
-                    $event_manager_roles[$role->name] = $role;
+                if (! isset($event_manager_roles[ $role->name ]) && $role->has_cap($capability)) {
+                    $event_manager_roles[ $role->name ] = $role;
                 }
             }
         }

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -3,6 +3,8 @@
 namespace EventEspresso\core\domain\services\admin\events\editor;
 
 use EventEspresso\core\domain\services\graphql\Utilities;
+use stdClass;
+use WP_Role;
 
 /**
  * Class EventManagers
@@ -37,35 +39,78 @@ class EventManagers implements EventEditorDataInterface
      */
     public function getData(int $eventId)
     {
-        global $wpdb, $wp_roles;
-        $roles = $wp_roles->role_objects;
-        $capabilities = apply_filters(
-            'FHEE__EventEspresso_core_domain_services_admin_events_editor_EventManagers__getData__capability',
-            ['ee_edit_events', 'ee_edit_event'],
-            $roles
-        );
-        $SQL = "SELECT u1.ID, u1.display_name FROM {$wpdb->users} AS u1 "
-               . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
-               . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
-               . 'WHERE';
-        $operator = '';
-        foreach ($roles as $role) {
-            foreach ($capabilities as $capability) {
-                if($role->has_cap($capability)) {
-                    $SQL .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
-                    $operator = 'OR';
-                }
-            }
-        }
-        $SQL .= "ORDER BY user_id ASC";
-        $users = $wpdb->get_results($SQL);
+        // first get a list of WP_Role names that have "event manager" capabilities
+        $event_manager_roles = $this->getEventManagerRoles();
+        // then get a list of WP Users that have any of those roles
+        $event_manager_users = $this->getEventManagerUsers($event_manager_roles);
+        // now convert to a format that's usable by AGQL
         $event_managers = [];
-        foreach ($users as $user) {
+        foreach ($event_manager_users as $user) {
             $event_managers[] = [
                 'id' => $this->utilities->convertToGlobalId('User', $user->ID),
                 'name' => $user->display_name,
             ];
         }
         return $event_managers;
+    }
+
+
+    /**
+     * Returns a list of WP_Role names that have "event manager" capabilities
+     * The list of "event manager" capabilities is filtered but defaults to:
+     *      - 'ee_edit_events'
+     *      - 'ee_edit_event'
+     *
+     * @return WP_Role[]
+     */
+    private function getEventManagerRoles()
+    {
+        global $wp_roles;
+        // first let's grab all of the WP_Role objects
+        $roles = $wp_roles->role_objects;
+        // then filter a list of capabilities we want to use to define an event manager
+        $capabilities = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_admin_events_editor_EventManagers__getData__capabilities',
+            ['ee_edit_events', 'ee_edit_event'],
+            $roles
+        );
+        // we'll use this array to capture all of the WP_Role objects that have any of the caps we are targeting
+        $event_manager_roles = [];
+        foreach ($roles as $role) {
+            foreach ($capabilities as $capability) {
+                // we're using the role name as the array index to prevent duplicates
+                if(! isset($event_manager_roles[ $role->name ]) && $role->has_cap($capability)) {
+                    $event_manager_roles[ $role->name ] = $role;
+                }
+            }
+        }
+        return $event_manager_roles;
+    }
+
+
+    /**
+     * Returns a list of users that have any of the supplied roles
+     *
+     * @param array $event_manager_roles
+     * @return stdClass[]
+     */
+    private function getEventManagerUsers(array $event_manager_roles)
+    {
+        global $wpdb;
+        // now begin to build our
+        $SQL = "SELECT u1.ID, u1.display_name FROM {$wpdb->users} AS u1 "
+               . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.ID = u2.user_id "
+               . "AND u2.meta_key='{$wpdb->prefix}capabilities' "
+               . 'WHERE';
+        $operator = '';
+        foreach ($event_manager_roles as $role) {
+            if ($role instanceof WP_Role) {
+                $SQL .= $operator . ' u2.meta_value LIKE \'%"' . $role->name . '"%\' ';
+                $operator = 'OR';
+            }
+        }
+        $SQL .= "ORDER BY user_id ASC";
+        $users = $wpdb->get_results($SQL);
+        return ! empty($users) ? $users : [];
     }
 }

--- a/core/domain/services/admin/events/editor/EventManagers.php
+++ b/core/domain/services/admin/events/editor/EventManagers.php
@@ -39,15 +39,16 @@ class EventManagers implements EventEditorDataInterface
      */
     public function getData(int $eventId)
     {
-        // first get a list of WP_Role names that have "event manager" capabilities
+        // first get a list of WP_Roles that have "event manager" capabilities
         $event_manager_roles = $this->getEventManagerRoles();
         // then get a list of WP Users that have any of those roles
         $event_manager_users = $this->getEventManagerUsers($event_manager_roles);
-        // now convert to a format that's usable by AGQL
+        // now convert to a format that's usable by GQL
         $event_managers = [];
         foreach ($event_manager_users as $user) {
-            $event_managers[] = [
-                'id' => $this->utilities->convertToGlobalId('User', $user->ID),
+            $GUID = $this->utilities->convertToGlobalId('User', $user->ID);
+            $event_managers[ $GUID ] = [
+                'id' => $GUID,
                 'name' => $user->display_name,
             ];
         }


### PR DESCRIPTION
This PR:

- adds a new `\EventEspresso\core\domain\services\admin\events\editor\EventManagers` data class which queries for WP users with event edit caps

- converts that data to a format that is usable by GQL