### PR TITLE
Remove (and replace) the 'hidden' class from the ee modal then its shown/hidden

### DIFF
--- a/core/admin/assets/ee-dialog-helper.js
+++ b/core/admin/assets/ee-dialog-helper.js
@@ -33,6 +33,7 @@ jQuery(document).ready(function($) {
 		var dialogLeft =  ( (wndwWidth - ( wndwWidth/dialogWidthFraction ) ) /2 ) - parOff.left;
 		var dialogWidth = wndwWidth / dialogWidthFraction;
 		eedialog.css({ 'top' : dialogTop, 'left' : dialogLeft, 'width' : dialogWidth }).fadeIn('fast');
+		eedialog.removeClass('hidden');
 	};
 
 
@@ -79,9 +80,8 @@ jQuery(document).ready(function($) {
 
 			return this;
 		},
-
 		closeModal: function() {
-			eedialog.fadeOut( 'fast' );
+			eedialog.fadeOut( 'fast' ).addClass('hidden');
 			overlay.fadeOut( 'fast' );
 			overlay.removeClass('active');
 			$('.ee-admin-dialog-container-inner-content').html('');

--- a/core/admin/assets/ee-dialog-helper.js
+++ b/core/admin/assets/ee-dialog-helper.js
@@ -80,6 +80,7 @@ jQuery(document).ready(function($) {
 
 			return this;
 		},
+		
 		closeModal: function() {
 			eedialog.fadeOut( 'fast' ).addClass('hidden');
 			overlay.fadeOut( 'fast' );


### PR DESCRIPTION
Within the admin if someone is loading:

`.hidden {
    display: none!important;
}`

Then when this a modal is shown in the event editor, it remains hidden: https://monosnap.com/file/DanDLK2zefcfU7KEEqTrCoq3HeZRjY

This PR just removes that class when the model is shown and adds it when it's hidden again.

## Testing:
Install Add Admin CSS: https://en-gb.wordpress.org/plugins/add-admin-css/
(Just a quick and easy way to add styles in the admin)

Go to Appearance -> Admin CSS and add the above style there.

Create an event with 2 datetimes and 2 tickets. assigned each ticket to 1 datetime only.

Now click to delete a DateTime. You should see a modal like this:
https://monosnap.com/file/iGAZhe43Lclxkbz9rQi4fDf03irnnW

Close the modal and confirm it is hidden again.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
