### PR TITLE
Switch usage of .unload() to .on("unload", handler)

### DIFF
--- a/admin_pages/registrations/assets/espresso_attendees_admin.js
+++ b/admin_pages/registrations/assets/espresso_attendees_admin.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
 	$.ajaxSetup ({ cache: false });
 
 	// clear firefox and safari cache
-	$(window).unload( function() {}); 
+	$(window).on("unload", function() {}); 
 	
 
 	$('#entries-per-page-btn').hide();

--- a/admin_pages/registrations/assets/espresso_registrations_admin.js
+++ b/admin_pages/registrations/assets/espresso_registrations_admin.js
@@ -3,8 +3,7 @@ jQuery(document).ready(function($) {
 	$.ajaxSetup ({ cache: false });
 
 	// clear firefox and safari cache
-	$(window).unload( function() {});
-
+	$(window).on("unload", function() {});
 
 	$('#reg-admin-attendee-questions-submit').prop( 'disabled', true );
 

--- a/admin_pages/registrations/assets/spco_for_admin.js
+++ b/admin_pages/registrations/assets/spco_for_admin.js
@@ -42,7 +42,7 @@ jQuery(document).ready( function($) {
 			// don't cache ajax
 			$.ajaxSetup ({ cache: false });
 			// clear firefox and safari cache
-			$(window).unload( function() {});
+			$(window).on("unload", function() {});
 		},
 
 

--- a/caffeinated/admin/new/pricing/assets/espresso_pricing_admin.js
+++ b/caffeinated/admin/new/pricing/assets/espresso_pricing_admin.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
 	$.ajaxSetup ({ cache: false });
 
 	// clear firefox and safari cache
-	$(window).unload( function() {}); 
+	$(window).on("unload", function() {});
 	
 
 	$('#entries-per-page-btn').hide();

--- a/core/admin/assets/ee-admin-page.js
+++ b/core/admin/assets/ee-admin-page.js
@@ -2,7 +2,7 @@ jQuery(document).ready(function($) {
 
 	$.ajaxSetup ({ cache: false });
 	// clear firefox and safari cache
-	$(window).unload( function() {});
+	$(window).on("unload", function() {});
 
 
 	function validate_form_inputs( submittedForm ) {

--- a/modules/single_page_checkout/js/single_page_checkout.js
+++ b/modules/single_page_checkout/js/single_page_checkout.js
@@ -191,7 +191,7 @@ jQuery(document).ready( function($) {
 			// don't cache ajax
 			$.ajaxSetup ({ cache: false });
 			// clear firefox and safari cache
-			$(window).unload( function() {});
+			$(window).on("unload", function() {});
 		},
 
 


### PR DESCRIPTION
.unload() has been removed from jQuery 3

This is preventing payments with Stripe so need to get this pushed.

There may also be others needed.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
