### PR TITLE
Use array_shift() to set the reg_obj to the first reg_obj in the array (the Primary Reg obj).

### DIFF
--- a/core/libraries/messages/data_class/EE_Messages_Preview_incoming_data.class.php
+++ b/core/libraries/messages/data_class/EE_Messages_Preview_incoming_data.class.php
@@ -592,8 +592,7 @@ class EE_Messages_Preview_incoming_data extends EE_Messages_incoming_data
         $this->reg_info = array();
         
         // let's set a reg_obj for messengers expecting one.
-        $this->reg_obj = array_pop($this->_attendees[999999991]['reg_objs']);
-        
+        $this->reg_obj = array_shift($this->_attendees[999999991]['reg_objs']);
         
         // the below are just dummy items.
         $this->user_id     = 1;


### PR DESCRIPTION
The message system uses 'real' data for some of the preview data, it grabs the first event created in EE and uses that for event-based data, then the related datetimes and tickets from that event for their related data an so on.

Problem was if your very first event had a DateTime with 2 or more ticket types assigned to it, when you used preview and had a shortcode that used the Primary Registrant from the current reg_obj, everything blew up

Fix was to switch from array_pop() to array_shift()  when setting the reg_obj in previews... (from an array of reg objects created from the tickets I mentioned above)

This is only used for message previews and becomes an issue when using primary registrant based shortcodes.

---

The easiest way to reproduce is using the Wait List add-on (however, note the issue isn't specific to that add-on)

**Using Master to confirm the issue**:

Edit the 'Registration Promoted From Wait List Notification' message template.

Click the preview button. 

If you get an error like:

`Fatal error: Call to a member function reg_url_link() on null
in \eea-wait-lists\domain\services\modules\EED_Wait_Lists.module.php on line 654`

Then your all set to check if this works.

If you do NOT get an error, the first event on your system isn't set up to reproduce, lets 'fix' that.

Edit the very first event created on your site, (Event Espresso -> Events -> {Click the ID column to sort by ID}

Edit that event and you'll likely have 1 DateTime and 1 Ticket.

Add another ticket to the first (and likely only) DateTime on that event. Just duplicate the current ticket and save if preferred.

Refresh the preview page above, error now? Great!

----

Switch to this branch and refresh the preview, check it now works.

The change here only affects the preview data so isn't a big deal but also confirm that something like Registration Approved shows the correct data you expect to see when previewing (for example it should NOT just loop over the same reg details).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
