### PR TITLE
Add userId to GQL for capability checks

### DIFF
--- a/core/domain/entities/admin/GraphQLData/Tickets.php
+++ b/core/domain/entities/admin/GraphQLData/Tickets.php
@@ -50,6 +50,7 @@ class Tickets extends GraphQLData
                     reverseCalculate
                     sold
                     startDate
+                    userId
                     uses
                     __typename
                 }

--- a/core/domain/services/graphql/types/Price.php
+++ b/core/domain/services/graphql/types/Price.php
@@ -161,6 +161,12 @@ class Price extends TypeBase
                 null,
                 esc_html__('Price Creator', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'userId',
+                'ID',
+                null,
+                esc_html__('Price Creator ID', 'event_espresso')
+            ),
             new GraphQLInputField(
                 'wpUser',
                 'Int',

--- a/core/domain/services/graphql/types/PriceType.php
+++ b/core/domain/services/graphql/types/PriceType.php
@@ -116,6 +116,12 @@ class PriceType extends TypeBase
                 null,
                 esc_html__('Price Type Creator', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'userId',
+                'ID',
+                null,
+                esc_html__('Price Type Creator ID', 'event_espresso')
+            ),
             new GraphQLInputField(
                 'wpUser',
                 'Int',

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -290,6 +290,12 @@ class Ticket extends TypeBase
                 null,
                 esc_html__('Ticket Creator', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'userId',
+                'ID',
+                null,
+                esc_html__('Ticket Creator ID', 'event_espresso')
+            ),
             new GraphQLInputField(
                 'wpUser',
                 'Int',


### PR DESCRIPTION
This PR adds `userId` field to `Ticket`, `Price` and `PriceType` objects to use in capability checks.

Please see https://github.com/eventespresso/barista/issues/707