### PR TITLE
Add Default Reg Status to Event GQL Data Type and Mutator

### DIFF
--- a/core/domain/entities/admin/GraphQLData/Event.php
+++ b/core/domain/entities/admin/GraphQLData/Event.php
@@ -21,6 +21,7 @@ class Event extends GraphQLData
                 allowOverflow
                 altRegPage
                 created
+                defaultRegStatus
                 description
                 displayDescription
                 displayTicketSelector

--- a/core/domain/services/graphql/data/loaders/AbstractLoader.php
+++ b/core/domain/services/graphql/data/loaders/AbstractLoader.php
@@ -23,13 +23,13 @@ abstract class AbstractLoader extends AbstractDataLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    abstract protected function getQuery();
+    abstract protected function getQuery(): EEM_Base;
 
     /**
      * @param array $keys
      * @return array
      */
-    abstract protected function getWhereParams(array $keys);
+    abstract protected function getWhereParams(array $keys): array;
 
     /**
      * Given array of keys, loads and returns a map consisting of keys from `keys` array and loaded

--- a/core/domain/services/graphql/data/loaders/AttendeeLoader.php
+++ b/core/domain/services/graphql/data/loaders/AttendeeLoader.php
@@ -15,23 +15,23 @@ use InvalidArgumentException;
 class AttendeeLoader extends AbstractLoader
 {
     /**
-     * @return EEM_Base
+     * @return EEM_Base|EEM_Attendee
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Attendee::instance();
     }
 
+
     /**
      * @param array $keys
-     *
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'ATT_ID' => ['IN', $keys],

--- a/core/domain/services/graphql/data/loaders/DatetimeLoader.php
+++ b/core/domain/services/graphql/data/loaders/DatetimeLoader.php
@@ -21,7 +21,7 @@ class DatetimeLoader extends AbstractLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Datetime::instance();
     }
@@ -30,7 +30,7 @@ class DatetimeLoader extends AbstractLoader
      * @param array $keys
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'DTT_ID'      => ['IN', $keys],

--- a/core/domain/services/graphql/data/loaders/PriceLoader.php
+++ b/core/domain/services/graphql/data/loaders/PriceLoader.php
@@ -21,7 +21,7 @@ class PriceLoader extends AbstractLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Price::instance();
     }
@@ -30,7 +30,7 @@ class PriceLoader extends AbstractLoader
      * @param array $keys
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'PRC_ID' => ['IN', $keys],

--- a/core/domain/services/graphql/data/loaders/PriceTypeLoader.php
+++ b/core/domain/services/graphql/data/loaders/PriceTypeLoader.php
@@ -21,7 +21,7 @@ class PriceTypeLoader extends AbstractLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Price_Type::instance();
     }
@@ -30,7 +30,7 @@ class PriceTypeLoader extends AbstractLoader
      * @param array $keys
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'PRT_ID' => ['IN', $keys],

--- a/core/domain/services/graphql/data/loaders/TicketLoader.php
+++ b/core/domain/services/graphql/data/loaders/TicketLoader.php
@@ -21,7 +21,7 @@ class TicketLoader extends AbstractLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Ticket::instance();
     }
@@ -30,7 +30,7 @@ class TicketLoader extends AbstractLoader
      * @param array $keys
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'TKT_ID'      => ['IN', $keys],

--- a/core/domain/services/graphql/data/loaders/VenueLoader.php
+++ b/core/domain/services/graphql/data/loaders/VenueLoader.php
@@ -21,7 +21,7 @@ class VenueLoader extends AbstractLoader
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected function getQuery()
+    protected function getQuery(): EEM_Base
     {
         return EEM_Venue::instance();
     }
@@ -30,7 +30,7 @@ class VenueLoader extends AbstractLoader
      * @param array $keys
      * @return array
      */
-    protected function getWhereParams(array $keys)
+    protected function getWhereParams(array $keys): array
     {
         return [
             'VNU_ID' => ['IN', $keys],

--- a/core/domain/services/graphql/data/mutations/DatetimeMutation.php
+++ b/core/domain/services/graphql/data/mutations/DatetimeMutation.php
@@ -28,7 +28,7 @@ class DatetimeMutation
      * @return array
      * @throws Exception
      */
-    public static function prepareFields(array $input)
+    public static function prepareFields(array $input): array
     {
         $args = [];
 
@@ -107,7 +107,7 @@ class DatetimeMutation
      * @throws InvalidArgumentException
      * @throws ReflectionException
      */
-    public static function setRelatedTickets($entity, array $tickets)
+    public static function setRelatedTickets(EE_Datetime $entity, array $tickets)
     {
         $relationName = 'Ticket';
         // Remove all the existing related tickets

--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -23,7 +23,7 @@ class EventMutation
      * @return array
      * @throws Exception
      */
-    public static function prepareFields(array $input, $mutation_name)
+    public static function prepareFields(array $input, string $mutation_name): array
     {
         $args = [];
 

--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -28,15 +28,19 @@ class EventMutation
         $args = [];
 
         if (array_key_exists('allowDonations', $input)) {
-            $args['EVT_donations'] = (bool) ($input['allowDonations']);
+            $args['EVT_donations'] = filter_var($input['allowDonations'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (array_key_exists('allowOverflow', $input)) {
-            $args['EVT_allow_overflow'] = (bool) ($input['allowOverflow']);
+            $args['EVT_allow_overflow'] = filter_var($input['allowOverflow'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (! empty($input['altRegPage'])) {
             $args['EVT_external_URL'] = sanitize_text_field($input['altRegPage']);
+        }
+
+        if (! empty($input['defaultRegStatus'])) {
+            $args['EVT_default_registration_status'] = sanitize_text_field($input['defaultRegStatus']);
         }
 
         if (! empty($input['description'])) {
@@ -44,11 +48,11 @@ class EventMutation
         }
 
         if (array_key_exists('displayDescription', $input)) {
-            $args['EVT_display_desc'] = (bool) ($input['displayDescription']);
+            $args['EVT_display_desc'] = filter_var($input['displayDescription'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (array_key_exists('displayTicketSelector', $input)) {
-            $args['EVT_display_ticket_selector'] = (bool) ($input['displayTicketSelector']);
+            $args['EVT_display_ticket_selector'] = filter_var($input['displayTicketSelector'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (! empty($input['maxRegistrations'])) {
@@ -56,7 +60,7 @@ class EventMutation
         }
 
         if (array_key_exists('memberOnly', $input)) {
-            $args['EVT_member_only'] = (bool) ($input['memberOnly']);
+            $args['EVT_member_only'] = filter_var($input['memberOnly'], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (! empty($input['name'])) {

--- a/core/domain/services/graphql/data/mutations/PriceMutation.php
+++ b/core/domain/services/graphql/data/mutations/PriceMutation.php
@@ -19,7 +19,7 @@ class PriceMutation
      * @param array $input Data coming from the GraphQL mutation query input
      * @return array
      */
-    public static function prepareFields(array $input)
+    public static function prepareFields(array $input): array
     {
         $args = [];
 

--- a/core/domain/services/graphql/data/mutations/TicketMutation.php
+++ b/core/domain/services/graphql/data/mutations/TicketMutation.php
@@ -31,7 +31,7 @@ class TicketMutation
      * @return array
      * @throws Exception
      */
-    public static function prepareFields(array $input)
+    public static function prepareFields(array $input): array
     {
         $args = [];
 
@@ -146,7 +146,7 @@ class TicketMutation
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function setRelatedDatetimes($entity, array $datetimes)
+    public static function setRelatedDatetimes(EE_Ticket $entity, array $datetimes)
     {
         $relationName = 'Datetime';
         // Remove all the existing related datetimes

--- a/core/domain/services/graphql/data/mutations/VenueMutation.php
+++ b/core/domain/services/graphql/data/mutations/VenueMutation.php
@@ -2,6 +2,9 @@
 
 namespace EventEspresso\core\domain\services\graphql\data\mutations;
 
+use DateTime;
+use Exception;
+
 /**
  * Class VenueMutation
  *
@@ -17,12 +20,10 @@ class VenueMutation
      * @param array  $input         Data coming from the GraphQL mutation query input
      * @param string $mutation_name Name of the mutation being performed
      * @return array
+     * @throws Exception
      */
-    public static function prepareFields(array $input, $mutation_name)
+    public static function prepareFields(array $input, string $mutation_name): array
     {
-
-        $args = [];
-
         if (! empty($input['name'])) {
             $args['VNU_name'] = sanitize_text_field($input['name']);
         }

--- a/core/domain/services/graphql/enums/AttendeesConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/AttendeesConnectionOrderbyEnum.php
@@ -28,9 +28,8 @@ class AttendeesConnectionOrderbyEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'ID'     => [

--- a/core/domain/services/graphql/enums/DatetimeStatusEnum.php
+++ b/core/domain/services/graphql/enums/DatetimeStatusEnum.php
@@ -29,9 +29,8 @@ class DatetimeStatusEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'SOLD_OUT'     => [

--- a/core/domain/services/graphql/enums/DatetimesConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/DatetimesConnectionOrderbyEnum.php
@@ -28,9 +28,8 @@ class DatetimesConnectionOrderbyEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'NAME'     => [

--- a/core/domain/services/graphql/enums/ModelNameEnum.php
+++ b/core/domain/services/graphql/enums/ModelNameEnum.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\domain\services\graphql\enums;
 
+use EE_Error;
 use EEM_Datetime;
 use EEM_Ticket;
 use EEM_Price;
@@ -31,9 +32,9 @@ class ModelNameEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
+     * @throws EE_Error
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'DATETIME' => [

--- a/core/domain/services/graphql/enums/PriceBaseTypeEnum.php
+++ b/core/domain/services/graphql/enums/PriceBaseTypeEnum.php
@@ -29,9 +29,8 @@ class PriceBaseTypeEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'BASE_PRICE'     => [

--- a/core/domain/services/graphql/enums/RegistrationStatusEnum.php
+++ b/core/domain/services/graphql/enums/RegistrationStatusEnum.php
@@ -29,9 +29,8 @@ class RegistrationStatusEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'APPROVED'        => [

--- a/core/domain/services/graphql/enums/TicketStatusEnum.php
+++ b/core/domain/services/graphql/enums/TicketStatusEnum.php
@@ -29,9 +29,8 @@ class TicketStatusEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'SOLD_OUT'     => [

--- a/core/domain/services/graphql/enums/TicketsConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/TicketsConnectionOrderbyEnum.php
@@ -28,9 +28,8 @@ class TicketsConnectionOrderbyEnum extends EnumBase
 
     /**
      * @return array
-     * @since $VID:$
      */
-    protected function getValues()
+    protected function getValues(): array
     {
         return [
             'NAME'     => [

--- a/core/domain/services/graphql/mutators/BulkEntityMutator.php
+++ b/core/domain/services/graphql/mutators/BulkEntityMutator.php
@@ -18,7 +18,7 @@ class BulkEntityMutator extends EntityMutator
     /**
      * BulkEntityMutator constructor.
      *
-     * @param array $entity_mutator The mutator for an entity.
+     * @param callable $entity_mutator The mutator for an entity.
      */
     public function __construct(callable $entity_mutator)
     {
@@ -32,7 +32,7 @@ class BulkEntityMutator extends EntityMutator
      * @param ResolveInfo $info    The ResolveInfo passed down to all resolvers
      * @return array
      */
-    public function updateEntities($input, AppContext $context, ResolveInfo $info)
+    public function updateEntities(array $input, AppContext $context, ResolveInfo $info): array
     {
 
         $updated = [];

--- a/core/domain/services/graphql/mutators/DatetimeUpdate.php
+++ b/core/domain/services/graphql/mutators/DatetimeUpdate.php
@@ -30,7 +30,7 @@ class DatetimeUpdate extends EntityMutator
          * @param ResolveInfo $info    The ResolveInfo passed down to all resolvers
          * @return array
          */
-        return static function ($input, AppContext $context, ResolveInfo $info) use ($model, $type) {
+        return static function (array $input, AppContext $context, ResolveInfo $info) use ($model, $type) {
             try {
                 /** @var EE_Datetime $entity */
                 $entity = EntityMutator::getEntityFromInputData($model, $input);

--- a/core/domain/services/graphql/mutators/EntityMutator.php
+++ b/core/domain/services/graphql/mutators/EntityMutator.php
@@ -15,7 +15,7 @@ use RuntimeException;
  * Description
  *
  * @package EventEspresso\core\domain\services\graphql\mutators
- * @author  Brent Christensen
+ * @author  Manzoor Wani
  * @since   $VID:$
  */
 abstract class EntityMutator
@@ -23,18 +23,18 @@ abstract class EntityMutator
 
     /**
      * @param EEM_Base $model
-     * @param integer $ID
+     * @param integer  $ID
      * @param string   $capability
      * @return EE_Base_Class
      * @throws OutOfBoundsException
      * @throws UserError
-     * @since $VID:$
      */
-    protected static function getEntityFromID(EEM_Base $model, $ID, $capability = 'ee_edit_events')
+    protected static function getEntityFromID(EEM_Base $model, int $ID, $capability = 'ee_edit_events'): EE_Base_Class
     {
         EntityMutator::checkPermissions($model, $capability);
         return EntityMutator::getEntity($model, $ID);
     }
+
 
     /**
      * @param EEM_Base $model
@@ -43,10 +43,12 @@ abstract class EntityMutator
      * @return EE_Base_Class
      * @throws OutOfBoundsException
      * @throws UserError
-     * @since $VID:$
      */
-    protected static function getEntityFromInputData(EEM_Base $model, array $input, $capability = 'ee_edit_events')
-    {
+    protected static function getEntityFromInputData(
+        EEM_Base $model,
+        array $input,
+        $capability = 'ee_edit_events'
+    ): EE_Base_Class {
         EntityMutator::checkPermissions($model, $capability);
         $ID = EntityMutator::getEntityIDFromGlobalId($model, $input);
         return EntityMutator::getEntity($model, $ID);
@@ -55,9 +57,8 @@ abstract class EntityMutator
 
     /**
      * @param EEM_Base $model
-     * @param string $capability
+     * @param string   $capability
      * @throws UserError
-     * @since $VID:$
      */
     protected static function checkPermissions(EEM_Base $model, $capability = 'ee_edit_events')
     {
@@ -66,7 +67,7 @@ abstract class EntityMutator
          */
         if (! current_user_can($capability)) {
             $model_name = $model->get_this_model_name();
-            $message = sprintf(
+            $message    = sprintf(
                 esc_html_x(
                     'We\'re sorry but you do not have the required permissions to execute %1$s mutations!',
                     'We\'re sorry but you do not have the required permissions to execute entity(datetime/ticket/etc) mutations!',
@@ -78,17 +79,17 @@ abstract class EntityMutator
         }
     }
 
+
     /**
      * @param EEM_Base $model
      * @param array    $input
      * @return int
      * @throws OutOfBoundsException
-     * @since $VID:$
      */
-    protected static function getEntityIDFromGlobalId(EEM_Base $model, array $input)
+    protected static function getEntityIDFromGlobalId(EEM_Base $model, array $input): int
     {
         $id_parts = ! empty($input['id']) ? Relay::fromGlobalId($input['id']) : null;
-        $id = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
+        $id       = ! empty($id_parts['id']) ? absint($id_parts['id']) : 0;
         if ($id > 0) {
             return $id;
         }
@@ -112,9 +113,8 @@ abstract class EntityMutator
      * @param int      $ID
      * @return EE_Base_Class
      * @throws OutOfBoundsException
-     * @since $VID:$
      */
-    protected static function getEntity(EEM_Base $model, $ID = 0)
+    protected static function getEntity(EEM_Base $model, $ID = 0): EE_Base_Class
     {
         $entity = $model->get_one_by_ID($ID);
         $model_name = $model->get_this_model_name();
@@ -140,7 +140,6 @@ abstract class EntityMutator
      * @param        $results
      * @param string $message
      * @throws RuntimeException
-     * @since $VID:$
      */
     protected static function validateResults($results, $message = '')
     {
@@ -160,7 +159,6 @@ abstract class EntityMutator
      * @param Exception $exception
      * @param string    $message_prefix
      * @throws RuntimeException
-     * @since $VID:$
      */
     protected static function handleExceptions(Exception $exception, $message_prefix = '')
     {

--- a/core/domain/services/graphql/types/Datetime.php
+++ b/core/domain/services/graphql/types/Datetime.php
@@ -20,6 +20,7 @@ use EventEspresso\core\domain\services\graphql\mutators\DatetimeUpdate;
 use EventEspresso\core\domain\services\graphql\mutators\DatetimeBulkUpdate;
 use EventEspresso\core\domain\services\graphql\mutators\BulkEntityDelete;
 use EventEspresso\core\domain\services\graphql\mutators\EntityReorder;
+use GraphQL\Error\UserError;
 use InvalidArgumentException;
 use ReflectionException;
 use WPGraphQL\AppContext;
@@ -30,7 +31,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  * Description
  *
  * @package EventEspresso\core\domain\services\graphql\types
- * @author  Brent Christensen
+ * @author  Manzoor Wani
  * @since   $VID:$
  */
 class Datetime extends TypeBase
@@ -53,9 +54,8 @@ class Datetime extends TypeBase
 
     /**
      * @return GraphQLFieldInterface[]
-     * @since $VID:$
      */
-    public function getFields()
+    public function getFields(): array
     {
         $fields = [
             new GraphQLField(

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -15,7 +15,7 @@ use EventEspresso\core\domain\services\graphql\mutators\EventUpdate;
  * Description
  *
  * @package EventEspresso\core\domain\services\graphql\types
- * @author  Brent Christensen
+ * @author  Manzoor Wani
  * @since   $VID:$
  */
 class Event extends TypeBase
@@ -37,9 +37,8 @@ class Event extends TypeBase
 
     /**
      * @return GraphQLFieldInterface[]
-     * @since $VID:$
      */
-    public function getFields()
+    public function getFields(): array
     {
         $fields = [
             new GraphQLField(
@@ -78,11 +77,11 @@ class Event extends TypeBase
                 'ID',
                 esc_html__('The event ID.', 'event_espresso')
             ),
-            new GraphQLField(
+            new GraphQLOutputField(
                 'defaultRegStatus',
-                'String',
+                $this->namespace . 'RegistrationStatusEnum',
                 'default_registration_status',
-                esc_html__('Default Registration Status', 'event_espresso')
+                esc_html__('Default Event Registration Status', 'event_espresso')
             ),
             new GraphQLField(
                 'description',
@@ -108,7 +107,7 @@ class Event extends TypeBase
                 'is_active',
                 esc_html__('Flag indicating event is active', 'event_espresso')
             ),
-            new GraphQLField(
+            new GraphQLOutputField(
                 'isCancelled',
                 'Boolean',
                 'is_cancelled',
@@ -126,13 +125,13 @@ class Event extends TypeBase
                 'is_inactive',
                 esc_html__('Flag indicating event is inactive', 'event_espresso')
             ),
-            new GraphQLField(
+            new GraphQLOutputField(
                 'isPostponed',
                 'Boolean',
                 'is_postponed',
                 esc_html__('Flag indicating whether the event is marked as postponed', 'event_espresso')
             ),
-            new GraphQLField(
+            new GraphQLOutputField(
                 'isSoldOut',
                 'Boolean',
                 'is_sold_out',
@@ -147,17 +146,17 @@ class Event extends TypeBase
                 'is_upcoming',
                 esc_html__('Whether the event is upcoming', 'event_espresso')
             ),
-            new GraphQLOutputField(
-                'manager',
-                'User',
-                null,
-                esc_html__('Event Manager', 'event_espresso')
-            ),
             new GraphQLInputField(
                 'manager',
                 'String',
                 null,
                 esc_html__('Globally unique event ID for the event manager', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'manager',
+                'User',
+                null,
+                esc_html__('Event Manager', 'event_espresso')
             ),
             new GraphQLField(
                 'maxRegistrations',

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -42,11 +42,23 @@ class Event extends TypeBase
     public function getFields()
     {
         $fields = [
-            new GraphQLOutputField(
-                'dbId',
-                ['non_null' => 'Int'],
-                'ID',
-                esc_html__('The event ID.', 'event_espresso')
+            new GraphQLField(
+                'allowDonations',
+                'Boolean',
+                'donations',
+                esc_html__('Accept Donations?', 'event_espresso')
+            ),
+            new GraphQLField(
+                'allowOverflow',
+                'Boolean',
+                'allow_overflow',
+                esc_html__('Enable Wait List for Event', 'event_espresso')
+            ),
+            new GraphQLField(
+                'altRegPage',
+                'String',
+                'external_url',
+                esc_html__('URL of Event Page if hosted elsewhere', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'cacheId',
@@ -55,10 +67,22 @@ class Event extends TypeBase
                 esc_html__('The cache ID of the object.', 'event_espresso')
             ),
             new GraphQLField(
-                'name',
+                'created',
                 'String',
-                'name',
-                esc_html__('Event Name', 'event_espresso')
+                'created',
+                esc_html__('Date/Time Event Created', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'dbId',
+                ['non_null' => 'Int'],
+                'ID',
+                esc_html__('The event ID.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'defaultRegStatus',
+                'String',
+                'default_registration_status',
+                esc_html__('Default Registration Status', 'event_espresso')
             ),
             new GraphQLField(
                 'description',
@@ -67,16 +91,61 @@ class Event extends TypeBase
                 esc_html__('Event Description', 'event_espresso')
             ),
             new GraphQLField(
-                'shortDescription',
-                'String',
-                'short_description',
-                esc_html__('Event Short Description', 'event_espresso')
+                'displayDescription',
+                'Boolean',
+                'display_description',
+                esc_html__('Display Description Flag', 'event_espresso')
             ),
             new GraphQLField(
-                'created',
-                'String',
-                'created',
-                esc_html__('Date/Time Event Created', 'event_espresso')
+                'displayTicketSelector',
+                'Boolean',
+                'display_ticket_selector',
+                esc_html__('Display Ticket Selector Flag', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isActive',
+                'Boolean',
+                'is_active',
+                esc_html__('Flag indicating event is active', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isCancelled',
+                'Boolean',
+                'is_cancelled',
+                esc_html__('Flag indicating whether the event is marked as cancelled', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isExpired',
+                'Boolean',
+                'is_expired',
+                esc_html__('Flag indicating event is expired or not', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'isInactive',
+                'Boolean',
+                'is_inactive',
+                esc_html__('Flag indicating event is inactive', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isPostponed',
+                'Boolean',
+                'is_postponed',
+                esc_html__('Flag indicating whether the event is marked as postponed', 'event_espresso')
+            ),
+            new GraphQLField(
+                'isSoldOut',
+                'Boolean',
+                'is_sold_out',
+                esc_html__(
+                    'Flag indicating whether the tickets sold for the event, met or exceed the registration limit',
+                    'event_espresso'
+                )
+            ),
+            new GraphQLOutputField(
+                'isUpcoming',
+                'Boolean',
+                'is_upcoming',
+                esc_html__('Whether the event is upcoming', 'event_espresso')
             ),
             new GraphQLOutputField(
                 'manager',
@@ -91,40 +160,10 @@ class Event extends TypeBase
                 esc_html__('Globally unique event ID for the event manager', 'event_espresso')
             ),
             new GraphQLField(
-                'order',
-                'Int',
-                'order',
-                esc_html__('Event Menu Order', 'event_espresso')
-            ),
-            new GraphQLField(
-                'displayDescription',
-                'Boolean',
-                'display_description',
-                esc_html__('Display Description Flag', 'event_espresso')
-            ),
-            new GraphQLField(
-                'displayTicketSelector',
-                'Boolean',
-                'display_ticket_selector',
-                esc_html__('Display Ticket Selector Flag', 'event_espresso')
-            ),
-            new GraphQLField(
-                'visibleOn',
-                'String',
-                'visible_on',
-                esc_html__('Event Visible Date', 'event_espresso')
-            ),
-            new GraphQLField(
                 'maxRegistrations',
                 'Int',
                 'additional_limit',
                 esc_html__('Limit of Additional Registrations on Same Transaction', 'event_espresso')
-            ),
-            new GraphQLField(
-                'phoneNumber',
-                'String',
-                'phone',
-                esc_html__('Event Phone Number', 'event_espresso')
             ),
             new GraphQLField(
                 'memberOnly',
@@ -133,10 +172,28 @@ class Event extends TypeBase
                 esc_html__('Member-Only Event Flag', 'event_espresso')
             ),
             new GraphQLField(
-                'allowOverflow',
-                'Boolean',
-                'allow_overflow',
-                esc_html__('Allow Overflow on Event', 'event_espresso')
+                'name',
+                'String',
+                'name',
+                esc_html__('Event Name', 'event_espresso')
+            ),
+            new GraphQLField(
+                'order',
+                'Int',
+                'order',
+                esc_html__('Event Menu Order', 'event_espresso')
+            ),
+            new GraphQLField(
+                'phoneNumber',
+                'String',
+                'phone',
+                esc_html__('Event Phone Number', 'event_espresso')
+            ),
+            new GraphQLField(
+                'shortDescription',
+                'String',
+                'short_description',
+                esc_html__('Event Short Description', 'event_espresso')
             ),
             new GraphQLField(
                 'timezoneString',
@@ -145,61 +202,10 @@ class Event extends TypeBase
                 esc_html__('Timezone (name) for Event times', 'event_espresso')
             ),
             new GraphQLField(
-                'altRegPage',
+                'visibleOn',
                 'String',
-                'external_url',
-                esc_html__('URL of Event Page if hosted elsewhere', 'event_espresso')
-            ),
-            new GraphQLField(
-                'allowDonations',
-                'Boolean',
-                'donations',
-                esc_html__('Accept Donations?', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isSoldOut',
-                'Boolean',
-                'is_sold_out',
-                esc_html__(
-                    'Flag indicating whether the tickets sold for the event, met or exceed the registration limit',
-                    'event_espresso'
-                )
-            ),
-            new GraphQLField(
-                'isPostponed',
-                'Boolean',
-                'is_postponed',
-                esc_html__('Flag indicating whether the event is marked as postponed', 'event_espresso')
-            ),
-            new GraphQLField(
-                'isCancelled',
-                'Boolean',
-                'is_cancelled',
-                esc_html__('Flag indicating whether the event is marked as cancelled', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isUpcoming',
-                'Boolean',
-                'is_upcoming',
-                esc_html__('Whether the event is upcoming', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isActive',
-                'Boolean',
-                'is_active',
-                esc_html__('Flag indicating event is active', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isInactive',
-                'Boolean',
-                'is_inactive',
-                esc_html__('Flag indicating event is inactive', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isExpired',
-                'Boolean',
-                'is_expired',
-                esc_html__('Flag indicating event is expired or not', 'event_espresso')
+                'visible_on',
+                esc_html__('Event Visible Date', 'event_espresso')
             ),
         ];
 

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -77,7 +77,7 @@ class Event extends TypeBase
                 'ID',
                 esc_html__('The event ID.', 'event_espresso')
             ),
-            new GraphQLOutputField(
+            new GraphQLField(
                 'defaultRegStatus',
                 $this->namespace . 'RegistrationStatusEnum',
                 'default_registration_status',

--- a/core/services/graphql/enums/EnumBase.php
+++ b/core/services/graphql/enums/EnumBase.php
@@ -44,15 +44,14 @@ abstract class EnumBase implements EnumInterface
 
     /**
      * @return array
-     * @since $VID:$
      */
-    abstract protected function getValues();
+    abstract protected function getValues(): array;
 
 
     /**
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return $this->name;
     }
@@ -61,7 +60,7 @@ abstract class EnumBase implements EnumInterface
     /**
      * @param string $name
      */
-    protected function setName($name)
+    protected function setName(string $name)
     {
         $this->name = $name;
     }
@@ -70,7 +69,7 @@ abstract class EnumBase implements EnumInterface
     /**
      * @return string
      */
-    public function description()
+    public function description(): string
     {
         return $this->description;
     }
@@ -79,7 +78,7 @@ abstract class EnumBase implements EnumInterface
     /**
      * @param string $description
      */
-    protected function setDescription($description)
+    protected function setDescription(string $description)
     {
         $this->description = $description;
     }
@@ -87,9 +86,8 @@ abstract class EnumBase implements EnumInterface
 
     /**
      * @return array
-     * @since $VID:$
      */
-    public function values()
+    public function values(): array
     {
         return (array) $this->values;
     }


### PR DESCRIPTION
Noticed while reviewing https://github.com/eventespresso/barista/pull/514 that out GQL Event object was missing a value for the default registration status.

This PR adds that in so that it can be used to wire up that input in the new Reg Options "meta box" in the EDTR