### PR TITLE
Add filters to Tickets GQL query

### DIFF
--- a/core/domain/services/graphql/connection_resolvers/TicketConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/TicketConnectionResolver.php
@@ -148,6 +148,10 @@ class TicketConnectionResolver extends AbstractConnectionResolver
             'datetimeIn'   => 'Datetime.DTT_ID',
             'datetimeIdIn' => 'Datetime.DTT_ID',
             'datetimeId'   => 'Datetime.DTT_ID', // priority.
+            'isDefault'    => 'TKT_is_default',
+            'isRequired'   => 'TKT_required',
+            'isTaxable'    => 'TKT_taxable',
+            'isTrashed'    => 'TKT_deleted',
         ];
         return $this->sanitizeWhereArgsForInputFields(
             $where_args,

--- a/core/domain/services/graphql/connections/DatetimeTicketsConnection.php
+++ b/core/domain/services/graphql/connections/DatetimeTicketsConnection.php
@@ -99,6 +99,22 @@ class DatetimeTicketsConnection extends ConnectionBase
                 'type'        => 'String',
                 'description' => esc_html__('The search keywords', 'event_espresso'),
             ],
+            'isDefault' => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Filter the default tickets', 'event_espresso'),
+            ],
+            'isRequired'   => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Filter the required tickets', 'event_espresso'),
+            ],
+            'isTaxable'   => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Filter the taxable tickets', 'event_espresso'),
+            ],
+            'isTrashed'   => [
+                'type'        => 'Boolean',
+                'description' => esc_html__('Filter the trashed tickets', 'event_espresso'),
+            ],
         ];
 
         $newArgs = apply_filters(


### PR DESCRIPTION
This PR enhances GQL API for tickets query by adding filter options.

See [https://github.com/eventespresso/barista/issues/590](https://github.com/eventespresso/barista/issues/590)