### PR TITLE
States don't 'hide' on mobile when selecting another country

### DIFF
--- a/core/templates/global_assets/scripts/espresso_core.js
+++ b/core/templates/global_assets/scripts/espresso_core.js
@@ -399,12 +399,14 @@ jQuery( document ).ready( function ( $ ) {
                         .hide()
                         .children('option')
                         .prop('selected', false)
-                        .prop('disabled', true);
+                        .prop('disabled', true)
+                        .hide();
                     // then enable all options for selected country, but don't select anything
                     $('optgroup[label="' + selected_country + '"]', $state_select)
                         .show()
                         .children('option')
-                        .prop('disabled', false);
+                        .prop('disabled', false)
+                        .show();
                     // if a valid corresponding state select exists
 					if ( selected_state.length ) {
 						// loop through all of its optgroups


### PR DESCRIPTION
On desktop if you set the reg form to collect address details it will hide states from other countries when you select one.

On mobile they are disabled but still visible.

To test make sure you have Country and State in your Address Questions group, set you event to request it for the Primary Reg.

Register onto the event and select a country other than what is set as the country in your organization.

On Desktop I see: https://monosnap.com/file/jCSmTdVIct2TI3COjJcwKhMAcVb3r8
(Note that using Chrome to emulate mobile during testing, same happens when not emulating as expected)

On Mobile I see: https://monosnap.com/file/NyB8kbCpFDeljQLsh9zlleBgEaFf2e

It shows all options and they look disabled until you find the states for the selected country which show correct.

Thie branch sets `display:none` on each child element of the hidden optgroups to fix this.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
