### PR TITLE
Fix REST API Loading

### DIFF
--- a/core/domain/entities/routing/handlers/shared/RestApiRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RestApiRequests.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
+use EED_Core_Rest_Api;
 use EventEspresso\core\services\routing\Route;
 
 /**
@@ -24,7 +25,7 @@ class RestApiRequests extends Route
      */
     public function matchesCurrentRequest(): bool
     {
-        return $this->request->isWordPressApi();
+        return $this->request->isApi() || $this->request->isWordPressApi();
     }
 
 
@@ -62,7 +63,7 @@ class RestApiRequests extends Route
      */
     protected function requestHandler(): bool
     {
-        // rest api handled by module for now
+        EED_Core_Rest_Api::set_hooks_both();
         return true;
     }
 }

--- a/core/libraries/rest_api/controllers/model/Meta.php
+++ b/core/libraries/rest_api/controllers/model/Meta.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\libraries\rest_api\controllers\model;
 
+use EE_Belongs_To_Relation;
 use Exception;
 use EE_Boolean_Field;
 use EE_Maintenance_Mode;
@@ -10,6 +11,8 @@ use EE_Serialized_Text_Field;
 use EED_Core_Rest_Api;
 use EEM_System_Status;
 use EventEspresso\core\libraries\rest_api\ModelDataTranslator;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Controller for handling requests regarding meta info about the models
@@ -24,11 +27,11 @@ class Meta extends Base
 
 
     /**
-     * @param \WP_REST_Request $request
+     * @param WP_REST_Request $request
      * @param string           $version
-     * @return array|\WP_REST_Response
+     * @return array|WP_REST_Response
      */
-    public static function handleRequestModelsMeta(\WP_REST_Request $request, $version)
+    public static function handleRequestModelsMeta(WP_REST_Request $request, $version)
     {
         $controller = new Meta();
         try {
@@ -96,7 +99,7 @@ class Meta extends Base
                 $relation_json = array(
                     'name'   => $relation_name,
                     'type'   => str_replace('EE_', '', get_class($relation_obj)),
-                    'single' => $relation_obj instanceof \EE_Belongs_To_Relation ? true : false,
+                    'single' => $relation_obj instanceof EE_Belongs_To_Relation,
                 );
                 $relations_json[ $relation_name ] = $relation_json;
             }
@@ -113,10 +116,10 @@ class Meta extends Base
     /**
      * Adds EE metadata to the index
      *
-     * @param \WP_REST_Response $rest_response_obj
-     * @return \WP_REST_Response
+     * @param WP_REST_Response $rest_response_obj
+     * @return WP_REST_Response
      */
-    public static function filterEeMetadataIntoIndex(\WP_REST_Response $rest_response_obj)
+    public static function filterEeMetadataIntoIndex(WP_REST_Response $rest_response_obj)
     {
         $response_data = $rest_response_obj->get_data();
         $addons = array();

--- a/modules/core_rest_api/EED_Core_Rest_Api.module.php
+++ b/modules/core_rest_api/EED_Core_Rest_Api.module.php
@@ -58,7 +58,6 @@ class EED_Core_Rest_Api extends EED_Module
      */
     public static function set_hooks()
     {
-        EED_Core_Rest_Api::set_hooks_both();
     }
 
 
@@ -70,24 +69,26 @@ class EED_Core_Rest_Api extends EED_Module
      */
     public static function set_hooks_admin()
     {
-        EED_Core_Rest_Api::set_hooks_both();
     }
 
 
     public static function set_hooks_both()
     {
-        /** @var EventEspresso\core\services\request\Request $request */
-        $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\Request');
-        if (! $request->isWordPressApi()) {
-            return;
-        }
-        add_action('rest_api_init', array('EED_Core_Rest_Api', 'set_hooks_rest_api'), 5);
-        add_action('rest_api_init', array('EED_Core_Rest_Api', 'register_routes'), 10);
-        add_filter('rest_route_data', array('EED_Core_Rest_Api', 'hide_old_endpoints'), 10, 2);
+        add_action('rest_api_init', ['EED_Core_Rest_Api', 'set_hooks_rest_api'], 5);
+        add_action('rest_api_init', ['EED_Core_Rest_Api', 'register_routes'], 10);
+        add_filter('rest_route_data', ['EED_Core_Rest_Api', 'hide_old_endpoints'], 10, 2);
         add_filter(
             'rest_index',
             ['EventEspresso\core\libraries\rest_api\controllers\model\Meta', 'filterEeMetadataIntoIndex']
         );
+    }
+
+
+    /**
+     * @since   $VID:$
+     */
+    public static function loadCalculatedModelFields()
+    {
         EED_Core_Rest_Api::$_field_calculator = LoaderFactory::getLoader()->load(
             'EventEspresso\core\libraries\rest_api\CalculatedModelFields'
         );
@@ -726,6 +727,7 @@ class EED_Core_Rest_Api extends EED_Module
      */
     protected function _get_response_selection_query_params(EEM_Base $model, $version, $single_only = false)
     {
+        EED_Core_Rest_Api::loadCalculatedModelFields();
         $query_params = [
             'include'   => [
                 'required' => false,
@@ -737,7 +739,7 @@ class EED_Core_Rest_Api extends EED_Module
                 'default'           => '',
                 'enum'              => EED_Core_Rest_Api::$_field_calculator->retrieveCalculatedFieldsForModel($model),
                 'type'              => 'string',
-                // because we accept a CSV'd list of the enumerated strings, WP core validation and sanitization
+                // because we accept a CSV list of the enumerated strings, WP core validation and sanitization
                 // freaks out. We'll just validate this argument while handling the request
                 'validate_callback' => null,
                 'sanitize_callback' => null,


### PR DESCRIPTION
closes #3276 

Fixes big oops I made with the setup for the `RestApiRequests` route handler class as well as a similar bit of code in the REST API itself.

Basically the EE request class has two functions for detecting whether the current request is for the REST API or not, `isApi()` and `isWordPressApi()`. The former detects requests that are specifically for the EE rest api and the other detects requests to the WP core api which i mistakenly thought would ALSO detect EE REST requests since we piggyback off of the core API, but I was wrong!

This PR: 

- adds the extra check for `isApi()` in `RestApiRequests::matchesCurrentRequest()`
- calls `EED_Core_Rest_Api::set_hooks_both()` from `RestApiRequests::requestHandler()` instead of doing so from the module since the route handler already has the `Request` class loaded
- does a little bit of formatting