### PR TITLE
Fix Exceptions on Post/Page Update

### DIFF
--- a/caffeinated/modules/recaptcha_invisible/InvisibleRecaptcha.php
+++ b/caffeinated/modules/recaptcha_invisible/InvisibleRecaptcha.php
@@ -53,7 +53,7 @@ class InvisibleRecaptcha
      * @param EE_Registration_Config $registration_config
      * @param EE_Session             $session
      */
-    public function __construct(EE_Registration_Config $registration_config, EE_Session $session)
+    public function __construct(EE_Registration_Config $registration_config, EE_Session $session = null)
     {
         $this->config = $registration_config;
         $this->session = $session;
@@ -65,7 +65,9 @@ class InvisibleRecaptcha
      */
     public function useInvisibleRecaptcha()
     {
-        return $this->config->use_captcha && $this->config->recaptcha_theme === 'invisible';
+        return $this->session instanceof EE_Session
+               && $this->config->use_captcha
+               && $this->config->recaptcha_theme === 'invisible';
     }
 
 
@@ -287,8 +289,8 @@ class InvisibleRecaptcha
      */
     public function setSessionData()
     {
-        $this->session->set_session_data(
-            array(InvisibleRecaptcha::SESSION_DATA_KEY_RECAPTCHA_PASSED => true)
-        );
+        if ($this->session instanceof EE_Session) {
+            $this->session->set_session_data([InvisibleRecaptcha::SESSION_DATA_KEY_RECAPTCHA_PASSED => true]);
+        }
     }
 }

--- a/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
+++ b/core/domain/entities/routing/handlers/admin/GutenbergEditor.php
@@ -32,7 +32,8 @@ class GutenbergEditor extends AdminRoute
                        $pagenow === 'post.php'
                        && $this->request->getRequestParam('action') === 'edit'
                    )
-               );
+               )
+               && apply_filters('FHEE__EE_System__canLoadBlocks', true);
     }
 
 


### PR DESCRIPTION
plz see: https://github.com/eventespresso/eventsmart.com-website/issues/799#issuecomment-762390494

- error described above was because the block loading was disabled on Event Smart here: https://github.com/eventespresso/eventsmart.com-website/issues/486

- and after fixing that issue another error appeared on the new Post page on the frontend because the session appeared to be missing, although I didn't go looking to see if that was intended or not.

This PR:

- checks the `FHEE__EE_System__canLoadBlocks` filter before loading the GutenbergEditor admin route handler

- sets the `EE_Session` dependency on `InvisibleRecaptcha` to be optional and verifies its existence prior to access