### PR TITLE
Add GraphQL Mutator action hooks

### DIFF
--- a/core/domain/services/graphql/mutators/DatetimeCreate.php
+++ b/core/domain/services/graphql/mutators/DatetimeCreate.php
@@ -49,6 +49,8 @@ class DatetimeCreate extends EntityMutator
                 if (! empty($tickets)) {
                     DatetimeMutation::setRelatedTickets($entity, $tickets);
                 }
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_datetime_create', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/DatetimeDelete.php
+++ b/core/domain/services/graphql/mutators/DatetimeDelete.php
@@ -46,6 +46,8 @@ class DatetimeDelete extends EntityMutator
                     $result = DatetimeDelete::trashDatetimeAndRelations($entity);
                 }
                 EntityMutator::validateResults($result);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_datetime_delete', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/DatetimeUpdate.php
+++ b/core/domain/services/graphql/mutators/DatetimeUpdate.php
@@ -49,6 +49,8 @@ class DatetimeUpdate extends EntityMutator
                 if (! empty($tickets)) {
                     DatetimeMutation::setRelatedTickets($entity, $tickets);
                 }
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_datetime_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/EventUpdate.php
+++ b/core/domain/services/graphql/mutators/EventUpdate.php
@@ -58,6 +58,8 @@ class EventUpdate extends EntityMutator
 
                 // Update the entity
                 $entity->save($args);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_event_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/PriceCreate.php
+++ b/core/domain/services/graphql/mutators/PriceCreate.php
@@ -47,6 +47,8 @@ class PriceCreate extends EntityMutator
                 $entity = EE_Price::new_instance($args);
                 $id = $entity->save();
                 EntityMutator::validateResults($id);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_price_create', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/PriceDelete.php
+++ b/core/domain/services/graphql/mutators/PriceDelete.php
@@ -47,6 +47,8 @@ class PriceDelete extends EntityMutator
                     $result = $entity->delete();
                 }
                 EntityMutator::validateResults($result);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_price_delete', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/PriceUpdate.php
+++ b/core/domain/services/graphql/mutators/PriceUpdate.php
@@ -39,6 +39,8 @@ class PriceUpdate extends EntityMutator
 
                 // Update the entity
                 $entity->save($args);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_price_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/TicketCreate.php
+++ b/core/domain/services/graphql/mutators/TicketCreate.php
@@ -62,6 +62,8 @@ class TicketCreate extends EntityMutator
                     // we do this client-side
                     // TicketMutation::addDefaultPrices($entity, $model);
                 }
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_ticket_create', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/TicketDelete.php
+++ b/core/domain/services/graphql/mutators/TicketDelete.php
@@ -47,6 +47,8 @@ class TicketDelete extends EntityMutator
                     $result = TicketDelete::trashTicket($entity);
                 }
                 EntityMutator::validateResults($result);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_ticket_delete', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/TicketUpdate.php
+++ b/core/domain/services/graphql/mutators/TicketUpdate.php
@@ -58,6 +58,8 @@ class TicketUpdate extends EntityMutator
                 if (is_array($prices)) {
                     TicketMutation::setRelatedPrices($entity, $prices);
                 }
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_ticket_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,

--- a/core/domain/services/graphql/mutators/VenueUpdate.php
+++ b/core/domain/services/graphql/mutators/VenueUpdate.php
@@ -59,6 +59,8 @@ class VenueUpdate extends EntityMutator
 
                 // Update the entity
                 $entity->save($args);
+
+                do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_venue_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,


### PR DESCRIPTION
This PR adds WP action hooks to graphql mutators. This is in preparation for addons to be able to update any kind of meta on GQL update.

See [barista/issues/474](https://github.com/eventespresso/barista/issues/474)