### PR TITLE
Allow payment methods to pass arrays as values in redirect_args

### DIFF
--- a/core/db_classes/EE_Payment.class.php
+++ b/core/db_classes/EE_Payment.class.php
@@ -689,7 +689,7 @@ class EE_Payment extends EE_Base_Class implements EEI_Payment
 
 
     /**
-     * Converts a 1d array of key-value pairs into html hidden inputs
+     * Converts a 2d array of key-value pairs into html hidden inputs
      * and returns the string of html
      *
      * @param array $args key-value pairs
@@ -700,26 +700,33 @@ class EE_Payment extends EE_Base_Class implements EEI_Payment
         $html = '';
         if ($args !== null && is_array($args)) {
             foreach ($args as $name => $value) {
-                if (is_array($value)) {
-                    foreach ($value as $array_value) {
-                        $html .= EEH_HTML::nl(0)
-                             . '<input type="hidden" name="'
-                             . $name
-                             . '[]" value="'
-                             . esc_attr($array_value)
-                             . '"/>';
-                    }
-                } else {
-                    $html .= EEH_HTML::nl(0)
-                         . '<input type="hidden" name="'
-                         . $name
-                         . '" value="'
-                         . esc_attr($value)
-                         . '"/>';
-                }
+                $html .= $this->generateInput($name, $value);
             }
         }
         return $html;
+    }
+
+    /**
+     * Converts either a single name and value or array of values into html hidden inputs
+     * and returns the string of html
+     *
+     * @param string $name
+     * @param string|array $value
+     * @return string
+     */
+    private function generateInput($name, $value)
+    {
+        if (is_array($value)) {
+            $html = '';
+            $name = "{$name}[]";
+            foreach ($value as $array_value) {
+                $html .= $this->generateInput($name, $array_value);
+            }
+            return $html;
+        }
+        return EEH_HTML::nl()
+            . '<input type="hidden" name="' . $name . '"'
+            . ' value="' . esc_attr($value) . '"/>';
     }
 
 

--- a/core/db_classes/EE_Payment.class.php
+++ b/core/db_classes/EE_Payment.class.php
@@ -700,12 +700,23 @@ class EE_Payment extends EE_Base_Class implements EEI_Payment
         $html = '';
         if ($args !== null && is_array($args)) {
             foreach ($args as $name => $value) {
-                $html .= EEH_HTML::nl(0)
+                if (is_array($value)) {
+                    foreach ($value as $array_value) {
+                        $html .= EEH_HTML::nl(0)
+                             . '<input type="hidden" name="'
+                             . $name
+                             . '[]" value="'
+                             . esc_attr($array_value)
+                             . '"/>';
+                    }
+                } else {
+                    $html .= EEH_HTML::nl(0)
                          . '<input type="hidden" name="'
                          . $name
                          . '" value="'
                          . esc_attr($value)
                          . '"/>';
+                }
             }
         }
         return $html;


### PR DESCRIPTION
Requested here: https://eventespresso.com/topic/generate-a-registration-form-from-2d-array/

Allows you to pass an array of values in redirect_args to be passed to the merchant.

Quick examples:

`$redirect_args['Products'] = array('Product1', 'Product2');`

Currently outputs:

`<input type="hidden" name="Products" value="array">`

With this change, outputs:

`<input type="hidden" name="Products[]" value="Product1">
<input type="hidden" name="Products[]" value="Product2">`

## How has this been tested
I used PayPal standard to test this.

In `\event-espresso-core-reg\payment_methods\Paypal_Standard\EEG_Paypal_Standard.gateway.php`

Add this:

`$redirect_args['Products'] = array('Product1', 'Product2');`

It can be anywhere before `$payment->set_redirect_args($redirect_args);`

Now select PayPal standard as a payment method.

When you click to proceed through to PayPal the page will show 'Forwarding to secure payment provider', at that point, hit the stop button on your browser.

Inspect the 'Click Here' button with dev tools and you'll now see the form data.

This is how it should show:

https://monosnap.com/file/tKxUM6pXdgAHHBf2SVhP7olcmpI7D0

----

This change leaves all other values working as they currently would, unless its an array (which wouldn't be working anyway).

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
