### PR TITLE
Add WP Users to Incompatible Addons List

### DIFF
--- a/core/services/addon/api/IncompatibleAddonHandler.php
+++ b/core/services/addon/api/IncompatibleAddonHandler.php
@@ -25,6 +25,13 @@ class IncompatibleAddonHandler
             'load_espresso_automated_upcoming_event_notification',
             'EE_AUTOMATED_UPCOMING_EVENT_NOTIFICATION_PLUGIN_FILE'
         );
+        $this->deactivateIncompatibleAddon(
+            'WP Users Integration',
+            'EE_WPUSERS_VERSION',
+            '2.1.0.rc.003',
+            'load_ee_core_wpusers',
+            'EE_WPUSERS_PLUGIN_FILE'
+        );
     }
 
 


### PR DESCRIPTION
plz see https://github.com/eventespresso/event-espresso-core/issues/3308#issuecomment-772003886

This PR simply makes any version of the WP Users add-on less than `2.1.0.rc.003` incompatible with EE Core