### PR TITLE
Fix Activation Errors

### DIFF
--- a/core/EE_Addon.core.php
+++ b/core/EE_Addon.core.php
@@ -216,7 +216,7 @@ abstract class EE_Addon extends EE_Configurable implements RequiresDependencyMap
      *
      * @return string
      */
-    public function name(): string
+    public function name()
     {
         return $this->_addon_name;
     }

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -762,6 +762,14 @@ class EE_Dependency_Map
             'EventEspresso\core\services\addon\api\ThirdPartyPluginHandler' => [
                 'EventEspresso\core\services\request\Request'  => EE_Dependency_Map::load_from_cache,
             ],
+            'EventEspresso\core\libraries\rest_api\CalculatedModelFields' => [
+                'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => EE_Dependency_Map::load_from_cache
+            ],
+            'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => [
+                'EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache
+            ],
+            'EventEspresso\core\libraries\rest_api\controllers\model\Read' => [
+                'EventEspresso\core\libraries\rest_api\CalculatedModelFields' => EE_Dependency_Map::load_from_cache]
         ];
     }
 

--- a/core/admin/templates/admin_general_metabox_contents_espresso_sponsors.template.php
+++ b/core/admin/templates/admin_general_metabox_contents_espresso_sponsors.template.php
@@ -1,11 +1,38 @@
 <div class="padding">
-    <p>Upgrade to an <a
+    <p>
+        <?php
+        printf(
+            esc_html__(
+                'Upgrade to an %1$sEvent Espresso 4 support license%2$s to get access to dedicated support staff and premium features, such as a calendar, printable tickets and check-in capabilities, MailChimp integration, and more!',
+                'event_espresso'
+            ),
+            '<a
             href="https://eventespresso.com/pricing/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=event_espresso_highlights_widget&utm_content=link"
-            target="_blank">Event Espresso 4 support license</a> to get access to dedicated support staff and premium
-        features, such as a calendar, printable tickets and check-in capabilities, Mailchimp integration, and more!</p>
-    <a href="https://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=event_espresso_highlights_widget&utm_content=banner"
-       target="_blank"><img src="<?php echo EE_GLOBAL_ASSETS_URL; ?>images/manage-events-faster-240x240.jpg"/></a>
-    <p>Visit <a
+            target="_blank">',
+            '</a>'
+        );
+        ?>
+    </p>
+    <p>
+        <a href='https://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=event_espresso_highlights_widget&utm_content=banner'
+           target='_blank'>
+            <img alt="<?php esc_html_e('manage events faster', 'event_espresso'); ?>"
+                 src='<?php echo EE_GLOBAL_ASSETS_URL; ?>images/manage-events-faster-240x240.jpg'
+            />
+        </a>
+    </p>
+    <p>
+        <?php
+        printf(
+            esc_html__(
+                'Visit %1$sEvent Espresso%2$s for more details.',
+                'event_espresso'
+            ),
+            '<a
             href="https://eventespresso.com/?ee_ver=ee4&utm_source=ee4_plugin_admin&utm_medium=link&utm_campaign=event_espresso_highlights_widget&utm_content=link"
-            target="_blank">Event Espresso</a> for more details.</p>
+            target="_blank">',
+            '</a>'
+        );
+        ?>
+        </p>
 </div>

--- a/core/domain/entities/routing/handlers/shared/RestApiRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RestApiRequests.php
@@ -34,20 +34,6 @@ class RestApiRequests extends Route
     protected function registerDependencies()
     {
         $this->dependency_map->registerDependencies(
-            'EventEspresso\core\libraries\rest_api\CalculatedModelFields',
-            [
-                'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => EE_Dependency_Map::load_from_cache
-            ]
-        );
-        $this->dependency_map->registerDependencies(
-            'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory',
-            ['EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache]
-        );
-        $this->dependency_map->registerDependencies(
-            'EventEspresso\core\libraries\rest_api\controllers\model\Read',
-            ['EventEspresso\core\libraries\rest_api\CalculatedModelFields' => EE_Dependency_Map::load_from_cache]
-        );
-        $this->dependency_map->registerDependencies(
             'EventEspresso\core\libraries\rest_api\calculations\Datetime',
             [
                 'EEM_Datetime'     => EE_Dependency_Map::load_from_cache,


### PR DESCRIPTION
closes #3259 
closes #3260 
closes #3261 

this PR:

- relaxes some PHP type safety added to the EE_Addon class because the MailChimp add-on was unnecessarily overriding a method that it did not need to (plz see: https://github.com/eventespresso/eea-mailchimp/pull/19)
- moves some dependencies for the REST API into `EE_Dependency_Map` to give them global scope