### PR TITLE
Moar Betterer Default Price and Tax Cloning

### DIFF
--- a/core/domain/services/admin/entities/DefaultPrices.php
+++ b/core/domain/services/admin/entities/DefaultPrices.php
@@ -26,14 +26,24 @@ class DefaultPrices implements DefaultEntityGeneratorInterface
 {
 
     /**
-     * @var EEM_Price $price_model
+     * @var EEM_Price
      */
     protected $price_model;
 
     /**
-     * @var EEM_Price_Type $price_type_model
+     * @var EEM_Price_Type
      */
     protected $price_type_model;
+
+    /**
+     * @var EE_Price[]
+     */
+    protected $new_prices = [];
+
+    /**
+     * @var EE_Price[]
+     */
+    protected $taxes = [];
 
 
     /**
@@ -42,7 +52,7 @@ class DefaultPrices implements DefaultEntityGeneratorInterface
      */
     public function __construct(EEM_Price $price_model, EEM_Price_Type $price_type_model)
     {
-        $this->price_model = $price_model;
+        $this->price_model      = $price_model;
         $this->price_type_model = $price_type_model;
     }
 
@@ -55,66 +65,114 @@ class DefaultPrices implements DefaultEntityGeneratorInterface
      * @throws ReflectionException
      * @since $VID:$
      */
-    public function create(EE_Base_Class $entity)
+    public function create(EE_Base_Class $entity): array
     {
         if (! $entity instanceof EE_Ticket) {
             throw new InvalidEntityException($entity, 'EE_Ticket');
         }
-        $taxes = [];
-        $new_prices = [];
-        $is_free = true;
-        $has_base_price = false;
-        $default_prices = $this->price_model->get_all_default_prices(false, true);
-        if (is_array($default_prices)) {
-            foreach ($default_prices as $default_price) {
-                if (! $default_price instanceof EE_Price) {
-                    throw new InvalidEntityException($default_price, 'EE_Price');
-                }
-                // grab any taxes but don't do anything just yet
-                if ($default_price->is_tax()) {
-                    $taxes[] = $default_price;
-                    continue;
-                }
-                // duplicate the default price so that it does not get mutated
-                /** @var EE_Price $default_price_clone */
-                $default_price_clone = clone $default_price;
-                if ((
-                    // has non-zero base price
-                    $default_price_clone->is_base_price()
-                    && $default_price_clone->amount() > 0
-                ) ||(
-                    // or has fixed amount surcharge
-                    $default_price_clone->is_surcharge()
-                    && ! $default_price_clone->is_percent()
-                )) {
-                    $is_free = false;
-                }
-                $default_price_clone->set('PRC_ID', null);
-                $default_price_clone->set('PRC_is_default', false);
-                $default_price_clone->save();
-                $default_price_clone->_add_relation_to($entity, 'Ticket');
-                // verify that a base price has been set
-                $has_base_price = $default_price_clone->is_base_price() ? true : $has_base_price;
-                $new_prices[ $default_price_clone->ID() ] = $default_price_clone;
-            }
+        $is_free                   = true;
+        $has_base_price            = false;
+        $remove_existing_relations = true;
+        // first, let's get all of the default taxes for the site
+        $this->taxes = $this->price_model->getAllDefaultTaxes();
+        // then separate taxes from the other prices for the existing default ticket prices
+        $default_prices = $this->separateTaxesFromOtherPrices($entity->prices());
+        // but if that's empty, then let's get the default global prices
+        if (empty($default_prices)) {
+            $default_global_prices     = $this->price_model->get_all_default_prices();
+            $default_prices            = $this->separateTaxesFromOtherPrices($default_global_prices);
+            $remove_existing_relations = false;
         }
-        if (! $is_free && ! empty($taxes)) {
-            foreach ($taxes as $tax) {
-                // assign taxes but don't duplicate them because they operate globally
-                $entity->set_taxable(true);
-                $tax->_add_relation_to($entity, 'Ticket');
-            }
-        }
+        // then clone and apply all of the default prices
+        [$has_base_price, $is_free] = $this->cloneDefaultPrices(
+            $entity,
+            $default_prices,
+            $remove_existing_relations,
+            $has_base_price,
+            $is_free
+        );
         if (! $has_base_price) {
-            $new_base_price = $this->createNewBasePrice($entity);
-            $new_prices[ $new_base_price->ID() ] = $new_base_price;
+            $new_base_price                            = $this->createNewBasePrice($entity);
+            $this->new_prices[ $new_base_price->ID() ] = $new_base_price;
         }
+        $this->applyTaxes($entity, $is_free);
         $ticket_total = $entity->get_ticket_total_with_taxes(true);
         if ($ticket_total !== $entity->ticket_price()) {
             $entity->set_price($ticket_total);
             $entity->save();
         }
-        return $new_prices;
+        return $this->new_prices;
+    }
+
+
+    /**
+     * @param EE_Ticket $ticket
+     * @param bool      $is_free
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    private function applyTaxes(EE_Ticket $ticket, bool $is_free)
+    {
+        if (! $is_free && ! empty($this->taxes)) {
+            foreach ($this->taxes as $tax) {
+                // assign taxes but don't duplicate them because they operate globally
+                $ticket->set_taxable(true);
+                $tax->_add_relation_to($ticket, 'Ticket');
+            }
+        }
+    }
+
+
+    /**
+     * @param EE_Ticket  $ticket
+     * @param EE_Price[] $default_prices
+     * @param bool       $remove_existing_relations
+     * @param bool       $has_base_price
+     * @param bool       $is_free
+     * @return bool[]
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    private function cloneDefaultPrices(
+        EE_Ticket $ticket,
+        array $default_prices,
+        bool $remove_existing_relations,
+        bool $has_base_price,
+        bool $is_free
+    ): array {
+        foreach ($default_prices as $default_price) {
+            // duplicate the default price so that it does not get mutated
+            $default_price_clone = clone $default_price;
+            if ($remove_existing_relations) {
+                $ticket->_remove_relation_to($default_price, 'Price');
+            }
+            if ((
+                    // has non-zero base price
+                    $default_price_clone->is_base_price()
+                    && $default_price_clone->amount() > 0
+                )
+                || (
+                    // or has fixed amount surcharge
+                    $default_price_clone->is_surcharge()
+                    && ! $default_price_clone->is_percent()
+                )
+            ) {
+                $is_free = false;
+            }
+            $is_base_price = $default_price_clone->is_base_price();
+            // add this price to ticket if it is a regular price modifier, ie: NOT a base price,
+            // OR if it IS a base price but this ticket does NOT already have a base price
+            if (! $is_base_price || ! $has_base_price) {
+                $default_price_clone->set('PRC_ID', null);
+                $default_price_clone->set('PRC_is_default', false);
+                $default_price_clone->save();
+                $default_price_clone->_add_relation_to($ticket, 'Ticket');
+                $this->new_prices[ $default_price_clone->ID() ] = $default_price_clone;
+                // then recheck that a base price has been set so that we don't add another one
+                $has_base_price = $is_base_price ? true : $has_base_price;
+            }
+        }
+        return [$has_base_price, $is_free];
     }
 
 
@@ -123,16 +181,17 @@ class DefaultPrices implements DefaultEntityGeneratorInterface
      * @return EE_Price
      * @throws EE_Error
      * @throws ReflectionException
-     * @since $VID:$
      */
-    protected function createNewBasePrice(EE_Ticket $ticket)
+    private function createNewBasePrice(EE_Ticket $ticket): EE_Price
     {
-        $new_base_price = $this->price_model->get_new_price();
-        $base_price_type = $this->price_type_model->get_one([
+        $new_base_price  = $this->price_model->get_new_price();
+        $base_price_type = $this->price_type_model->get_one(
             [
-                'PBT_ID' => EEM_Price_Type::base_type_base_price
+                [
+                    'PBT_ID' => EEM_Price_Type::base_type_base_price,
+                ],
             ]
-        ]);
+        );
         if (! $base_price_type instanceof EE_Price_Type) {
             throw new RuntimeException(
                 esc_html__(
@@ -146,5 +205,31 @@ class DefaultPrices implements DefaultEntityGeneratorInterface
         $new_base_price->save();
         $new_base_price->_add_relation_to($ticket, 'Ticket');
         return $new_base_price;
+    }
+
+
+    /**
+     * @param array $prices
+     * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    private function separateTaxesFromOtherPrices(array $prices = []): array
+    {
+        $default_prices = [];
+        if (is_array($prices)) {
+            foreach ($prices as $key => $price) {
+                if (! $price instanceof EE_Price) {
+                    throw new InvalidEntityException($price, 'EE_Price');
+                }
+                // grab any taxes but don't do anything just yet
+                if ($price->is_tax()) {
+                    $this->taxes[ $price->ID() ] = $price;
+                    continue;
+                }
+                $default_prices[ $price->ID() ] = $price;
+            }
+        }
+        return $default_prices;
     }
 }

--- a/core/domain/services/admin/entities/DefaultTickets.php
+++ b/core/domain/services/admin/entities/DefaultTickets.php
@@ -5,6 +5,7 @@ namespace EventEspresso\core\domain\services\admin\entities;
 use EE_Base_Class;
 use EE_Datetime;
 use EE_Error;
+use EE_Price;
 use EE_Ticket;
 use EEM_Ticket;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -34,12 +35,12 @@ class DefaultTickets implements DefaultEntityGeneratorInterface
 
     /**
      * @param DefaultPrices $default_prices
-     * @param EEM_Ticket $ticket_model
+     * @param EEM_Ticket    $ticket_model
      */
     public function __construct(DefaultPrices $default_prices, EEM_Ticket $ticket_model)
     {
         $this->default_prices = $default_prices;
-        $this->ticket_model = $ticket_model;
+        $this->ticket_model   = $ticket_model;
     }
 
 
@@ -51,24 +52,32 @@ class DefaultTickets implements DefaultEntityGeneratorInterface
      * @throws ReflectionException
      * @since $VID:$
      */
-    public function create(EE_Base_Class $entity)
+    public function create(EE_Base_Class $entity): array
     {
         if (! $entity instanceof EE_Datetime) {
             throw new InvalidEntityException($entity, 'EE_Datetime');
         }
-        $new_tickets = [];
+        $new_tickets     = [];
         $default_tickets = $this->ticket_model->get_all_default_tickets();
         if (is_array($default_tickets)) {
             foreach ($default_tickets as $default_ticket) {
                 if (! $default_ticket instanceof EE_Ticket) {
                     throw new InvalidEntityException($default_ticket, 'EE_Ticket');
                 }
+                $existing_default_prices = $default_ticket->prices();
                 // clone ticket, strip out ID, then save to get a new ID
                 $default_ticket_clone = clone $default_ticket;
                 $default_ticket_clone->set('TKT_ID', null);
                 $default_ticket_clone->set('TKT_is_default', false);
                 $default_ticket_clone->save();
                 $default_ticket_clone->_add_relation_to($entity, 'Datetime');
+                // temporarily adding relations to existing prices, but these will be cloned and removed
+                // when passed to DefaultPrices::create() below so that they the clones can be freely mutated
+                foreach ($existing_default_prices as $existing_default_price) {
+                    if ($existing_default_price instanceof EE_Price) {
+                        $existing_default_price->_add_relation_to($default_ticket_clone, 'Ticket');
+                    }
+                }
                 $this->default_prices->create($default_ticket_clone);
                 $new_tickets[ $default_ticket_clone->ID() ] = $default_ticket_clone;
             }


### PR DESCRIPTION
plz see #3287

Previously the Default Prices DOM Data loader was only retrieving global default prices, which is the same behaviour as the existing legacy editor. The new Default Tickets UI however allows for much finer control over default tickets and pricing but the extra data needed to be added to the appropriate DOM data loaders.

This PR:

- temporarily adds relations between default ticket clones and their existing prices, which are later removed after the prices are cloned. This allows the newly created default tickets added to a new event to be freely mutated without affecting any existing entities

- improves the logic in `EventEspresso\core\domain\services\admin\entities\DefaultPrices` by:

    - cloning the default prices assigned to the ticket as mentioned above
    - assigning global default prices if the new ticket has no other prices
    - retrieves and assigns any global default taxes regardless of the above


- adds a new method to the Prices model for retrieving default taxes

- formats all touched files
