### PR TITLE
Fix event mutation for empty values

### DIFF
--- a/core/domain/services/graphql/data/mutations/EventMutation.php
+++ b/core/domain/services/graphql/data/mutations/EventMutation.php
@@ -35,7 +35,7 @@ class EventMutation
             $args['EVT_allow_overflow'] = filter_var($input['allowOverflow'], FILTER_VALIDATE_BOOLEAN);
         }
 
-        if (! empty($input['altRegPage'])) {
+        if (array_key_exists('altRegPage', $input)) {
             $args['EVT_external_URL'] = sanitize_text_field($input['altRegPage']);
         }
 
@@ -67,11 +67,11 @@ class EventMutation
             $args['EVT_name'] = sanitize_text_field($input['name']);
         }
 
-        if (! empty($input['order'])) {
+        if (array_key_exists('order', $input)) {
             $args['EVT_order'] = absint($input['order']);
         }
 
-        if (! empty($input['phoneNumber'])) {
+        if (array_key_exists('phoneNumber', $input)) {
             $args['EVT_phone'] = sanitize_text_field($input['phoneNumber']);
         }
 

--- a/tests/testcases/core/db_classes/EE_Attendee_Test.php
+++ b/tests/testcases/core/db_classes/EE_Attendee_Test.php
@@ -74,7 +74,7 @@ class EE_Attendee_Test extends EE_UnitTestCase{
 				'phone'		=> '9991231234',
 				'credit_card'=>'4007000000027',
 				'exp_month'=>'12',
-				'exp_year'=>'2020',
+				'exp_year'=>'2030',
 				'cvv'=>'123',
 			);
 		$form->receive_form_submission( array( $form_name => $form_values  ) );

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Model_Matching_Query_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Model_Matching_Query_Validation_Strategy_Test.php
@@ -52,7 +52,6 @@ class EE_Model_Matching_Query_Validation_Strategy_Test extends EE_UnitTestCase {
      * @since 4.10.7.p
      * @throws EE_Error
      * @throws EE_Validation_Error
-     * @doesNotPerformAssertions
      */
 	public function test_valid__treating_input_as_other_field() {
 		$validator = new EE_Model_Matching_Query_Validation_Strategy(


### PR DESCRIPTION
This PR fixes event mutation for empty values which were being ignored by `empty()` check.

Closes #3249 