### PR TITLE
Fix nav tabs

### DIFF
--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -74,7 +74,7 @@
 
 .poststuff .ee-nav-tabs-small .nav-tab,
 #poststuff .ee-nav-tabs-small .nav-tab {
-    box-sizing: content-box;
+	box-sizing: content-box;
 	height : 18px;
 }
 

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -74,6 +74,7 @@
 
 .poststuff .ee-nav-tabs-small .nav-tab,
 #poststuff .ee-nav-tabs-small .nav-tab {
+    box-sizing: content-box;
 	height : 18px;
 }
 


### PR DESCRIPTION
closes #3282 

this PR simply sets the "box-sizing" property for the nav tabs to "content-box"