### PR TITLE
EEM_Base Code CLeanup

### DIFF
--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -570,7 +570,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! did_action('AHEE__EE_System__load_espresso_addons')) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'The %1$s model can not be loaded before the "AHEE__EE_System__load_espresso_addons" hook has been called. This gives other addons a chance to extend this model.',
                         'event_espresso'
                     ),
@@ -611,7 +611,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! array_key_exists($table_alias, $this->_tables)) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "Table alias %s does not exist in EEM_Base child's _tables array. Only tables defined are %s",
                             'event_espresso'
                         ),
@@ -694,7 +694,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 if (! $generator_object instanceof EE_Restriction_Generator_Base) {
                     throw new EE_Error(
                         sprintf(
-                            __(
+                            esc_html__(
                                 'Index "%1$s" in the model %2$s\'s _cap_restriction_generators is not a child of EE_Restriction_Generator_Base. It should be that or NULL.',
                                 'event_espresso'
                             ),
@@ -1082,7 +1082,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 if (! is_array($selection_and_datatype) || ! isset($selection_and_datatype[1])) {
                     throw new EE_Error(
                         sprintf(
-                            __(
+                            esc_html__(
                                 "Custom selection %s (alias %s) needs to be an array like array('COUNT(REG_ID)','%%d')",
                                 'event_espresso'
                             ),
@@ -1192,7 +1192,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::get_one',
                 sprintf(
-                    __('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
+                    esc_html__('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
                     gettype($query_params)
                 ),
                 '4.6.0'
@@ -1378,7 +1378,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             } else {
                 if (WP_DEBUG) {
                     throw new EE_Error(
-                        __(
+                        esc_html__(
                             'EEM_Base::_get_consecutive() has been called with no $field_to_order_by argument and there is no primary key on the field.  Please provide the field you would like to use as the base for retrieving the next item(s).',
                             'event_espresso'
                         )
@@ -1392,7 +1392,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::_get_consecutive',
                 sprintf(
-                    __('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
+                    esc_html__('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
                     gettype($query_params)
                 ),
                 '4.6.0'
@@ -1481,7 +1481,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! $field_settings instanceof EE_Datetime_Field) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'The field sent into EEM_Base::get_formats_for (%s) is not registered as a EE_Datetime_Field. Please check the spelling and make sure you are submitting the right field name to retrieve date_formats for.',
                         'event_espresso'
                     ),
@@ -1633,7 +1633,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::update',
                 sprintf(
-                    __('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
+                    esc_html__('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
                     gettype($query_params)
                 ),
                 '4.6.0'
@@ -2169,7 +2169,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // sorry, can't help you
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "Cannot delete objects of type %s because there is no primary key NOR combined key",
                         "event_espresso"
                     ),
@@ -2337,7 +2337,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! EE_Maintenance_Mode::instance()->models_can_query()) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.",
                         "event_espresso"
                     )
@@ -2348,7 +2348,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! method_exists($wpdb, $wpdb_method)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'There is no method named "%s" on Wordpress\' $wpdb object',
                         'event_espresso'
                     ),
@@ -2370,7 +2370,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if ($result === false) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             'WPDB Error occurred, but no error message was logged by wpdb! The wpdb method called was "%1$s" and the arguments were "%2$s"',
                             'event_espresso'
                         ),
@@ -2382,7 +2382,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } elseif ($result === false) {
             EE_Error::add_error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'A database error has occurred. Turn on WP_DEBUG for more information.||A database error occurred doing wpdb method "%1$s", with arguments "%2$s". The error was "%3$s"',
                         'event_espresso'
                     ),
@@ -2459,7 +2459,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // ok remember that we've already attempted fixing the core db, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_core;
         $error_message                    = sprintf(
-            __(
+            esc_html__(
                 'WPDB Error "%1$s" while running wpdb method "%2$s" with arguments %3$s. Automatically attempting to fix EE Core DB',
                 'event_espresso'
             ),
@@ -2487,7 +2487,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // ok remember that we've already attempted fixing the addons dbs, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_addons;
         $error_message                    = sprintf(
-            __(
+            esc_html__(
                 'WPDB AGAIN: Error "%1$s" while running the same method and arguments as before. Automatically attempting to fix EE Addons DB',
                 'event_espresso'
             ),
@@ -2738,7 +2738,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::sum_related',
                 sprintf(
-                    __('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
+                    esc_html__('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
                     gettype($query_params)
                 ),
                 '4.6.0'
@@ -2807,7 +2807,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! isset($field_with_model_name) || ! $field_with_model_name) {
             throw new EE_Error(
                 sprintf(
-                    __("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
+                    esc_html__("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
                     $this->get_this_model_name()
                 )
             );
@@ -2880,7 +2880,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if ($this->exists([$uniqueness_where_params])) {
                 EE_Error::add_error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "Could not %s %s. %s uniqueness index failed. Fields %s must form a unique set, but an entry already exists with values %s.",
                             "event_espresso"
                         ),
@@ -2927,7 +2927,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } else {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "%s get_all_conflicting should be called with a model object or an array of field names and values, you provided %d",
                         "event_espresso"
                     ),
@@ -3139,7 +3139,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     'There are no main tables on %s. They should be added to _tables array in the constructor',
                     'event_espresso'
                 ),
@@ -3319,7 +3319,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     if (! is_array($possibly_array_of_params)) {
                         throw new EE_Error(
                             sprintf(
-                                __(
+                                esc_html__(
                                     "You used a special where query param %s, but the value isn't an array of where query params, it's just %s'. It should be an array, eg array('EVT_ID'=>23,'OR'=>array('Venue.VNU_ID'=>32,'Venue.VNU_name'=>'monkey_land'))",
                                     "event_espresso"
                                 ),
@@ -3345,7 +3345,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     if (! isset($possibly_array_of_params[0], $possibly_array_of_params[1])) {
                         throw new EE_Error(
                             sprintf(
-                                __(
+                                esc_html__(
                                     "Improperly formed query parameter %s. It should be numerically indexed like array('<','DTT_sold',true); but you provided %s",
                                     "event_espresso"
                                 ),
@@ -3386,7 +3386,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! is_array($sub_query_params)) {
                 throw new EE_Error(
                     sprintf(
-                        __("Query parameter %s should be an array, but it isn't.", "event_espresso"),
+                        esc_html__("Query parameter %s should be an array, but it isn't.", "event_espresso"),
                         $sub_query_params
                     )
                 );
@@ -3425,7 +3425,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::_create_model_query_info_carrier',
                 sprintf(
-                    __(
+                    esc_html__(
                         '$query_params should be an array, you passed a variable of type %s',
                         'event_espresso'
                     ),
@@ -3463,7 +3463,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (is_int($key)) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "WHERE query params must NOT be numerically-indexed. You provided the array key '%s' for value '%s' while querying model %s. All the query params provided were '%s' Please read documentation on EEM_Base::get_all.",
                             "event_espresso"
                         ),
@@ -3510,7 +3510,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (is_array($query_params['limit'])) {
                 if (! isset($query_params['limit'][0], $query_params['limit'][1])) {
                     $e = sprintf(
-                        __(
+                        esc_html__(
                             "Invalid DB query. You passed '%s' for the LIMIT, but only the following are valid: an integer, string representing an integer, a string like 'int,int', or an array like array(int,int)",
                             "event_espresso"
                         ),
@@ -3533,7 +3533,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 if (array_key_exists('order', $query_params)) {
                     throw new EE_Error(
                         sprintf(
-                            __(
+                            esc_html__(
                                 "In querying %s, we are using query parameter 'order_by' as an array (keys:%s,values:%s), and so we can't use query parameter 'order' (value %s). You should just use the 'order_by' parameter ",
                                 "event_espresso"
                             ),
@@ -3605,7 +3605,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! in_array($query_key, $this->_allowed_query_params, true)) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "You passed %s as a query parameter to %s, which is illegal! The allowed query parameters are %s",
                             'event_espresso'
                         ),
@@ -3670,7 +3670,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     "While performing a query on '%s', tried to use '%s' as an order parameter. ",
                     "event_espresso"
                 ),
@@ -3709,7 +3709,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! in_array($use_default_where_conditions, $allowed_used_default_where_conditions_values)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "You passed an invalid value to the query parameter 'default_where_conditions' of '%s'. Allowed values are %s",
                         "event_espresso"
                     ),
@@ -4018,7 +4018,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "Using a field name (%s) on model %s is not allowed on this query param type '%s'. Original query param was %s",
                         "event_espresso"
                     ),
@@ -4333,7 +4333,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     } else {
                         throw new EE_Error(
                             sprintf(
-                                __(
+                                esc_html__(
                                     "%s is neither a valid model field name, nor a custom selection",
                                     "event_espresso"
                                 ),
@@ -4380,7 +4380,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             : '';
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     "%s is not a valid field on this model, nor a custom selection (%s)",
                     "event_espresso"
                 ),
@@ -4429,7 +4429,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "You setup a query parameter like you were going to specify an operator, but didn't. You provided '(%s)', but the operator should be at array key index 0 (eg array('>',32))",
                             "event_espresso"
                         ),
@@ -4458,7 +4458,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (count($value) !== 2) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "The '%s' operator must be used with an array of values and there must be exactly TWO values in that array.",
                             'event_espresso'
                         ),
@@ -4473,7 +4473,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if ($value !== null) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "You attempted to give a value  (%s) while using a NULL-style operator (%s). That isn't valid",
                             "event_espresso"
                         ),
@@ -4495,7 +4495,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (in_array($operator, $this->valid_in_style_operators()) && ! is_array($value)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "Operator '%s' must be used with an array of values, eg 'Registration.REG_ID' => array('%s',array(1,2,3))",
                         'event_espresso'
                     ),
@@ -4507,7 +4507,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! in_array($operator, $this->valid_in_style_operators()) && is_array($value)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "Operator '%s' must be used with a single value, not an array. Eg 'Registration.REG_ID => array('%s',23))",
                         'event_espresso'
                     ),
@@ -4518,7 +4518,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     "It appears you've provided some totally invalid query parameters. Operator and value were:'%s', which isn't right at all",
                     "event_espresso"
                 ),
@@ -4605,7 +4605,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! in_array($field_obj, $this->_valid_wpdb_data_types)) {
             throw new EE_Error(
                 sprintf(
-                    __("%s is not a valid wpdb datatype. Valid ones are %s", "event_espresso"),
+                    esc_html__("%s is not a valid wpdb datatype. Valid ones are %s", "event_espresso"),
                     $field_obj,
                     implode(",", $this->_valid_wpdb_data_types)
                 )
@@ -4630,7 +4630,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (empty($query_param_parts)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "_extract_column_name is empty when trying to extract column and table name from %s",
                         'event_espresso'
                     ),
@@ -4673,7 +4673,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     "There is no field titled %s on model %s. Either the query trying to use it is bad, or you need to add it to the list of fields on the model.",
                     'event_espresso'
                 ),
@@ -4857,7 +4857,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! class_exists($model_classname)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "You specified a related model named %s in your query. No such model exists, if it did, it would have the classname %s",
                         'event_espresso'
                     ),
@@ -4913,7 +4913,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! array_key_exists($relation_name, $relatedModels)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'Cannot get %s related to %s. There is no model relation of that type. There is, however, %s...',
                         'event_espresso'
                     ),
@@ -4942,7 +4942,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! array_key_exists($fieldName, $fieldSettings)) {
             throw new EE_Error(
                 sprintf(
-                    __("There is no field/column '%s' on '%s'", 'event_espresso'),
+                    esc_html__("There is no field/column '%s' on '%s'", 'event_espresso'),
                     $fieldName,
                     get_class($this)
                 )
@@ -5016,7 +5016,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! $this->_primary_key_field instanceof EE_Primary_Key_Field_Base) {
                 throw new EE_Error(
                     sprintf(
-                        __("There is no Primary Key defined on model %s", 'event_espresso'),
+                        esc_html__("There is no Primary Key defined on model %s", 'event_espresso'),
                         get_class($this)
                     )
                 );
@@ -5086,7 +5086,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! isset($this->_cache_foreign_key_to_fields[ $model_name ])) {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "There is no foreign key field pointing to model %s on model %s",
                             'event_espresso'
                         ),
@@ -5191,7 +5191,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! $classInstance) {
                 throw new EE_Error(
                     sprintf(
-                        __('Could not create instance of class %s from row %s', 'event_espresso'),
+                        esc_html__('Could not create instance of class %s from row %s', 'event_espresso'),
                         $this->get_this_model_name(),
                         http_build_query($row)
                     )
@@ -5395,7 +5395,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! $object instanceof $className) {
             throw new EE_Error(
                 sprintf(
-                    __("You tried adding a %s to a mapping of %ss", "event_espresso"),
+                    esc_html__("You tried adding a %s to a mapping of %ss", "event_espresso"),
                     is_object($object) ? get_class($object) : $object,
                     $className
                 )
@@ -5404,7 +5404,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! $object->ID()) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "You tried storing a model object with NO ID in the %s entity mapper.",
                         "event_espresso"
                     ),
@@ -5715,7 +5715,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             } else {
                 throw new EE_Error(
                     sprintf(
-                        __(
+                        esc_html__(
                             "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
                             'event_espresso'
                         ),
@@ -5757,7 +5757,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } else {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
                         'event_espresso'
                     ),
@@ -5940,7 +5940,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } else {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "get_all_copies should be provided with either a model object or an array of field-value-pairs, but was given %s",
                         "event_espresso"
                     ),
@@ -5977,7 +5977,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             EE_Error::doing_it_wrong(
                 'EEM_Base::get_one_copy',
                 sprintf(
-                    __('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
+                    esc_html__('$query_params should be an array, you passed a variable of type %s', 'event_espresso'),
                     gettype($query_params)
                 ),
                 '4.6.0'
@@ -6030,7 +6030,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     "The operator '%s' is not in the list of valid operators: %s",
                     "event_espresso"
                 ),
@@ -6146,7 +6146,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! $this->has_primary_key_field()) {
             if (WP_DEBUG) {
                 EE_Error::add_error(
-                    __('Trying to get IDs from a model than has no primary key', 'event_espresso'),
+                    esc_html__('Trying to get IDs from a model than has no primary key', 'event_espresso'),
                     __FILE__,
                     __FUNCTION__,
                     __LINE__
@@ -6162,7 +6162,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
                 if (WP_DEBUG) {
                     EE_Error::add_error(
-                        __(
+                        esc_html__(
                             'Called %1$s on a model object that has no ID and so probably hasn\'t been saved to the database',
                             'event_espresso'
                         ),
@@ -6294,7 +6294,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __('Cannot find capability restrictions for context "%1$s", allowed values are:%2$s', 'event_espresso'),
+                esc_html__('Cannot find capability restrictions for context "%1$s", allowed values are:%2$s', 'event_espresso'),
                 $context,
                 implode(',', array_keys($this->cap_contexts_to_cap_action_map()))
             )
@@ -6356,7 +6356,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                __(
+                esc_html__(
                     'Context "%1$s" passed into model "%2$s" is not a valid context. They are: %3$s',
                     'event_espresso'
                 ),

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -845,10 +845,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * Gets all the EE_Base_Class objects which match the $query_params, by querying the DB.
      *
-     * @param array $query_params             @see
-     *                                        https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     *                                        or if you have the development copy of EE you can view this at the path:
-     *                                        /docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
      * @return EE_Base_Class[]  *note that there is NO option to pass the output type. If you want results different
      *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object
      *                                        IDs (if there is a primary key on the model. if not, numerically indexed)
@@ -871,6 +868,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                        ));
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     *                                        or if you have the development copy of EE you can view this at the path:
+     *                                        /docs/G--Model-System/model-query-params.md
      */
     public function get_all($query_params = [])
     {
@@ -888,11 +888,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Modifies the query parameters so we only get back model objects
      * that "belong" to the current user
      *
-     * @param array $query_params @see
-     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see
-     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
+     * @return array
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function alter_query_params_to_only_include_mine($query_params = [])
     {
@@ -976,8 +975,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * may want to preserve the WPDB results (eg, update, which first queries to make sure we have all the tables on
      * the model)
      *
-     * @param array  $query_params      @see
-     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -991,6 +989,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     protected function _get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
@@ -1037,8 +1036,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * but you can use the model query params to more easily
      * take care of joins, field preparation etc.
      *
-     * @param array  $query_params      @see
-     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -1051,6 +1049,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return array|stdClass[] like results of $wpdb->get_results($sql,OBJECT), (ie, output type is OBJECT)
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
@@ -1061,9 +1060,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * For creating a custom select statement
      *
-     * @param mixed $columns_to_select either a string to be inserted directly as the select statement,
-     *                                 or an array where keys are aliases, and values are arrays where 0=>the selection
-     *                                 SQL, and 1=>is the datatype
+     * @param array|string $columns_to_select either a string to be inserted directly as the select statement,
+     *                                        or an array where keys are aliases, and values are arrays where 0=>the
+     *                                        selection SQL, and 1=>is the datatype
      * @return string
      * @throws EE_Error
      */
@@ -1149,10 +1148,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * or could just be a simple primary key ID
      *
      * @param int   $id
-     * @param array $query_params
-     * @return array of normal query params, @see
-     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
+     * @return array of normal query params,
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function alter_query_params_to_restrict_by_ID($id, $query_params = [])
     {
@@ -1593,9 +1592,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                         EEM_Transaction::instance()->update(
      *                                         array('TXN_details'=>array('detail1'=>'monkey','detail2'=>'banana'),
      *                                         array(array('TXN_ID'=>34)));
-     * @param array   $query_params            @see
-     *                                         https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     *                                         Eg, consider updating Question's QST_admin_label field is of type
+     * @param array   $query_params            Eg, consider updating Question's QST_admin_label field is of type
      *                                         Simple_HTML. If you use this function to update that field to $new_value
      *                                         = (note replace 8's with appropriate opening and closing tags in the
      *                                         following example)"8script8alert('I hack all');8/script88b8boom
@@ -1620,6 +1617,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                         bad)
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function update($fields_n_values, $query_params, $keep_model_objs_in_sync = true)
     {
@@ -1778,12 +1776,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * that matched the query params. Note that you should pass the name of the
      * model FIELD, not the database table's column name.
      *
-     * @param array  $query_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $field_to_select
      * @return array just like $wpdb->get_col()
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function get_col($query_params = [], $field_to_select = null)
     {
@@ -1923,8 +1921,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * in EEM_Soft_Delete_Base so that soft-deleted model objects are instead only flagged
      * as archived, not actually deleted
      *
-     * @param array   $query_params   @see
-     *                                https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array   $query_params
      * @param boolean $allow_blocking if TRUE, matched objects will only be deleted if there is no related model info
      *                                that blocks it (ie, there' sno other data that depends on this data); if false,
      *                                deletes regardless of other objects which may depend on it. Its generally
@@ -1933,6 +1930,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return int how many rows got deleted
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function delete_permanently($query_params, $allow_blocking = true)
     {
@@ -1942,8 +1940,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          *
          * @param EEM_Base $model
          * @param array    $query_params
-         * @param boolean  $allow_blocking whether or not to allow related model objects
-         *                                 to block (prevent) this deletion
+         * @param boolean $allow_blocking whether or not to allow related model objects
+         *                                to block (prevent) this deletion
          * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
          */
         do_action('AHEE__EEM_Base__delete__begin', $this, $query_params, $allow_blocking);
@@ -2242,14 +2240,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * If $field_to_count isn't provided, the model's primary key is used. Otherwise, we count by field_to_count's
      * column
      *
-     * @param array  $query_params   @see
-     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $field_to_count field on model to count by (not column name)
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
      * @return int
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function count($query_params = [], $field_to_count = null, $distinct = false)
     {
@@ -2285,12 +2283,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * Sums up the value of the $field_to_sum (defaults to the primary key, which isn't terribly useful)
      *
-     * @param array  $query_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $field_to_sum name of field (array key in $_fields array)
      * @return float
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function sum($query_params, $field_to_sum = null)
     {
@@ -2621,11 +2619,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param mixed  $id_or_obj    EE_Base_Class child or its ID
      * @param string $model_name   like 'Event', 'Registration', etc. always singular
-     * @param array  $query_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
      * @return EE_Base_Class[]
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function get_all_related($id_or_obj, $model_name, $query_params = null)
     {
@@ -2683,14 +2681,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int             /EE_Base_Class $id_or_obj
      * @param string $model_name     like 'Event', or 'Registration'
-     * @param array  $query_params   @see
-     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $field_to_count name of field to count by. By default, uses primary key
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
      * @return int
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function count_related(
         $id_or_obj,
@@ -2718,12 +2716,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int           /EE_Base_Class $id_or_obj
      * @param string $model_name   like 'Event', or 'Registration'
-     * @param array  $query_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params
      * @param string $field_to_sum name of field to count by. By default, uses primary key
      * @return float
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function sum_related($id_or_obj, $model_name, $query_params, $field_to_sum = null)
     {
@@ -2757,11 +2755,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int | EE_Base_Class $id_or_obj        EE_Base_Class child or its ID
      * @param string              $other_model_name , key in $this->_relatedModels, eg 'Registration', or 'Events'
-     * @param array               $query_params     @see
-     *                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
      * @return EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function get_first_related(EE_Base_Class $id_or_obj, $other_model_name, $query_params)
     {
@@ -3219,10 +3217,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Registration model. If it were array('Registrations.Transactions.Payments.PAY_ID'=>3), then we'd need the
      * related Registration, Transaction, and Payment models.
      *
-     * @param array $query_params @see
-     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function _extract_related_models_from_query($query_params)
     {
@@ -3282,12 +3280,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * For extracting related models from WHERE (0), HAVING (having), ORDER BY (order_by) or forced joins (force_join)
      *
-     * @param array                       $sub_query_params @see
-     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
+     * @param array                       $sub_query_params
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
      */
     private function _extract_related_models_from_sub_params_array_keys(
         $sub_query_params,
@@ -3364,12 +3362,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * For extracting related models from forced_joins, where the array values contain the info about what
      * models to join with. Eg an array like array('Attendee','Price.Price_Type');
      *
-     * @param array                       $sub_query_params @see
-     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array                       $sub_query_params
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _extract_related_models_from_sub_params_array_values(
         $sub_query_params,
@@ -3406,12 +3404,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * before we know what joins to perform. However, we need to know what data types correspond to which fields on
      * other models before we can finalize the where clause SQL.
      *
-     * @param array $query_params @see
-     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
      * @throws ModelConfigurationException
      * @throws ReflectionException
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
     public function _create_model_query_info_carrier($query_params)
     {
@@ -3624,9 +3622,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * context (eg reading frontend, backend, edit or delete).
      *
      * @param string $context one of EEM_Base::valid_cap_contexts()
-     * @return array @see
-     *                        https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     public function caps_where_conditions($context = self::caps_read)
     {
@@ -3689,11 +3687,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                                  not for this primary model. 'all', the default,
      *                                                                  means default where conditions will apply as
      *                                                                  normal
-     * @param array                       $where_query_params           @see
-     *                                                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
-     * @return array @see
-     *                                                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array $where_query_params
+     * @return array
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _get_default_where_conditions_for_models_in_query(
         EE_Model_Query_Info_Carrier $query_info_carrier,
@@ -3828,9 +3825,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array    $provided_where_conditions
      * @param EEM_Base $model
      * @param string   $model_relation_path like 'Transaction.Payment.'
-     * @return array @see
-     *                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _override_defaults_or_make_null_friendly(
         $default_where_conditions,
@@ -4238,10 +4235,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * Constructs SQL for where clause, like "WHERE Event.ID = 23 AND Transaction.amount > 100" etc.
      *
-     * @param array $where_params @see
-     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array $where_params
      * @return string of SQL
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _construct_where_clause($where_params)
     {
@@ -4275,11 +4272,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Used for creating nested WHERE conditions. Eg "WHERE ! (Event.ID = 3 OR ( Event_Meta.meta_key = 'bob' AND
      * Event_Meta.meta_value = 'foo'))"
      *
-     * @param array  $where_params @see
-     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array  $where_params
      * @param string $glue         joins each sub-clause together. Should really only be " AND " or " OR "...
      * @return string of SQL
      * @throws EE_Error
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _construct_condition_clause_recursive($where_params, $glue = ' AND')
     {
@@ -5457,7 +5454,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Given an array where keys are column (or column alias) names and values,
      * returns an array of their corresponding field names and database values
      *
-     * @param string $cols_n_values
+     * @param array $cols_n_values
      * @return array
      */
     protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values)
@@ -5497,9 +5494,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
 
     /**
-     * @param $cols_n_values
-     * @param $qualified_column
-     * @param $regular_column
+     * @param array $cols_n_values
+     * @param string $qualified_column
+     * @param string $regular_column
      * @return null
      */
     protected function _get_column_value_with_table_alias_or_not($cols_n_values, $qualified_column, $regular_column)
@@ -5883,14 +5880,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         $key_fields = $this->get_combined_primary_key_fields();
         // check all of them are in the $id
-        $key_vals_in_combined_pk = [];
-        parse_str($index_primary_key_string, $key_vals_in_combined_pk);
+        $key_values_in_combined_pk = [];
+        parse_str($index_primary_key_string, $key_values_in_combined_pk);
         foreach ($key_fields as $key_field_name => $field_obj) {
-            if (! isset($key_vals_in_combined_pk[ $key_field_name ])) {
+            if (! isset($key_values_in_combined_pk[ $key_field_name ])) {
                 return null;
             }
         }
-        return $key_vals_in_combined_pk;
+        return $key_values_in_combined_pk;
     }
 
 
@@ -5898,15 +5895,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * verifies that an array of key-value pairs for model fields has a key
      * for each field comprising the primary key index
      *
-     * @param array $key_vals
+     * @param array $key_values
      * @return boolean
      * @throws EE_Error
      */
-    public function has_all_combined_primary_key_fields($key_vals)
+    public function has_all_combined_primary_key_fields($key_values)
     {
         $keys_it_should_have = array_keys($this->get_combined_primary_key_fields());
         foreach ($keys_it_should_have as $key) {
-            if (! isset($key_vals[ $key ])) {
+            if (! isset($key_values[ $key ])) {
                 return false;
             }
         }
@@ -5919,8 +5916,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * We consider something to be a copy if all the attributes match (except the ID, of course).
      *
      * @param array|EE_Base_Class $model_object_or_attributes_array If its an array, it's field-value pairs
-     * @param array               $query_params                     @see
-     *                                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params see github link below for more info
+     * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @throws ReflectionException
      * @return EE_Base_Class[] Array keys are object IDs (if there is a primary key on the model. if not, numerically

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -845,7 +845,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * Gets all the EE_Base_Class objects which match the $query_params, by querying the DB.
      *
-     * @param array $query_params see github link below for more info
+     * @param array $query_params             see github link below for more info
      * @return EE_Base_Class[]  *note that there is NO option to pass the output type. If you want results different
      *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object
      *                                        IDs (if there is a primary key on the model. if not, numerically indexed)
@@ -1940,8 +1940,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          *
          * @param EEM_Base $model
          * @param array    $query_params
-         * @param boolean $allow_blocking whether or not to allow related model objects
-         *                                to block (prevent) this deletion
+         * @param boolean  $allow_blocking whether or not to allow related model objects
+         *                                 to block (prevent) this deletion
          * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
          */
         do_action('AHEE__EEM_Base__delete__begin', $this, $query_params, $allow_blocking);
@@ -2619,7 +2619,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param mixed  $id_or_obj    EE_Base_Class child or its ID
      * @param string $model_name   like 'Event', 'Registration', etc. always singular
-     * @param array $query_params see github link below for more info
+     * @param array  $query_params see github link below for more info
      * @return EE_Base_Class[]
      * @throws EE_Error
      * @throws ReflectionException
@@ -2755,7 +2755,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int | EE_Base_Class $id_or_obj        EE_Base_Class child or its ID
      * @param string              $other_model_name , key in $this->_relatedModels, eg 'Registration', or 'Events'
-     * @param array $query_params see github link below for more info
+     * @param array               $query_params     see github link below for more info
      * @return EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
@@ -3687,7 +3687,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                                  not for this primary model. 'all', the default,
      *                                                                  means default where conditions will apply as
      *                                                                  normal
-     * @param array $where_query_params
+     * @param array                       $where_query_params
      * @return array
      * @throws EE_Error
      * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
@@ -4273,7 +4273,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Event_Meta.meta_value = 'foo'))"
      *
      * @param array  $where_params
-     * @param string $glue         joins each sub-clause together. Should really only be " AND " or " OR "...
+     * @param string $glue joins each sub-clause together. Should really only be " AND " or " OR "...
      * @return string of SQL
      * @throws EE_Error
      * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
@@ -5494,7 +5494,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
 
     /**
-     * @param array $cols_n_values
+     * @param array  $cols_n_values
      * @param string $qualified_column
      * @param string $regular_column
      * @return null
@@ -5916,7 +5916,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * We consider something to be a copy if all the attributes match (except the ID, of course).
      *
      * @param array|EE_Base_Class $model_object_or_attributes_array If its an array, it's field-value pairs
-     * @param array $query_params see github link below for more info
+     * @param array               $query_params                     see github link below for more info
      * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @throws ReflectionException

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -95,7 +95,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * @var \EE_Index[] $_indexes
      */
-    protected $_indexes = array();
+    protected $_indexes = [];
 
     /**
      * Default strategy for getting where conditions on this model. This strategy is used to get default
@@ -138,6 +138,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * you can read the registration or not on the front-end (it just depends on your capabilities.)
      * This is 'Datetime.Event' on the Ticket model, because model queries for tickets that set "exclude_protected"
      * should hide tickets for datetimes for events that have a password set.
+     *
      * @var string |null
      */
     protected $model_chain_to_password = null;
@@ -169,12 +170,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_cap_restrictions = array(
-        self::caps_read       => array(),
-        self::caps_read_admin => array(),
-        self::caps_edit       => array(),
-        self::caps_delete     => array(),
-    );
+    protected $_cap_restrictions = [
+        self::caps_read       => [],
+        self::caps_read_admin => [],
+        self::caps_edit       => [],
+        self::caps_delete     => [],
+    ];
 
     /**
      * Array defining which cap restriction generators to use to create default
@@ -185,7 +186,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var EE_Restriction_Generator_Base[]
      */
-    protected $_cap_restriction_generators = array();
+    protected $_cap_restriction_generators = [];
 
     /**
      * constants used to categorize capability restrictions on EEM_Base::_caps_restrictions
@@ -206,12 +207,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_cap_contexts_to_cap_action_map = array(
+    protected $_cap_contexts_to_cap_action_map = [
         self::caps_read       => 'read',
         self::caps_read_admin => 'read',
         self::caps_edit       => 'edit',
         self::caps_delete     => 'delete',
-    );
+    ];
 
     /**
      * Timezone
@@ -239,7 +240,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var EE_Model_Field_Base[]
      */
-    private $_cache_foreign_key_to_fields = array();
+    private $_cache_foreign_key_to_fields = [];
 
     /**
      * Cached list of all the fields on the model, indexed by their name
@@ -289,6 +290,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * It would be false, however, if you could guarantee the model would only interact with EE data,
      * even if it uses a WP core table (eg event and venue models set this to false for that reason:
      * they can only read and insert events and venues custom post types, not arbitrary post types)
+     *
      * @var boolean
      */
     protected $_wp_core_model = false;
@@ -311,7 +313,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_valid_operators = array(
+    protected $_valid_operators = [
         '='           => '=',
         '<='          => '<=',
         '<'           => '<',
@@ -346,14 +348,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         'not_regexp'  => 'NOT REGEXP',
         'NOT REGEXP'  => 'NOT REGEXP',
         'not regexp'  => 'NOT REGEXP',
-    );
+    ];
 
     /**
      * operators that work like 'IN', accepting a comma-separated list of values inside brackets. Eg '(1,2,3)'
      *
      * @var array
      */
-    protected $_in_style_operators = array('IN', 'NOT IN');
+    protected $_in_style_operators = ['IN', 'NOT IN'];
 
     /**
      * operators that work like 'BETWEEN'.  Typically used for datetime calculations, i.e. "BETWEEN '12-1-2011' AND
@@ -361,27 +363,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_between_style_operators = array('BETWEEN');
+    protected $_between_style_operators = ['BETWEEN'];
 
     /**
      * Operators that work like SQL's like: input should be assumed to be a string, already prepared for a LIKE query.
+     *
      * @var array
      */
-    protected $_like_style_operators = array('LIKE', 'NOT LIKE');
+    protected $_like_style_operators = ['LIKE', 'NOT LIKE'];
+
     /**
      * operators that are used for handling NUll and !NULL queries.  Typically used for when checking if a row exists
      * on a join table.
      *
      * @var array
      */
-    protected $_null_style_operators = array('IS NOT NULL', 'IS NULL');
+    protected $_null_style_operators = ['IS NOT NULL', 'IS NULL'];
 
     /**
      * Allowed values for $query_params['order'] for ordering in queries
      *
      * @var array
      */
-    protected $_allowed_order_values = array('asc', 'desc', 'ASC', 'DESC');
+    protected $_allowed_order_values = ['asc', 'desc', 'ASC', 'DESC'];
 
     /**
      * When these are keys in a WHERE or HAVING clause, they are handled much differently
@@ -389,7 +393,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    private $_logic_query_param_keys = array('not', 'and', 'or', 'NOT', 'AND', 'OR');
+    private $_logic_query_param_keys = ['not', 'and', 'or', 'NOT', 'AND', 'OR'];
 
     /**
      * Allowed keys in $query_params arrays passed into queries. Note that 0 is meant to always be a
@@ -397,7 +401,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    private $_allowed_query_params = array(
+    private $_allowed_query_params = [
         0,
         'limit',
         'order_by',
@@ -410,14 +414,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         'caps',
         'extra_selects',
         'exclude_protected',
-    );
+    ];
 
     /**
      * All the data types that can be used in $wpdb->prepare statements.
      *
      * @var array
      */
-    private $_valid_wpdb_data_types = array('%d', '%s', '%f');
+    private $_valid_wpdb_data_types = ['%d', '%s', '%f'];
 
     /**
      * @var EE_Registry $EE
@@ -439,7 +443,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var CustomSelects
      */
-    protected $_custom_selections = array();
+    protected $_custom_selections = [];
 
     /**
      * key => value Entity Map using  array( EEM_Base::$_model_query_blog_id => array( ID => model object ) )
@@ -532,7 +536,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     const default_where_conditions_none = 'none';
 
 
-
     /**
      * About all child constructors:
      * they should define the _tables, _fields and _model_relations arrays.
@@ -577,7 +580,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          *
          * @var EE_Table_Base[] $_tables
          */
-        $this->_tables = (array) apply_filters('FHEE__' . get_class($this) . '__construct__tables', $this->_tables);
+        $this->_tables = (array)apply_filters('FHEE__' . get_class($this) . '__construct__tables', $this->_tables);
         foreach ($this->_tables as $table_alias => $table_obj) {
             /** @var $table_obj EE_Table_Base */
             $table_obj->_construct_finalize_with_alias($table_alias);
@@ -592,14 +595,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          *
          * @param EE_Model_Field_Base[] $_fields
          */
-        $this->_fields = (array) apply_filters('FHEE__' . get_class($this) . '__construct__fields', $this->_fields);
+        $this->_fields = (array)apply_filters('FHEE__' . get_class($this) . '__construct__fields', $this->_fields);
         $this->_invalidate_field_caches();
         foreach ($this->_fields as $table_alias => $fields_for_table) {
             if (! array_key_exists($table_alias, $this->_tables)) {
-                throw new EE_Error(sprintf(__(
-                    "Table alias %s does not exist in EEM_Base child's _tables array. Only tables defined are %s",
-                    'event_espresso'
-                ), $table_alias, implode(",", $this->_fields)));
+                throw new EE_Error(
+                    sprintf(
+                        __(
+                            "Table alias %s does not exist in EEM_Base child's _tables array. Only tables defined are %s",
+                            'event_espresso'
+                        ),
+                        $table_alias,
+                        implode(",", $this->_fields)
+                    )
+                );
             }
             foreach ($fields_for_table as $field_name => $field_obj) {
                 /** @var $field_obj EE_Model_Field_Base | EE_Primary_Key_Field_Base */
@@ -625,7 +634,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          *
          * @param EE_Model_Relation_Base[] $_model_relations
          */
-        $this->_model_relations = (array) apply_filters(
+        $this->_model_relations = (array)apply_filters(
             'FHEE__' . get_class($this) . '__construct__model_relations',
             $this->_model_relations
         );
@@ -695,7 +704,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Used to set the $_model_query_blog_id static property.
      *
@@ -704,9 +712,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public static function set_model_query_blog_id($blog_id = 0)
     {
-        EEM_Base::$_model_query_blog_id = $blog_id > 0 ? (int) $blog_id : get_current_blog_id();
+        EEM_Base::$_model_query_blog_id = $blog_id > 0 ? (int)$blog_id : get_current_blog_id();
     }
-
 
 
     /**
@@ -720,11 +727,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * This function is a singleton method used to instantiate the Espresso_model object
      *
-     * @param string $timezone string representing the timezone we want to set for returned Date Time Strings
+     * @param string $timezone        string representing the timezone we want to set for returned Date Time Strings
      *                                (and any incoming timezone data that gets saved).
      *                                Note this just sends the timezone info to the date time model field objects.
      *                                Default is NULL
@@ -752,7 +758,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * resets the model and returns it
      *
@@ -772,7 +777,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // because if someone has a reference to it, we can't remove their reference
             // so it's best to keep using the same reference, but change the original object
             // reset all its properties to their original values as defined in the class
-            $r = new ReflectionClass(get_class(static::$_instance));
+            $r                 = new ReflectionClass(get_class(static::$_instance));
             $static_properties = $r->getStaticProperties();
             foreach ($r->getDefaultProperties() as $property => $value) {
                 // don't set instance to null like it was originally,
@@ -792,7 +797,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * @return LoaderInterface
      * @throws InvalidArgumentException
@@ -808,11 +812,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * retrieve the status details from esp_status table as an array IF this model has the status table as a relation.
      *
-     * @param  boolean $translated return localized strings or JUST the array.
+     * @param boolean $translated return localized strings or JUST the array.
      * @return array
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -822,12 +825,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function status_array($translated = false)
     {
         if (! array_key_exists('Status', $this->_model_relations)) {
-            return array();
+            return [];
         }
-        $model_name = $this->get_this_model_name();
-        $status_type = str_replace(' ', '_', strtolower(str_replace('_', ' ', $model_name)));
-        $stati = EEM_Status::instance()->get_all(array(array('STS_type' => $status_type)));
-        $status_array = array();
+        $model_name   = $this->get_this_model_name();
+        $status_type  = str_replace(' ', '_', strtolower(str_replace('_', ' ', $model_name)));
+        $stati        = EEM_Status::instance()->get_all([['STS_type' => $status_type]]);
+        $status_array = [];
         foreach ($stati as $status) {
             $status_array[ $status->ID() ] = $status->get('STS_code');
         }
@@ -837,18 +840,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the EE_Base_Class objects which match the $query_params, by querying the DB.
      *
-     * @param array $query_params  @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     *                             or if you have the development copy of EE you can view this at the path:
-     *                             /docs/G--Model-System/model-query-params.md
+     * @param array $query_params             @see
+     *                                        https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     *                                        or if you have the development copy of EE you can view this at the path:
+     *                                        /docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class[]  *note that there is NO option to pass the output type. If you want results different
-     *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object IDs (if there is a primary key on the model.
-     *                                        if not, numerically indexed) Some full examples: get 10 transactions
-     *                                        which have Scottish attendees: EEM_Transaction::instance()->get_all(
-     *                                        array( array(
+     *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object
+     *                                        IDs (if there is a primary key on the model. if not, numerically indexed)
+     *                                        Some full examples: get 10 transactions which have Scottish attendees:
+     *                                        EEM_Transaction::instance()->get_all( array( array(
      *                                        'OR'=>array(
      *                                        'Registration.Attendee.ATT_fname'=>array('like','Mc%'),
      *                                        'Registration.Attendee.ATT_fname*other'=>array('like','Mac%')
@@ -866,7 +869,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                        ));
      * @throws EE_Error
      */
-    public function get_all($query_params = array())
+    public function get_all($query_params = [])
     {
         if (
             isset($query_params['limit'])
@@ -878,15 +881,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Modifies the query parameters so we only get back model objects
      * that "belong" to the current user
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
-    public function alter_query_params_to_only_include_mine($query_params = array())
+    public function alter_query_params_to_only_include_mine($query_params = [])
     {
         $wp_user_field_name = $this->wp_user_field_name();
         if ($wp_user_field_name) {
@@ -894,7 +898,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $query_params;
     }
-
 
 
     /**
@@ -910,12 +913,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         try {
             if (! empty($this->_model_chain_to_wp_user)) {
                 $models_to_follow_to_wp_users = explode('.', $this->_model_chain_to_wp_user);
-                $last_model_name = end($models_to_follow_to_wp_users);
-                $model_with_fk_to_wp_users = EE_Registry::instance()->load_model($last_model_name);
-                $model_chain_to_wp_user = $this->_model_chain_to_wp_user . '.';
+                $last_model_name              = end($models_to_follow_to_wp_users);
+                $model_with_fk_to_wp_users    = EE_Registry::instance()->load_model($last_model_name);
+                $model_chain_to_wp_user       = $this->_model_chain_to_wp_user . '.';
             } else {
                 $model_with_fk_to_wp_users = $this;
-                $model_chain_to_wp_user = '';
+                $model_chain_to_wp_user    = '';
             }
             $wp_user_field = $model_with_fk_to_wp_users->get_foreign_key_to('WP_User');
             return $model_chain_to_wp_user . $wp_user_field->get_name();
@@ -923,7 +926,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             return false;
         }
     }
-
 
 
     /**
@@ -940,7 +942,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_model_chain_to_wp_user;
     }
-
 
 
     /**
@@ -970,7 +971,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * may want to preserve the WPDB results (eg, update, which first queries to make sure we have all the tables on
      * the model)
      *
-     * @param array  $query_params      @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params      @see
+     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -984,11 +986,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function _get_all_wpdb_results($query_params = array(), $output = ARRAY_A, $columns_to_select = null)
+    protected function _get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
-        $this->_custom_selections = $this->getCustomSelection($query_params, $columns_to_select);
-        ;
-        $model_query_info = $this->_create_model_query_info_carrier($query_params);
+        $this->_custom_selections = $this->getCustomSelection($query_params, $columns_to_select);;
+        $model_query_info   = $this->_create_model_query_info_carrier($query_params);
         $select_expressions = $columns_to_select === null
             ? $this->_construct_default_select_sql($model_query_info)
             : '';
@@ -1000,7 +1001,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
 
         $SQL = "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return $this->_do_wpdb_query('get_results', array($SQL, $output));
+        return $this->_do_wpdb_query('get_results', [$SQL, $output]);
     }
 
 
@@ -1025,13 +1026,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets an array of rows from the database just like $wpdb->get_results would,
      * but you can use the model query params to more easily
      * take care of joins, field preparation etc.
      *
-     * @param array  $query_params      @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params      @see
+     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -1044,11 +1045,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return array|stdClass[] like results of $wpdb->get_results($sql,OBJECT), (ie, output type is OBJECT)
      * @throws EE_Error
      */
-    public function get_all_wpdb_results($query_params = array(), $output = ARRAY_A, $columns_to_select = null)
+    public function get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
         return $this->_get_all_wpdb_results($query_params, $output, $columns_to_select);
     }
-
 
 
     /**
@@ -1057,13 +1057,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param mixed $columns_to_select either a string to be inserted directly as the select statement,
      *                                 or an array where keys are aliases, and values are arrays where 0=>the selection
      *                                 SQL, and 1=>is the datatype
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     private function _construct_select_from_input($columns_to_select)
     {
         if (is_array($columns_to_select)) {
-            $select_sql_array = array();
+            $select_sql_array = [];
             foreach ($columns_to_select as $alias => $selection_and_datatype) {
                 if (! is_array($selection_and_datatype) || ! isset($selection_and_datatype[1])) {
                     throw new EE_Error(
@@ -1101,7 +1101,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Convenient wrapper for getting the primary key field's name. Eg, on Registration, this would be 'REG_ID'
      *
@@ -1112,7 +1111,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->get_primary_key_field()->get_name();
     }
-
 
 
     /**
@@ -1130,11 +1128,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return $this->get_one(
             $this->alter_query_params_to_restrict_by_ID(
                 $id,
-                array('default_where_conditions' => EEM_Base::default_where_conditions_minimum_all)
+                ['default_where_conditions' => EEM_Base::default_where_conditions_minimum_all]
             )
         );
     }
-
 
 
     /**
@@ -1144,13 +1141,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int   $id
      * @param array $query_params
-     * @return array of normal query params, @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @return array of normal query params, @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      */
-    public function alter_query_params_to_restrict_by_ID($id, $query_params = array())
+    public function alter_query_params_to_restrict_by_ID($id, $query_params = [])
     {
         if (! isset($query_params[0])) {
-            $query_params[0] = array();
+            $query_params[0] = [];
         }
         $conditions_from_id = $this->parse_index_primary_key_string($id);
         if ($conditions_from_id === null) {
@@ -1163,7 +1161,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets a single item for this model from the DB, given the $query_params. Only returns a single class, not an
      * array. If no item is found, null is returned.
@@ -1172,7 +1169,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return EE_Base_Class|EE_Soft_Delete_Base_Class|NULL
      * @throws EE_Error
      */
-    public function get_one($query_params = array())
+    public function get_one($query_params = [])
     {
         if (! is_array($query_params)) {
             EE_Error::doing_it_wrong(
@@ -1183,16 +1180,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         $query_params['limit'] = 1;
-        $items = $this->get_all($query_params);
+        $items                 = $this->get_all($query_params);
         if (empty($items)) {
             return null;
         }
         return array_shift($items);
     }
-
 
 
     /**
@@ -1215,7 +1211,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $current_field_value,
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         return $this->_get_consecutive(
@@ -1227,7 +1223,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $columns_to_select
         );
     }
-
 
 
     /**
@@ -1250,7 +1245,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $current_field_value,
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         return $this->_get_consecutive(
@@ -1262,7 +1257,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $columns_to_select
         );
     }
-
 
 
     /**
@@ -1284,7 +1278,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function next(
         $current_field_value,
         $field_to_order_by = null,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         $results = $this->_get_consecutive(
@@ -1297,7 +1291,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         return empty($results) ? null : reset($results);
     }
-
 
 
     /**
@@ -1319,7 +1312,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function previous(
         $current_field_value,
         $field_to_order_by = null,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         $results = $this->_get_consecutive(
@@ -1332,7 +1325,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         return empty($results) ? null : reset($results);
     }
-
 
 
     /**
@@ -1354,7 +1346,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $operand = '>',
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         // if $field_to_order_by is empty then let's assume we're ordering by the primary key.
@@ -1363,13 +1355,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $field_to_order_by = $this->get_primary_key_field()->get_name();
             } else {
                 if (WP_DEBUG) {
-                    throw new EE_Error(__(
-                        'EEM_Base::_get_consecutive() has been called with no $field_to_order_by argument and there is no primary key on the field.  Please provide the field you would like to use as the base for retrieving the next item(s).',
-                        'event_espresso'
-                    ));
+                    throw new EE_Error(
+                        __(
+                            'EEM_Base::_get_consecutive() has been called with no $field_to_order_by argument and there is no primary key on the field.  Please provide the field you would like to use as the base for retrieving the next item(s).',
+                            'event_espresso'
+                        )
+                    );
                 }
                 EE_Error::add_error(__('There was an error with the query.', 'event_espresso'));
-                return array();
+                return [];
             }
         }
         if (! is_array($query_params)) {
@@ -1381,16 +1375,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         // let's add the where query param for consecutive look up.
-        $query_params[0][ $field_to_order_by ] = array($operand, $current_field_value);
-        $query_params['limit'] = $limit;
+        $query_params[0][ $field_to_order_by ] = [$operand, $current_field_value];
+        $query_params['limit']                 = $limit;
         // set direction
-        $incoming_orderby = isset($query_params['order_by']) ? (array) $query_params['order_by'] : array();
+        $incoming_orderby         = isset($query_params['order_by']) ? (array)$query_params['order_by'] : [];
         $query_params['order_by'] = $operand === '>'
-            ? array($field_to_order_by => 'ASC') + $incoming_orderby
-            : array($field_to_order_by => 'DESC') + $incoming_orderby;
+            ? [$field_to_order_by => 'ASC'] + $incoming_orderby
+            : [$field_to_order_by => 'DESC'] + $incoming_orderby;
         // if $columns_to_select is empty then that means we're returning EE_Base_Class objects
         if (empty($columns_to_select)) {
             return $this->get_all($query_params);
@@ -1398,7 +1392,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // getting just the fields
         return $this->_get_all_wpdb_results($query_params, ARRAY_A, $columns_to_select);
     }
-
 
 
     /**
@@ -1422,7 +1415,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
     }
-
 
 
     /**
@@ -1450,33 +1442,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * This returns the date formats set for the given field name and also ensures that
      * $this->_timezone property is set correctly.
      *
-     * @since 4.6.x
      * @param string $field_name The name of the field the formats are being retrieved for.
      * @param bool   $pretty     Whether to return the pretty formats (true) or not (false).
-     * @throws EE_Error   If the given field_name is not of the EE_Datetime_Field type.
      * @return array formats in an array with the date format first, and the time format last.
+     * @throws EE_Error   If the given field_name is not of the EE_Datetime_Field type.
+     * @since 4.6.x
      */
     public function get_formats_for($field_name, $pretty = false)
     {
         $field_settings = $this->field_settings_for($field_name);
         // if not a valid EE_Datetime_Field then throw error
         if (! $field_settings instanceof EE_Datetime_Field) {
-            throw new EE_Error(sprintf(__(
-                'The field sent into EEM_Base::get_formats_for (%s) is not registered as a EE_Datetime_Field. Please check the spelling and make sure you are submitting the right field name to retrieve date_formats for.',
-                'event_espresso'
-            ), $field_name));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        'The field sent into EEM_Base::get_formats_for (%s) is not registered as a EE_Datetime_Field. Please check the spelling and make sure you are submitting the right field name to retrieve date_formats for.',
+                        'event_espresso'
+                    ),
+                    $field_name
+                )
+            );
         }
         // while we are here, let's make sure the timezone internally in EEM_Base matches what is stored on
         // the field.
         $this->_timezone = $field_settings->get_timezone();
-        return array($field_settings->get_date_format($pretty), $field_settings->get_time_format($pretty));
+        return [$field_settings->get_date_format($pretty), $field_settings->get_time_format($pretty)];
     }
-
 
 
     /**
@@ -1489,19 +1484,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Note: When requesting a formatted string, if the date or time format doesn't include seconds, for example,
      * the time returned, because it uses that format, will also NOT include seconds. For this reason, if you want
      * the time returned to be the current time down to the exact second, set $timestamp to true.
-     * @since 4.6.x
+     *
      * @param string $field_name       The field the current time is needed for.
      * @param bool   $timestamp        True means to return a unix timestamp. Otherwise a
      *                                 formatted string matching the set format for the field in the set timezone will
      *                                 be returned.
      * @param string $what             Whether to return the string in just the time format, the date format, or both.
-     * @throws EE_Error    If the given field_name is not of the EE_Datetime_Field type.
      * @return int|string  If the given field_name is not of the EE_Datetime_Field type, then an EE_Error
      *                                 exception is triggered.
+     * @throws EE_Error    If the given field_name is not of the EE_Datetime_Field type.
+     * @since 4.6.x
      */
     public function current_time_for_query($field_name, $timestamp = false, $what = 'both')
     {
-        $formats = $this->get_formats_for($field_name);
+        $formats  = $this->get_formats_for($field_name);
         $DateTime = new DateTime("now", new DateTimeZone($this->_timezone));
         if ($timestamp) {
             return $DateTime->format('U');
@@ -1519,7 +1515,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 break;
         }
     }
-
 
 
     /**
@@ -1544,12 +1539,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // just using this to ensure the timezone is set correctly internally
         $this->get_formats_for($field_name);
         // load EEH_DTT_Helper
-        $set_timezone = empty($timezone) ? EEH_DTT_Helper::get_timezone() : $timezone;
+        $set_timezone     = empty($timezone) ? EEH_DTT_Helper::get_timezone() : $timezone;
         $incomingDateTime = date_create_from_format($incoming_format, $timestring, new DateTimeZone($set_timezone));
         EEH_DTT_Helper::setTimezone($incomingDateTime, new DateTimeZone($this->_timezone));
         return \EventEspresso\core\domain\entities\DbSafeDateTime::createFromDateTime($incomingDateTime);
     }
-
 
 
     /**
@@ -1561,7 +1555,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_tables;
     }
-
 
 
     /**
@@ -1586,7 +1579,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                         EEM_Transaction::instance()->update(
      *                                         array('TXN_details'=>array('detail1'=>'monkey','detail2'=>'banana'),
      *                                         array(array('TXN_ID'=>34)));
-     * @param array   $query_params            @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array   $query_params            @see
+     *                                         https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      *                                         Eg, consider updating Question's QST_admin_label field is of type
      *                                         Simple_HTML. If you use this function to update that field to $new_value
      *                                         = (note replace 8's with appropriate opening and closing tags in the
@@ -1623,7 +1617,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         /**
          * Action called before a model update call has been made.
@@ -1641,7 +1635,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          * @param EEM_Base $model           the model being queried
          * @param array    $query_params    @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
          */
-        $fields_n_values = (array) apply_filters(
+        $fields_n_values = (array)apply_filters(
             'FHEE__EEM_Base__update__fields_n_values',
             $fields_n_values,
             $this,
@@ -1656,10 +1650,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // as it's dangerous. says Mike August 8 2014
         // we want to make sure the default_where strategy is ignored
         $this->_ignore_where_strategy = true;
-        $wpdb_select_results = $this->_get_all_wpdb_results($query_params);
+        $wpdb_select_results          = $this->_get_all_wpdb_results($query_params);
         foreach ($wpdb_select_results as $wpdb_result) {
             // type cast stdClass as array
-            $wpdb_result = (array) $wpdb_result;
+            $wpdb_result = (array)$wpdb_result;
             // get the model object's PK, as we'll want this if we need to insert a row into secondary tables
             if ($this->has_primary_key_field()) {
                 $main_table_pk_value = $wpdb_result[ $this->get_primary_key_field()->get_qualified_column() ];
@@ -1677,8 +1671,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     // if there is no private key for this table on the results, it means there's no entry
                     // in this table, right? so insert a row in the current table, using any fields available
                     if (
-                        ! (array_key_exists($this_table_pk_column, $wpdb_result)
-                           && $wpdb_result[ $this_table_pk_column ])
+                    ! (array_key_exists($this_table_pk_column, $wpdb_result)
+                       && $wpdb_result[ $this_table_pk_column ])
                     ) {
                         $success = $this->_insert_into_specific_table(
                             $table_obj,
@@ -1711,9 +1705,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             } else {
                 // we need to select a bunch of columns and then combine them into the the "index primary key string"s
                 $models_affected_key_columns = $this->_get_all_wpdb_results($query_params, ARRAY_A);
-                $model_objs_affected_ids = array();
+                $model_objs_affected_ids     = [];
                 foreach ($models_affected_key_columns as $row) {
-                    $combined_index_key = $this->get_index_primary_key_string($row);
+                    $combined_index_key                             = $this->get_index_primary_key_string($row);
                     $model_objs_affected_ids[ $combined_index_key ] = $combined_index_key;
                 }
             }
@@ -1732,20 +1726,21 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // if there is a primary key on this model, we can now do a slight optimization
             if ($this->has_primary_key_field()) {
                 // we already know what we want to update. So let's make the query simpler so it's a little more efficient
-                $query_params = array(
-                    array($this->primary_key_name() => array('IN', $model_objs_affected_ids)),
+                $query_params = [
+                    [$this->primary_key_name() => ['IN', $model_objs_affected_ids]],
                     'limit'                    => count($model_objs_affected_ids),
                     'default_where_conditions' => EEM_Base::default_where_conditions_none,
-                );
+                ];
             }
         }
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
-        $SQL = "UPDATE "
-               . $model_query_info->get_full_join_sql()
-               . " SET "
-               . $this->_construct_update_sql($fields_n_values)
-               . $model_query_info->get_where_sql();// note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
-        $rows_affected = $this->_do_wpdb_query('query', array($SQL));
+        $SQL              = "UPDATE "
+                            . $model_query_info->get_full_join_sql()
+                            . " SET "
+                            . $this->_construct_update_sql($fields_n_values)
+                            . $model_query_info->get_where_sql(
+            );// note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
+        $rows_affected    = $this->_do_wpdb_query('query', [$SQL]);
         /**
          * Action called after a model update call has been made.
          *
@@ -1759,19 +1754,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Analogous to $wpdb->get_col, returns a 1-dimensional array where teh values
      * are teh values of the field specified (or by default the primary key field)
      * that matched the query params. Note that you should pass the name of the
      * model FIELD, not the database table's column name.
      *
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_select
      * @return array just like $wpdb->get_col()
      * @throws EE_Error
      */
-    public function get_col($query_params = array(), $field_to_select = null)
+    public function get_col($query_params = [], $field_to_select = null)
     {
         if ($field_to_select) {
             $field = $this->field_settings_for($field_to_select);
@@ -1781,26 +1776,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // no primary key, just grab the first column
             $field = reset($this->field_settings());
         }
-        $model_query_info = $this->_create_model_query_info_carrier($query_params);
+        $model_query_info   = $this->_create_model_query_info_carrier($query_params);
         $select_expressions = $field->get_qualified_column();
-        $SQL = "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return $this->_do_wpdb_query('get_col', array($SQL));
+        $SQL                =
+            "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
+        return $this->_do_wpdb_query('get_col', [$SQL]);
     }
-
 
 
     /**
      * Returns a single column value for a single row from the database
      *
-     * @param array  $query_params    @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params    @see
+     *                                https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_select @see EEM_Base::get_col()
      * @return string
      * @throws EE_Error
      */
-    public function get_var($query_params = array(), $field_to_select = null)
+    public function get_var($query_params = [], $field_to_select = null)
     {
         $query_params['limit'] = 1;
-        $col = $this->get_col($query_params, $field_to_select);
+        $col                   = $this->get_col($query_params, $field_to_select);
         if (! empty($col)) {
             return reset($col);
         }
@@ -1808,35 +1804,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Makes the SQL for after "UPDATE table_X inner join table_Y..." and before "...WHERE". Eg "Question.name='party
      * time?', Question.desc='what do you think?',..." Values are filtered through wpdb->prepare to avoid against SQL
      * injection, but currently no further filtering is done
      *
-     * @global      $wpdb
      * @param array $fields_n_values array keys are field names on this model, and values are what those fields should
      *                               be updated to in the DB
      * @return string of SQL
      * @throws EE_Error
+     * @global      $wpdb
      */
     public function _construct_update_sql($fields_n_values)
     {
         /** @type WPDB $wpdb */
         global $wpdb;
-        $cols_n_values = array();
+        $cols_n_values = [];
         foreach ($fields_n_values as $field_name => $value) {
             $field_obj = $this->field_settings_for($field_name);
             // if the value is NULL, we want to assign the value to that.
             // wpdb->prepare doesn't really handle that properly
-            $prepared_value = $this->_prepare_value_or_use_default($field_obj, $fields_n_values);
-            $value_sql = $prepared_value === null ? 'NULL'
+            $prepared_value  = $this->_prepare_value_or_use_default($field_obj, $fields_n_values);
+            $value_sql       = $prepared_value === null ? 'NULL'
                 : $wpdb->prepare($field_obj->get_wpdb_data_type(), $prepared_value);
             $cols_n_values[] = $field_obj->get_qualified_column() . "=" . $value_sql;
         }
         return implode(",", $cols_n_values);
     }
-
 
 
     /**
@@ -1845,7 +1839,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * not just have a flag field on it switched
      * Wrapper for EEM_Base::delete_permanently()
      *
-     * @param mixed $id
+     * @param mixed   $id
      * @param boolean $allow_blocking
      * @return int the number of rows deleted
      * @throws EE_Error
@@ -1853,21 +1847,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function delete_permanently_by_ID($id, $allow_blocking = true)
     {
         return $this->delete_permanently(
-            array(
-                array($this->get_primary_key_field()->get_name() => $id),
+            [
+                [$this->get_primary_key_field()->get_name() => $id],
                 'limit' => 1,
-            ),
+            ],
             $allow_blocking
         );
     }
-
 
 
     /**
      * Deletes a single row from the DB given the model object's primary key value. (eg, EE_Attendee->ID()'s value).
      * Wrapper for EEM_Base::delete()
      *
-     * @param mixed $id
+     * @param mixed   $id
      * @param boolean $allow_blocking
      * @return int the number of rows deleted
      * @throws EE_Error
@@ -1875,14 +1868,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function delete_by_ID($id, $allow_blocking = true)
     {
         return $this->delete(
-            array(
-                array($this->get_primary_key_field()->get_name() => $id),
+            [
+                [$this->get_primary_key_field()->get_name() => $id],
                 'limit' => 1,
-            ),
+            ],
             $allow_blocking
         );
     }
-
 
 
     /**
@@ -1890,11 +1882,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * meaning if the model has a field that indicates its been "trashed" or
      * "soft deleted", we will just set that instead of actually deleting the rows.
      *
-     * @see EEM_Base::delete_permanently
      * @param array   $query_params
      * @param boolean $allow_blocking
      * @return int how many rows got deleted
      * @throws EE_Error
+     * @see EEM_Base::delete_permanently
      */
     public function delete($query_params, $allow_blocking = true)
     {
@@ -1902,13 +1894,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Deletes the model objects that meet the query params. Note: this method is overridden
      * in EEM_Soft_Delete_Base so that soft-deleted model objects are instead only flagged
      * as archived, not actually deleted
      *
-     * @param array   $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array   $query_params   @see
+     *                                https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param boolean $allow_blocking if TRUE, matched objects will only be deleted if there is no related model info
      *                                that blocks it (ie, there' sno other data that depends on this data); if false,
      *                                deletes regardless of other objects which may depend on it. Its generally
@@ -1933,20 +1925,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // deletion if there is no KEY column used in the WHERE statement of a deletion.
         // to get around this, we first do a SELECT, get all the IDs, and then run another query
         // to delete them
-        $items_for_deletion = $this->_get_all_wpdb_results($query_params);
+        $items_for_deletion           = $this->_get_all_wpdb_results($query_params);
         $columns_and_ids_for_deleting = $this->_get_ids_for_delete($items_for_deletion, $allow_blocking);
-        $deletion_where_query_part = $this->_build_query_part_for_deleting_from_columns_and_values(
+        $deletion_where_query_part    = $this->_build_query_part_for_deleting_from_columns_and_values(
             $columns_and_ids_for_deleting
         );
         /**
          * Allows client code to act on the items being deleted before the query is actually executed.
          *
-         * @param EEM_Base $this  The model instance being acted on.
-         * @param array    $query_params  The incoming array of query parameters influencing what gets deleted.
-         * @param bool     $allow_blocking @see param description in method phpdoc block.
-         * @param array $columns_and_ids_for_deleting       An array indicating what entities will get removed as
+         * @param EEM_Base $this                            The model instance being acted on.
+         * @param array    $query_params                    The incoming array of query parameters influencing what gets deleted.
+         * @param bool     $allow_blocking                  @see param description in method phpdoc block.
+         * @param array    $columns_and_ids_for_deleting    An array indicating what entities will get removed as
          *                                                  derived from the incoming query parameters.
-         *                                                  @see details on the structure of this array in the phpdocs
+         * @see details on the structure of this array in the phpdocs
          *                                                  for the `_get_ids_for_delete_method`
          *
          */
@@ -1959,14 +1951,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         if ($deletion_where_query_part) {
             $model_query_info = $this->_create_model_query_info_carrier($query_params);
-            $table_aliases = array_keys($this->_tables);
-            $SQL = "DELETE "
-                   . implode(", ", $table_aliases)
-                   . " FROM "
-                   . $model_query_info->get_full_join_sql()
-                   . " WHERE "
-                   . $deletion_where_query_part;
-            $rows_deleted = $this->_do_wpdb_query('query', array($SQL));
+            $table_aliases    = array_keys($this->_tables);
+            $SQL              = "DELETE "
+                                . implode(", ", $table_aliases)
+                                . " FROM "
+                                . $model_query_info->get_full_join_sql()
+                                . " WHERE "
+                                . $deletion_where_query_part;
+            $rows_deleted     = $this->_do_wpdb_query('query', [$SQL]);
         } else {
             $rows_deleted = 0;
         }
@@ -1991,21 +1983,23 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // (although it is possible).
             // Note this can be skipped by using the provided filter and returning false.
             if (
-                apply_filters(
-                    'FHEE__EEM_Base__delete_permanently__dont_delete_extra_meta_for_extra_meta',
-                    ! $this instanceof EEM_Extra_Meta,
-                    $this
-                )
+            apply_filters(
+                'FHEE__EEM_Base__delete_permanently__dont_delete_extra_meta_for_extra_meta',
+                ! $this instanceof EEM_Extra_Meta,
+                $this
+            )
             ) {
-                EEM_Extra_Meta::instance()->delete_permanently(array(
-                    0 => array(
-                        'EXM_type' => $this->get_this_model_name(),
-                        'OBJ_ID'   => array(
-                            'IN',
-                            $ids_for_removal
-                        )
-                    )
-                ));
+                EEM_Extra_Meta::instance()->delete_permanently(
+                    [
+                        0 => [
+                            'EXM_type' => $this->get_this_model_name(),
+                            'OBJ_ID'   => [
+                                'IN',
+                                $ids_for_removal,
+                            ],
+                        ],
+                    ]
+                );
             }
         }
 
@@ -2020,7 +2014,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         do_action('AHEE__EEM_Base__delete__end', $this, $query_params, $rows_deleted, $columns_and_ids_for_deleting);
         return $rows_deleted;// how many supposedly got deleted
     }
-
 
 
     /**
@@ -2054,14 +2047,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 // if $ignore_this_model_obj was supplied, then for the query
                 // on that model needs to be told to ignore $ignore_this_model_obj
                 if ($ignored_model && $relation_name === $ignored_model->get_this_model_name()) {
-                    $related_model_objects = $relation_obj->get_all_related($this_model_obj_or_id, array(
-                        array(
-                            $ignored_model->get_primary_key_field()->get_name() => array(
-                                '!=',
-                                $ignore_this_model_obj->ID(),
-                            ),
-                        ),
-                    ));
+                    $related_model_objects = $relation_obj->get_all_related(
+                        $this_model_obj_or_id,
+                        [
+                            [
+                                $ignored_model->get_primary_key_field()->get_name() => [
+                                    '!=',
+                                    $ignore_this_model_obj->ID(),
+                                ],
+                            ],
+                        ]
+                    );
                 } else {
                     $related_model_objects = $relation_obj->get_all_related($this_model_obj_or_id);
                 }
@@ -2077,35 +2073,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Builds the columns and values for items to delete from the incoming $row_results_for_deleting array.
+     *
      * @param array $row_results_for_deleting
      * @param bool  $allow_blocking
      * @return array   The shape of this array depends on whether the model `has_primary_key_field` or not.  If the
-     *                 model DOES have a primary_key_field, then the array will be a simple single dimension array where
-     *                 the key is the fully qualified primary key column and the value is an array of ids that will be
-     *                 deleted. Example:
-     *                      array('Event.EVT_ID' => array( 1,2,3))
-     *                 If the model DOES NOT have a primary_key_field, then the array will be a two dimensional array
-     *                 where each element is a group of columns and values that get deleted. Example:
-     *                      array(
-     *                          0 => array(
+     *                              model DOES have a primary_key_field, then the array will be a simple single
+     *                              dimension array where the key is the fully qualified primary key column and the
+     *                              value is an array of ids that will be deleted. Example: array('Event.EVT_ID' =>
+     *                              array( 1,2,3)) If the model DOES NOT have a primary_key_field, then the array will
+     *                              be a two dimensional array where each element is a group of columns and values that
+     *                              get deleted. Example: array(
+     *                              0 => array(
      *                              'Term_Relationship.object_id' => 1
      *                              'Term_Relationship.term_taxonomy_id' => 5
-     *                          ),
-     *                          1 => array(
+     *                              ),
+     *                              1 => array(
      *                              'Term_Relationship.object_id' => 1
      *                              'Term_Relationship.term_taxonomy_id' => 6
-     *                          )
-     *                      )
+     *                              )
+     *                              )
      * @throws EE_Error
      */
     protected function _get_ids_for_delete(array $row_results_for_deleting, $allow_blocking = true)
     {
-        $ids_to_delete_indexed_by_column = array();
+        $ids_to_delete_indexed_by_column = [];
         if ($this->has_primary_key_field()) {
-            $primary_table = $this->_get_main_table();
-            $primary_table_pk_field = $this->get_field_by_column($primary_table->get_fully_qualified_pk_column());
-            $other_tables = $this->_get_other_tables();
-            $ids_to_delete_indexed_by_column = $query = array();
+            $primary_table                   = $this->_get_main_table();
+            $primary_table_pk_field          =
+                $this->get_field_by_column($primary_table->get_fully_qualified_pk_column());
+            $other_tables                    = $this->_get_other_tables();
+            $ids_to_delete_indexed_by_column = $query = [];
             foreach ($row_results_for_deleting as $item_to_delete) {
                 // before we mark this item for deletion,
                 // make sure there's no related entities blocking its deletion (if we're checking)
@@ -2126,7 +2123,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } elseif (count($this->get_combined_primary_key_fields()) > 1) {
             $fields = $this->get_combined_primary_key_fields();
             foreach ($row_results_for_deleting as $item_to_delete) {
-                $ids_to_delete_indexed_by_column_for_row = array();
+                $ids_to_delete_indexed_by_column_for_row = [];
                 foreach ($fields as $cpk_field) {
                     if ($cpk_field instanceof EE_Model_Field_Base) {
                         $ids_to_delete_indexed_by_column_for_row[ $cpk_field->get_qualified_column() ] =
@@ -2166,17 +2163,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (empty($ids_to_delete_indexed_by_column)) {
             return $query_part;
         } elseif ($this->has_primary_key_field()) {
-            $query = array();
+            $query = [];
             foreach ($ids_to_delete_indexed_by_column as $column => $ids) {
                 // make sure we have unique $ids
-                $ids = array_unique($ids);
+                $ids     = array_unique($ids);
                 $query[] = $column . ' IN(' . implode(',', $ids) . ')';
             }
             $query_part = ! empty($query) ? implode(' AND ', $query) : $query_part;
         } elseif (count($this->get_combined_primary_key_fields()) > 1) {
-            $ways_to_identify_a_row = array();
+            $ways_to_identify_a_row = [];
             foreach ($ids_to_delete_indexed_by_column as $ids_to_delete_indexed_by_column_for_each_row) {
-                $values_for_each_combined_primary_key_for_a_row = array();
+                $values_for_each_combined_primary_key_for_a_row = [];
                 foreach ($ids_to_delete_indexed_by_column_for_each_row as $column => $id) {
                     $values_for_each_combined_primary_key_for_a_row[] = $column . '=' . $id;
                 }
@@ -2190,9 +2187,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the model field by the fully qualified name
+     *
      * @param string $qualified_column_name eg 'Event_CPT.post_name' or $field_obj->get_qualified_column()
      * @return EE_Model_Field_Base
      */
@@ -2213,27 +2210,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Count all the rows that match criteria the model query params.
      * If $field_to_count isn't provided, the model's primary key is used. Otherwise, we count by field_to_count's
      * column
      *
-     * @param array  $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params   @see
+     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_count field on model to count by (not column name)
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
      * @return int
      * @throws EE_Error
      */
-    public function count($query_params = array(), $field_to_count = null, $distinct = false)
+    public function count($query_params = [], $field_to_count = null, $distinct = false)
     {
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
         if ($field_to_count) {
-            $field_obj = $this->field_settings_for($field_to_count);
+            $field_obj       = $this->field_settings_for($field_to_count);
             $column_to_count = $field_obj->get_qualified_column();
         } elseif ($this->has_primary_key_field()) {
-            $pk_field_obj = $this->get_primary_key_field();
+            $pk_field_obj    = $this->get_primary_key_field();
             $column_to_count = $pk_field_obj->get_qualified_column();
         } else {
             // there's no primary key
@@ -2241,7 +2238,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // we need to list out the columns for distinction;
             // otherwise we can just use star
             if ($distinct) {
-                $columns_to_use = array();
+                $columns_to_use = [];
                 foreach ($this->get_combined_primary_key_fields() as $field_obj) {
                     $columns_to_use[] = $field_obj->get_qualified_column();
                 }
@@ -2251,16 +2248,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
         $column_to_count = $distinct ? "DISTINCT " . $column_to_count : $column_to_count;
-        $SQL = "SELECT COUNT(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return (int) $this->_do_wpdb_query('get_var', array($SQL));
+        $SQL             =
+            "SELECT COUNT(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
+        return (int)$this->_do_wpdb_query('get_var', [$SQL]);
     }
-
 
 
     /**
      * Sums up the value of the $field_to_sum (defaults to the primary key, which isn't terribly useful)
      *
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_sum name of field (array key in $_fields array)
      * @return float
      * @throws EE_Error
@@ -2274,16 +2272,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $field_obj = $this->get_primary_key_field();
         }
         $column_to_count = $field_obj->get_qualified_column();
-        $SQL = "SELECT SUM(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
-        $return_value = $this->_do_wpdb_query('get_var', array($SQL));
-        $data_type = $field_obj->get_wpdb_data_type();
+        $SQL             =
+            "SELECT SUM(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
+        $return_value    = $this->_do_wpdb_query('get_var', [$SQL]);
+        $data_type       = $field_obj->get_wpdb_data_type();
         if ($data_type === '%d' || $data_type === '%s') {
-            return (float) $return_value;
+            return (float)$return_value;
         }
         // must be %f
-        return (float) $return_value;
+        return (float)$return_value;
     }
-
 
 
     /**
@@ -2292,9 +2290,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $wpdb_method
      * @param array  $arguments_to_provide
+     * @return mixed
      * @throws EE_Error
      * @global wpdb  $wpdb
-     * @return mixed
      */
     protected function _do_wpdb_query($wpdb_method, $arguments_to_provide)
     {
@@ -2302,18 +2300,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // because level 2 indicates the database needs updating and
         // is probably out of sync with the code
         if (! EE_Maintenance_Mode::instance()->models_can_query()) {
-            throw new EE_Error(sprintf(__(
-                "Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.",
-                "event_espresso"
-            )));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.",
+                        "event_espresso"
+                    )
+                )
+            );
         }
         /** @type WPDB $wpdb */
         global $wpdb;
         if (! method_exists($wpdb, $wpdb_method)) {
-            throw new EE_Error(sprintf(__(
-                'There is no method named "%s" on Wordpress\' $wpdb object',
-                'event_espresso'
-            ), $wpdb_method));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        'There is no method named "%s" on Wordpress\' $wpdb object',
+                        'event_espresso'
+                    ),
+                    $wpdb_method
+                )
+            );
         }
         if (WP_DEBUG) {
             $old_show_errors_value = $wpdb->show_errors;
@@ -2327,10 +2334,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 throw new EE_Error(sprintf(__('WPDB Error: "%s"', 'event_espresso'), $wpdb->last_error));
             }
             if ($result === false) {
-                throw new EE_Error(sprintf(__(
-                    'WPDB Error occurred, but no error message was logged by wpdb! The wpdb method called was "%1$s" and the arguments were "%2$s"',
-                    'event_espresso'
-                ), $wpdb_method, var_export($arguments_to_provide, true)));
+                throw new EE_Error(
+                    sprintf(
+                        __(
+                            'WPDB Error occurred, but no error message was logged by wpdb! The wpdb method called was "%1$s" and the arguments were "%2$s"',
+                            'event_espresso'
+                        ),
+                        $wpdb_method,
+                        var_export($arguments_to_provide, true)
+                    )
+                );
             }
         } elseif ($result === false) {
             EE_Error::add_error(
@@ -2352,7 +2365,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Attempts to run the indicated WPDB method with the provided arguments,
      * and if there's an error tries to verify the DB is correct. Uses
@@ -2368,7 +2380,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         /** @type WPDB $wpdb */
         global $wpdb;
         $wpdb->last_error = null;
-        $result = call_user_func_array(array($wpdb, $wpdb_method), $arguments_to_provide);
+        $result           = call_user_func_array([$wpdb, $wpdb_method], $arguments_to_provide);
         // was there an error running the query? but we don't care on new activations
         // (we're going to setup the DB anyway on new activations)
         if (
@@ -2399,7 +2411,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Verifies the EE core database is up-to-date and records that we've done it on
      * EEM_Base::$_db_verification_level
@@ -2414,7 +2425,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         global $wpdb;
         // ok remember that we've already attempted fixing the core db, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_core;
-        $error_message = sprintf(
+        $error_message                    = sprintf(
             __(
                 'WPDB Error "%1$s" while running wpdb method "%2$s" with arguments %3$s. Automatically attempting to fix EE Core DB',
                 'event_espresso'
@@ -2426,7 +2437,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_System::instance()->initialize_db_if_no_migrations_required(false, true);
         return $error_message;
     }
-
 
 
     /**
@@ -2443,7 +2453,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         global $wpdb;
         // ok remember that we've already attempted fixing the addons dbs, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_addons;
-        $error_message = sprintf(
+        $error_message                    = sprintf(
             __(
                 'WPDB AGAIN: Error "%1$s" while running the same method and arguments as before. Automatically attempting to fix EE Addons DB',
                 'event_espresso'
@@ -2455,7 +2465,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_System::instance()->initialize_addons();
         return $error_message;
     }
-
 
 
     /**
@@ -2478,7 +2487,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Set to easily debug the next X queries ran from this model.
      *
@@ -2488,7 +2496,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         $this->_show_next_x_db_queries = $count;
     }
-
 
 
     /**
@@ -2503,7 +2510,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Adds a relationship of the correct type between $modelObject and $otherModelObject.
      * There are the 3 cases:
@@ -2515,8 +2521,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * If one of the model Objects has not yet been saved to the database, it is saved before adding the entry in the
      * join table
      *
-     * @param        EE_Base_Class                     /int $thisModelObject
-     * @param        EE_Base_Class                     /int $id_or_obj EE_base_Class or ID of other Model Object
+     * @param EE_Base_Class                     /int $thisModelObject
+     * @param EE_Base_Class                     /int $id_or_obj EE_base_Class or ID of other Model Object
      * @param string $relationName                     , key in EEM_Base::_relations
      *                                                 an attendee to a group, you also want to specify which role they
      *                                                 will have in that group. So you would use this parameter to
@@ -2533,12 +2539,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $id_or_obj,
         $other_model_id_or_obj,
         $relationName,
-        $extra_join_model_fields_n_values = array()
+        $extra_join_model_fields_n_values = []
     ) {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->add_relation_to($id_or_obj, $other_model_id_or_obj, $extra_join_model_fields_n_values);
     }
-
 
 
     /**
@@ -2550,38 +2555,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * an error
      * 'hasAndBelongsToMany' relationships:removes any existing entry in the join table between the two models.
      *
-     * @param        EE_Base_Class /int $id_or_obj
-     * @param        EE_Base_Class /int $other_model_id_or_obj EE_Base_Class or ID of other Model Object
+     * @param EE_Base_Class /int $id_or_obj
+     * @param EE_Base_Class /int $other_model_id_or_obj EE_Base_Class or ID of other Model Object
      * @param string $relationName key in EEM_Base::_relations
-     * @return boolean of success
-     * @throws EE_Error
      * @param array  $where_query  This allows you to enter further query params for the relation to for relation to
      *                             methods that allow you to further specify extra columns to join by (such as HABTM).
      *                             Keep in mind that the only acceptable query_params is strict "col" => "value" pairs
      *                             because these will be inserted in any new rows created as well.
+     * @return boolean of success
+     * @throws EE_Error
      */
-    public function remove_relationship_to($id_or_obj, $other_model_id_or_obj, $relationName, $where_query = array())
+    public function remove_relationship_to($id_or_obj, $other_model_id_or_obj, $relationName, $where_query = [])
     {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->remove_relation_to($id_or_obj, $other_model_id_or_obj, $where_query);
     }
 
 
-
     /**
-     * @param mixed           $id_or_obj
-     * @param string          $relationName
-     * @param array           $where_query_params
+     * @param mixed  $id_or_obj
+     * @param string $relationName
+     * @param array  $where_query_params
      * @param EE_Base_Class[] objects to which relations were removed
      * @return \EE_Base_Class[]
      * @throws EE_Error
      */
-    public function remove_relations($id_or_obj, $relationName, $where_query_params = array())
+    public function remove_relations($id_or_obj, $relationName, $where_query_params = [])
     {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->remove_relations($id_or_obj, $where_query_params);
     }
-
 
 
     /**
@@ -2591,17 +2594,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param mixed  $id_or_obj    EE_Base_Class child or its ID
      * @param string $model_name   like 'Event', 'Registration', etc. always singular
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class[]
      * @throws EE_Error
      */
     public function get_all_related($id_or_obj, $model_name, $query_params = null)
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->get_all_related($model_obj, $query_params);
     }
-
 
 
     /**
@@ -2616,13 +2619,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return int how many deleted
      * @throws EE_Error
      */
-    public function delete_related($id_or_obj, $model_name, $query_params = array())
+    public function delete_related($id_or_obj, $model_name, $query_params = [])
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->delete_all_related($model_obj, $query_params);
     }
-
 
 
     /**
@@ -2637,22 +2639,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return int how many deleted
      * @throws EE_Error
      */
-    public function delete_related_permanently($id_or_obj, $model_name, $query_params = array())
+    public function delete_related_permanently($id_or_obj, $model_name, $query_params = [])
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->delete_related_permanently($model_obj, $query_params);
     }
-
 
 
     /**
      * Instead of getting the related model objects, simply counts them. Ignores default_where_conditions by default,
      * unless otherwise specified in the $query_params
      *
-     * @param        int             /EE_Base_Class $id_or_obj
+     * @param int             /EE_Base_Class $id_or_obj
      * @param string $model_name     like 'Event', or 'Registration'
-     * @param array  $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params   @see
+     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_count name of field to count by. By default, uses primary key
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
@@ -2662,7 +2664,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function count_related(
         $id_or_obj,
         $model_name,
-        $query_params = array(),
+        $query_params = [],
         $field_to_count = null,
         $distinct = false
     ) {
@@ -2672,21 +2674,21 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! isset($query_params['default_where_conditions'])) {
             $query_params['default_where_conditions'] = EEM_Base::default_where_conditions_none;
         }
-        $this_model_name = $this->get_this_model_name();
-        $this_pk_field_name = $this->get_primary_key_field()->get_name();
+        $this_model_name                                                 = $this->get_this_model_name();
+        $this_pk_field_name                                              = $this->get_primary_key_field()->get_name();
         $query_params[0][ $this_model_name . "." . $this_pk_field_name ] = $id_or_obj;
         return $related_model->count($query_params, $field_to_count, $distinct);
     }
-
 
 
     /**
      * Instead of getting the related model objects, simply sums up the values of the specified field.
      * Note: ignores default_where_conditions by default, unless otherwise specified in the $query_params
      *
-     * @param        int           /EE_Base_Class $id_or_obj
+     * @param int           /EE_Base_Class $id_or_obj
      * @param string $model_name   like 'Event', or 'Registration'
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_sum name of field to count by. By default, uses primary key
      * @return float
      * @throws EE_Error
@@ -2703,19 +2705,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         // we're just going to use the query params on the related model's normal get_all query,
         // except add a condition to say to match the current mod
         if (! isset($query_params['default_where_conditions'])) {
             $query_params['default_where_conditions'] = EEM_Base::default_where_conditions_none;
         }
-        $this_model_name = $this->get_this_model_name();
-        $this_pk_field_name = $this->get_primary_key_field()->get_name();
+        $this_model_name                                                 = $this->get_this_model_name();
+        $this_pk_field_name                                              = $this->get_primary_key_field()->get_name();
         $query_params[0][ $this_model_name . "." . $this_pk_field_name ] = $id_or_obj;
         return $related_model->sum($query_params, $field_to_sum);
     }
-
 
 
     /**
@@ -2724,20 +2725,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int | EE_Base_Class $id_or_obj        EE_Base_Class child or its ID
      * @param string              $other_model_name , key in $this->_relatedModels, eg 'Registration', or 'Events'
-     * @param array               $query_params     @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array               $query_params     @see
+     *                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class
      * @throws EE_Error
      */
     public function get_first_related(EE_Base_Class $id_or_obj, $other_model_name, $query_params)
     {
         $query_params['limit'] = 1;
-        $results = $this->get_all_related($id_or_obj, $other_model_name, $query_params);
+        $results               = $this->get_all_related($id_or_obj, $other_model_name, $query_params);
         if ($results) {
             return array_shift($results);
         }
         return null;
     }
-
 
 
     /**
@@ -2749,7 +2750,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return str_replace("EEM_", "", get_class($this));
     }
-
 
 
     /**
@@ -2766,14 +2766,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
         if (! isset($field_with_model_name) || ! $field_with_model_name) {
-            throw new EE_Error(sprintf(
-                __("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
-                $this->get_this_model_name()
-            ));
+            throw new EE_Error(
+                sprintf(
+                    __("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
+                    $this->get_this_model_name()
+                )
+            );
         }
         return $field_with_model_name;
     }
-
 
 
     /**
@@ -2800,10 +2801,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
          * @param array    $fields_n_values keys are the fields and values are their new values
          * @param EEM_Base $model           the model used
          */
-        $field_n_values = (array) apply_filters('FHEE__EEM_Base__insert__fields_n_values', $field_n_values, $this);
+        $field_n_values = (array)apply_filters('FHEE__EEM_Base__insert__fields_n_values', $field_n_values, $this);
         if ($this->_satisfies_unique_indexes($field_n_values)) {
             $main_table = $this->_get_main_table();
-            $new_id = $this->_insert_into_specific_table($main_table, $field_n_values, false);
+            $new_id     = $this->_insert_into_specific_table($main_table, $field_n_values, false);
             if ($new_id !== false) {
                 foreach ($this->_get_other_tables() as $other_table) {
                     $this->_insert_into_specific_table($other_table, $field_n_values, $new_id);
@@ -2812,8 +2813,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             /**
              * Done just after attempting to insert a new model object
              *
-             * @param EEM_Base   $model           used
-             * @param array      $fields_n_values fields and their values
+             * @param EEM_Base $model           used
+             * @param array    $fields_n_values fields and their values
              * @param int|string the              ID of the newly-inserted model object
              */
             do_action('AHEE__EEM_Base__insert__end', $this, $field_n_values, $new_id);
@@ -2821,7 +2822,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return false;
     }
-
 
 
     /**
@@ -2836,7 +2836,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         foreach ($this->unique_indexes() as $index_name => $index) {
             $uniqueness_where_params = array_intersect_key($field_n_values, $index->fields());
-            if ($this->exists(array($uniqueness_where_params))) {
+            if ($this->exists([$uniqueness_where_params])) {
                 EE_Error::add_error(
                     sprintf(
                         __(
@@ -2860,7 +2860,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Checks the database for an item that conflicts (ie, if this item were
      * saved to the DB would break some uniqueness requirement, like a primary key
@@ -2874,8 +2873,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                 when finding "conflicts". If true, it's also considered).
      *                                                 Only works for INT primary key,
      *                                                 STRING primary keys cannot be ignored
-     * @throws EE_Error
      * @return EE_Base_Class|array
+     * @throws EE_Error
      */
     public function get_one_conflicting($obj_or_fields_array, $include_primary_key = true)
     {
@@ -2895,7 +2894,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 )
             );
         }
-        $query_params = array();
+        $query_params = [];
         if (
             $this->has_primary_key_field()
             && ($include_primary_key
@@ -2907,16 +2906,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $query_params[0]['OR'][ $this->primary_key_name() ] = $fields_n_values[ $this->primary_key_name() ];
         }
         foreach ($this->unique_indexes() as $unique_index_name => $unique_index) {
-            $uniqueness_where_params = array_intersect_key($fields_n_values, $unique_index->fields());
+            $uniqueness_where_params                              =
+                array_intersect_key($fields_n_values, $unique_index->fields());
             $query_params[0]['OR'][ 'AND*' . $unique_index_name ] = $uniqueness_where_params;
         }
         // if there is nothing to base this search on, then we shouldn't find anything
         if (empty($query_params)) {
-            return array();
+            return [];
         }
         return $this->get_one($query_params);
     }
-
 
 
     /**
@@ -2933,7 +2932,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Wrapper for exists, except ignores default query parameters so we're only considering ID
      *
@@ -2944,15 +2942,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function exists_by_ID($id)
     {
         return $this->exists(
-            array(
+            [
                 'default_where_conditions' => EEM_Base::default_where_conditions_none,
-                array(
+                [
                     $this->primary_key_name() => $id,
-                ),
-            )
+                ],
+            ]
         );
     }
-
 
 
     /**
@@ -2968,16 +2965,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array         $fields_n_values each key should be in field's keys, and value should be an int, string or
      *                                       float
      * @param int           $new_id          for now we assume only int keys
+     * @return int ID of new row inserted, or FALSE on failure
      * @throws EE_Error
      * @global WPDB         $wpdb            only used to get the $wpdb->insert_id after performing an insert
-     * @return int ID of new row inserted, or FALSE on failure
      */
     protected function _insert_into_specific_table(EE_Table_Base $table, $fields_n_values, $new_id = 0)
     {
         global $wpdb;
-        $insertion_col_n_values = array();
-        $format_for_insertion = array();
-        $fields_on_table = $this->_get_fields_for_table($table->get_table_alias());
+        $insertion_col_n_values = [];
+        $format_for_insertion   = [];
+        $fields_on_table        = $this->_get_fields_for_table($table->get_table_alias());
         foreach ($fields_on_table as $field_name => $field_obj) {
             // check if its an auto-incrementing column, in which case we should just leave it to do its autoincrement thing
             if ($field_obj->is_auto_increment()) {
@@ -2987,19 +2984,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // if the value we want to assign it to is NULL, just don't mention it for the insertion
             if ($prepared_value !== null) {
                 $insertion_col_n_values[ $field_obj->get_table_column() ] = $prepared_value;
-                $format_for_insertion[] = $field_obj->get_wpdb_data_type();
+                $format_for_insertion[]                                   = $field_obj->get_wpdb_data_type();
             }
         }
         if ($table instanceof EE_Secondary_Table && $new_id) {
             // its not the main table, so we should have already saved the main table's PK which we just inserted
             // so add the fk to the main table as a column
             $insertion_col_n_values[ $table->get_fk_on_table() ] = $new_id;
-            $format_for_insertion[] = '%d';// yes right now we're only allowing these foreign keys to be INTs
+            $format_for_insertion[]                              =
+                '%d';// yes right now we're only allowing these foreign keys to be INTs
         }
         // insert the new entry
         $result = $this->_do_wpdb_query(
             'insert',
-            array($table->get_table_name(), $insertion_col_n_values, $format_for_insertion)
+            [$table->get_table_name(), $insertion_col_n_values, $format_for_insertion]
         );
         if ($result === false) {
             return false;
@@ -3017,7 +3015,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // a unique string indicating this model
         return $this->get_index_primary_key_string($fields_n_values);
     }
-
 
 
     /**
@@ -3047,7 +3044,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             : null;
         return $this->_prepare_value_for_use_in_db($unprepared_value, $field_obj);
     }
-
 
 
     /**
@@ -3084,7 +3080,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns the main table on this model
      *
@@ -3098,12 +3093,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 return $table;
             }
         }
-        throw new EE_Error(sprintf(__(
-            'There are no main tables on %s. They should be added to _tables array in the constructor',
-            'event_espresso'
-        ), get_class($this)));
+        throw new EE_Error(
+            sprintf(
+                __(
+                    'There are no main tables on %s. They should be added to _tables array in the constructor',
+                    'event_espresso'
+                ),
+                get_class($this)
+            )
+        );
     }
-
 
 
     /**
@@ -3117,7 +3116,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_get_main_table()->get_table_name();
     }
-
 
 
     /**
@@ -3134,7 +3132,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * get_table_obj_by_alias
      * returns table name given it's alias
@@ -3148,7 +3145,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the tables of type EE_Other_Table from EEM_CPT_Basel_Model::_tables
      *
@@ -3156,7 +3152,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function _get_other_tables()
     {
-        $other_tables = array();
+        $other_tables = [];
         foreach ($this->_tables as $table_alias => $table) {
             if ($table instanceof EE_Secondary_Table) {
                 $other_tables[ $table_alias ] = $table;
@@ -3164,7 +3160,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $other_tables;
     }
-
 
 
     /**
@@ -3179,7 +3174,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Recurses through all the where parameters, and finds all the related models we'll need
      * to complete this query. Eg, given where parameters like array('EVT_ID'=>3) from within Event model, we won't
@@ -3187,7 +3181,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Registration model. If it were array('Registrations.Transactions.Payments.PAY_ID'=>3), then we'd need the
      * related Registration, Transaction, and Payment models.
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
      */
@@ -3246,11 +3241,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * For extracting related models from WHERE (0), HAVING (having), ORDER BY (order_by) or forced joins (force_join)
      *
-     * @param array                       $sub_query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
+     * @param array                       $sub_query_params @see
+     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @throws EE_Error
@@ -3262,7 +3257,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $query_param_type
     ) {
         if (! empty($sub_query_params)) {
-            $sub_query_params = (array) $sub_query_params;
+            $sub_query_params = (array)$sub_query_params;
             foreach ($sub_query_params as $param => $possibly_array_of_params) {
                 // $param could be simply 'EVT_ID', or it could be 'Registrations.REG_ID', or even 'Registrations.Transactions.Payments.PAY_amount'
                 $this->_extract_related_model_info_from_query_param(
@@ -3274,17 +3269,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 // indicate needed joins. Eg, array('NOT'=>array('Registration.TXN_ID'=>23)). In this case, we tried
                 // extracting models out of the 'NOT', which obviously wasn't successful, and then we recurse into the value
                 // of array('Registration.TXN_ID'=>23)
-                $query_param_sans_stars = $this->_remove_stars_and_anything_after_from_condition_query_param_key($param);
+                $query_param_sans_stars =
+                    $this->_remove_stars_and_anything_after_from_condition_query_param_key($param);
                 if (in_array($query_param_sans_stars, $this->_logic_query_param_keys, true)) {
                     if (! is_array($possibly_array_of_params)) {
-                        throw new EE_Error(sprintf(
-                            __(
-                                "You used a special where query param %s, but the value isn't an array of where query params, it's just %s'. It should be an array, eg array('EVT_ID'=>23,'OR'=>array('Venue.VNU_ID'=>32,'Venue.VNU_name'=>'monkey_land'))",
-                                "event_espresso"
-                            ),
-                            $param,
-                            $possibly_array_of_params
-                        ));
+                        throw new EE_Error(
+                            sprintf(
+                                __(
+                                    "You used a special where query param %s, but the value isn't an array of where query params, it's just %s'. It should be an array, eg array('EVT_ID'=>23,'OR'=>array('Venue.VNU_ID'=>32,'Venue.VNU_name'=>'monkey_land'))",
+                                    "event_espresso"
+                                ),
+                                $param,
+                                $possibly_array_of_params
+                            )
+                        );
                     }
                     $this->_extract_related_models_from_sub_params_array_keys(
                         $possibly_array_of_params,
@@ -3293,18 +3291,24 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     );
                 } elseif (
                     $query_param_type === 0 // ie WHERE
-                          && is_array($possibly_array_of_params)
-                          && isset($possibly_array_of_params[2])
-                          && $possibly_array_of_params[2] == true
+                    && is_array($possibly_array_of_params)
+                    && isset($possibly_array_of_params[2])
+                    && $possibly_array_of_params[2] == true
                 ) {
                     // then $possible_array_of_params looks something like array('<','DTT_sold',true)
                     // indicating that $possible_array_of_params[1] is actually a field name,
                     // from which we should extract query parameters!
                     if (! isset($possibly_array_of_params[0], $possibly_array_of_params[1])) {
-                        throw new EE_Error(sprintf(__(
-                            "Improperly formed query parameter %s. It should be numerically indexed like array('<','DTT_sold',true); but you provided %s",
-                            "event_espresso"
-                        ), $query_param_type, implode(",", $possibly_array_of_params)));
+                        throw new EE_Error(
+                            sprintf(
+                                __(
+                                    "Improperly formed query parameter %s. It should be numerically indexed like array('<','DTT_sold',true); but you provided %s",
+                                    "event_espresso"
+                                ),
+                                $query_param_type,
+                                implode(",", $possibly_array_of_params)
+                            )
+                        );
                     }
                     $this->_extract_related_model_info_from_query_param(
                         $possibly_array_of_params[1],
@@ -3318,12 +3322,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * For extracting related models from forced_joins, where the array values contain the info about what
      * models to join with. Eg an array like array('Attendee','Price.Price_Type');
      *
-     * @param array                       $sub_query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array                       $sub_query_params @see
+     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @throws EE_Error
@@ -3336,10 +3340,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     ) {
         if (! empty($sub_query_params)) {
             if (! is_array($sub_query_params)) {
-                throw new EE_Error(sprintf(
-                    __("Query parameter %s should be an array, but it isn't.", "event_espresso"),
-                    $sub_query_params
-                ));
+                throw new EE_Error(
+                    sprintf(
+                        __("Query parameter %s should be an array, but it isn't.", "event_espresso"),
+                        $sub_query_params
+                    )
+                );
             }
             foreach ($sub_query_params as $param) {
                 // $param could be simply 'EVT_ID', or it could be 'Registrations.REG_ID', or even 'Registrations.Transactions.Payments.PAY_amount'
@@ -3362,7 +3368,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * before we know what joins to perform. However, we need to know what data types correspond to which fields on
      * other models before we can finalize the where clause SQL.
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @return EE_Model_Query_Info_Carrier
      * @throws ModelConfigurationException
@@ -3381,9 +3388,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
-        $query_params[0] = isset($query_params[0]) ? $query_params[0] : array();
+        $query_params[0] = isset($query_params[0]) ? $query_params[0] : [];
         // first check if we should alter the query to account for caps or not
         // because the caps might require us to do extra joins
         if (isset($query_params['caps']) && $query_params['caps'] !== 'none') {
@@ -3400,10 +3407,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (isset($query_params['exclude_protected']) && $query_params['exclude_protected'] === true) {
             $where_param_key_for_password = $this->modelChainAndPassword();
             // only include if related to a cpt where no password has been set
-            $query_params[0]['OR*nopassword'] = array(
-                $where_param_key_for_password => '',
-                $where_param_key_for_password . '*' => array('IS_NULL')
-            );
+            $query_params[0]['OR*nopassword'] = [
+                $where_param_key_for_password       => '',
+                $where_param_key_for_password . '*' => ['IS_NULL'],
+            ];
         }
         $query_object = $this->_extract_related_models_from_query($query_params);
         // verify where_query_params has NO numeric indexes.... that's simply not how you use it!
@@ -3498,9 +3505,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     'order_by'
                 );
                 // assume it's an array of fields to order by
-                $order_array = array();
+                $order_array = [];
                 foreach ($query_params['order_by'] as $field_name_to_order_by => $order) {
-                    $order = $this->_extract_order($order);
+                    $order         = $this->_extract_order($order);
                     $order_array[] = $this->_deduce_column_name_from_query_param($field_name_to_order_by) . SP . $order;
                 }
                 $query_object->set_order_by_sql(" ORDER BY " . implode(",", $order_array));
@@ -3526,14 +3533,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             && ! empty($query_params['order'])
         ) {
             $pk_field = $this->get_primary_key_field();
-            $order = $this->_extract_order($query_params['order']);
+            $order    = $this->_extract_order($query_params['order']);
             $query_object->set_order_by_sql(" ORDER BY " . $pk_field->get_qualified_column() . SP . $order);
         }
         // set group by
         if (array_key_exists('group_by', $query_params)) {
             if (is_array($query_params['group_by'])) {
                 // it's an array, so assume we'll be grouping by a bunch of stuff
-                $group_by_array = array();
+                $group_by_array = [];
                 foreach ($query_params['group_by'] as $field_name_to_group_by) {
                     $group_by_array[] = $this->_deduce_column_name_from_query_param($field_name_to_group_by);
                 }
@@ -3573,20 +3580,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the where conditions that should be imposed on the query based on the
      * context (eg reading frontend, backend, edit or delete).
      *
      * @param string $context one of EEM_Base::valid_cap_contexts()
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
      */
     public function caps_where_conditions($context = self::caps_read)
     {
         EEM_Base::verify_is_valid_cap_context($context);
-        $cap_where_conditions = array();
-        $cap_restrictions = $this->caps_missing($context);
+        $cap_where_conditions = [];
+        $cap_restrictions     = $this->caps_missing($context);
         /**
          * @var $cap_restrictions EE_Default_Where_Conditions[]
          */
@@ -3604,7 +3611,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $cap_restrictions
         );
     }
-
 
 
     /**
@@ -3633,7 +3639,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Looks at all the models which are included in this query, and asks each
      * for their universal_where_params, and returns them in the same format as $query_params[0] (where),
@@ -3648,27 +3653,31 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                                  not for this primary model. 'all', the default,
      *                                                                  means default where conditions will apply as
      *                                                                  normal
-     * @param array                       $where_query_params           @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array                       $where_query_params           @see
+     *                                                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _get_default_where_conditions_for_models_in_query(
         EE_Model_Query_Info_Carrier $query_info_carrier,
         $use_default_where_conditions = EEM_Base::default_where_conditions_all,
-        $where_query_params = array()
+        $where_query_params = []
     ) {
         $allowed_used_default_where_conditions_values = EEM_Base::valid_default_where_conditions();
         if (! in_array($use_default_where_conditions, $allowed_used_default_where_conditions_values)) {
-            throw new EE_Error(sprintf(
-                __(
-                    "You passed an invalid value to the query parameter 'default_where_conditions' of '%s'. Allowed values are %s",
-                    "event_espresso"
-                ),
-                $use_default_where_conditions,
-                implode(", ", $allowed_used_default_where_conditions_values)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "You passed an invalid value to the query parameter 'default_where_conditions' of '%s'. Allowed values are %s",
+                        "event_espresso"
+                    ),
+                    $use_default_where_conditions,
+                    implode(", ", $allowed_used_default_where_conditions_values)
+                )
+            );
         }
-        $universal_query_params = array();
+        $universal_query_params = [];
         if ($this->_should_use_default_where_conditions($use_default_where_conditions, true)) {
             $universal_query_params = $this->_get_default_where_conditions();
         } elseif ($this->_should_use_minimum_where_conditions($use_default_where_conditions, true)) {
@@ -3677,14 +3686,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         foreach ($query_info_carrier->get_model_names_included() as $model_relation_path => $model_name) {
             $related_model = $this->get_related_model_obj($model_name);
             if ($this->_should_use_default_where_conditions($use_default_where_conditions, false)) {
-                $related_model_universal_where_params = $related_model->_get_default_where_conditions($model_relation_path);
+                $related_model_universal_where_params =
+                    $related_model->_get_default_where_conditions($model_relation_path);
             } elseif ($this->_should_use_minimum_where_conditions($use_default_where_conditions, false)) {
-                $related_model_universal_where_params = $related_model->_get_minimum_where_conditions($model_relation_path);
+                $related_model_universal_where_params =
+                    $related_model->_get_minimum_where_conditions($model_relation_path);
             } else {
                 // we don't want to add full or even minimum default where conditions from this model, so just continue
                 continue;
             }
-            $overrides = $this->_override_defaults_or_make_null_friendly(
+            $overrides              = $this->_override_defaults_or_make_null_friendly(
                 $related_model_universal_where_params,
                 $where_query_params,
                 $related_model,
@@ -3699,7 +3710,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Determines whether or not we should use default where conditions for the model in question
      * (this model, or other related models).
@@ -3707,6 +3717,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * this model only, or to use minimum where conditions on all other models and normal where conditions on this one.
      * We should use default where conditions on related models when they requested to use default where conditions
      * on all models, or specifically just on other related models
+     *
      * @param      $default_where_conditions_value
      * @param bool $for_this_model false means this is for OTHER related models
      * @return bool
@@ -3717,11 +3728,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_all,
                            EEM_Base::default_where_conditions_this_only,
                            EEM_Base::default_where_conditions_minimum_others,
-                       ),
+                       ],
                        true
                    )
                )
@@ -3729,14 +3740,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    ! $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_all,
                            EEM_Base::default_where_conditions_others_only,
-                       ),
+                       ],
                        true
                    )
                );
     }
+
 
     /**
      * Determines whether or not we should use default minimum conditions for the model in question
@@ -3745,6 +3757,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * where conditions.
      * We should use minimum where conditions on related models if they requested to use minimum where conditions
      * on this model or others
+     *
      * @param      $default_where_conditions_value
      * @param bool $for_this_model false means this is for OTHER related models
      * @return bool
@@ -3759,10 +3772,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    ! $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_minimum_others,
                            EEM_Base::default_where_conditions_minimum_all,
-                       ),
+                       ],
                        true
                    )
                );
@@ -3779,7 +3792,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array    $provided_where_conditions
      * @param EEM_Base $model
      * @param string   $model_relation_path like 'Transaction.Payment.'
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
      */
     private function _override_defaults_or_make_null_friendly(
@@ -3788,9 +3802,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $model,
         $model_relation_path
     ) {
-        $null_friendly_where_conditions = array();
-        $none_overridden = true;
-        $or_condition_key_for_defaults = 'OR*' . get_class($model);
+        $null_friendly_where_conditions = [];
+        $none_overridden                = true;
+        $or_condition_key_for_defaults  = 'OR*' . get_class($model);
         foreach ($default_where_conditions as $key => $val) {
             if (isset($provided_where_conditions[ $key ])) {
                 $none_overridden = false;
@@ -3801,15 +3815,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if ($none_overridden && $default_where_conditions) {
             if ($model->has_primary_key_field()) {
                 $null_friendly_where_conditions[ $or_condition_key_for_defaults ][ $model_relation_path
-                                                                                . "."
-                                                                                . $model->primary_key_name() ] = array('IS NULL');
+                                                                                   . "."
+                                                                                   . $model->primary_key_name() ] =
+                    ['IS NULL'];
             }/*else{
                 //@todo NO PK, use other defaults
             }*/
         }
         return $null_friendly_where_conditions;
     }
-
 
 
     /**
@@ -3819,16 +3833,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * NOT array('Event_CPT.post_type'=>'esp_event').
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _get_default_where_conditions($model_relation_path = '')
     {
         if ($this->_ignore_where_strategy) {
-            return array();
+            return [];
         }
         return $this->_default_where_conditions_strategy->get_default_where_conditions($model_relation_path);
     }
-
 
 
     /**
@@ -3839,16 +3853,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Similar to _get_default_where_conditions
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     protected function _get_minimum_where_conditions($model_relation_path = '')
     {
         if ($this->_ignore_where_strategy) {
-            return array();
+            return [];
         }
         return $this->_minimum_where_conditions_strategy->get_default_where_conditions($model_relation_path);
     }
-
 
 
     /**
@@ -3862,16 +3876,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     private function _construct_default_select_sql(EE_Model_Query_Info_Carrier $model_query_info)
     {
         $selects = $this->_get_columns_to_select_for_this_model();
-        foreach ($model_query_info->get_model_names_included() as $model_relation_chain => $name_of_other_model_included) {
+        foreach (
+            $model_query_info->get_model_names_included() as $model_relation_chain => $name_of_other_model_included
+        ) {
             $other_model_included = $this->get_related_model_obj($name_of_other_model_included);
-            $other_model_selects = $other_model_included->_get_columns_to_select_for_this_model($model_relation_chain);
+            $other_model_selects  = $other_model_included->_get_columns_to_select_for_this_model($model_relation_chain);
             foreach ($other_model_selects as $key => $value) {
                 $selects[] = $value;
             }
         }
         return implode(", ", $selects);
     }
-
 
 
     /**
@@ -3883,12 +3898,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _get_columns_to_select_for_this_model($model_relation_chain = '')
     {
-        $fields = $this->field_settings();
-        $selects = array();
-        $table_alias_with_model_relation_chain_prefix = EE_Model_Parser::extract_table_alias_model_relation_chain_prefix(
-            $model_relation_chain,
-            $this->get_this_model_name()
-        );
+        $fields                                       = $this->field_settings();
+        $selects                                      = [];
+        $table_alias_with_model_relation_chain_prefix =
+            EE_Model_Parser::extract_table_alias_model_relation_chain_prefix(
+                $model_relation_chain,
+                $this->get_this_model_name()
+            );
         foreach ($fields as $field_obj) {
             $selects[] = $table_alias_with_model_relation_chain_prefix
                          . $field_obj->get_table_alias()
@@ -3916,7 +3932,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Given a $query_param like 'Registration.Transaction.TXN_ID', pops off 'Registration.',
      * gets the join statement for it; gets the data types for it; and passes the remaining 'Transaction.TXN_ID'
@@ -3926,15 +3941,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param null|string                 $original_query_param
      * @param string                      $query_param          like Registration.Transaction.TXN_ID
      * @param EE_Model_Query_Info_Carrier $passed_in_query_info
-     * @param    string                   $query_param_type     like Registration.Transaction.TXN_ID
+     * @param string                      $query_param_type     like Registration.Transaction.TXN_ID
      *                                                          or 'PAY_ID'. Otherwise, we don't expect there to be a
      *                                                          column name. We only want model names, eg 'Event.Venue'
      *                                                          or 'Registration's
      * @param string                      $original_query_param what it originally was (eg
      *                                                          Registration.Transaction.TXN_ID). If null, we assume it
      *                                                          matches $query_param
-     * @throws EE_Error
      * @return void only modifies the EEM_Related_Model_Info_Carrier passed into it
+     * @throws EE_Error
      */
     private function _extract_related_model_info_from_query_param(
         $query_param,
@@ -3947,10 +3962,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         $query_param = $this->_remove_stars_and_anything_after_from_condition_query_param_key($query_param);
         /** @var $allow_logic_query_params bool whether or not to allow logic_query_params like 'NOT','OR', or 'AND' */
-        $allow_logic_query_params = in_array($query_param_type, array('where', 'having', 0, 'custom_selects'), true);
-        $allow_fields = in_array(
+        $allow_logic_query_params = in_array($query_param_type, ['where', 'having', 0, 'custom_selects'], true);
+        $allow_fields             = in_array(
             $query_param_type,
-            array('where', 'having', 'order_by', 'group_by', 'order', 'custom_selects', 0),
+            ['where', 'having', 'order_by', 'group_by', 'order', 'custom_selects', 0],
             true
         );
         // check to see if we have a field on this model
@@ -4011,12 +4026,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // and
         // check if it's a field on a related model
         if (
-            $this->extractJoinModelFromQueryParams(
-                $passed_in_query_info,
-                $query_param,
-                $original_query_param,
-                $query_param_type
-            )
+        $this->extractJoinModelFromQueryParams(
+            $passed_in_query_info,
+            $query_param,
+            $original_query_param,
+            $query_param_type
+        )
         ) {
             return;
         }
@@ -4041,14 +4056,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Extracts any possible join model information from the provided possible_join_string.
-     * This method will read the provided $possible_join_string value and determine if there are any possible model join
+     * This method will read the provided $possible_join_string value and determine if there are any possible model
+     * join
      * parts that should be added to the query.
      *
      * @param EE_Model_Query_Info_Carrier $query_info_carrier
      * @param string                      $possible_join_string  Such as Registration.REG_ID, or Registration
      * @param null|string                 $original_query_param
      * @param string                      $query_parameter_type  The type for the source of the $possible_join_string
-     *                                                           ('where', 'order_by', 'group_by', 'custom_selects' etc.)
+     *                                                           ('where', 'order_by', 'group_by', 'custom_selects'
+     *                                                           etc.)
      * @return bool  returns true if a join was added and false if not.
      * @throws EE_Error
      */
@@ -4102,6 +4119,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Extracts related models from Custom Selects and sets up any joins for those related models.
+     *
      * @param EE_Model_Query_Info_Carrier $query_info_carrier
      * @throws EE_Error
      */
@@ -4124,7 +4142,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
     }
-
 
 
     /**
@@ -4151,21 +4168,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_Model_Query_Info_Carrier $passed_in_query_info,
         $original_query_param
     ) {
-        $relation_obj = $this->related_settings_for($model_name);
+        $relation_obj         = $this->related_settings_for($model_name);
         $model_relation_chain = EE_Model_Parser::extract_model_relation_chain($model_name, $original_query_param);
         // check if the relation is HABTM, because then we're essentially doing two joins
         // If so, join first to the JOIN table, and add its data types, and then continue as normal
         if ($relation_obj instanceof EE_HABTM_Relation) {
             $join_model_obj = $relation_obj->get_join_model();
             // replace the model specified with the join model for this relation chain, whi
-            $relation_chain_to_join_model = EE_Model_Parser::replace_model_name_with_join_model_name_in_model_relation_chain(
-                $model_name,
-                $join_model_obj->get_this_model_name(),
-                $model_relation_chain
-            );
+            $relation_chain_to_join_model =
+                EE_Model_Parser::replace_model_name_with_join_model_name_in_model_relation_chain(
+                    $model_name,
+                    $join_model_obj->get_this_model_name(),
+                    $model_relation_chain
+                );
             $passed_in_query_info->merge(
                 new EE_Model_Query_Info_Carrier(
-                    array($relation_chain_to_join_model => $join_model_obj->get_this_model_name()),
+                    [$relation_chain_to_join_model => $join_model_obj->get_this_model_name()],
                     $relation_obj->get_join_to_intermediate_model_statement($relation_chain_to_join_model)
                 )
             );
@@ -4173,18 +4191,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // now just join to the other table pointed to by the relation object, and add its data types
         $passed_in_query_info->merge(
             new EE_Model_Query_Info_Carrier(
-                array($model_relation_chain => $model_name),
+                [$model_relation_chain => $model_name],
                 $relation_obj->get_join_statement($model_relation_chain)
             )
         );
     }
 
 
-
     /**
      * Constructs SQL for where clause, like "WHERE Event.ID = 23 AND Transaction.amount > 100" etc.
      *
-     * @param array $where_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array $where_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @return string of SQL
      * @throws EE_Error
      */
@@ -4196,7 +4214,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return '';
     }
-
 
 
     /**
@@ -4221,43 +4238,47 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Used for creating nested WHERE conditions. Eg "WHERE ! (Event.ID = 3 OR ( Event_Meta.meta_key = 'bob' AND
      * Event_Meta.meta_value = 'foo'))"
      *
-     * @param array  $where_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array  $where_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @param string $glue         joins each subclause together. Should really only be " AND " or " OR "...
      * @throws EE_Error
      * @return string of SQL
      */
     private function _construct_condition_clause_recursive($where_params, $glue = ' AND')
     {
-        $where_clauses = array();
+        $where_clauses = [];
         foreach ($where_params as $query_param => $op_and_value_or_sub_condition) {
-            $query_param = $this->_remove_stars_and_anything_after_from_condition_query_param_key($query_param);// str_replace("*",'',$query_param);
+            $query_param =
+                $this->_remove_stars_and_anything_after_from_condition_query_param_key(
+                    $query_param
+                );// str_replace("*",'',$query_param);
             if (in_array($query_param, $this->_logic_query_param_keys)) {
                 switch ($query_param) {
                     case 'not':
                     case 'NOT':
                         $where_clauses[] = "! ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               $glue
-                                           )
+                                $op_and_value_or_sub_condition,
+                                $glue
+                            )
                                            . ")";
                         break;
                     case 'and':
                     case 'AND':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               ' AND '
-                                           )
+                                $op_and_value_or_sub_condition,
+                                ' AND '
+                            )
                                            . ")";
                         break;
                     case 'or':
                     case 'OR':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               ' OR '
-                                           )
+                                $op_and_value_or_sub_condition,
+                                ' OR '
+                            )
                                            . ")";
                         break;
                 }
@@ -4268,27 +4289,31 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     if ($this->_custom_selections instanceof CustomSelects) {
                         $field_obj = $this->_custom_selections->getDataTypeForAlias($query_param);
                     } else {
-                        throw new EE_Error(sprintf(__(
-                            "%s is neither a valid model field name, nor a custom selection",
-                            "event_espresso"
-                        ), $query_param));
+                        throw new EE_Error(
+                            sprintf(
+                                __(
+                                    "%s is neither a valid model field name, nor a custom selection",
+                                    "event_espresso"
+                                ),
+                                $query_param
+                            )
+                        );
                     }
                 }
                 $op_and_value_sql = $this->_construct_op_and_value($op_and_value_or_sub_condition, $field_obj);
-                $where_clauses[] = $this->_deduce_column_name_from_query_param($query_param) . SP . $op_and_value_sql;
+                $where_clauses[]  = $this->_deduce_column_name_from_query_param($query_param) . SP . $op_and_value_sql;
             }
         }
         return $where_clauses ? implode($glue, $where_clauses) : '';
     }
 
 
-
     /**
      * Takes the input parameter and extract the table name (alias) and column name
      *
      * @param string $query_param like Registration.Transaction.TXN_ID, Event.Datetime.start_time, or REG_ID
-     * @throws EE_Error
      * @return string table alias and column name for SQL, eg "Transaction.TXN_ID"
+     * @throws EE_Error
      */
     private function _deduce_column_name_from_query_param($query_param)
     {
@@ -4324,7 +4349,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Removes the * and anything after it from the condition query param key. It is useful to add the * to condition
      * query param keys (eg, 'OR*', 'EVT_ID') in order for the array keys to still be unique, so that they don't get
@@ -4345,21 +4369,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * creates the SQL for the operator and the value in a WHERE clause, eg "< 23" or "LIKE '%monkey%'"
      *
-     * @param                            mixed      array | string    $op_and_value
+     * @param mixed      array | string    $op_and_value
      * @param EE_Model_Field_Base|string $field_obj . If string, should be one of EEM_Base::_valid_wpdb_data_types
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     private function _construct_op_and_value($op_and_value, $field_obj)
     {
         if (is_array($op_and_value)) {
             $operator = isset($op_and_value[0]) ? $this->_prepare_operator_for_sql($op_and_value[0]) : null;
             if (! $operator) {
-                $php_array_like_string = array();
+                $php_array_like_string = [];
                 foreach ($op_and_value as $key => $value) {
                     $php_array_like_string[] = "$key=>$value";
                 }
@@ -4376,7 +4399,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $value = isset($op_and_value[1]) ? $op_and_value[1] : null;
         } else {
             $operator = '=';
-            $value = $op_and_value;
+            $value    = $op_and_value;
         }
         // check to see if the value is actually another field
         if (is_array($op_and_value) && isset($op_and_value[2]) && $op_and_value[2] == true) {
@@ -4464,7 +4487,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Creates the operands to be used in a BETWEEN query, eg "'2014-12-31 20:23:33' AND '2015-01-23 12:32:54'"
      *
@@ -4476,13 +4498,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _construct_between_value($values, $field_obj)
     {
-        $cleaned_values = array();
+        $cleaned_values = [];
         foreach ($values as $value) {
             $cleaned_values[] = $this->_wpdb_prepare_using_field($value, $field_obj);
         }
         return $cleaned_values[0] . " AND " . $cleaned_values[1];
     }
-
 
 
     /**
@@ -4504,7 +4525,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // in which case, turn it into an array
             $values = explode(",", $values);
         }
-        $cleaned_values = array();
+        $cleaned_values = [];
         foreach ($values as $value) {
             $cleaned_values[] = $this->_wpdb_prepare_using_field($value, $field_obj);
         }
@@ -4512,9 +4533,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // but unfortunately that's invalid SQL. So instead we return a string which we KNOW will evaluate to be the empty set
         // which is effectively equivalent to returning "()". We don't return "(0)" because that only works for auto-incrementing columns
         if (empty($cleaned_values)) {
-            $all_fields = $this->field_settings();
-            $a_field = array_shift($all_fields);
-            $main_table = $this->_get_main_table();
+            $all_fields       = $this->field_settings();
+            $a_field          = array_shift($all_fields);
+            $main_table       = $this->_get_main_table();
             $cleaned_values[] = "SELECT "
                                 . $a_field->get_table_column()
                                 . " FROM "
@@ -4525,12 +4546,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * @param mixed                      $value
      * @param EE_Model_Field_Base|string $field_obj if string it should be a wpdb data type like '%d'
-     * @throws EE_Error
      * @return false|null|string
+     * @throws EE_Error
      */
     private function _wpdb_prepare_using_field($value, $field_obj)
     {
@@ -4555,13 +4575,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Takes the input parameter and finds the model field that it indicates.
      *
      * @param string $query_param_name like Registration.Transaction.TXN_ID, Event.Datetime.start_time, or REG_ID
-     * @throws EE_Error
      * @return EE_Model_Field_Base
+     * @throws EE_Error
      */
     protected function _deduce_field_from_query_param($query_param_name)
     {
@@ -4569,20 +4588,25 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // which will help us find the database table and column
         $query_param_parts = explode(".", $query_param_name);
         if (empty($query_param_parts)) {
-            throw new EE_Error(sprintf(__(
-                "_extract_column_name is empty when trying to extract column and table name from %s",
-                'event_espresso'
-            ), $query_param_name));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "_extract_column_name is empty when trying to extract column and table name from %s",
+                        'event_espresso'
+                    ),
+                    $query_param_name
+                )
+            );
         }
-        $number_of_parts = count($query_param_parts);
+        $number_of_parts       = count($query_param_parts);
         $last_query_param_part = $query_param_parts[ count($query_param_parts) - 1 ];
         if ($number_of_parts === 1) {
             $field_name = $last_query_param_part;
-            $model_obj = $this;
+            $model_obj  = $this;
         } else {// $number_of_parts >= 2
             // the last part is the column name, and there are only 2parts. therefore...
             $field_name = $last_query_param_part;
-            $model_obj = $this->get_related_model_obj($query_param_parts[ $number_of_parts - 2 ]);
+            $model_obj  = $this->get_related_model_obj($query_param_parts[ $number_of_parts - 2 ]);
         }
         try {
             return $model_obj->field_settings_for($field_name);
@@ -4592,19 +4616,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Given a field's name (ie, a key in $this->field_settings()), uses the EE_Model_Field object to get the table's
      * alias and column which corresponds to it
      *
      * @param string $field_name
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     public function _get_qualified_column_for_field($field_name)
     {
         $all_fields = $this->field_settings();
-        $field = isset($all_fields[ $field_name ]) ? $all_fields[ $field_name ] : false;
+        $field      = isset($all_fields[ $field_name ]) ? $all_fields[ $field_name ] : false;
         if ($field) {
             return $field->get_qualified_column();
         }
@@ -4619,7 +4642,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             )
         );
     }
-
 
 
     /**
@@ -4665,9 +4687,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                            Also, when querying from the venue model and selecting fields from
      *                                            the ticket model, you should provide the string 'Event.Datetime',
      *                                            indicating you need to join the venue model to the event model,
-     *                                            to the datetime model, in order to find its relation to the ticket model.
-     *                                            This string is used to deduce the prefix that gets added onto the
-     *                                            models' tables qualified columns
+     *                                            to the datetime model, in order to find its relation to the ticket
+     *                                            model. This string is used to deduce the prefix that gets added onto
+     *                                            the models' tables qualified columns
      * @param bool   $return_string               if true, will return a string with qualified column names separated
      *                                            by ', ' if false, will simply return a numerically indexed array of
      *                                            qualified column names
@@ -4675,14 +4697,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function get_qualified_columns_for_all_fields($model_relation_chain = '', $return_string = true)
     {
-        $table_prefix = str_replace('.', '__', $model_relation_chain) . (empty($model_relation_chain) ? '' : '__');
-        $qualified_columns = array();
+        $table_prefix      = str_replace('.', '__', $model_relation_chain) . (empty($model_relation_chain) ? '' : '__');
+        $qualified_columns = [];
         foreach ($this->field_settings() as $field_name => $field) {
             $qualified_columns[] = $table_prefix . $field->get_qualified_column();
         }
         return $return_string ? implode(', ', $qualified_columns) : $qualified_columns;
     }
-
 
 
     /**
@@ -4691,8 +4712,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * its setup so the select query will be setup on and just doing the special select join off of the primary table
      * (as that is typically where the limits would be set).
      *
-     * @param  string       $table_alias The table the select is being built for
-     * @param  mixed|string $limit       The limit for this select
+     * @param string       $table_alias The table the select is being built for
+     * @param mixed|string $limit       The limit for this select
      * @return string                The final select join element for the query.
      */
     public function _construct_limit_join_select($table_alias, $limit)
@@ -4713,7 +4734,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Constructs the internal join if there are multiple tables, or simply the table's name and alias
      * Eg "wp_post AS Event" or "wp_post AS Event INNER JOIN wp_postmeta Event_Meta ON Event.ID = Event_Meta.post_id"
@@ -4727,7 +4747,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $SQL .= $this->_construct_internal_join_to_table_with_alias($this->_get_main_table()->get_table_alias());
         return $SQL;
     }
-
 
 
     /**
@@ -4745,7 +4764,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _construct_internal_join_to_table_with_alias($alias_prefixed)
     {
-        $SQL = '';
+        $SQL               = '';
         $alias_sans_prefix = EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($alias_prefixed);
         foreach ($this->_tables as $table_obj) {
             if ($table_obj instanceof EE_Secondary_Table) {// table is secondary table
@@ -4764,7 +4783,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets an array for storing all the data types on the next-to-be-executed-query.
      * This should be a growing array of keys being table-columns (eg 'EVT_ID' and 'Event.EVT_ID'), and values being
@@ -4774,7 +4792,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _get_data_types()
     {
-        $data_types = array();
+        $data_types = [];
         foreach ($this->field_settings() as $field_obj) {
             // $data_types[$field_obj->get_table_column()] = $field_obj->get_wpdb_data_type();
             /** @var $field_obj EE_Model_Field_Base */
@@ -4784,26 +4802,30 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the model object given the relation's name / model's name (eg, 'Event', 'Registration',etc. Always singular)
      *
      * @param string $model_name
-     * @throws EE_Error
      * @return EEM_Base
+     * @throws EE_Error
      */
     public function get_related_model_obj($model_name)
     {
         $model_classname = "EEM_" . $model_name;
         if (! class_exists($model_classname)) {
-            throw new EE_Error(sprintf(__(
-                "You specified a related model named %s in your query. No such model exists, if it did, it would have the classname %s",
-                'event_espresso'
-            ), $model_name, $model_classname));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "You specified a related model named %s in your query. No such model exists, if it did, it would have the classname %s",
+                        'event_espresso'
+                    ),
+                    $model_name,
+                    $model_classname
+                )
+            );
         }
         return call_user_func($model_classname . "::instance");
     }
-
 
 
     /**
@@ -4817,7 +4839,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all related models that this model BELONGS TO. Handy to know sometimes
      * because without THOSE models, this model probably doesn't have much purpose.
@@ -4827,7 +4848,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function belongs_to_relations()
     {
-        $belongs_to_relations = array();
+        $belongs_to_relations = [];
         foreach ($this->relation_settings() as $model_name => $relation_obj) {
             if ($relation_obj instanceof EE_Belongs_To_Relation) {
                 $belongs_to_relations[ $model_name ] = $relation_obj;
@@ -4837,13 +4858,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns the specified EE_Model_Relation, or throws an exception
      *
      * @param string $relation_name name of relation, key in $this->_relatedModels
-     * @throws EE_Error
      * @return EE_Model_Relation_Base
+     * @throws EE_Error
      */
     public function related_settings_for($relation_name)
     {
@@ -4865,29 +4885,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * A convenience method for getting a specific field's settings, instead of getting all field settings for all
      * fields
      *
-     * @param string $fieldName
+     * @param string  $fieldName
      * @param boolean $include_db_only_fields
-     * @throws EE_Error
      * @return EE_Model_Field_Base
+     * @throws EE_Error
      */
     public function field_settings_for($fieldName, $include_db_only_fields = true)
     {
         $fieldSettings = $this->field_settings($include_db_only_fields);
         if (! array_key_exists($fieldName, $fieldSettings)) {
-            throw new EE_Error(sprintf(
-                __("There is no field/column '%s' on '%s'", 'event_espresso'),
-                $fieldName,
-                get_class($this)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    __("There is no field/column '%s' on '%s'", 'event_espresso'),
+                    $fieldName,
+                    get_class($this)
+                )
+            );
         }
         return $fieldSettings[ $fieldName ];
     }
-
 
 
     /**
@@ -4906,7 +4926,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns whether or not this model has a relation to the specified model
      *
@@ -4923,7 +4942,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * gets the field object of type 'primary_key' from the fieldsSettings attribute.
      * Eg, on EE_Answer that would be ANS_ID field object
@@ -4935,7 +4953,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $field_obj instanceof EE_Primary_Key_Field_Base ? true : false;
     }
-
 
 
     /**
@@ -4955,15 +4972,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
             }
             if (! $this->_primary_key_field instanceof EE_Primary_Key_Field_Base) {
-                throw new EE_Error(sprintf(
-                    __("There is no Primary Key defined on model %s", 'event_espresso'),
-                    get_class($this)
-                ));
+                throw new EE_Error(
+                    sprintf(
+                        __("There is no Primary Key defined on model %s", 'event_espresso'),
+                        get_class($this)
+                    )
+                );
             }
         }
         return $this->_primary_key_field;
     }
-
 
 
     /**
@@ -4986,7 +5004,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Finds the first field of type $field_class_name.
      *
@@ -5003,7 +5020,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return null;
     }
-
 
 
     /**
@@ -5026,15 +5042,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
             }
             if (! isset($this->_cache_foreign_key_to_fields[ $model_name ])) {
-                throw new EE_Error(sprintf(__(
-                    "There is no foreign key field pointing to model %s on model %s",
-                    'event_espresso'
-                ), $model_name, get_class($this)));
+                throw new EE_Error(
+                    sprintf(
+                        __(
+                            "There is no foreign key field pointing to model %s on model %s",
+                            'event_espresso'
+                        ),
+                        $model_name,
+                        get_class($this)
+                    )
+                );
             }
         }
         return $this->_cache_foreign_key_to_fields[ $model_name ];
     }
-
 
 
     /**
@@ -5047,10 +5068,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function get_table_for_alias($table_alias)
     {
-        $table_alias_sans_model_relation_chain_prefix = EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($table_alias);
+        $table_alias_sans_model_relation_chain_prefix =
+            EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($table_alias);
         return $this->_tables[ $table_alias_sans_model_relation_chain_prefix ]->get_table_name();
     }
-
 
 
     /**
@@ -5064,7 +5085,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         if ($include_db_only_fields) {
             if ($this->_cached_fields === null) {
-                $this->_cached_fields = array();
+                $this->_cached_fields = [];
                 foreach ($this->_fields as $fields_corresponding_to_table) {
                     foreach ($fields_corresponding_to_table as $field_name => $field_obj) {
                         $this->_cached_fields[ $field_name ] = $field_obj;
@@ -5074,7 +5095,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             return $this->_cached_fields;
         }
         if ($this->_cached_fields_non_db_only === null) {
-            $this->_cached_fields_non_db_only = array();
+            $this->_cached_fields_non_db_only = [];
             foreach ($this->_fields as $fields_corresponding_to_table) {
                 foreach ($fields_corresponding_to_table as $field_name => $field_obj) {
                     /** @var $field_obj EE_Model_Field_Base */
@@ -5088,29 +5109,28 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      *        cycle though array of attendees and create objects out of each item
      *
      * @access        private
-     * @param        array $rows of results of $wpdb->get_results($query,ARRAY_A)
+     * @param array $rows        of results of $wpdb->get_results($query,ARRAY_A)
      * @return \EE_Base_Class[] array keys are primary keys (if there is a primary key on the model. if not,
      *                           numerically indexed)
      * @throws EE_Error
      */
-    protected function _create_objects($rows = array())
+    protected function _create_objects($rows = [])
     {
-        $array_of_objects = array();
+        $array_of_objects = [];
         if (empty($rows)) {
-            return array();
+            return [];
         }
         $count_if_model_has_no_primary_key = 0;
-        $has_primary_key = $this->has_primary_key_field();
-        $primary_key_field = $has_primary_key ? $this->get_primary_key_field() : null;
-        foreach ((array) $rows as $row) {
+        $has_primary_key                   = $this->has_primary_key_field();
+        $primary_key_field                 = $has_primary_key ? $this->get_primary_key_field() : null;
+        foreach ((array)$rows as $row) {
             if (empty($row)) {
                 // wp did its weird thing where it returns an array like array(0=>null), which is totally not helpful...
-                return array();
+                return [];
             }
             // check if we've already set this object in the results array,
             // in which case there's no need to process it further (again)
@@ -5137,7 +5157,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // set the timezone on the instantiated objects
             $classInstance->set_timezone($this->_timezone);
             // make sure if there is any timezone setting present that we set the timezone for the object
-            $key = $has_primary_key ? $classInstance->ID() : $count_if_model_has_no_primary_key++;
+            $key                      = $has_primary_key ? $classInstance->ID() : $count_if_model_has_no_primary_key++;
             $array_of_objects[ $key ] = $classInstance;
             // also, for all the relations of type BelongsTo, see if we can cache
             // those related models
@@ -5147,7 +5167,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             foreach ($this->_model_relations as $modelName => $relation_obj) {
                 if ($relation_obj instanceof EE_Belongs_To_Relation) {
                     // check if this model's INFO is present. If so, cache it on the model
-                    $other_model = $relation_obj->get_other_model();
+                    $other_model           = $relation_obj->get_other_model();
                     $other_model_obj_maybe = $other_model->instantiate_class_from_array_or_object($row);
                     // if we managed to make a model object from the results, cache it on the main model object
                     if ($other_model_obj_maybe) {
@@ -5179,7 +5199,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function getValuesForCustomSelectAliasesFromResults(array $db_results_row)
     {
-        $results = array();
+        $results = [];
         if ($this->_custom_selections instanceof CustomSelects) {
             foreach ($this->_custom_selections->columnAliases() as $alias) {
                 if (isset($db_results_row[ $alias ])) {
@@ -5196,6 +5216,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * This will set the value for the given alias
+     *
      * @param string $value
      * @param string $datatype (one of %d, %s, %f)
      * @return int|string|float (int for %d, string for %s, float for %f)
@@ -5204,11 +5225,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         switch ($datatype) {
             case '%f':
-                return (float) $value;
+                return (float)$value;
             case '%d':
-                return (int) $value;
+                return (int)$value;
             default:
-                return (string) $value;
+                return (string)$value;
         }
     }
 
@@ -5223,17 +5244,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function create_default_object()
     {
-        $this_model_fields_and_values = array();
+        $this_model_fields_and_values = [];
         // setup the row using default values;
         foreach ($this->field_settings() as $field_name => $field_obj) {
             $this_model_fields_and_values[ $field_name ] = $field_obj->get_default_value();
         }
-        $className = $this->_get_class_name();
+        $className     = $this->_get_class_name();
         $classInstance = EE_Registry::instance()
-                                    ->load_class($className, array($this_model_fields_and_values), false, false);
+                                    ->load_class($className, [$this_model_fields_and_values], false, false);
         return $classInstance;
     }
-
 
 
     /**
@@ -5273,7 +5293,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $classInstance = EE_Registry::instance()
                                             ->load_class(
                                                 $className,
-                                                array($this_model_fields_n_values, $this->_timezone),
+                                                [$this_model_fields_n_values, $this->_timezone],
                                                 true,
                                                 false
                                             );
@@ -5284,14 +5304,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $classInstance = EE_Registry::instance()
                                         ->load_class(
                                             $className,
-                                            array($this_model_fields_n_values, $this->_timezone),
+                                            [$this_model_fields_n_values, $this->_timezone],
                                             true,
                                             false
                                         );
         }
         return $classInstance;
     }
-
 
 
     /**
@@ -5307,7 +5326,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * add_to_entity_map
      * Adds the object to the model's entity mappings
@@ -5319,26 +5337,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Note: The map is indexed by whatever the current blog id is set (via EEM_Base::$_model_query_blog_id).  This is
      * so on multisite, the entity map is specific to the query being done for a specific site.
      *
-     * @param    EE_Base_Class $object
-     * @throws EE_Error
+     * @param EE_Base_Class $object
      * @return \EE_Base_Class
+     * @throws EE_Error
      */
     public function add_to_entity_map(EE_Base_Class $object)
     {
         $className = $this->_get_class_name();
         if (! $object instanceof $className) {
-            throw new EE_Error(sprintf(
-                __("You tried adding a %s to a mapping of %ss", "event_espresso"),
-                is_object($object) ? get_class($object) : $object,
-                $className
-            ));
+            throw new EE_Error(
+                sprintf(
+                    __("You tried adding a %s to a mapping of %ss", "event_espresso"),
+                    is_object($object) ? get_class($object) : $object,
+                    $className
+                )
+            );
         }
         /** @var $object EE_Base_Class */
         if (! $object->ID()) {
-            throw new EE_Error(sprintf(__(
-                "You tried storing a model object with NO ID in the %s entity mapper.",
-                "event_espresso"
-            ), get_class($this)));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "You tried storing a model object with NO ID in the %s entity mapper.",
+                        "event_espresso"
+                    ),
+                    get_class($this)
+                )
+            );
         }
         // double check it's not already there
         $classInstance = $this->get_from_entity_map($object->ID());
@@ -5348,7 +5373,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $object->ID() ] = $object;
         return $object;
     }
-
 
 
     /**
@@ -5361,7 +5385,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function clear_entity_map($id = null)
     {
         if (empty($id)) {
-            $this->_entity_map[ EEM_Base::$_model_query_blog_id ] = array();
+            $this->_entity_map[ EEM_Base::$_model_query_blog_id ] = [];
             return true;
         }
         if (isset($this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $id ])) {
@@ -5370,7 +5394,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return false;
     }
-
 
 
     /**
@@ -5387,7 +5410,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * _deduce_fields_n_values_from_cols_n_values
      * Given an array where keys are column (or column alias) names and values,
@@ -5398,7 +5420,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values)
     {
-        $this_model_fields_n_values = array();
+        $this_model_fields_n_values = [];
         foreach ($this->get_tables() as $table_alias => $table_obj) {
             $table_pk_value = $this->_get_column_value_with_table_alias_or_not(
                 $cols_n_values,
@@ -5410,7 +5432,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 foreach ($this->_get_fields_for_table($table_alias) as $field_name => $field_obj) {
                     if (! $field_obj->is_db_only_field()) {
                         // prepare field as if its coming from db
-                        $prepared_value = $field_obj->prepare_for_set($field_obj->get_default_value());
+                        $prepared_value                            =
+                            $field_obj->prepare_for_set($field_obj->get_default_value());
                         $this_model_fields_n_values[ $field_name ] = $field_obj->prepare_for_use_in_db($prepared_value);
                     }
                 }
@@ -5429,7 +5452,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $this_model_fields_n_values;
     }
-
 
 
     /**
@@ -5463,7 +5485,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * refresh_entity_map_from_db
      * Makes sure the model object in the entity map at $id assumes the values
@@ -5478,7 +5499,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $obj_in_map = $this->get_from_entity_map($id);
         if ($obj_in_map) {
             $wpdb_results = $this->_get_all_wpdb_results(
-                array(array($this->get_primary_key_field()->get_name() => $id), 'limit' => 1)
+                [[$this->get_primary_key_field()->get_name() => $id], 'limit' => 1]
             );
             if ($wpdb_results && is_array($wpdb_results)) {
                 $one_row = reset($wpdb_results);
@@ -5495,7 +5516,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $this->get_one_by_ID($id);
     }
-
 
 
     /**
@@ -5533,7 +5553,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the EE class that corresponds to this model. Eg, for EEM_Answer that
      * would be EE_Answer.To import that class, you'd just add ".class.php" to the name, like so
@@ -5547,7 +5566,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Get the name of the items this model represents, for the quantity specified. Eg,
      * if $quantity==1, on EEM_Event, it would 'Event' (internationalized), otherwise
@@ -5558,9 +5576,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function item_name($quantity = 1)
     {
-        return (int) $quantity === 1 ? $this->singular_item : $this->plural_item;
+        return (int)$quantity === 1 ? $this->singular_item : $this->plural_item;
     }
-
 
 
     /**
@@ -5584,13 +5601,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $methodName name of method which was called on a child of EE_TempBase, but which
      * @param array  $args       array of original arguments passed to the function
-     * @throws EE_Error
      * @return mixed whatever the plugin which calls add_filter decides
+     * @throws EE_Error
      */
     public function __call($methodName, $args)
     {
         $className = get_class($this);
-        $tagName = "FHEE__{$className}__{$methodName}";
+        $tagName   = "FHEE__{$className}__{$methodName}";
         if (! has_filter($tagName)) {
             throw new EE_Error(
                 sprintf(
@@ -5609,7 +5626,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Ensures $base_class_obj_or_id is of the EE_Base_Class child that corresponds ot this model.
      * If not, assumes its an ID, and uses $this->get_one_by_ID() to get the EE_Base_Class.
@@ -5620,8 +5636,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                       or object's ID
      * @param boolean                  $ensure_is_in_db      if set, we will also verify this model object
      *                                                       exists in the database. If it does not, we add it
-     * @throws EE_Error
      * @return EE_Base_Class
+     * @throws EE_Error
      */
     public function ensure_is_obj($base_class_obj_or_id, $ensure_is_in_db = false)
     {
@@ -5667,7 +5683,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Similar to ensure_is_obj(), this method makes sure $base_class_obj_or_id
      * is a value of the this model's primary key. If it's an EE_Base_Class child,
@@ -5690,19 +5705,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // assume its a string representation of the object
             $id = $base_class_obj_or_id;
         } else {
-            throw new EE_Error(sprintf(
-                __(
-                    "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
-                    'event_espresso'
-                ),
-                $base_class_obj_or_id,
-                $this->_get_class_name(),
-                print_r($base_class_obj_or_id, true)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
+                        'event_espresso'
+                    ),
+                    $base_class_obj_or_id,
+                    $this->_get_class_name(),
+                    print_r($base_class_obj_or_id, true)
+                )
+            );
         }
         return $id;
     }
-
 
 
     /**
@@ -5729,7 +5745,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Read comments for assume_values_already_prepared_by_model_object()
      *
@@ -5739,7 +5754,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_values_already_prepared_by_model_object;
     }
-
 
 
     /**
@@ -5753,7 +5767,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the Unique Indexes on this model
      *
@@ -5761,7 +5774,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function unique_indexes()
     {
-        $unique_indexes = array();
+        $unique_indexes = [];
         foreach ($this->_indexes as $name => $index) {
             if ($index instanceof EE_Unique_Index) {
                 $unique_indexes [ $name ] = $index;
@@ -5769,7 +5782,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $unique_indexes;
     }
-
 
 
     /**
@@ -5788,9 +5800,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 return $index->fields();
             }
         }
-        return array($this->primary_key_name() => $this->get_primary_key_field());
+        return [$this->primary_key_name() => $this->get_primary_key_field()];
     }
-
 
 
     /**
@@ -5815,20 +5826,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the field values from the primary key string
      *
-     * @see EEM_Base::get_combined_primary_key_fields() and EEM_Base::get_index_primary_key_string()
      * @param string $index_primary_key_string
      * @return null|array
      * @throws EE_Error
+     * @see EEM_Base::get_combined_primary_key_fields() and EEM_Base::get_index_primary_key_string()
      */
     public function parse_index_primary_key_string($index_primary_key_string)
     {
         $key_fields = $this->get_combined_primary_key_fields();
         // check all of them are in the $id
-        $key_vals_in_combined_pk = array();
+        $key_vals_in_combined_pk = [];
         parse_str($index_primary_key_string, $key_vals_in_combined_pk);
         foreach ($key_fields as $key_field_name => $field_obj) {
             if (! isset($key_vals_in_combined_pk[ $key_field_name ])) {
@@ -5837,7 +5847,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $key_vals_in_combined_pk;
     }
-
 
 
     /**
@@ -5860,28 +5869,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Finds all model objects in the DB that appear to be a copy of $model_object_or_attributes_array.
      * We consider something to be a copy if all the attributes match (except the ID, of course).
      *
      * @param array|EE_Base_Class $model_object_or_attributes_array If its an array, it's field-value pairs
-     * @param array               $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array               $query_params                     @see
+     *                                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @return \EE_Base_Class[] Array keys are object IDs (if there is a primary key on the model. if not, numerically
      *                                                              indexed)
      */
-    public function get_all_copies($model_object_or_attributes_array, $query_params = array())
+    public function get_all_copies($model_object_or_attributes_array, $query_params = [])
     {
         if ($model_object_or_attributes_array instanceof EE_Base_Class) {
             $attributes_array = $model_object_or_attributes_array->model_field_array();
         } elseif (is_array($model_object_or_attributes_array)) {
             $attributes_array = $model_object_or_attributes_array;
         } else {
-            throw new EE_Error(sprintf(__(
-                "get_all_copies should be provided with either a model object or an array of field-value-pairs, but was given %s",
-                "event_espresso"
-            ), $model_object_or_attributes_array));
+            throw new EE_Error(
+                sprintf(
+                    __(
+                        "get_all_copies should be provided with either a model object or an array of field-value-pairs, but was given %s",
+                        "event_espresso"
+                    ),
+                    $model_object_or_attributes_array
+                )
+            );
         }
         // even copies obviously won't have the same ID, so remove the primary key
         // from the WHERE conditions for finding copies (if there is a primary key, of course)
@@ -5897,16 +5911,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the first copy we find. See get_all_copies for more details
      *
-     * @param       mixed EE_Base_Class | array        $model_object_or_attributes_array
+     * @param mixed EE_Base_Class | array        $model_object_or_attributes_array
      * @param array $query_params
      * @return EE_Base_Class
      * @throws EE_Error
      */
-    public function get_one_copy($model_object_or_attributes_array, $query_params = array())
+    public function get_one_copy($model_object_or_attributes_array, $query_params = [])
     {
         if (! is_array($query_params)) {
             EE_Error::doing_it_wrong(
@@ -5917,16 +5930,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         $query_params['limit'] = 1;
-        $copies = $this->get_all_copies($model_object_or_attributes_array, $query_params);
+        $copies                = $this->get_all_copies($model_object_or_attributes_array, $query_params);
         if (is_array($copies)) {
             return array_shift($copies);
         }
         return null;
     }
-
 
 
     /**
@@ -5940,13 +5952,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function update_by_ID($fields_n_values, $id)
     {
-        $query_params = array(
-            0                          => array($this->get_primary_key_field()->get_name() => $id),
+        $query_params = [
+            0                          => [$this->get_primary_key_field()->get_name() => $id],
             'default_where_conditions' => EEM_Base::default_where_conditions_others_only,
-        );
+        ];
         return $this->update($fields_n_values, $query_params);
     }
-
 
 
     /**
@@ -5958,8 +5969,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     private function _prepare_operator_for_sql($operator_supplied)
     {
-        $sql_operator = isset($this->_valid_operators[ $operator_supplied ]) ? $this->_valid_operators[ $operator_supplied ]
-            : null;
+        $sql_operator =
+            isset($this->_valid_operators[ $operator_supplied ]) ? $this->_valid_operators[ $operator_supplied ]
+                : null;
         if ($sql_operator) {
             return $sql_operator;
         }
@@ -5976,9 +5988,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the valid operators
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_operators()
@@ -5987,9 +5999,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the between-style operators (take 2 arguments).
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_between_style_operators()
@@ -6000,8 +6012,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "like"-style operators (take a single argument, but it may contain wildcards)
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_like_style_operators()
@@ -6012,8 +6026,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "in"-style operators
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_in_style_operators()
@@ -6024,8 +6040,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "null"-style operators (accept no arguments)
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_null_style_operators()
@@ -6036,6 +6054,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets an array where keys are the primary keys and values are their 'names'
      * (as determined by the model object's name() function, which is often overridden)
@@ -6044,16 +6063,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return string[]
      * @throws EE_Error
      */
-    public function get_all_names($query_params = array())
+    public function get_all_names($query_params = [])
     {
-        $objs = $this->get_all($query_params);
-        $names = array();
+        $objs  = $this->get_all($query_params);
+        $names = [];
         foreach ($objs as $obj) {
             $names[ $obj->ID() ] = $obj->name();
         }
         return $names;
     }
-
 
 
     /**
@@ -6080,7 +6098,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 );
             }
         }
-        $IDs = array();
+        $IDs = [];
         foreach ($model_objects as $model_object) {
             $id = $model_object->ID();
             if (! $id) {
@@ -6105,7 +6123,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns the string used in capabilities relating to this model. If there
      * are no capabilities that relate to this model returns false
@@ -6118,16 +6135,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
-     * Returns the capability-restrictions array (@see EEM_Base::_cap_restrictions).
-     * If $context is provided (which should be set to one of EEM_Base::valid_cap_contexts())
-     * only returns the cap restrictions array in that context (ie, the array
-     * at that key)
+     * Returns the capability-restrictions array (@param string $context
      *
-     * @param string $context
      * @return EE_Default_Where_Conditions[] indexed by associated capability
      * @throws EE_Error
+     * @see EEM_Base::_cap_restrictions).
+     *      If $context is provided (which should be set to one of EEM_Base::valid_cap_contexts())
+     *      only returns the cap restrictions array in that context (ie, the array
+     *      at that key)
+     *
      */
     public function cap_restrictions($context = EEM_Base::caps_read)
     {
@@ -6153,7 +6170,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Indicating whether or not this model thinks its a wp core model
      *
@@ -6163,7 +6179,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_wp_core_model;
     }
-
 
 
     /**
@@ -6176,19 +6191,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function caps_missing($context = EEM_Base::caps_read)
     {
-        $missing_caps = array();
+        $missing_caps     = [];
         $cap_restrictions = $this->cap_restrictions($context);
         foreach ($cap_restrictions as $cap => $restriction_if_no_cap) {
             if (
-                ! EE_Capabilities::instance()
-                                 ->current_user_can($cap, $this->get_this_model_name() . '_model_applying_caps')
+            ! EE_Capabilities::instance()
+                             ->current_user_can($cap, $this->get_this_model_name() . '_model_applying_caps')
             ) {
                 $missing_caps[ $cap ] = $restriction_if_no_cap;
             }
         }
         return $missing_caps;
     }
-
 
 
     /**
@@ -6205,7 +6219,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $this
         );
     }
-
 
 
     /**
@@ -6234,7 +6247,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns all the capability contexts which are valid when querying models
      *
@@ -6242,14 +6254,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public static function valid_cap_contexts()
     {
-        return apply_filters('FHEE__EEM_Base__valid_cap_contexts', array(
-            self::caps_read,
-            self::caps_read_admin,
-            self::caps_edit,
-            self::caps_delete,
-        ));
+        return apply_filters(
+            'FHEE__EEM_Base__valid_cap_contexts',
+            [
+                self::caps_read,
+                self::caps_read_admin,
+                self::caps_edit,
+                self::caps_delete,
+            ]
+        );
     }
-
 
 
     /**
@@ -6259,17 +6273,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public static function valid_default_where_conditions()
     {
-        return array(
+        return [
             EEM_Base::default_where_conditions_all,
             EEM_Base::default_where_conditions_this_only,
             EEM_Base::default_where_conditions_others_only,
             EEM_Base::default_where_conditions_minimum_all,
             EEM_Base::default_where_conditions_minimum_others,
-            EEM_Base::default_where_conditions_none
-        );
+            EEM_Base::default_where_conditions_none,
+        ];
     }
 
     // public static function default_where_conditions_full
+
+
     /**
      * Verifies $context is one of EEM_Base::valid_cap_contexts(), if not it throws an exception
      *
@@ -6297,18 +6313,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Clears all the models field caches. This is only useful when a sub-class
      * might have added a field or something and these caches might be invalidated
      */
     protected function _invalidate_field_caches()
     {
-        $this->_cache_foreign_key_to_fields = array();
-        $this->_cached_fields = null;
-        $this->_cached_fields_non_db_only = null;
+        $this->_cache_foreign_key_to_fields = [];
+        $this->_cached_fields               = null;
+        $this->_cached_fields_non_db_only   = null;
     }
-
 
 
     /**
@@ -6321,7 +6335,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_logic_query_param_keys;
     }
-
 
 
     /**
@@ -6345,25 +6358,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return false;
     }
 
+
     /**
      * Returns true if this model has a password field on it (regardless of whether that password field has any content)
-     * @since 4.9.74.p
+     *
      * @return boolean
+     * @since 4.9.74.p
      */
     public function hasPassword()
     {
         // if we don't yet know if there's a password field, find out and remember it for next time.
         if ($this->has_password_field === null) {
-            $password_field = $this->getPasswordField();
+            $password_field           = $this->getPasswordField();
             $this->has_password_field = $password_field instanceof EE_Password_Field ? true : false;
         }
         return $this->has_password_field;
     }
 
+
     /**
      * Returns the password field on this model, if there is one
-     * @since 4.9.74.p
+     *
      * @return EE_Password_Field|null
+     * @since 4.9.74.p
      */
     public function getPasswordField()
     {
@@ -6379,14 +6396,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Returns the list of field (as EE_Model_Field_Bases) that are protected by the password
-     * @since 4.9.74.p
+     *
      * @return EE_Model_Field_Base[]
      * @throws EE_Error
+     * @since 4.9.74.p
      */
     public function getPasswordProtectedFields()
     {
         $password_field = $this->getPasswordField();
-        $fields = array();
+        $fields         = [];
         if ($password_field instanceof EE_Password_Field) {
             $field_names = $password_field->protectedFields();
             foreach ($field_names as $field_name) {
@@ -6399,8 +6417,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Checks if the current user can perform the requested action on this model
-     * @since 4.9.74.p
-     * @param string $cap_to_check one of the array keys from _cap_contexts_to_cap_action_map
+     *
+     * @param string              $cap_to_check one of the array keys from _cap_contexts_to_cap_action_map
      * @param EE_Base_Class|array $model_obj_or_fields_n_values
      * @return bool
      * @throws EE_Error
@@ -6409,18 +6427,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      * @throws UnexpectedEntityException
+     * @since 4.9.74.p
      */
     public function currentUserCan($cap_to_check, $model_obj_or_fields_n_values)
     {
         if ($model_obj_or_fields_n_values instanceof EE_Base_Class) {
             $model_obj_or_fields_n_values = $model_obj_or_fields_n_values->model_field_array();
         }
-        if (!is_array($model_obj_or_fields_n_values)) {
+        if (! is_array($model_obj_or_fields_n_values)) {
             throw new UnexpectedEntityException(
                 $model_obj_or_fields_n_values,
                 'EE_Base_Class',
                 sprintf(
-                    esc_html__('%1$s must be passed an `EE_Base_Class or an array of fields names with their values. You passed in something different.', 'event_espresso'),
+                    esc_html__(
+                        '%1$s must be passed an `EE_Base_Class or an array of fields names with their values. You passed in something different.',
+                        'event_espresso'
+                    ),
                     __FUNCTION__
                 )
             );
@@ -6428,18 +6450,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return $this->exists(
             $this->alter_query_params_to_restrict_by_ID(
                 $this->get_index_primary_key_string($model_obj_or_fields_n_values),
-                array(
+                [
                     'default_where_conditions' => 'none',
                     'caps'                     => $cap_to_check,
-                )
+                ]
             )
         );
     }
 
+
     /**
      * Returns the query param where conditions key to the password affecting this model.
      * Eg on EEM_Event this would just be "password", on EEM_Datetime this would be "Event.password", etc.
-     * @since 4.9.74.p
+     *
      * @return null|string
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -6447,6 +6470,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidInterfaceException
      * @throws ModelConfigurationException
      * @throws ReflectionException
+     * @since 4.9.74.p
      */
     public function modelChainAndPassword()
     {
@@ -6493,11 +6517,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return ($this->model_chain_to_password ? $this->model_chain_to_password . '.' : '') . $password_field_name;
     }
 
+
     /**
      * Returns true if there is a password on a related model which restricts access to some of this model's rows,
      * or if this model itself has a password affecting access to some of its other fields.
-     * @since 4.9.74.p
+     *
      * @return boolean
+     * @since 4.9.74.p
      */
     public function restrictedByRelatedModelPassword()
     {

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -4036,7 +4036,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'Logic query params ("%1$s") are being used incorrectly with the following query param ("%2$s") on model %3$s. %4$sAdditional Info:%4$s%5$s',
                         'event_espresso'
                     ),
@@ -5660,7 +5660,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! has_filter($tagName)) {
             throw new EE_Error(
                 sprintf(
-                    __(
+                    esc_html__(
                         'Method %1$s on model %2$s does not exist! You can create one with the following code in functions.php or in a plugin: %4$s function my_callback(%4$s \$previousReturnValue, EEM_Base \$object\ $argsArray=NULL ){%4$s     /*function body*/%4$s      return \$whatever;%4$s }%4$s add_filter( \'%3$s\', \'my_callback\', 10, 3 );',
                         'event_espresso'
                     ),


### PR DESCRIPTION
this PR:

- auto-formats to PSR12
- imports all dependencies via use statements
- declares all exceptions
- removes all unused vars or those matching defaults
- fixes formatting for @see links
- moves all constant declarations to top of class
- uses esc_html__()

because of the high number of changes made due to auto-formatting,
it may be beneficial to review this PR by looking at each commit individually, since they focus on doing one thing at a time