### PR TITLE
Fix tax calculation with discounts

### DIFF
--- a/core/db_classes/EE_Line_Item.class.php
+++ b/core/db_classes/EE_Line_Item.class.php
@@ -1554,6 +1554,9 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
                     }
                 } elseif ($child_line_item->type() === EEM_Line_Item::type_sub_total) {
                     $total += $child_line_item->taxable_total();
+                } elseif ($child_line_item->is_percent()) {
+                    // Taxes should be charged on the discounted price.
+                    $total += $child_line_item->total();
                 }
             }
         }


### PR DESCRIPTION
## Problem this Pull Request solves
This fixes the tax calculation when discount's are used.

For more info see: https://github.com/eventespresso/eea-square-gateway/pull/3#issuecomment-789178680

## How has this been tested
Requires quires the Promotions add-on.
* [ ] Purchase one or a few tickets that have applicable taxes. Apply any discount. The tax amounts should be counted on the discounted item price.
* [ ] Try mixing up the ticket prices and taxable options on them.
* [ ] Add more than one tax item to the mix.
* [ ] Try applying more than one type of a discount.
* [ ] Finally purchase taxable tickets without applying discounts.
* [ ] Test different payment methods we have. QuickBooks and PP Express for example.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
