### PR TITLE
move root status color vars

### DIFF
--- a/core/admin/assets/admin-menu-styles.css
+++ b/core/admin/assets/admin-menu-styles.css
@@ -2,6 +2,25 @@
 * Event Espresso admin menu styles
 */
 
+:root {
+    --ee-status-color-red: #fc1922;
+    --ee-status-color-pink: #e65983;
+    --ee-status-color-orange: #ff582c;
+    --ee-status-color-gold: #fdad02;
+    --ee-status-color-yellow: #fad800;
+    --ee-status-color-green: #7ab540;
+    --ee-status-color-green-high-contrast: #699f34;
+    --ee-status-color-dark-green: #01873a;
+    --ee-status-color-dark-green-low-contrast: #02ac4a;
+    --ee-status-color-light-blue: #94d5ff;
+    --ee-status-color-blue: #008dcb;
+    --ee-status-color-purple: #795d9d;
+    --ee-status-color-light-grey: #d4d4d4;
+    --ee-status-color-grey: #9b9b9b;
+    --ee-status-color-dark-grey: #626262;
+    --ee-status-color-charcoal: #292929;
+}
+
 .ee_menu_group {
 	display: block;
 	background-color: var(--ee-status-color-light-grey);

--- a/core/templates/global_assets/css/espresso-admin-toolbar.css
+++ b/core/templates/global_assets/css/espresso-admin-toolbar.css
@@ -1,21 +1,3 @@
-:root {
-    --ee-status-color-red: #fc1922;
-    --ee-status-color-pink: #e65983;
-    --ee-status-color-orange: #ff582c;
-    --ee-status-color-gold: #fdad02;
-    --ee-status-color-yellow: #fad800;
-    --ee-status-color-green: #7ab540;
-    --ee-status-color-green-high-contrast: #699f34;
-    --ee-status-color-dark-green: #01873a;
-    --ee-status-color-dark-green-low-contrast: #02ac4a;
-    --ee-status-color-light-blue: #94d5ff;
-    --ee-status-color-blue: #008dcb;
-    --ee-status-color-purple: #795d9d;
-    --ee-status-color-light-grey: #d4d4d4;
-    --ee-status-color-grey: #9b9b9b;
-    --ee-status-color-dark-grey: #626262;
-    --ee-status-color-charcoal: #292929;
-}
 
 #wp-admin-bar-espresso-toolbar-events-add-edit .ab-empty-item,
 #wp-admin-bar-espresso-toolbar-registrations-today .ab-empty-item {

--- a/core/templates/global_assets/css/espresso_default.css
+++ b/core/templates/global_assets/css/espresso_default.css
@@ -8,6 +8,24 @@
 /****                                               ****/
 /*******************************************************/
 
+:root {
+    --ee-status-color-red: #fc1922;
+    --ee-status-color-pink: #e65983;
+    --ee-status-color-orange: #ff582c;
+    --ee-status-color-gold: #fdad02;
+    --ee-status-color-yellow: #fad800;
+    --ee-status-color-green: #7ab540;
+    --ee-status-color-green-high-contrast: #699f34;
+    --ee-status-color-dark-green: #01873a;
+    --ee-status-color-dark-green-low-contrast: #02ac4a;
+    --ee-status-color-light-blue: #94d5ff;
+    --ee-status-color-blue: #008dcb;
+    --ee-status-color-purple: #795d9d;
+    --ee-status-color-light-grey: #d4d4d4;
+    --ee-status-color-grey: #9b9b9b;
+    --ee-status-color-dark-grey: #626262;
+    --ee-status-color-charcoal: #292929;
+}
 
 /******************* DASHICONS ****************** */
 


### PR DESCRIPTION
Lorenzo discovered that some of the colors were missing on the Thank You page after registering:

![ScreenShot_20210202113221](https://user-images.githubusercontent.com/1751030/106653255-67998900-654b-11eb-93e7-24df90ad763d.png)

This was because some of the root color vars were not declared in any files loaded on the frontend

this PR simply copies those vars into locations where they will load for both the frontend AND the admin