### PR TITLE
Remove espresso-ui-theme as a script dependency and enqueue as a style.

### DIFF
--- a/admin_pages/payments/Payments_Admin_Page.core.php
+++ b/admin_pages/payments/Payments_Admin_Page.core.php
@@ -234,12 +234,15 @@ class Payments_Admin_Page extends EE_Admin_Page
 
     public function load_scripts_styles()
     {
+        // styles
+        wp_enqueue_style('espresso-ui-theme');
+        // scripts
         wp_enqueue_script('ee_admin_js');
         wp_enqueue_script('ee-text-links');
         wp_enqueue_script(
             'espresso_payments',
             EE_PAYMENTS_ASSETS_URL . 'espresso_payments_admin.js',
-            array('espresso-ui-theme', 'ee-datepicker'),
+            array('ee-datepicker'),
             EVENT_ESPRESSO_VERSION,
             true
         );

--- a/admin_pages/payments/assets/espresso_payments_admin.js
+++ b/admin_pages/payments/assets/espresso_payments_admin.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function($) {
-
 	$( '.datepicker' ).datepicker({
 		defaultDate: "-1m",
-		numberOfMonths: 2
-	});/**/
+		numberOfMonths: 2,
+		dateFormat: 'mm/dd/yy'
+	});
 });


### PR DESCRIPTION
To reproduce, install the Query Monitor: https://wordpress.org/plugins/query-monitor/

Go to Event Espresso -> Payment methods and check the notices shown in the admin bar by the above plugin.

It'll show a missing script dependency - espresso-ui-theme

Removed 'espresso-ui-theme' from the script dependencies and enqueued the style on it's own.

This is currently only used on the payment logs datepicker.

Go to the logs tab and click on the date filter, in master, you don't get a datepicker at all, now you will.

As it's only actually used on the payment_log view this could be pulled out into a 'load_scripts_styles_payment_log()' method if needed.

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
