### PR TITLE
Hide Ticket Selector Ticket Rows Immediately

### DIFF
--- a/modules/ticket_selector/TicketSelectorRowStandard.php
+++ b/modules/ticket_selector/TicketSelectorRowStandard.php
@@ -147,7 +147,7 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         $ticket_selector_row_html = EEH_HTML::tr(
             '',
             '',
-            "tckt-slctr-tbl-tr {$this->status_class}{$this->ticket_datetime_classes} "
+            "tckt-slctr-tbl-tr ee-hidden-ticket-tr {$this->status_class}{$this->ticket_datetime_classes} "
             . espresso_get_object_css_class($this->ticket)
         );
         $filtered_row_content = $this->getFilteredRowContents();

--- a/modules/ticket_selector/assets/ticket_selector.css
+++ b/modules/ticket_selector/assets/ticket_selector.css
@@ -427,7 +427,14 @@
     top: -2px;
 }
 
-.ee-hidden-ticket-tr {
+
+.tckt-slctr-tbl-tr,
+.tckt-slctr-tkt-details-tr {
+    display: table-row;
+}
+
+.tckt-slctr-tbl-tr.ee-hidden-ticket-tr,
+.tckt-slctr-tkt-details-tr.ee-hidden-ticket-tr {
     display: none;
 }
 

--- a/modules/ticket_selector/templates/ticket_details.template.php
+++ b/modules/ticket_selector/templates/ticket_details.template.php
@@ -13,7 +13,7 @@
 /** @var \EventEspresso\modules\ticket_selector\TicketDetails $ticket_details */
 ?>
 <?php if ($show_ticket_details) : ?>
-    <tr class="tckt-slctr-tkt-details-tr <?php echo $ticket_details_row_class; ?>">
+    <tr class="tckt-slctr-tkt-details-tr ee-hidden-ticket-tr <?php echo $ticket_details_row_class; ?>">
         <td class="tckt-slctr-tkt-details-td" colspan="<?php echo $cols; ?>">
             <div id="<?php echo $ticket_details_css_id; ?>-dv" class="tckt-slctr-tkt-details-dv" style="display: none;">
 


### PR DESCRIPTION
If you create way too many dates then even on a decent server it takes a few seconds for an event listing to load, which results in every ticket row in the TS being displayed until the JS kicks in and hides them.

This PR simply hides ALL TS ticket rows by default, so now for the first few seconds the TS body will be empty until the JS kicks in and displays however many tickets have been configured for display.