### PR TITLE
Fix Trashed Datetimes in Queries closes #3211

### DIFF
--- a/core/db_models/EEM_Datetime.model.php
+++ b/core/db_models/EEM_Datetime.model.php
@@ -6,9 +6,9 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 /**
  * Class Datetime Model
  *
- * @package               Event Espresso
- * @subpackage            includes/models/
- * @author                Michael Nelson, Brent Christensen
+ * @package     Event Espresso
+ * @subpackage  includes/models/
+ * @author      Michael Nelson, Brent Christensen
  */
 class EEM_Datetime extends EEM_Soft_Delete_Base
 {
@@ -171,8 +171,8 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
          * Filters the initial start date for the new datetime.
          * Any time included in this value will be overridden later so use additional filters to modify the time.
          *
-         * @param int $start_date Unixtimestamp representing now + 30 days in seconds.
-         * @return int unixtimestamp
+         * @param int $start_date Unix timestamp representing now + 30 days in seconds.
+         * @return int Unix timestamp
          */
         $start_date = apply_filters(
             'FHEE__EEM_Datetime__create_new_blank_datetime__start_date',
@@ -182,8 +182,8 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
          * Filters the initial end date for the new datetime.
          * Any time included in this value will be overridden later so use additional filters to modify the time.
          *
-         * @param int $end_data Unixtimestamp representing now + 30 days in seconds.
-         * @return int unixtimestamp
+         * @param int $end_data Unix timestamp representing now + 30 days in seconds.
+         * @return int Unix timestamp
          */
         $end_date       = apply_filters(
             'FHEE__EEM_Datetime__create_new_blank_datetime__end_date',
@@ -313,10 +313,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws EE_Error
      */
     public function get_datetimes_for_event_ordered_by_DTT_order(
-        $EVT_ID,
-        $include_expired = true,
-        $include_deleted = true,
-        $limit = null
+        int $EVT_ID,
+        bool $include_expired = true,
+        bool $include_deleted = true,
+        int $limit = 0
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
         $where_params         = ['Event.EVT_ID' => absint($EVT_ID)];
@@ -338,7 +338,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return EE_Datetime[]|EE_Base_Class[]
      * @throws EE_Error
      */
-    public function get_datetimes_for_event_ordered_by_importance($EVT_ID = 0, $limit = 0)
+    public function get_datetimes_for_event_ordered_by_importance(int $EVT_ID, int $limit = 0)
     {
         $query_params[0] = ['Event.EVT_ID' => absint($EVT_ID)];
         $query_params    = $this->addDefaultWhereConditions($query_params);
@@ -354,8 +354,12 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return EE_Datetime
      * @throws EE_Error
      */
-    public function get_oldest_datetime_for_event($EVT_ID, $include_expired = false, $include_deleted = false)
-    {
+    public function get_oldest_datetime_for_event(
+        int $EVT_ID,
+        bool $include_expired = false,
+        bool $include_deleted =
+        false
+    ) {
         $results = $this->get_datetimes_for_event_ordered_by_start_time(
             $EVT_ID,
             $include_expired,
@@ -375,13 +379,13 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @param int  $EVT_ID
      * @param bool $try_to_exclude_expired
      * @param bool $try_to_exclude_deleted
-     * @return \EE_Datetime
+     * @return EE_Datetime
      * @throws EE_Error
      */
     public function get_primary_datetime_for_event(
-        $EVT_ID,
-        $try_to_exclude_expired = true,
-        $try_to_exclude_deleted = true
+        int $EVT_ID,
+        bool $try_to_exclude_expired = true,
+        bool $try_to_exclude_deleted = true
     ) {
         if ($try_to_exclude_expired) {
             $non_expired = $this->get_oldest_datetime_for_event($EVT_ID, false, false);
@@ -411,10 +415,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws EE_Error
      */
     public function get_datetimes_for_event_ordered_by_start_time(
-        $EVT_ID,
-        $include_expired = true,
-        $include_deleted = true,
-        $limit = null
+        int $EVT_ID,
+        bool $include_expired = true,
+        bool $include_deleted = true,
+        $limit = 0
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
         $where_params         = ['Event.EVT_ID' => absint($EVT_ID)];
@@ -440,10 +444,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws EE_Error
      */
     public function get_datetimes_for_ticket_ordered_by_start_time(
-        $TKT_ID,
-        $include_expired = true,
-        $include_deleted = true,
-        $limit = null
+        int $TKT_ID,
+        bool $include_expired = true,
+        bool $include_deleted = true,
+        $limit = 0
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
         $where_params         = ['Ticket.TKT_ID' => absint($TKT_ID)];
@@ -466,9 +470,9 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws EE_Error
      */
     public function get_datetimes_for_ticket_ordered_by_DTT_order(
-        $TKT_ID,
-        $include_expired = true,
-        $include_deleted = true,
+        int $TKT_ID,
+        bool $include_expired = true,
+        bool $include_deleted = true,
         $limit = null
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
@@ -487,7 +491,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return EE_Datetime
      * @throws EE_Error
      */
-    public function get_most_important_datetime_for_event($EVT_ID)
+    public function get_most_important_datetime_for_event(int $EVT_ID)
     {
         $results = $this->get_datetimes_for_event_ordered_by_importance($EVT_ID, 1);
         if ($results) {
@@ -632,7 +636,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function sum_tickets_currently_available_at_datetime($DTT_ID, array $query_params = [])
+    public function sum_tickets_currently_available_at_datetime(int $DTT_ID, array $query_params = [])
     {
         $datetime = $this->get_one_by_ID($DTT_ID);
         if ($datetime instanceof EE_Datetime) {
@@ -743,7 +747,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addDefaultQueryParams(array $query_params, $limit = 0, $order_by = 'DTT_EVT_start', $order = 'ASC')
+    private function addDefaultQueryParams(array $query_params, int $limit = 0, $order_by = 'DTT_EVT_start', $order = 'ASC')
     {
         $query_params = $this->addOrderByQueryParams($query_params, $order_by, $order);
         $query_params = $this->addLimitQueryParams($query_params, $limit);
@@ -773,7 +777,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addDefaultWhereParams(array $where_params, $include_deleted = true, $include_expired = true)
+    private function addDefaultWhereParams(array $where_params, bool $include_deleted = true, bool $include_expired = true)
     {
         $where_params = $this->addExpiredWhereParams($where_params, $include_expired);
         $where_params = $this->addDeletedWhereParams($where_params, $include_deleted);
@@ -787,7 +791,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addDeletedWhereParams(array $where_params, $include_deleted = true)
+    private function addDeletedWhereParams(array $where_params, bool $include_deleted = true)
     {
         $deleted                     = $include_deleted ? [true, false] : [false];
         $where_params['DTT_deleted'] = ['IN', $deleted];
@@ -801,7 +805,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addExpiredWhereParams(array $where_params, $include_expired = true)
+    private function addExpiredWhereParams(array $where_params, bool $include_expired = true)
     {
         if (! $include_expired) {
             $where_params['DTT_EVT_end'] = ['>=', current_time('mysql', true)];
@@ -816,7 +820,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addLimitQueryParams(array $query_params, $limit = 0)
+    private function addLimitQueryParams(array $query_params, int $limit = 0)
     {
         if ($limit) {
             $query_params['limit'] = $limit;

--- a/core/db_models/EEM_Datetime.model.php
+++ b/core/db_models/EEM_Datetime.model.php
@@ -316,7 +316,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         int $EVT_ID,
         bool $include_expired = true,
         bool $include_deleted = true,
-        int $limit = 0
+        $limit = 0
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
         $where_params         = ['Event.EVT_ID' => absint($EVT_ID)];
@@ -338,7 +338,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return EE_Datetime[]|EE_Base_Class[]
      * @throws EE_Error
      */
-    public function get_datetimes_for_event_ordered_by_importance(int $EVT_ID, int $limit = 0)
+    public function get_datetimes_for_event_ordered_by_importance(int $EVT_ID, $limit = 0)
     {
         $query_params[0] = ['Event.EVT_ID' => absint($EVT_ID)];
         $query_params    = $this->addDefaultWhereConditions($query_params);
@@ -357,8 +357,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
     public function get_oldest_datetime_for_event(
         int $EVT_ID,
         bool $include_expired = false,
-        bool $include_deleted =
-        false
+        bool $include_deleted = false
     ) {
         $results = $this->get_datetimes_for_event_ordered_by_start_time(
             $EVT_ID,
@@ -473,7 +472,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         int $TKT_ID,
         bool $include_expired = true,
         bool $include_deleted = true,
-        $limit = null
+        $limit = 0
     ) {
         $prev_data_prep_value = $this->prepModelForQuery();
         $where_params         = ['Ticket.TKT_ID' => absint($TKT_ID)];
@@ -747,7 +746,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addDefaultQueryParams(array $query_params, int $limit = 0, $order_by = 'DTT_EVT_start', $order = 'ASC')
+    private function addDefaultQueryParams(array $query_params, $limit = 0, $order_by = 'DTT_EVT_start', $order = 'ASC')
     {
         $query_params = $this->addOrderByQueryParams($query_params, $order_by, $order);
         $query_params = $this->addLimitQueryParams($query_params, $limit);
@@ -820,7 +819,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return array
      * @since   $VID:$
      */
-    private function addLimitQueryParams(array $query_params, int $limit = 0)
+    private function addLimitQueryParams(array $query_params, $limit = 0)
     {
         if ($limit) {
             $query_params['limit'] = $limit;

--- a/core/db_models/EEM_Datetime.model.php
+++ b/core/db_models/EEM_Datetime.model.php
@@ -836,7 +836,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
     {
         $order                    = $order === 'ASC' ? 'ASC' : 'DESC';
         $valid_order_columns      = ['DTT_ID', 'DTT_EVT_start', 'DTT_EVT_end', 'DTT_order'];
-        $order_by                 = in_array($order_by, $valid_order_columns) ? $order_by : 'DTT_EVT_start';
+        $order_by                 = in_array($order_by, $valid_order_columns, true) ? $order_by : 'DTT_EVT_start';
         $query_params['order_by'] = [$order_by => $order];
         return $query_params;
     }

--- a/core/db_models/EEM_Datetime.model.php
+++ b/core/db_models/EEM_Datetime.model.php
@@ -35,11 +35,11 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
     {
         $this->singular_item           = esc_html__('Datetime', 'event_espresso');
         $this->plural_item             = esc_html__('Datetimes', 'event_espresso');
-        $this->_tables                 = array(
+        $this->_tables                 = [
             'Datetime' => new EE_Primary_Table('esp_datetime', 'DTT_ID'),
-        );
-        $this->_fields                 = array(
-            'Datetime' => array(
+        ];
+        $this->_fields                 = [
+            'Datetime' => [
                 'DTT_ID'          => new EE_Primary_Key_Int_Field(
                     'DTT_ID',
                     esc_html__('Datetime ID', 'event_espresso')
@@ -119,31 +119,35 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                     false,
                     false
                 ),
-            ),
-        );
-        $this->_model_relations        = array(
-            'Ticket'  => new EE_HABTM_Relation('Datetime_Ticket'),
-            'Event'   => new EE_Belongs_To_Relation(),
-            'Checkin' => new EE_Has_Many_Relation(),
+            ],
+        ];
+        $this->_model_relations        = [
+            'Ticket'          => new EE_HABTM_Relation('Datetime_Ticket'),
+            'Event'           => new EE_Belongs_To_Relation(),
+            'Checkin'         => new EE_Has_Many_Relation(),
             'Datetime_Ticket' => new EE_Has_Many_Relation(),
-        );
-        $path_to_event_model = 'Event';
+        ];
+        $path_to_event_model           = 'Event';
         $this->model_chain_to_password = $path_to_event_model;
         $this->_model_chain_to_wp_user = $path_to_event_model;
         // this model is generally available for reading
-        $this->_cap_restriction_generators[ EEM_Base::caps_read ]       = new EE_Restriction_Generator_Event_Related_Public(
-            $path_to_event_model
-        );
-        $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] = new EE_Restriction_Generator_Event_Related_Protected(
-            $path_to_event_model
-        );
-        $this->_cap_restriction_generators[ EEM_Base::caps_edit ]       = new EE_Restriction_Generator_Event_Related_Protected(
-            $path_to_event_model
-        );
-        $this->_cap_restriction_generators[ EEM_Base::caps_delete ]     = new EE_Restriction_Generator_Event_Related_Protected(
-            $path_to_event_model,
-            EEM_Base::caps_edit
-        );
+        $this->_cap_restriction_generators[ EEM_Base::caps_read ]       =
+            new EE_Restriction_Generator_Event_Related_Public(
+                $path_to_event_model
+            );
+        $this->_cap_restriction_generators[ EEM_Base::caps_read_admin ] =
+            new EE_Restriction_Generator_Event_Related_Protected(
+                $path_to_event_model
+            );
+        $this->_cap_restriction_generators[ EEM_Base::caps_edit ]       =
+            new EE_Restriction_Generator_Event_Related_Protected(
+                $path_to_event_model
+            );
+        $this->_cap_restriction_generators[ EEM_Base::caps_delete ]     =
+            new EE_Restriction_Generator_Event_Related_Protected(
+                $path_to_event_model,
+                EEM_Base::caps_edit
+            );
         parent::__construct($timezone);
     }
 
@@ -181,17 +185,17 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
          * @param int $end_data Unixtimestamp representing now + 30 days in seconds.
          * @return int unixtimestamp
          */
-        $end_date = apply_filters(
+        $end_date       = apply_filters(
             'FHEE__EEM_Datetime__create_new_blank_datetime__end_date',
             $this->current_time_for_query('DTT_EVT_end', true) + MONTH_IN_SECONDS
         );
         $blank_datetime = EE_Datetime::new_instance(
-            array(
+            [
                 'DTT_EVT_start' => $start_date,
                 'DTT_EVT_end'   => $end_date,
                 'DTT_order'     => 1,
                 'DTT_reg_limit' => EE_INF,
-            ),
+            ],
             $timezone_string
         );
         /**
@@ -233,18 +237,19 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                 $timezone_string
             )
         );
-        return array($blank_datetime);
+        return [$blank_datetime];
     }
 
 
     /**
      * Validates whether the start_time and end_time are in the expected format.
+     *
      * @param array $start_time
      * @param array $end_time
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      */
-    private function validateStartAndEndTimeForBlankDate($start_time, $end_time)
+    private function validateStartAndEndTimeForBlankDate(array $start_time, array $end_time)
     {
         if (! is_array($start_time)) {
             throw new InvalidDataTypeException('start_time', $start_time, 'array');
@@ -277,9 +282,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * get event start date from db
      *
      * @access public
-     * @param  int $EVT_ID
+     * @param int $EVT_ID
      * @return EE_Datetime[] array on success, FALSE on fail
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_all_event_dates($EVT_ID = 0)
     {
@@ -298,10 +304,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * get all datetimes attached to an event ordered by the DTT_order field
      *
      * @public
-     * @param  int    $EVT_ID     event id
+     * @param int     $EVT_ID     event id
      * @param boolean $include_expired
      * @param boolean $include_deleted
-     * @param  int    $limit      If included then limit the count of results by
+     * @param int     $limit      If included then limit the count of results by
      *                            the given number
      * @return EE_Datetime[]
      * @throws EE_Error
@@ -312,33 +318,12 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         $include_deleted = true,
         $limit = null
     ) {
-        // sanitize EVT_ID
-        $EVT_ID         = absint($EVT_ID);
-        $old_assumption = $this->get_assumption_concerning_values_already_prepared_by_model_object();
-        $this->assume_values_already_prepared_by_model_object(EEM_Base::prepared_for_use_in_db);
-        $where_params = array('Event.EVT_ID' => $EVT_ID);
-        $query_params = ! empty($limit)
-            ? array(
-                $where_params,
-                'limit'                    => $limit,
-                'order_by'                 => array('DTT_order' => 'ASC'),
-                'default_where_conditions' => 'none',
-            )
-            : array(
-                $where_params,
-                'order_by'                 => array('DTT_order' => 'ASC'),
-                'default_where_conditions' => 'none',
-            );
-        if (! $include_expired) {
-            $query_params[0]['DTT_EVT_end'] = array('>=', current_time('mysql', true));
-        }
-        if ($include_deleted) {
-            $query_params[0]['DTT_deleted'] = array('IN', array(true, false));
-        }
-        /** @var EE_Datetime[] $result */
-        $result = $this->get_all($query_params);
-        $this->assume_values_already_prepared_by_model_object($old_assumption);
-        return $result;
+        $prev_data_prep_value = $this->prepModelForQuery();
+        $where_params         = ['Event.EVT_ID' => absint($EVT_ID)];
+        $query_params[0]      = $this->addDefaultWhereParams($where_params, $include_deleted, $include_expired);
+        $query_params         = $this->addDefaultWhereConditions($query_params);
+        $query_params         = $this->addDefaultQueryParams($query_params, $limit, 'DTT_order');
+        return $this->getDatetimesAndRestoreModel($query_params, $prev_data_prep_value);
     }
 
 
@@ -353,16 +338,12 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return EE_Datetime[]|EE_Base_Class[]
      * @throws EE_Error
      */
-    public function get_datetimes_for_event_ordered_by_importance($EVT_ID = 0, $limit = null)
+    public function get_datetimes_for_event_ordered_by_importance($EVT_ID = 0, $limit = 0)
     {
-        return $this->get_all(
-            array(
-                array('Event.EVT_ID' => $EVT_ID),
-                'limit'                    => $limit,
-                'order_by'                 => array('DTT_EVT_start' => 'ASC'),
-                'default_where_conditions' => 'none',
-            )
-        );
+        $query_params[0] = ['Event.EVT_ID' => absint($EVT_ID)];
+        $query_params    = $this->addDefaultWhereConditions($query_params);
+        $query_params    = $this->addDefaultQueryParams($query_params, $limit);
+        return $this->get_all($query_params);
     }
 
 
@@ -435,32 +416,15 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         $include_deleted = true,
         $limit = null
     ) {
-        // sanitize EVT_ID
-        $EVT_ID         = absint($EVT_ID);
-        $old_assumption = $this->get_assumption_concerning_values_already_prepared_by_model_object();
-        $this->assume_values_already_prepared_by_model_object(EEM_Base::prepared_for_use_in_db);
-        $query_params = array(
-            array(
-                'Event.EVT_ID' => $EVT_ID
-            ),
-            'order_by' => array(
-                'DTT_EVT_start' => 'asc'
-            ),
-            'default_where_conditions' => EEM_Base::default_where_conditions_this_only
+        $prev_data_prep_value = $this->prepModelForQuery();
+        $where_params         = ['Event.EVT_ID' => absint($EVT_ID)];
+        $query_params[0]      = $this->addDefaultWhereParams($where_params, $include_deleted, $include_expired);
+        $query_params         = $this->addDefaultWhereConditions(
+            $query_params,
+            EEM_Base::default_where_conditions_this_only
         );
-        if (! $include_expired) {
-            $query_params[0]['DTT_EVT_end'] = array('>=', current_time('mysql', true));
-        }
-        if ($include_deleted) {
-            $query_params[0]['DTT_deleted'] = array('IN', array(true, false));
-        }
-        if ($limit) {
-            $query_params['limit'] = $limit;
-        }
-        /** @var EE_Datetime[] $result */
-        $result = $this->get_all($query_params);
-        $this->assume_values_already_prepared_by_model_object($old_assumption);
-        return $result;
+        $query_params         = $this->addDefaultQueryParams($query_params, $limit, 'DTT_order');
+        return $this->getDatetimesAndRestoreModel($query_params, $prev_data_prep_value);
     }
 
 
@@ -481,24 +445,11 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         $include_deleted = true,
         $limit = null
     ) {
-        // sanitize TKT_ID
-        $TKT_ID         = absint($TKT_ID);
-        $old_assumption = $this->get_assumption_concerning_values_already_prepared_by_model_object();
-        $this->assume_values_already_prepared_by_model_object(EEM_Base::prepared_for_use_in_db);
-        $query_params = array(array('Ticket.TKT_ID' => $TKT_ID), 'order_by' => array('DTT_EVT_start' => 'asc'));
-        if (! $include_expired) {
-            $query_params[0]['DTT_EVT_end'] = array('>=', current_time('mysql', true));
-        }
-        if ($include_deleted) {
-            $query_params[0]['DTT_deleted'] = array('IN', array(true, false));
-        }
-        if ($limit) {
-            $query_params['limit'] = $limit;
-        }
-        /** @var EE_Datetime[] $result */
-        $result = $this->get_all($query_params);
-        $this->assume_values_already_prepared_by_model_object($old_assumption);
-        return $result;
+        $prev_data_prep_value = $this->prepModelForQuery();
+        $where_params         = ['Ticket.TKT_ID' => absint($TKT_ID)];
+        $query_params[0]      = $this->addDefaultWhereParams($where_params, $include_deleted, $include_expired);
+        $query_params         = $this->addDefaultQueryParams($query_params, $limit);
+        return $this->getDatetimesAndRestoreModel($query_params, $prev_data_prep_value);
     }
 
 
@@ -506,10 +457,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * Gets all the datetimes for a ticket (including trashed ones, for now), ordered by the DTT_order for the
      * datetimes.
      *
-     * @param  int      $TKT_ID          ID of ticket to retrieve the datetimes for
-     * @param  boolean  $include_expired whether to include expired datetimes or not
-     * @param  boolean  $include_deleted whether to include trashed datetimes or not.
-     * @param  int|null $limit           if null, no limit, if int then limit results by
+     * @param int      $TKT_ID           ID of ticket to retrieve the datetimes for
+     * @param boolean  $include_expired  whether to include expired datetimes or not
+     * @param boolean  $include_deleted  whether to include trashed datetimes or not.
+     * @param int|null $limit            if null, no limit, if int then limit results by
      *                                   that number
      * @return EE_Datetime[]
      * @throws EE_Error
@@ -520,25 +471,11 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
         $include_deleted = true,
         $limit = null
     ) {
-        // sanitize id.
-        $TKT_ID         = absint($TKT_ID);
-        $old_assumption = $this->get_assumption_concerning_values_already_prepared_by_model_object();
-        $this->assume_values_already_prepared_by_model_object(EEM_Base::prepared_for_use_in_db);
-        $where_params = array('Ticket.TKT_ID' => $TKT_ID);
-        $query_params = array($where_params, 'order_by' => array('DTT_order' => 'ASC'));
-        if (! $include_expired) {
-            $query_params[0]['DTT_EVT_end'] = array('>=', current_time('mysql', true));
-        }
-        if ($include_deleted) {
-            $query_params[0]['DTT_deleted'] = array('IN', array(true, false));
-        }
-        if ($limit) {
-            $query_params['limit'] = $limit;
-        }
-        /** @var EE_Datetime[] $result */
-        $result = $this->get_all($query_params);
-        $this->assume_values_already_prepared_by_model_object($old_assumption);
-        return $result;
+        $prev_data_prep_value = $this->prepModelForQuery();
+        $where_params         = ['Ticket.TKT_ID' => absint($TKT_ID)];
+        $query_params[0]      = $this->addDefaultWhereParams($where_params, $include_deleted, $include_expired);
+        $query_params         = $this->addDefaultQueryParams($query_params, $limit, 'DTT_order');
+        return $this->getDatetimesAndRestoreModel($query_params, $prev_data_prep_value);
     }
 
 
@@ -564,8 +501,9 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * This returns a wpdb->results        Array of all DTT month and years matching the incoming query params and
      * grouped by month and year.
      *
-     * @param  array  $where_params      @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
-     * @param  string $evt_active_status A string representing the evt active status to filter the months by.
+     * @param array  $where_params       @see
+     *                                   https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param string $evt_active_status  A string representing the evt active status to filter the months by.
      *                                   Can be:
      *                                   - '' = no filter
      *                                   - upcoming = Published events with at least one upcoming datetime.
@@ -578,7 +516,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws InvalidArgumentException
      * @throws InvalidArgumentException
      */
-    public function get_dtt_months_and_years($where_params, $evt_active_status = '')
+    public function get_dtt_months_and_years(array $where_params, $evt_active_status = '')
     {
         $current_time_for_DTT_EVT_start = $this->current_time_for_query('DTT_EVT_start');
         $current_time_for_DTT_EVT_end   = $this->current_time_for_query('DTT_EVT_end');
@@ -589,7 +527,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                 if (isset($where_params['DTT_EVT_start'])) {
                     $where_params['DTT_EVT_start*****'] = $where_params['DTT_EVT_start'];
                 }
-                $where_params['DTT_EVT_start'] = array('>', $current_time_for_DTT_EVT_start);
+                $where_params['DTT_EVT_start'] = ['>', $current_time_for_DTT_EVT_start];
                 break;
             case 'expired':
                 if (isset($where_params['Event.status'])) {
@@ -598,7 +536,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                 // get events to exclude
                 $exclude_query[0] = array_merge(
                     $where_params,
-                    array('DTT_EVT_end' => array('>', $current_time_for_DTT_EVT_end))
+                    ['DTT_EVT_end' => ['>', $current_time_for_DTT_EVT_end]]
                 );
                 // first get all events that have datetimes where its not expired.
                 $event_ids = $this->_get_all_wpdb_results(
@@ -610,8 +548,8 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                 if (isset($where_params['DTT_EVT_end'])) {
                     $where_params['DTT_EVT_end****'] = $where_params['DTT_EVT_end'];
                 }
-                $where_params['DTT_EVT_end']  = array('<', $current_time_for_DTT_EVT_end);
-                $where_params['Event.EVT_ID'] = array('NOT IN', $event_ids);
+                $where_params['DTT_EVT_end']  = ['<', $current_time_for_DTT_EVT_end];
+                $where_params['Event.EVT_ID'] = ['NOT IN', $event_ids];
                 break;
             case 'active':
                 $where_params['Event.status'] = 'publish';
@@ -621,8 +559,8 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                 if (isset($where_params['Datetime.DTT_EVT_end'])) {
                     $where_params['Datetime.DTT_EVT_end*****'] = $where_params['DTT_EVT_end'];
                 }
-                $where_params['DTT_EVT_start'] = array('<', $current_time_for_DTT_EVT_start);
-                $where_params['DTT_EVT_end']   = array('>', $current_time_for_DTT_EVT_end);
+                $where_params['DTT_EVT_start'] = ['<', $current_time_for_DTT_EVT_start];
+                $where_params['DTT_EVT_end']   = ['>', $current_time_for_DTT_EVT_end];
                 break;
             case 'inactive':
                 if (isset($where_params['Event.status'])) {
@@ -639,21 +577,22 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
                     $where_params['AND']['DTT_EVT_start'] = $where_params['DTT_EVT_start'];
                     unset($where_params['DTT_EVT_start']);
                 }
-                $where_params['AND']['Event.status'] = array('!=', 'publish');
+                $where_params['AND']['Event.status'] = ['!=', 'publish'];
                 break;
         }
         $query_params[0]          = $where_params;
-        $query_params['group_by'] = array('dtt_year', 'dtt_month');
-        $query_params['order_by'] = array('DTT_EVT_start' => 'DESC');
-        $query_interval           = EEH_DTT_Helper::get_sql_query_interval_for_offset(
+        $query_params['group_by'] = ['dtt_year', 'dtt_month'];
+        $query_params             = $this->addOrderByQueryParams($query_params, 'DTT_EVT_start', 'DESC');
+
+        $query_interval    = EEH_DTT_Helper::get_sql_query_interval_for_offset(
             $this->get_timezone(),
             'DTT_EVT_start'
         );
-        $columns_to_select        = array(
-            'dtt_year'      => array('YEAR(' . $query_interval . ')', '%s'),
-            'dtt_month'     => array('MONTHNAME(' . $query_interval . ')', '%s'),
-            'dtt_month_num' => array('MONTH(' . $query_interval . ')', '%s'),
-        );
+        $columns_to_select = [
+            'dtt_year'      => ['YEAR(' . $query_interval . ')', '%s'],
+            'dtt_month'     => ['MONTHNAME(' . $query_interval . ')', '%s'],
+            'dtt_month_num' => ['MONTH(' . $query_interval . ')', '%s'],
+        ];
         return $this->_get_all_wpdb_results($query_params, OBJECT, $columns_to_select);
     }
 
@@ -664,8 +603,9 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      *
      * @param EE_Base_Class[]|EE_Datetime[] $datetimes
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function update_sold($datetimes)
+    public function update_sold(array $datetimes)
     {
         EE_Error::doing_it_wrong(
             __FUNCTION__,
@@ -689,8 +629,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @param array $query_params
      * @return int of tickets available. If sold out, return less than 1. If infinite, returns EE_INF,  IF there are NO
      *             tickets attached to datetime then FALSE is returned.
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function sum_tickets_currently_available_at_datetime($DTT_ID, array $query_params = array())
+    public function sum_tickets_currently_available_at_datetime($DTT_ID, array $query_params = [])
     {
         $datetime = $this->get_one_by_ID($DTT_ID);
         if ($datetime instanceof EE_Datetime) {
@@ -703,34 +645,34 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
     /**
      * This returns an array of counts of datetimes in the database for each Datetime status that can be queried.
      *
-     * @param  array $stati_to_include If included you can restrict the statuses we return counts for by including the
+     * @param array $stati_to_include  If included you can restrict the statuses we return counts for by including the
      *                                 stati you want counts for as values in the array.  An empty array returns counts
      *                                 for all valid stati.
-     * @param  array $query_params     If included can be used to refine the conditions for returning the count (i.e.
+     * @param array $query_params      If included can be used to refine the conditions for returning the count (i.e.
      *                                 only for Datetimes connected to a specific event, or specific ticket.
      * @return array  The value returned is an array indexed by Datetime Status and the values are the counts.  The
      * @throws EE_Error
      *                                 stati used as index keys are: EE_Datetime::active EE_Datetime::upcoming
      *                                 EE_Datetime::expired
      */
-    public function get_datetime_counts_by_status(array $stati_to_include = array(), array $query_params = array())
+    public function get_datetime_counts_by_status(array $stati_to_include = [], array $query_params = [])
     {
         // only accept where conditions for this query.
-        $_where            = isset($query_params[0]) ? $query_params[0] : array();
-        $status_query_args = array(
+        $_where            = isset($query_params[0]) ? $query_params[0] : [];
+        $status_query_args = [
             EE_Datetime::active   => array_merge(
                 $_where,
-                array('DTT_EVT_start' => array('<', time()), 'DTT_EVT_end' => array('>', time()))
+                ['DTT_EVT_start' => ['<', time()], 'DTT_EVT_end' => ['>', time()]]
             ),
             EE_Datetime::upcoming => array_merge(
                 $_where,
-                array('DTT_EVT_start' => array('>', time()))
+                ['DTT_EVT_start' => ['>', time()]]
             ),
             EE_Datetime::expired  => array_merge(
                 $_where,
-                array('DTT_EVT_end' => array('<', time()))
+                ['DTT_EVT_end' => ['<', time()]]
             ),
-        );
+        ];
         if (! empty($stati_to_include)) {
             foreach (array_keys($status_query_args) as $status) {
                 if (! in_array($status, $stati_to_include, true)) {
@@ -739,10 +681,10 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
             }
         }
         // loop through and query counts for each stati.
-        $status_query_results = array();
+        $status_query_results = [];
         foreach ($status_query_args as $status => $status_where_conditions) {
             $status_query_results[ $status ] = EEM_Datetime::count(
-                array($status_where_conditions),
+                [$status_where_conditions],
                 'DTT_ID',
                 true
             );
@@ -759,9 +701,143 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @return int
      * @throws EE_Error
      */
-    public function get_datetime_count_for_status($status = EE_Datetime::active, array $query_params = array())
+    public function get_datetime_count_for_status($status = EE_Datetime::active, array $query_params = [])
     {
-        $count = $this->get_datetime_counts_by_status(array($status), $query_params);
+        $count = $this->get_datetime_counts_by_status([$status], $query_params);
         return ! empty($count[ $status ]) ? $count[ $status ] : 0;
+    }
+
+
+    /**
+     * @return bool|int
+     * @since   $VID:$
+     */
+    private function prepModelForQuery()
+    {
+        $prev_data_prep_value = $this->get_assumption_concerning_values_already_prepared_by_model_object();
+        $this->assume_values_already_prepared_by_model_object(EEM_Base::prepared_for_use_in_db);
+        return $prev_data_prep_value;
+    }
+
+
+    /**
+     * @param array    $query_params
+     * @param bool|int $prev_data_prep_value
+     * @return EE_Base_Class[]|EE_Datetime[]
+     * @throws EE_Error
+     * @since   $VID:$
+     */
+    private function getDatetimesAndRestoreModel(array $query_params, $prev_data_prep_value)
+    {
+        $result = $this->get_all($query_params);
+        $this->assume_values_already_prepared_by_model_object($prev_data_prep_value);
+        return $result;
+    }
+
+
+    /**
+     * @param array  $query_params
+     * @param int    $limit
+     * @param string $order_by
+     * @param string $order
+     * @return array
+     * @since   $VID:$
+     */
+    private function addDefaultQueryParams(array $query_params, $limit = 0, $order_by = 'DTT_EVT_start', $order = 'ASC')
+    {
+        $query_params = $this->addOrderByQueryParams($query_params, $order_by, $order);
+        $query_params = $this->addLimitQueryParams($query_params, $limit);
+        return $query_params;
+    }
+
+
+    /**
+     * @param array  $query_params
+     * @param string $default_where_conditions
+     * @return array
+     * @since   $VID:$
+     */
+    private function addDefaultWhereConditions(
+        array $query_params,
+        $default_where_conditions = EEM_Base::default_where_conditions_none
+    ) {
+        $query_params['default_where_conditions'] = $default_where_conditions;
+        return $query_params;
+    }
+
+
+    /**
+     * @param array $where_params
+     * @param bool  $include_deleted
+     * @param bool  $include_expired
+     * @return array
+     * @since   $VID:$
+     */
+    private function addDefaultWhereParams(array $where_params, $include_deleted = true, $include_expired = true)
+    {
+        $where_params = $this->addExpiredWhereParams($where_params, $include_expired);
+        $where_params = $this->addDeletedWhereParams($where_params, $include_deleted);
+        return $where_params;
+    }
+
+
+    /**
+     * @param array $where_params
+     * @param bool  $include_deleted
+     * @return array
+     * @since   $VID:$
+     */
+    private function addDeletedWhereParams(array $where_params, $include_deleted = true)
+    {
+        $deleted                     = $include_deleted ? [true, false] : [false];
+        $where_params['DTT_deleted'] = ['IN', $deleted];
+        return $where_params;
+    }
+
+
+    /**
+     * @param array $where_params
+     * @param bool  $include_expired
+     * @return array
+     * @since   $VID:$
+     */
+    private function addExpiredWhereParams(array $where_params, $include_expired = true)
+    {
+        if (! $include_expired) {
+            $where_params['DTT_EVT_end'] = ['>=', current_time('mysql', true)];
+        }
+        return $where_params;
+    }
+
+
+    /**
+     * @param array $query_params
+     * @param int   $limit
+     * @return array
+     * @since   $VID:$
+     */
+    private function addLimitQueryParams(array $query_params, $limit = 0)
+    {
+        if ($limit) {
+            $query_params['limit'] = $limit;
+        }
+        return $query_params;
+    }
+
+
+    /**
+     * @param array  $query_params
+     * @param string $order_by
+     * @param string $order
+     * @return array
+     * @since   $VID:$
+     */
+    private function addOrderByQueryParams(array $query_params, $order_by = 'DTT_EVT_start', $order = 'ASC')
+    {
+        $order                    = $order === 'ASC' ? 'ASC' : 'DESC';
+        $valid_order_columns      = ['DTT_ID', 'DTT_EVT_start', 'DTT_EVT_end', 'DTT_order'];
+        $order_by                 = in_array($order_by, $valid_order_columns) ? $order_by : 'DTT_EVT_start';
+        $query_params['order_by'] = [$order_by => $order];
+        return $query_params;
     }
 }

--- a/core/helpers/EEH_File.helper.php
+++ b/core/helpers/EEH_File.helper.php
@@ -151,7 +151,7 @@ class EEH_File extends EEH_Base implements EEHI_File
                 EE_Error::add_error($msg, __FILE__, __FUNCTION__, __LINE__);
             }
             // should be loaded if we are past the wp_loaded hook...
-            if (! function_exists('WP_Filesystem')) {
+            if (! function_exists('WP_Filesystem') || ! function_exists('submit_button')) {
                 require_once(ABSPATH . 'wp-admin/includes/file.php');
                 require_once(ABSPATH . 'wp-admin/includes/template.php');
             }

--- a/tests/testcases/core/db_models/EEM_Datetime_Test.php
+++ b/tests/testcases/core/db_models/EEM_Datetime_Test.php
@@ -375,11 +375,48 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
 
 		//setup some datetimes to attach to events.
 		$datetimes = array(
-			'expired_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $past_start_date->format( $full_format ), 'DTT_EVT_end' => $past_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'upcoming_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' => $formats ) ),
-			'active_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $current->sub( new DateInterval( "PT2H") )->format( $full_format ), 'DTT_EVT_end' => $current_end_date->add( new DateInterval( "PT2H" ) )->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'sold_out_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'DTT_reg_limit' => 10, 'DTT_sold' => 10,  'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'inactive_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $current->format( $full_format ), 'DTT_EVT_end' => $current_end_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) )
+            'expired_datetime' => $this->factory->datetime->create(
+                array(
+                    'DTT_EVT_start' => $past_start_date->format($full_format),
+                    'DTT_EVT_end'   => $past_start_date->format($full_format),
+                    'timezone'      => 'America/Toronto',
+                    'formats'       => $formats,
+                )
+            ),
+            'upcoming_datetime' => $this->factory->datetime->create(
+                array(
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'timezone'      => 'America/Toronto',
+                    'formats'       => $formats,
+                )
+            ),
+            'active_datetime' => $this->factory->datetime->create(
+                array(
+                    'DTT_EVT_start' => $current->sub(new DateInterval("PT2H"))->format($full_format),
+                    'DTT_EVT_end'   => $current_end_date->add(new DateInterval("PT2H"))->format($full_format),
+                    'timezone'      => 'America/Toronto',
+                    'formats'       => $formats,
+                )
+            ),
+            'sold_out_datetime' => $this->factory->datetime->create(
+                array(
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'DTT_reg_limit' => 10,
+                    'DTT_sold'      => 10,
+                    'timezone'      => 'America/Toronto',
+                    'formats'       => $formats,
+                )
+            ),
+            'inactive_datetime' => $this->factory->datetime->create(
+                array(
+                    'DTT_EVT_start' => $current->format($full_format),
+                    'DTT_EVT_end'   => $current_end_date->format($full_format),
+                    'timezone'      => 'America/Toronto',
+                    'formats'       => $formats,
+                )
+            ),
 		);
 
 
@@ -414,6 +451,7 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
 					$this->assertEquals( $past_start_date->format('Y'), $dtt->dtt_year );
 					$this->assertEquals( $past_start_date->format('F'), $dtt->dtt_month );
 					break;
+				case 'sold_out_datetime' :
 				case 'upcoming_datetime' :
 					$dtts = EEM_Datetime::instance()->get_dtt_months_and_years( array(), 'upcoming' );
 					$dtt = reset( $dtts );
@@ -427,13 +465,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
 					$this->assertEquals( 1, count( $dtts ) );
 					$this->assertEquals( $current->format('Y'), $dtt->dtt_year );
 					$this->assertEquals( $current->format('F'), $dtt->dtt_month );
-					break;
-				case 'sold_out_datetime' :
-					$dtts = EEM_Datetime::instance()->get_dtt_months_and_years( array(), 'upcoming' );
-					$dtt = reset( $dtts );
-					$this->assertEquals( 1, count( $dtts ) );
-					$this->assertEquals( $upcoming_start_date->format('Y'), $dtt->dtt_year );
-					$this->assertEquals( $upcoming_start_date->format('F'), $dtt->dtt_month );
 					break;
 				case 'inactive_datetime' :
 					$dtts = EEM_Datetime::instance()->get_dtt_months_and_years( array(), 'inactive' );

--- a/tests/testcases/core/domain/services/contexts/RequestTypeContextDetectorTest.php
+++ b/tests/testcases/core/domain/services/contexts/RequestTypeContextDetectorTest.php
@@ -5,6 +5,7 @@ namespace EventEspresso\tests\testcases\core\domain\services\contexts;
 use EventEspresso\core\domain\Domain;
 use EventEspresso\core\domain\entities\contexts\RequestTypeContext;
 use EventEspresso\core\domain\services\contexts\RequestTypeContextDetector;
+use EventEspresso\core\services\graphql\GraphQLEndpoint;
 use EventEspresso\tests\mocks\core\domain\services\contexts\RequestTypeContextFactoryMock;
 use EventEspresso\tests\mocks\core\services\request\RequestMock;
 use InvalidArgumentException;
@@ -37,6 +38,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
         return [
             'Detect WP Scrape Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array('wp_scrape_key' => '123', 'wp_scrape_nonce' => '456'),
                         array(),
@@ -50,6 +52,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect EE REST API Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -63,6 +66,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect WP REST API Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -76,6 +80,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Frontend AJAX Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array('ee_front_ajax' => true),
@@ -89,6 +94,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Admin AJAX Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array('ee_admin_ajax' => true),
@@ -102,6 +108,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Other AJAX Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -115,6 +122,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect WP Cron Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -128,6 +136,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect WP CLI Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -141,6 +150,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect WP Admin Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -154,6 +164,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Event List iFrame Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array('event_list' => 'iframe'),
                         array(),
@@ -167,6 +178,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Ticket Selector iFrame Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array('ticket_selector' => 'iframe'),
                         array(),
@@ -180,6 +192,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Calendar iFrame Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array('calendar' => 'iframe'),
                         array(),
@@ -193,6 +206,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Feed Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array(),
                         array(),
@@ -206,6 +220,7 @@ class RequestTypeContextDetectorTest extends EspressoPHPUnitFrameworkTestCase
             ],
             'Detect Frontend Request' => [
                 new RequestTypeContextDetector(
+                    new GraphQLEndpoint(),
                     new RequestMock(
                         array('param' => 'value'),
                         array(),


### PR DESCRIPTION
see #3211 

This PR:

 - fixes datetime model queries so that deleted dates are not displayed, unless specifically requested

- extracts a bunch of duplicated logic into new methods and simplifies previous methods

- auto-formats `EEM_Datetime`