### PR TITLE
Code Cleanup Model Objects A-C

### DIFF
--- a/core/db_classes/EE_Answer.class.php
+++ b/core/db_classes/EE_Answer.class.php
@@ -3,9 +3,9 @@
 /**
  * EE_Answer class
  *
- * @package               Event Espresso
- * @subpackage            includes/classes/EE_Answer.class.php
- * @author                Mike Nelson
+ * @package     Event Espresso
+ * @subpackage  includes/classes/EE_Answer.class.php
+ * @author      Mike Nelson
  */
 class EE_Answer extends EE_Base_Class
 {
@@ -13,6 +13,8 @@ class EE_Answer extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Answer
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function new_instance($props_n_values = [])
     {
@@ -24,6 +26,8 @@ class EE_Answer extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Answer
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function new_instance_from_db($props_n_values = [])
     {
@@ -32,10 +36,11 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    Set Question ID
+     * Set Question ID
      *
-     * @access        public
      * @param int $QST_ID
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_question($QST_ID = 0)
     {
@@ -44,10 +49,11 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    Set Registration ID
+     * Set Registration ID
      *
-     * @access        public
      * @param int $REG_ID
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_registration($REG_ID = 0)
     {
@@ -56,10 +62,11 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    Set Answer value
+     * Set Answer value
      *
-     * @access        public
      * @param mixed $ANS_value
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_value($ANS_value = '')
     {
@@ -68,10 +75,10 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    get Attendee First Name
+     * get Attendee First Name
      *
-     * @access        public
      * @return        int
+     * @throws EE_Error
      */
     public function registration_ID()
     {
@@ -80,10 +87,10 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    get Attendee Last Name
+     * get Attendee Last Name
      *
-     * @access        public
      * @return        int
+     * @throws EE_Error
      */
     public function question_ID()
     {
@@ -92,10 +99,10 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *    get Attendee Address
+     * get Attendee Address
      *
-     * @access        public
      * @return        string
+     * @throws EE_Error
      */
     public function value()
     {
@@ -108,6 +115,7 @@ class EE_Answer extends EE_Base_Class
      *
      * @param null $schema
      * @return string
+     * @throws EE_Error
      */
     public function pretty_value($schema = null)
     {
@@ -119,6 +127,7 @@ class EE_Answer extends EE_Base_Class
      * Echoes out a pretty value (even for multi-choice options)
      *
      * @param string $schema
+     * @throws EE_Error
      */
     public function e_value($schema = null)
     {
@@ -129,7 +138,9 @@ class EE_Answer extends EE_Base_Class
     /**
      * Gets the related EE_Question to this EE_Answer
      *
-     * @return EE_Question
+     * @return EE_Base_Class|EE_Question
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function question()
     {
@@ -140,13 +151,12 @@ class EE_Answer extends EE_Base_Class
     /**
      * Gets the related EE_Registration to this EE_Answer
      *
-     * @return EE_Registration
+     * @return EE_Base_Class|EE_Registration
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function registration()
     {
         return $this->get_first_related('Registration');
     }
 }
-
-/* End of file EE_Answer.class.php */
-/* Location: /includes/classes/EE_Answer.class.php */

--- a/core/db_classes/EE_Answer.class.php
+++ b/core/db_classes/EE_Answer.class.php
@@ -11,11 +11,10 @@ class EE_Answer extends EE_Base_Class
 {
 
     /**
-     *
      * @param array $props_n_values
      * @return EE_Answer
      */
-    public static function new_instance($props_n_values = array())
+    public static function new_instance($props_n_values = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__);
         return $has_object ? $has_object : new self($props_n_values);
@@ -23,11 +22,10 @@ class EE_Answer extends EE_Base_Class
 
 
     /**
-     *
      * @param array $props_n_values
      * @return EE_Answer
      */
-    public static function new_instance_from_db($props_n_values = array())
+    public static function new_instance_from_db($props_n_values = [])
     {
         return new self($props_n_values, true);
     }

--- a/core/db_classes/EE_Attendee.class.php
+++ b/core/db_classes/EE_Attendee.class.php
@@ -587,7 +587,12 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     public function save_and_clean_billing_info_for_payment_method($billing_form, $payment_method)
     {
         if (! $billing_form instanceof EE_Billing_Attendee_Info_Form) {
-            EE_Error::add_error(__('Cannot save billing info because there is none.', 'event_espresso'));
+            EE_Error::add_error(
+                __('Cannot save billing info because there is none.', 'event_espresso'),
+                __FILE__,
+                __FUNCTION__,
+                __LINE__
+            );
             return false;
         }
         $billing_form->clean_sensitive_data();

--- a/core/db_classes/EE_Attendee.class.php
+++ b/core/db_classes/EE_Attendee.class.php
@@ -4,23 +4,11 @@ use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
 /**
- * Event Espresso
- * Event Registration and Management Plugin for WordPress
- * @ package            Event Espresso
- * @ author                Seth Shoultes
- * @ copyright        (c) 2008-2011 Event Espresso  All Rights Reserved.
- * @ license            {@link http://eventespresso.com/support/terms-conditions/}   * see Plugin Licensing *
- * @ link                    {@link http://www.eventespresso.com}
- * @ since                4.0
- */
-
-
-/**
  * EE_Attendee class
  *
- * @package               Event Espresso
- * @subpackage            includes/classes/EE_Transaction.class.php
- * @author                Mike Nelson
+ * @package     Event Espresso
+ * @subpackage  includes/classes/EE_Transaction.class.php
+ * @author      Mike Nelson
  */
 class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_Admin_Links, EEI_Attendee
 {
@@ -33,12 +21,13 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * @param string $timezone
      * @param array  $date_formats
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function __construct($fieldValues = null, $bydb = false, $timezone = null, $date_formats = array())
+    protected function __construct($fieldValues = null, $bydb = false, $timezone = null, $date_formats = [])
     {
         if (! isset($fieldValues['ATT_full_name'])) {
-            $fname = isset($fieldValues['ATT_fname']) ? $fieldValues['ATT_fname'] . ' ' : '';
-            $lname = isset($fieldValues['ATT_lname']) ? $fieldValues['ATT_lname'] : '';
+            $fname                        = isset($fieldValues['ATT_fname']) ? $fieldValues['ATT_fname'] . ' ' : '';
+            $lname                        = isset($fieldValues['ATT_lname']) ? $fieldValues['ATT_lname'] : '';
             $fieldValues['ATT_full_name'] = $fname . $lname;
         }
         if (! isset($fieldValues['ATT_slug'])) {
@@ -53,15 +42,16 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     * @param array  $props_n_values          incoming values
-     * @param string $timezone                incoming timezone (if not set the timezone set for the website will be
-     *                                        used.)
-     * @param array  $date_formats            incoming date_formats in an array where the first value is the
-     *                                        date_format and the second value is the time format
+     * @param array  $props_n_values    incoming values
+     * @param string $timezone          incoming timezone
+     *                                  (if not set the timezone set for the website will be used.)
+     * @param array  $date_formats      incoming date_formats in an array where the first value is the
+     *                                  date_format and the second value is the time format
      * @return EE_Attendee
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -70,22 +60,25 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
     /**
      * @param array  $props_n_values  incoming values from the database
-     * @param string $timezone        incoming timezone as set by the model.  If not set the timezone for
-     *                                the website will be used.
+     * @param string $timezone        incoming timezone as set by the model.
+     *                                If not set the timezone for the website will be used.
      * @return EE_Attendee
+     * @throws EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = null)
     {
         return new self($props_n_values, true, $timezone);
     }
 
 
     /**
-     *        Set Attendee First Name
+     * Set Attendee First Name
      *
-     * @access        public
      * @param string $fname
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_fname($fname = '')
     {
@@ -94,11 +87,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Last Name
+     * Set Attendee Last Name
      *
-     * @access        public
      * @param string $lname
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_lname($lname = '')
     {
@@ -107,11 +100,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Address
+     * Set Attendee Address
      *
-     * @access        public
      * @param string $address
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_address($address = '')
     {
@@ -120,11 +113,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Address2
+     * Set Attendee Address2
      *
-     * @access        public
-     * @param        string $address2
+     * @param string $address2
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_address2($address2 = '')
     {
@@ -133,11 +126,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee City
+     * Set Attendee City
      *
-     * @access        public
-     * @param        string $city
+     * @param string $city
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_city($city = '')
     {
@@ -146,11 +139,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee State ID
+     * Set Attendee State ID
      *
-     * @access        public
-     * @param        int $STA_ID
+     * @param int $STA_ID
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_state($STA_ID = 0)
     {
@@ -159,11 +152,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Country ISO Code
+     * Set Attendee Country ISO Code
      *
-     * @access        public
-     * @param        string $CNT_ISO
+     * @param string $CNT_ISO
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_country($CNT_ISO = '')
     {
@@ -172,11 +165,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Zip/Postal Code
+     * Set Attendee Zip/Postal Code
      *
-     * @access        public
-     * @param        string $zip
+     * @param string $zip
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_zip($zip = '')
     {
@@ -185,11 +178,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Email Address
+     * Set Attendee Email Address
      *
-     * @access        public
-     * @param        string $email
+     * @param string $email
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_email($email = '')
     {
@@ -198,11 +191,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        Set Attendee Phone
+     * Set Attendee Phone
      *
-     * @access        public
-     * @param        string $phone
+     * @param string $phone
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_phone($phone = '')
     {
@@ -211,11 +204,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        set deleted
+     * set deleted
      *
-     * @access        public
-     * @param        bool $ATT_deleted
+     * @param bool $ATT_deleted
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_deleted($ATT_deleted = false)
     {
@@ -226,26 +219,13 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     /**
      * Returns the value for the post_author id saved with the cpt
      *
-     * @since 4.5.0
      * @return int
      * @throws EE_Error
+     * @since 4.5.0
      */
     public function wp_user()
     {
         return $this->get('ATT_author');
-    }
-
-
-    /**
-     *        get Attendee First Name
-     *
-     * @access        public
-     * @return string
-     * @throws EE_Error
-     */
-    public function fname()
-    {
-        return $this->get('ATT_fname');
     }
 
 
@@ -270,37 +250,33 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      */
     public function full_name($apply_html_entities = false)
     {
-        $full_name = array(
+        $full_name = [
             $this->fname(),
             $this->lname(),
-        );
+        ];
         $full_name = array_filter($full_name);
         $full_name = implode(' ', $full_name);
-        return $apply_html_entities ? htmlentities($full_name, ENT_QUOTES, 'UTF-8') : $full_name;
+        return $apply_html_entities
+            ? htmlentities($full_name, ENT_QUOTES, 'UTF-8')
+            : $full_name;
     }
 
 
     /**
-     * This returns the value of the `ATT_full_name` field which is usually equivalent to calling `full_name()` unless
-     * the post_title field has been directly modified in the db for the post (espresso_attendees post type) for this
-     * attendee.
+     * get Attendee First Name
      *
-     * @param bool $apply_html_entities
      * @return string
      * @throws EE_Error
      */
-    public function ATT_full_name($apply_html_entities = false)
+    public function fname()
     {
-        return $apply_html_entities
-            ? htmlentities($this->get('ATT_full_name'), ENT_QUOTES, 'UTF-8')
-            : $this->get('ATT_full_name');
+        return $this->get('ATT_fname');
     }
 
 
     /**
-     *        get Attendee Last Name
+     * get Attendee Last Name
      *
-     * @access        public
      * @return string
      * @throws EE_Error
      */
@@ -311,9 +287,55 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
+     * get Attendee Email Address
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function email()
+    {
+        return $this->get('ATT_email');
+    }
+
+
+    /**
+     * get Attendee Phone #
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function phone()
+    {
+        return $this->get('ATT_phone');
+    }
+
+
+    /**
+     * This returns the value of the `ATT_full_name` field
+     * which is usually equivalent to calling `full_name()`
+     * unless the post_title field has been directly modified
+     * in the db for the post (espresso_attendees post type)
+     * for this attendee.
+     *
+     * @param bool $apply_html_entities
+     * @return string
+     * @throws EE_Error
+     */
+    public function ATT_full_name($apply_html_entities = false)
+    {
+        return $apply_html_entities
+            ? htmlentities(
+                $this->get('ATT_full_name'),
+                ENT_QUOTES,
+                'UTF-8'
+            )
+            : $this->get('ATT_full_name');
+    }
+
+
+    /**
      * get Attendee bio
      *
-     * @access public
      * @return string
      * @throws EE_Error
      */
@@ -326,7 +348,6 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     /**
      * get Attendee short bio
      *
-     * @access public
      * @return string
      * @throws EE_Error
      */
@@ -337,18 +358,21 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     * Gets the attendee's full address as an array so client code can decide hwo to display it
+     * Gets the attendee's full address as an array
+     * so client code can decide hwo to display it
      *
-     * @return array numerically indexed, with each part of the address that is known.
-     * Eg, if the user only responded to state and country,
-     * it would be array(0=>'Alabama',1=>'USA')
+     * @return array numerically indexed,
+     *               with each part of the address that is known.
+     *               Eg, if the user only responded to state and country,
+     *               it would be array(0=>'Alabama',1=>'USA')
      * @return array
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function full_address_as_array()
     {
-        $full_address_array = array();
-        $initial_address_fields = array('ATT_address', 'ATT_address2', 'ATT_city',);
+        $full_address_array     = [];
+        $initial_address_fields = ['ATT_address', 'ATT_address2', 'ATT_city',];
         foreach ($initial_address_fields as $address_field_name) {
             $address_fields_value = $this->get($address_field_name);
             if (! empty($address_fields_value)) {
@@ -374,68 +398,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        get Attendee Address
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function address()
-    {
-        return $this->get('ATT_address');
-    }
-
-
-    /**
-     *        get Attendee Address2
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function address2()
-    {
-        return $this->get('ATT_address2');
-    }
-
-
-    /**
-     *        get Attendee City
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function city()
-    {
-        return $this->get('ATT_city');
-    }
-
-
-    /**
-     *        get Attendee State ID
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function state_ID()
-    {
-        return $this->get('STA_ID');
-    }
-
-
-    /**
-     * @return string
-     * @throws EE_Error
-     */
-    public function state_abbrev()
-    {
-        return $this->state_obj() instanceof EE_State ? $this->state_obj()->abbrev() : '';
-    }
-
-
-    /**
      * Gets the state set to this attendee
      *
-     * @return EE_State
+     * @return EE_Base_Class|EE_State
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function state_obj()
     {
@@ -444,55 +411,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     * Returns the state's name, otherwise 'Unknown'
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function state_name()
-    {
-        if ($this->state_obj()) {
-            return $this->state_obj()->name();
-        } else {
-            return '';
-        }
-    }
-
-
-    /**
-     * either displays the state abbreviation or the state name, as determined
-     * by the "FHEE__EEI_Address__state__use_abbreviation" filter.
-     * defaults to abbreviation
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function state()
-    {
-        if (apply_filters('FHEE__EEI_Address__state__use_abbreviation', true, $this->state_obj())) {
-            return $this->state_abbrev();
-        }
-        return $this->state_name();
-    }
-
-
-    /**
-     *    get Attendee Country ISO Code
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function country_ID()
-    {
-        return $this->get('CNT_ISO');
-    }
-
-
-    /**
      * Gets country set for this attendee
      *
-     * @return EE_Country
+     * @return EE_Base_Class|EE_Country
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function country_obj()
     {
@@ -501,39 +424,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     * Returns the country's name if known, otherwise 'Unknown'
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function country_name()
-    {
-        if ($this->country_obj()) {
-            return $this->country_obj()->name();
-        }
-        return '';
-    }
-
-
-    /**
-     * either displays the country ISO2 code or the country name, as determined
-     * by the "FHEE__EEI_Address__country__use_abbreviation" filter.
-     * defaults to abbreviation
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function country()
-    {
-        if (apply_filters('FHEE__EEI_Address__country__use_abbreviation', true, $this->country_obj())) {
-            return $this->country_ID();
-        }
-        return $this->country_name();
-    }
-
-
-    /**
-     *        get Attendee Zip/Postal Code
+     * get Attendee Zip/Postal Code
      *
      * @return string
      * @throws EE_Error
@@ -545,31 +436,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     *        get Attendee Email Address
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function email()
-    {
-        return $this->get('ATT_email');
-    }
-
-
-    /**
-     *        get Attendee Phone #
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function phone()
-    {
-        return $this->get('ATT_phone');
-    }
-
-
-    /**
-     *    get deleted
+     * get deleted
      *
      * @return        bool
      * @throws EE_Error
@@ -584,10 +451,11 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * Gets registrations of this attendee
      *
      * @param array $query_params
-     * @return EE_Registration[]
+     * @return array[]|EE_Base_Class[]|EE_Registration[]
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function get_registrations($query_params = array())
+    public function get_registrations($query_params = [])
     {
         return $this->get_many_related('Registration', $query_params);
     }
@@ -596,14 +464,15 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     /**
      * Gets the most recent registration of this attendee
      *
-     * @return EE_Registration
+     * @return EE_Base_Class|EE_Registration
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_most_recent_registration()
     {
         return $this->get_first_related(
             'Registration',
-            array('order_by' => array('REG_date' => 'DESC'))
+            ['order_by' => ['REG_date' => 'DESC']]
         ); // null, 'REG_date', 'DESC', '=', 'OBJECT_K');
     }
 
@@ -612,14 +481,15 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * Gets the most recent registration for this attend at this event
      *
      * @param int $event_id
-     * @return EE_Registration
+     * @return EE_Base_Class|EE_Registration
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_most_recent_registration_for_event($event_id)
     {
         return $this->get_first_related(
             'Registration',
-            array(array('EVT_ID' => $event_id), 'order_by' => array('REG_date' => 'DESC'))
+            [['EVT_ID' => $event_id], 'order_by' => ['REG_date' => 'DESC']]
         );
     }
 
@@ -629,6 +499,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      *
      * @return array
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function events()
     {
@@ -637,13 +508,25 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function state_abbrev()
+    {
+        return $this->state_obj() instanceof EE_State ? $this->state_obj()->abbrev() : '';
+    }
+
+
+    /**
      * Gets the billing info array where keys match espresso_reg_page_billing_inputs(),
-     * and keys are their cleaned values. @see EE_Attendee::save_and_clean_billing_info_for_payment_method() which was
-     * used to save the billing info
+     * and keys are their cleaned values.
      *
      * @param EE_Payment_Method $payment_method the _gateway_name property on the gateway class
      * @return EE_Form_Section_Proper|null
      * @throws EE_Error
+     * @see EE_Attendee::save_and_clean_billing_info_for_payment_method() which was
+     *                                          used to save the billing info
      */
     public function billing_info_for_payment_method($payment_method)
     {
@@ -668,7 +551,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
             return null;
         }
         if ($billing_form instanceof EE_Form_Section_Proper) {
-            $billing_form->receive_form_submission(array($billing_form->name() => $billing_info), false);
+            $billing_form->receive_form_submission([$billing_form->name() => $billing_info], false);
         }
 
         return $billing_form;
@@ -693,13 +576,13 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
 
 
     /**
-     * Saves the billing info to the attendee. @see EE_Attendee::billing_info_for_payment_method() which is used to
-     * retrieve it
+     * Saves the billing info to the attendee. @param EE_Billing_Attendee_Info_Form $billing_form
      *
-     * @param EE_Billing_Attendee_Info_Form $billing_form
-     * @param EE_Payment_Method             $payment_method
+     * @param EE_Payment_Method $payment_method
      * @return boolean
      * @throws EE_Error
+     * @see EE_Attendee::billing_info_for_payment_method() which is used to
+     *      retrieve it
      */
     public function save_and_clean_billing_info_for_payment_method($billing_form, $payment_method)
     {
@@ -746,13 +629,25 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     {
         EE_Registry::instance()->load_helper('URL');
         return EEH_URL::add_query_args_and_nonce(
-            array(
+            [
                 'page'   => 'espresso_registrations',
                 'action' => 'edit_attendee',
                 'post'   => $this->ID(),
-            ),
+            ],
             admin_url('admin.php')
         );
+    }
+
+
+    /**
+     * get Attendee Address
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function address()
+    {
+        return $this->get('ATT_address');
     }
 
 
@@ -786,11 +681,134 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
     {
         EE_Registry::instance()->load_helper('URL');
         return EEH_URL::add_query_args_and_nonce(
-            array(
+            [
                 'page'   => 'espresso_registrations',
                 'action' => 'contact_list',
-            ),
+            ],
             admin_url('admin.php')
         );
+    }
+
+
+
+
+
+
+
+
+    /**
+     * get Attendee Address2
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function address2()
+    {
+        return $this->get('ATT_address2');
+    }
+
+
+    /**
+     * Returns the state's name, otherwise 'Unknown'
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function state_name()
+    {
+        if ($this->state_obj()) {
+            return $this->state_obj()->name();
+        } else {
+            return '';
+        }
+    }
+
+
+    /**
+     * get Attendee City
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function city()
+    {
+        return $this->get('ATT_city');
+    }
+
+
+    /**
+     * either displays the state abbreviation or the state name, as determined
+     * by the "FHEE__EEI_Address__state__use_abbreviation" filter.
+     * defaults to abbreviation
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function state()
+    {
+        if (apply_filters('FHEE__EEI_Address__state__use_abbreviation', true, $this->state_obj())) {
+            return $this->state_abbrev();
+        }
+        return $this->state_name();
+    }
+
+
+    /**
+     * get Attendee State ID
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function state_ID()
+    {
+        return $this->get('STA_ID');
+    }
+
+
+    /**
+     * get Attendee Country ISO Code
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function country_ID()
+    {
+        return $this->get('CNT_ISO');
+    }
+
+
+    /**
+     * Returns the country's name if known, otherwise 'Unknown'
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function country_name()
+    {
+        if ($this->country_obj()) {
+            return $this->country_obj()->name();
+        }
+        return '';
+    }
+
+
+    /**
+     * either displays the country ISO2 code or the country name, as determined
+     * by the "FHEE__EEI_Address__country__use_abbreviation" filter.
+     * defaults to abbreviation
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function country()
+    {
+        if (apply_filters('FHEE__EEI_Address__country__use_abbreviation', true, $this->country_obj())) {
+            return $this->country_ID();
+        }
+        return $this->country_name();
     }
 }

--- a/core/db_classes/EE_CPT_Base.class.php
+++ b/core/db_classes/EE_CPT_Base.class.php
@@ -2,25 +2,24 @@
 
 /**
  * Class EE_CPT_Base
- *
  * Base class for all models which are really custom post types, as there is much functionality they share
  *
- * @package               Event Espresso
- * @subpackage            core
- * @author                Michael Nelson
- * @since                 EE4
- *
+ * @package     Event Espresso
+ * @subpackage  core
+ * @author      Michael Nelson
+ * @since       EE4
  */
 abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 {
 
     /**
-     * This is a property for holding cached feature images on CPT objects.  Cache's are set on the first
-     * "feature_image()" method call.  Each key in the array corresponds to the requested size.
+     * This is a property for holding cached feature images on CPT objects.
+     * Cache's are set on the first "feature_image()" method call.
+     * Each key in the array corresponds to the requested size.
      *
      * @var array
      */
-    protected $_feature_image = array();
+    protected $_feature_image = [];
 
     /**
      * @var WP_Post the WP_Post that corresponds with this CPT model object
@@ -32,88 +31,14 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
 
     /**
-     * Returns the WP post associated with this CPT model object. If this CPT is saved, fetches it
-     * from the DB. Otherwise, create an unsaved WP_POst object. Caches the post internally.
-     *
-     * @return WP_Post
-     */
-    public function wp_post()
-    {
-        global $wpdb;
-        if (! $this->_wp_post instanceof WP_Post) {
-            if ($this->ID()) {
-                $this->_wp_post = get_post($this->ID());
-            } else {
-                $simulated_db_result = new stdClass();
-                foreach ($this->get_model()->field_settings(true) as $field_name => $field_obj) {
-                    if (
-                        $this->get_model()->get_table_obj_by_alias($field_obj->get_table_alias())->get_table_name()
-                        === $wpdb->posts
-                    ) {
-                        $column = $field_obj->get_table_column();
-
-                        if ($field_obj instanceof EE_Datetime_Field) {
-                            $value_on_model_obj = $this->get_DateTime_object($field_name);
-                        } elseif ($field_obj->is_db_only_field()) {
-                            $value_on_model_obj = $field_obj->get_default_value();
-                        } else {
-                            $value_on_model_obj = $this->get_raw($field_name);
-                        }
-                        $simulated_db_result->{$column} = $field_obj->prepare_for_use_in_db($value_on_model_obj);
-                    }
-                }
-                $this->_wp_post = new WP_Post($simulated_db_result);
-            }
-            // and let's make retrieving the EE CPT object easy too
-            $classname = get_class($this);
-            if (! isset($this->_wp_post->{$classname})) {
-                $this->_wp_post->{$classname} = $this;
-            }
-        }
-        return $this->_wp_post;
-    }
-
-    /**
-     * When fetching a new value for a post field that uses the global $post for rendering,
-     * set the global $post temporarily to be this model object; and afterwards restore it
-     *
-     * @param string $fieldname
-     * @param bool   $pretty
-     * @param string $extra_cache_ref
-     * @return mixed
-     */
-    protected function _get_fresh_property($fieldname, $pretty = false, $extra_cache_ref = null)
-    {
-        global $post;
-
-        if (
-            $pretty
-            && (
-                ! (
-                    $post instanceof WP_Post
-                    && $post->ID
-                )
-                || (int) $post->ID !== $this->ID()
-            )
-            && $this->get_model()->field_settings_for($fieldname) instanceof EE_Post_Content_Field
-        ) {
-            $old_post = $post;
-            $post = $this->wp_post();
-            $return_value = parent::_get_fresh_property($fieldname, $pretty, $extra_cache_ref);
-            $post = $old_post;
-        } else {
-            $return_value = parent::_get_fresh_property($fieldname, $pretty, $extra_cache_ref);
-        }
-        return $return_value;
-    }
-
-    /**
      * Adds to the specified event category. If it category doesn't exist, creates it.
      *
      * @param string $category_name
      * @param string $category_description    optional
      * @param int    $parent_term_taxonomy_id optional
      * @return EE_Term_Taxonomy
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function add_event_category($category_name, $category_description = null, $parent_term_taxonomy_id = null)
     {
@@ -131,6 +56,8 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      *
      * @param string $category_name
      * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function remove_event_category($category_name)
     {
@@ -144,13 +71,15 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      *
      * @param EE_Term_Taxonomy $term_taxonomy
      * @return EE_Base_Class the relation was removed from
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function remove_relation_to_term_taxonomy($term_taxonomy)
     {
         if (! $term_taxonomy) {
             EE_Error::add_error(
                 sprintf(
-                    __(
+                    esc_html__(
                         "No Term_Taxonomy provided which to remove from model object of type %s and id %d",
                         "event_espresso"
                     ),
@@ -172,8 +101,9 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
     /**
      * The main purpose of this method is to return the post type for the model object
      *
-     * @access public
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function post_type()
     {
@@ -184,8 +114,8 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
     /**
      * The main purpose of this method is to return the parent for the model object
      *
-     * @access public
      * @return int
+     * @throws EE_Error
      */
     public function parent()
     {
@@ -197,6 +127,7 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      * return the _status property
      *
      * @return string
+     * @throws EE_Error
      */
     public function status()
     {
@@ -206,32 +137,12 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
     /**
      * @param string $status
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_status($status)
     {
         $this->set('status', $status);
-    }
-
-
-    /**
-     * This calls the equivalent model method for retrieving the feature image which in turn is a wrapper for
-     * WordPress' get_the_post_thumbnail() function.
-     *
-     * @link   http://codex.wordpress.org/Function_Reference/get_the_post_thumbnail
-     * @access protected
-     * @param string|array $size (optional) Image size. Defaults to 'post-thumbnail' but can also be a 2-item array
-     *                           representing width and height in pixels (i.e. array(32,32) ).
-     * @param string|array $attr Optional. Query string or array of attributes.
-     * @return string HTML image element
-     */
-    protected function _get_feature_image($size, $attr)
-    {
-        // first let's see if we already have the _feature_image property set AND if it has a cached element on it FOR the given size
-        $attr_key = is_array($attr) ? implode('_', $attr) : $attr;
-        $cache_key = is_array($size) ? implode('_', $size) . $attr_key : $size . $attr_key;
-        $this->_feature_image[ $cache_key ] = isset($this->_feature_image[ $cache_key ])
-            ? $this->_feature_image[ $cache_key ] : $this->get_model()->get_feature_image($this->ID(), $size, $attr);
-        return $this->_feature_image[ $cache_key ];
     }
 
 
@@ -241,6 +152,8 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      * @param string       $size
      * @param string|array $attr
      * @return string of html
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function feature_image($size = 'thumbnail', $attr = '')
     {
@@ -249,12 +162,43 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
 
     /**
+     * This calls the equivalent model method for retrieving the feature image
+     * which in turn is a wrapper for WordPress' get_the_post_thumbnail() function.
+     *
+     * @link   http://codex.wordpress.org/Function_Reference/get_the_post_thumbnail
+     * @access protected
+     * @param string|array $size (optional) Image size. Defaults to 'post-thumbnail' but can also be a 2-item array
+     *                           representing width and height in pixels (i.e. array(32,32) ).
+     * @param string|array $attr Optional. Query string or array of attributes.
+     * @return string HTML image element
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    protected function _get_feature_image($size, $attr)
+    {
+        // first let's see if we already have the _feature_image property set
+        // AND if it has a cached element on it FOR the given size
+        $attr_key                           = is_array($attr)
+            ? implode('_', $attr)
+            : $attr;
+        $cache_key                          = is_array($size)
+            ? implode('_', $size) . $attr_key
+            : $size . $attr_key;
+        $this->_feature_image[ $cache_key ] = isset($this->_feature_image[ $cache_key ])
+            ? $this->_feature_image[ $cache_key ]
+            : $this->get_model()->get_feature_image($this->ID(), $size, $attr);
+        return $this->_feature_image[ $cache_key ];
+    }
+
+
+    /**
      * This uses the wp "wp_get_attachment_image_src()" function to return the feature image for the current class
      * using the given size params.
      *
-     * @param  string|array $size can either be a string: 'thumbnail', 'medium', 'large', 'full' OR 2-item array
+     * @param string|array $size  can either be a string: 'thumbnail', 'medium', 'large', 'full' OR 2-item array
      *                            representing width and height in pixels eg. array(32,32).
      * @return string|boolean          the url of the image or false if not found
+     * @throws EE_Error
      */
     public function feature_image_url($size = 'thumbnail')
     {
@@ -280,8 +224,10 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      *                                 This array is INDEXED by RELATED OBJ NAME (so it corresponds with the obj_names
      *                                 sent);
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function restore_revision($revision_id, $related_obj_names = array(), $where_query = array())
+    public function restore_revision($revision_id, $related_obj_names = [], $where_query = [])
     {
         // get revision object
         $revision_obj = $this->get_model()->get_one_by_ID($revision_id);
@@ -298,9 +244,11 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
             foreach ($related_obj_names as $related_name) {
                 // related_obj_name so we're saving a revision on an object related to this object
                 // do we have $where_query params for this related object?  If we do then we include that.
-                $cols_n_values = isset($where_query[ $related_name ]) ? $where_query[ $related_name ] : array();
-                $where_params = ! empty($cols_n_values) ? array($cols_n_values) : array();
-                $related_objs = $this->get_many_related($related_name, $where_params);
+                $cols_n_values         = isset($where_query[ $related_name ])
+                    ? $where_query[ $related_name ]
+                    : [];
+                $where_params          = ! empty($cols_n_values) ? [$cols_n_values] : [];
+                $related_objs          = $this->get_many_related($related_name, $where_params);
                 $revision_related_objs = $revision_obj->get_many_related($related_name, $where_params);
                 // load helper
                 // remove related objs from this object that are not in revision
@@ -320,14 +268,17 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
     /**
      * Wrapper for get_post_meta, http://codex.wordpress.org/Function_Reference/get_post_meta
+     * If only $id is set:
+     *  it will return all meta values in an associative array.
+     * If $single is set to false, or left blank:
+     *  the function returns an array containing all values of the specified key.
+     * If $single is set to true:
+     *  the function returns the first value of the specified key (not in an array)
      *
      * @param string  $meta_key
      * @param boolean $single
-     * @return mixed <ul><li>If only $id is set it will return all meta values in an associative array.</li>
-     * <li>If $single is set to false, or left blank, the function returns an array containing all values of the
-     * specified key.</li>
-     * <li>If $single is set to true, the function returns the first value of the specified key (not in an
-     * array</li></ul>
+     * @return mixed
+     * @throws EE_Error
      */
     public function get_post_meta($meta_key = null, $single = false)
     {
@@ -337,13 +288,17 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
     /**
      * Wrapper for update_post_meta, http://codex.wordpress.org/Function_Reference/update_post_meta
+     * Returns meta_id if the meta doesn't exist,
+     * otherwise returns true on success and false on failure.
+     * NOTE: If the meta_value passed to this function is the same
+     * as the value that is already in the database, this function returns false.
      *
      * @param string $meta_key
      * @param mixed  $meta_value
      * @param mixed  $prev_value
-     * @return mixed Returns meta_id if the meta doesn't exist, otherwise returns true on success and false on failure.
-     *               NOTE: If the meta_value passed to this function is the same as the value that is already in the
-     *               database, this function returns false.
+     * @return mixed
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function update_post_meta($meta_key, $meta_value, $prev_value = null)
     {
@@ -359,9 +314,13 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      *
      * @param mixed $meta_key
      * @param mixed $meta_value
-     * @param bool  $unique . If postmeta for this $meta_key already exists, whether to add an additional item or not
-     * @return boolean Boolean true, except if the $unique argument was set to true and a custom field with the given
-     *                 key already exists, in which case false is returned.
+     * @param bool  $unique     If postmeta for this $meta_key already exists,
+     *                          whether to add an additional item or not
+     * @return boolean          Boolean true, except if the $unique argument was set to true
+     *                          and a custom field with the given key already exists,
+     *                          in which case false is returned.
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function add_post_meta($meta_key, $meta_value, $unique = false)
     {
@@ -378,11 +337,12 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      * @param mixed $meta_key
      * @param mixed $meta_value
      * @return boolean False for failure. True for success.
+     * @throws EE_Error
      */
     public function delete_post_meta($meta_key, $meta_value = '')
     {
         if (! $this->ID()) {
-            // there are obviously no postmetas for this if it's not saved
+            // there is obviously no postmeta for this if it's not saved
             // so let's just report this as a success
             return true;
         }
@@ -394,6 +354,7 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      * Gets the URL for viewing this event on the front-end
      *
      * @return string
+     * @throws EE_Error
      */
     public function get_permalink()
     {
@@ -405,9 +366,11 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
      * Gets all the term-taxonomies for this CPT
      *
      * @param array $query_params
-     * @return EE_Term_Taxonomy
+     * @return array[]|EE_Base_Class[]|EE_Term_Taxonomy
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function term_taxonomies($query_params = array())
+    public function term_taxonomies($query_params = [])
     {
         return $this->get_many_related('Term_Taxonomy', $query_params);
     }
@@ -415,6 +378,8 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
     /**
      * @return mixed
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_custom_post_statuses()
     {
@@ -424,6 +389,8 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
     /**
      * @return mixed
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_all_post_statuses()
     {
@@ -432,14 +399,100 @@ abstract class EE_CPT_Base extends EE_Soft_Delete_Base_Class
 
 
     /**
+     * When fetching a new value for a post field that uses the global $post for rendering,
+     * set the global $post temporarily to be this model object; and afterwards restore it
+     *
+     * @param string $field_name
+     * @param bool   $pretty
+     * @param string $extra_cache_ref
+     * @return mixed
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    protected function _get_fresh_property($field_name, $pretty = false, $extra_cache_ref = null)
+    {
+        global $post;
+
+        if (
+            $pretty
+            && (
+                ! (
+                    $post instanceof WP_Post
+                    && $post->ID
+                )
+                || (int) $post->ID !== $this->ID()
+            )
+            && $this->get_model()->field_settings_for($field_name) instanceof EE_Post_Content_Field
+        ) {
+            $old_post     = $post;
+            $post         = $this->wp_post();
+            $return_value = parent::_get_fresh_property($field_name, $pretty, $extra_cache_ref);
+            $post         = $old_post;
+        } else {
+            $return_value = parent::_get_fresh_property($field_name, $pretty, $extra_cache_ref);
+        }
+        return $return_value;
+    }
+
+
+    /**
+     * Returns the WP post associated with this CPT model object.
+     * If this CPT is saved, fetches it from the DB.
+     * Otherwise, create an unsaved WP_POst object. Caches the post internally.
+     *
+     * @return WP_Post
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function wp_post()
+    {
+        global $wpdb;
+        if (! $this->_wp_post instanceof WP_Post) {
+            if ($this->ID()) {
+                $this->_wp_post = get_post($this->ID());
+            } else {
+                $simulated_db_result = new stdClass();
+                $field_settings      = $this->get_model()->field_settings(true);
+                foreach ($field_settings as $field_name => $field_obj) {
+                    if (
+                        $this->get_model()->get_table_obj_by_alias($field_obj->get_table_alias())
+                             ->get_table_name() === $wpdb->posts
+                    ) {
+                        $column = $field_obj->get_table_column();
+
+                        if ($field_obj instanceof EE_Datetime_Field) {
+                            $value_on_model_obj = $this->get_DateTime_object($field_name);
+                        } elseif ($field_obj->is_db_only_field()) {
+                            $value_on_model_obj = $field_obj->get_default_value();
+                        } else {
+                            $value_on_model_obj = $this->get_raw($field_name);
+                        }
+                        $simulated_db_result->{$column} = $field_obj->prepare_for_use_in_db($value_on_model_obj);
+                    }
+                }
+                $this->_wp_post = new WP_Post($simulated_db_result);
+            }
+            // and let's make retrieving the EE CPT object easy too
+            $classname = get_class($this);
+            if (! isset($this->_wp_post->{$classname})) {
+                $this->_wp_post->{$classname} = $this;
+            }
+        }
+        return $this->_wp_post;
+    }
+
+
+    /**
      * Don't serialize the WP Post. That's just duplicate data and we want to avoid recursion
      *
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function __sleep()
     {
         $properties_to_serialize = parent::__sleep();
-        $properties_to_serialize = array_diff($properties_to_serialize, array('_wp_post'));
+        $properties_to_serialize = array_diff($properties_to_serialize, ['_wp_post']);
         return $properties_to_serialize;
     }
 }

--- a/core/db_classes/EE_CSV.class.php
+++ b/core/db_classes/EE_CSV.class.php
@@ -2,78 +2,73 @@
 
 /**
  * CSV Import Export class
- *
  * For dealing with CSV files directly. For exports/reports, it would generally
  * be preferred to use EventEspressoBatchRequest\BatchRequestProcessor and
  * EEH_Export to create csv files on the server and then direct the user to download them
  *
- * @package                   Event Espresso
- * @subpackage                includes/functions
- * @author                    Brent Christensen
- *
- * ------------------------------------------------------------------------
+ * @package     Event Espresso
+ * @subpackage  includes/functions
+ * @author      Brent Christensen
  */
 class EE_CSV
 {
 
-    // instance of the EE_CSV object
-    private static $_instance = null;
-
-
-    // multidimensional array to store update & error messages
-    // var $_notices = array( 'updates' => array(), 'errors' => array() );
-
-
-    private $_primary_keys;
-
     /**
-     *
-     * @var EE_Registry
-     */
-    private $EE;
-    /**
-     * string used for 1st cell in exports, which indicates that the following 2 rows will be metadata keys and values
+     * string used for 1st cell in exports,
+     * which indicates that the following 2 rows will be metadata keys and values
      */
     const metadata_header = 'Event Espresso Export Meta Data';
 
+
     /**
-     *        private constructor to prevent direct creation
+     * instance of the EE_CSV object
      *
-     * @Constructor
-     * @access private
+     * @var EE_CSV
+     */
+    private static $_instance;
+
+    /**
+     * @var array
+     */
+    private $_primary_keys;
+
+
+    /**
+     * private constructor to prevent direct creation
+     *
      * @return void
      */
     private function __construct()
     {
         global $wpdb;
 
-        $this->_primary_keys = array(
-            $wpdb->prefix . 'esp_answer'                  => array('ANS_ID'),
-            $wpdb->prefix . 'esp_attendee'                => array('ATT_ID'),
-            $wpdb->prefix . 'esp_datetime'                => array('DTT_ID'),
-            $wpdb->prefix . 'esp_event_question_group'    => array('EQG_ID'),
-            $wpdb->prefix . 'esp_message_template'        => array('MTP_ID'),
-            $wpdb->prefix . 'esp_payment'                 => array('PAY_ID'),
-            $wpdb->prefix . 'esp_price'                   => array('PRC_ID'),
-            $wpdb->prefix . 'esp_price_type'              => array('PRT_ID'),
-            $wpdb->prefix . 'esp_question'                => array('QST_ID'),
-            $wpdb->prefix . 'esp_question_group'          => array('QSG_ID'),
-            $wpdb->prefix . 'esp_question_group_question' => array('QGQ_ID'),
-            $wpdb->prefix . 'esp_question_option'         => array('QSO_ID'),
-            $wpdb->prefix . 'esp_registration'            => array('REG_ID'),
-            $wpdb->prefix . 'esp_status'                  => array('STS_ID'),
-            $wpdb->prefix . 'esp_transaction'             => array('TXN_ID'),
-            $wpdb->prefix . 'esp_transaction'             => array('TXN_ID'),
-            $wpdb->prefix . 'events_detail'               => array('id'),
-            $wpdb->prefix . 'events_category_detail'      => array('id'),
-            $wpdb->prefix . 'events_category_rel'         => array('id'),
-            $wpdb->prefix . 'events_venue'                => array('id'),
-            $wpdb->prefix . 'events_venue_rel'            => array('emeta_id'),
-            $wpdb->prefix . 'events_locale'               => array('id'),
-            $wpdb->prefix . 'events_locale_rel'           => array('id'),
-            $wpdb->prefix . 'events_personnel'            => array('id'),
-            $wpdb->prefix . 'events_personnel_rel'        => array('id'),
-        );
+        $this->_primary_keys = [
+            $wpdb->prefix . 'esp_answer'                  => ['ANS_ID'],
+            $wpdb->prefix . 'esp_attendee'                => ['ATT_ID'],
+            $wpdb->prefix . 'esp_datetime'                => ['DTT_ID'],
+            $wpdb->prefix . 'esp_event_question_group'    => ['EQG_ID'],
+            $wpdb->prefix . 'esp_message_template'        => ['MTP_ID'],
+            $wpdb->prefix . 'esp_payment'                 => ['PAY_ID'],
+            $wpdb->prefix . 'esp_price'                   => ['PRC_ID'],
+            $wpdb->prefix . 'esp_price_type'              => ['PRT_ID'],
+            $wpdb->prefix . 'esp_question'                => ['QST_ID'],
+            $wpdb->prefix . 'esp_question_group'          => ['QSG_ID'],
+            $wpdb->prefix . 'esp_question_group_question' => ['QGQ_ID'],
+            $wpdb->prefix . 'esp_question_option'         => ['QSO_ID'],
+            $wpdb->prefix . 'esp_registration'            => ['REG_ID'],
+            $wpdb->prefix . 'esp_status'                  => ['STS_ID'],
+            $wpdb->prefix . 'esp_transaction'             => ['TXN_ID'],
+            $wpdb->prefix . 'esp_transaction'             => ['TXN_ID'],
+            $wpdb->prefix . 'events_detail'               => ['id'],
+            $wpdb->prefix . 'events_category_detail'      => ['id'],
+            $wpdb->prefix . 'events_category_rel'         => ['id'],
+            $wpdb->prefix . 'events_venue'                => ['id'],
+            $wpdb->prefix . 'events_venue_rel'            => ['emeta_id'],
+            $wpdb->prefix . 'events_locale'               => ['id'],
+            $wpdb->prefix . 'events_locale_rel'           => ['id'],
+            $wpdb->prefix . 'events_personnel'            => ['id'],
+            $wpdb->prefix . 'events_personnel_rel'        => ['id'],
+        ];
     }
 
 
@@ -86,93 +81,10 @@ class EE_CSV
     public static function instance()
     {
         // check if class object is instantiated
-        if (self::$_instance === null or ! is_object(self::$_instance) or ! (self::$_instance instanceof EE_CSV)) {
+        if (! self::$_instance instanceof EE_CSV) {
             self::$_instance = new self();
         }
         return self::$_instance;
-    }
-
-    /**
-     * Opens a unicode or utf file (normal file_get_contents has difficulty readin ga unicode file. @see
-     * http://stackoverflow.com/questions/15092764/how-to-read-unicode-text-file-in-php
-     *
-     * @param string $file_path
-     * @return string
-     * @throws EE_Error
-     */
-    private function read_unicode_file($file_path)
-    {
-        $fc = "";
-        $fh = fopen($file_path, "rb");
-        if (! $fh) {
-            throw new EE_Error(sprintf(__("Cannot open file for read: %s<br>\n", 'event_espresso'), $file_path));
-        }
-        $flen = filesize($file_path);
-        $bc = fread($fh, $flen);
-        for ($i = 0; $i < $flen; $i++) {
-            $c = substr($bc, $i, 1);
-            if ((ord($c) != 0) && (ord($c) != 13)) {
-                $fc = $fc . $c;
-            }
-        }
-        if ((ord(substr($fc, 0, 1)) == 255) && (ord(substr($fc, 1, 1)) == 254)) {
-            $fc = substr($fc, 2);
-        }
-        return ($fc);
-    }
-
-
-    /**
-     * Generic CSV-functionality to turn an entire CSV file into a single array that's
-     * NOT in a specific format to EE. It's just a 2-level array, with top-level arrays
-     * representing each row in the CSV file, and the second-level arrays being each column in that row
-     *
-     * @param string $path_to_file
-     * @return array of arrays. Top-level array has rows, second-level array has each item
-     */
-    public function import_csv_to_multi_dimensional_array($path_to_file)
-    {
-        // needed to deal with Mac line endings
-        ini_set('auto_detect_line_endings', true);
-
-        // because fgetcsv does not correctly deal with backslashed quotes such as \"
-        // we'll read the file into a string
-        $file_contents = $this->read_unicode_file($path_to_file);
-        // replace backslashed quotes with CSV enclosures
-        $file_contents = str_replace('\\"', '"""', $file_contents);
-        // HEY YOU! PUT THAT FILE BACK!!!
-        file_put_contents($path_to_file, $file_contents);
-
-        if (($file_handle = fopen($path_to_file, "r")) !== false) {
-            # Set the parent multidimensional array key to 0.
-            $nn = 0;
-            $csvarray = array();
-
-            // in PHP 5.3 fgetcsv accepts a 5th parameter, but the pre 5.3 versions of fgetcsv choke if passed more than 4 - is that crazy or what?
-            if (version_compare(PHP_VERSION, '5.3.0') < 0) {
-                //  PHP 5.2- version
-                // loop through each row of the file
-                while (($data = fgetcsv($file_handle, 0, ',', '"')) !== false) {
-                    $csvarray[] = $data;
-                }
-            } else {
-                // loop through each row of the file
-                while (($data = fgetcsv($file_handle, 0, ',', '"', '\\')) !== false) {
-                    $csvarray[] = $data;
-                }
-            }
-            # Close the File.
-            fclose($file_handle);
-            return $csvarray;
-        } else {
-            EE_Error::add_error(
-                sprintf(__("An error occurred - the file: %s could not opened.", "event_espresso"), $path_to_file),
-                __FILE__,
-                __FUNCTION__,
-                __LINE__
-            );
-            return false;
-        }
     }
 
 
@@ -192,8 +104,9 @@ class EE_CSV
      * @param boolean $first_row_is_headers - whether the first row of data is headers or not - TRUE = headers, FALSE =
      *                                      data
      * @return mixed - array on success - multi dimensional with headers as keys (if headers exist) OR string on fail -
-     *               error message like the following array('Event'=>array( array('EVT_ID'=>1,'EVT_name'=>'bob
-     *               party',...), array('EVT_ID'=>2,'EVT_name'=>'llamarama',...),
+     *                                      error message like the following array('Event'=>array(
+     *                                      array('EVT_ID'=>1,'EVT_name'=>'bob party',...),
+     *                                      array('EVT_ID'=>2,'EVT_name'=>'llamarama',...),
      *                                      ...
      *                                      )
      *                                      'Venue'=>array(
@@ -203,29 +116,30 @@ class EE_CSV
      *                                      )
      *                                      ...
      *                                      )
+     * @throws EE_Error
      */
     public function import_csv_to_model_data_array($path_to_file, $model_name = false, $first_row_is_headers = true)
     {
         $multi_dimensional_array = $this->import_csv_to_multi_dimensional_array($path_to_file);
-        if (! $multi_dimensional_array) {
+        if (empty($multi_dimensional_array)) {
             return false;
         }
         // gotta start somewhere
         $row = 1;
         // array to store csv data in
-        $ee_formatted_data = array();
+        $ee_formatted_data = [];
         // array to store headers (column names)
-        $headers = array();
+        $headers = [];
         foreach ($multi_dimensional_array as $data) {
             // if first cell is MODEL, then second cell is the MODEL name
             if ($data[0] == 'MODEL') {
                 $model_name = $data[1];
-                // don't bother looking for model data in this row. The rest of this
-                // row should be blank
+                // don't bother looking for model data in this row.
+                // The rest of this row should be blank
                 // AND pretend this is the first row again
                 $row = 1;
                 // reset headers
-                $headers = array();
+                $headers = [];
                 continue;
             }
             if (strpos($data[0], EE_CSV::metadata_header) !== false) {
@@ -239,7 +153,7 @@ class EE_CSV
             // how many columns are there?
             $columns = count($data);
 
-            $model_entry = array();
+            $model_entry = [];
             // loop through each column
             for ($i = 0; $i < $columns; $i++) {
                 // replace csv_enclosures with backslashed quotes
@@ -249,11 +163,12 @@ class EE_CSV
                     if ($first_row_is_headers) {
                         // store the column names to use for keys
                         $column_name = $data[ $i ];
-                        // check it's not blank... sometimes CSV editign programs adda bunch of empty columns onto the end...
+                        // check it's not blank... sometimes CSV editing programs
+                        // add a bunch of empty columns onto the end...
                         if (! $column_name) {
                             continue;
                         }
-                        $matches = array();
+                        $matches = [];
                         if ($model_name == EE_CSV::metadata_header) {
                             $headers[ $i ] = $column_name;
                         } else {
@@ -262,7 +177,7 @@ class EE_CSV
                             if (! $success) {
                                 EE_Error::add_error(
                                     sprintf(
-                                        __(
+                                        esc_html__(
                                             "The column titled %s is invalid for importing. It must be be in the format of 'Nice Name[model_field_name]' in row %s",
                                             "event_espresso"
                                         ),
@@ -280,7 +195,7 @@ class EE_CSV
                     } else {
                         // no column names means our final array will just use counters for keys
                         $model_entry[ $headers[ $i ] ] = $data[ $i ];
-                        $headers[ $i ] = $i;
+                        $headers[ $i ]                 = $i;
                     }
                     // and we need to store csv data
                 } else {
@@ -291,7 +206,7 @@ class EE_CSV
                 }
             }
             // save the row's data IF it's a non-header-row
-            if (! $first_row_is_headers || ($first_row_is_headers && $row > 1)) {
+            if (! $first_row_is_headers || $row > 1) {
                 $ee_formatted_data[ $model_name ][] = $model_entry;
             }
             // advance to next row
@@ -300,19 +215,116 @@ class EE_CSV
 
         // delete the uploaded file
         unlink($path_to_file);
-        // echo '<pre style="height:auto;border:2px solid lightblue;">' . print_r( $ee_formatted_data, TRUE ) . '</pre><br /><span style="font-size:10px;font-weight:normal;">' . __FILE__ . '<br />line no: ' . __LINE__ . '</span>';
-        // die();
 
         // it's good to give back
         return $ee_formatted_data;
     }
 
 
+    /**
+     * Generic CSV-functionality to turn an entire CSV file into a single array that's
+     * NOT in a specific format to EE. It's just a 2-level array, with top-level arrays
+     * representing each row in the CSV file, and the second-level arrays being each column in that row
+     *
+     * @param string $path_to_file
+     * @return array of arrays. Top-level array has rows, second-level array has each item
+     * @throws EE_Error
+     */
+    public function import_csv_to_multi_dimensional_array($path_to_file)
+    {
+        // needed to deal with Mac line endings
+        ini_set('auto_detect_line_endings', true);
+        // because fgetcsv does not correctly deal with backslashed quotes such as \"
+        // we'll read the file into a string
+        $file_contents = $this->read_unicode_file($path_to_file);
+        // replace backslashed quotes with CSV enclosures
+        $file_contents = str_replace('\\"', '"""', $file_contents);
+        // HEY YOU! PUT THAT FILE BACK!!!
+        file_put_contents($path_to_file, $file_contents);
+
+        if (($file_handle = fopen($path_to_file, "r")) !== false) {
+            $csv_array = [];
+            // in PHP 5.3 fgetcsv accepts a 5th parameter, but the pre 5.3 versions
+            // of fgetcsv choke if passed more than 4 - is that crazy or what?
+            if (version_compare(PHP_VERSION, '5.3.0') < 0) {
+                //  PHP 5.2- version
+                // loop through each row of the file
+                while (($data = fgetcsv($file_handle)) !== false) {
+                    $csv_array[] = $data;
+                }
+            } else {
+                // loop through each row of the file
+                while (($data = fgetcsv($file_handle)) !== false) {
+                    $csv_array[] = $data;
+                }
+            }
+            # Close the File.
+            fclose($file_handle);
+            return $csv_array;
+        }
+        EE_Error::add_error(
+            sprintf(
+                esc_html__(
+                    "An error occurred - the file: %s could not opened.",
+                    "event_espresso"
+                ),
+                $path_to_file
+            ),
+            __FILE__,
+            __FUNCTION__,
+            __LINE__
+        );
+        return [];
+    }
+
+
+    /**
+     * Opens a unicode or utf file
+     * (normal file_get_contents has difficulty reading a unicode file)
+     *
+     * @param string $file_path
+     * @return string
+     * @throws EE_Error
+     * @see http://stackoverflow.com/questions/15092764/how-to-read-unicode-text-file-in-php
+     */
+    private function read_unicode_file($file_path)
+    {
+        $fc = "";
+        $fh = fopen($file_path, "rb");
+        if (! $fh) {
+            throw new EE_Error(
+                sprintf(
+                    esc_html__("Cannot open file for read: %s<br>\n", 'event_espresso'),
+                    $file_path
+                )
+            );
+        }
+        $file_length = filesize($file_path);
+        $bc          = fread($fh, $file_length);
+        for ($i = 0; $i < $file_length; $i++) {
+            $c = substr($bc, $i, 1);
+            if ((ord($c) != 0) && (ord($c) != 13)) {
+                $fc = $fc . $c;
+            }
+        }
+        if ((ord(substr($fc, 0, 1)) == 255) && (ord(substr($fc, 1, 1)) == 254)) {
+            $fc = substr($fc, 2);
+        }
+        return ($fc);
+    }
+
+
+    /**
+     * @param       $csv_data_array
+     * @param false $model_name
+     * @return bool
+     * @throws EE_Error
+     */
     public function save_csv_to_db($csv_data_array, $model_name = false)
     {
         EE_Error::doing_it_wrong(
             'save_csv_to_db',
-            __(
+            esc_html__(
                 'Function moved to EE_Import and renamed to save_csv_data_array_to_db',
                 'event_espresso'
             ),
@@ -321,12 +333,31 @@ class EE_CSV
         return EE_Import::instance()->save_csv_data_array_to_db($csv_data_array, $model_name);
     }
 
+
+    /**
+     * Writes the CSV file to the output buffer, with rows corresponding to $model_data_array,
+     * and dies (in order to avoid other plugins from messing up the csv output)
+     *
+     * @param string $filename         the filename you want to give the file
+     * @param array  $model_data_array 3d array, as described in EE_CSV::write_model_data_to_csv()
+     * @return bool | void writes CSV file to output and dies
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function export_multiple_model_data_to_csv($filename, $model_data_array)
+    {
+        $file_handle = $this->begin_sending_csv($filename);
+        $this->write_model_data_to_csv($file_handle, $model_data_array);
+        $this->end_sending_csv($file_handle);
+    }
+
+
     /**
      * Sends HTTP headers to indicate that the browser should download a file,
      * and starts writing the file to PHP's output. Returns the file handle so other functions can
      * also write to it
      *
-     * @param string $new_filename the name of the file that the user will download
+     * @param string $filename the name of the file that the user will download
      * @return resource, like the results of fopen(), which can be used for fwrite, fputcsv2, etc.
      */
     public function begin_sending_csv($filename)
@@ -360,242 +391,69 @@ class EE_CSV
             'FHEE__EE_CSV__begin_sending_csv__start_writing',
             "\xEF\xBB\xBF"
         ); // makes excel open it as UTF-8. UTF-8 BOM, see http://stackoverflow.com/a/4440143/2773835
-        $fh = fopen('php://output', 'w');
-        return $fh;
+        return fopen('php://output', 'w');
     }
+
+
+    /**
+     * Given an open file, writes all the model data to it in the format the importer expects.
+     * Usually preceded by begin_sending_csv($filename), and followed by end_sending_csv($file_handle).
+     *
+     * @param resource $file_handle
+     * @param array    $model_data_array is assumed to be a 3d array: 1st layer has keys of model names (eg 'Event'),
+     *                                   next layer is numerically indexed to represent each model object (eg, each
+     *                                   individual event), and the last layer has all the attributes of that model
+     *                                   object (eg, the event's id, name, etc)
+     * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function write_model_data_to_csv($file_handle, $model_data_array)
+    {
+        $this->write_metadata_to_csv($file_handle);
+        foreach ($model_data_array as $model_name => $model_instance_arrays) {
+            // first: output a special row stating the model
+            $this->fputcsv2($file_handle, ['MODEL', $model_name]);
+            // if we have items to put in the CSV, do it normally
+
+            if (! empty($model_instance_arrays)) {
+                $this->write_data_array_to_csv($file_handle, $model_instance_arrays);
+            } else {
+                // echo "no data to write... so just write the headers";
+                // so there's actually NO model objects for that model.
+                // probably still want to show the columns
+                $model        = EE_Registry::instance()->load_model($model_name);
+                $column_names = [];
+                foreach ($model->field_settings() as $field) {
+                    $column_names[ $field->get_nicename() . "[" . $field->get_name() . "]" ] = null;
+                }
+                $this->write_data_array_to_csv($file_handle, [$column_names]);
+            }
+        }
+    }
+
 
     /**
      * Writes some meta data to the CSV as a bunch of columns. Initially we're only
      * mentioning the version and timezone
      *
-     * @param resource $filehandle
+     * @param resource $file_handle
+     * @throws EE_Error
+     * @throws EE_Error
      */
-    public function write_metadata_to_csv($filehandle)
+    public function write_metadata_to_csv($file_handle)
     {
-        $data_row = array(EE_CSV::metadata_header);// do NOT translate because this exact string is used when importing
-        $this->fputcsv2($filehandle, $data_row);
-        $meta_data = array(
-            0 => array(
+        $data_row = [EE_CSV::metadata_header];// do NOT translate because this exact string is used when importing
+        $this->fputcsv2($file_handle, $data_row);
+        $meta_data = [
+            0 => [
                 'version'        => espresso_version(),
                 'timezone'       => EEH_DTT_Helper::get_timezone(),
                 'time_of_export' => current_time('mysql'),
                 'site_url'       => site_url(),
-            ),
-        );
-        $this->write_data_array_to_csv($filehandle, $meta_data);
-    }
-
-
-    /**
-     * Writes $data to the csv file open in $filehandle. uses the array indices of $data for column headers
-     *
-     * @param array   $data                 2D array, first numerically-indexed, and next-level-down preferably indexed
-     *                                      by string
-     * @param boolean $add_csv_column_names whether or not we should add the keys in the bottom-most array as a row for
-     *                                      headers in the CSV. Eg, if $data looked like
-     *                                      array(0=>array('EVT_ID'=>1,'EVT_name'=>'monkey'...), 1=>array(...),...))
-     *                                      then the first row we'd write to the CSV would be "EVT_ID,EVT_name,..."
-     * @return boolean if we successfully wrote to the CSV or not. If there's no $data, we consider that a success
-     *                 (because we wrote everything there was...nothing)
-     */
-    public function write_data_array_to_csv($filehandle, $data)
-    {
-
-
-        // determine if $data is actually a 2d array
-        if ($data && is_array($data) && is_array(EEH_Array::get_one_item_from_array($data))) {
-            // make sure top level is numerically indexed,
-
-            if (EEH_Array::is_associative_array($data)) {
-                throw new EE_Error(
-                    sprintf(
-                        __(
-                            "top-level array must be numerically indexed. Does these look like numbers to you? %s",
-                            "event_espresso"
-                        ),
-                        implode(",", array_keys($data))
-                    )
-                );
-            }
-            $item_in_top_level_array = EEH_Array::get_one_item_from_array($data);
-            // now, is the last item in the top-level array of $data an associative or numeric array?
-            if (EEH_Array::is_associative_array($item_in_top_level_array)) {
-                // its associative, so we want to output its keys as column headers
-                $keys = array_keys($item_in_top_level_array);
-                echo $this->fputcsv2($filehandle, $keys);
-            }
-            // start writing data
-            foreach ($data as $data_row) {
-                echo $this->fputcsv2($filehandle, $data_row);
-            }
-            return true;
-        } else {
-            // no data TO write... so we can assume that's a success
-            return true;
-        }
-        // //if 2nd level is indexed by strings, use those as csv column headers (ie, the first row)
-        //
-        //
-        // $no_table = TRUE;
-        //
-        // // loop through data and add each row to the file/stream as csv
-        // foreach ( $data as $model_name => $model_data ) {
-        // // test first row to see if it is data or a model name
-        // $model = EE_Registry::instance();->load_model($model_name);
-        // //if the model really exists,
-        // if ( $model ) {
-        //
-        // // we have a table name
-        // $no_table = FALSE;
-        //
-        // // put the tablename into an array cuz that's how fputcsv rolls
-        // $model_name_row = array( 'MODEL', $model_name );
-        //
-        // // add table name to csv output
-        // echo self::fputcsv2($filehandle, $model_name_row);
-        //
-        // // now get the rest of the data
-        // foreach ( $model_data as $row ) {
-        // // output the row
-        // echo self::fputcsv2($filehandle, $row);
-        // }
-        //
-        // }
-        //
-        // if ( $no_table ) {
-        // // no table so just put the data
-        // echo self::fputcsv2($filehandle, $model_data);
-        // }
-        //
-        // } // END OF foreach ( $data )
-    }
-
-    /**
-     * Should be called after begin_sending_csv(), and one or more write_data_array_to_csv()s.
-     * Calls exit to prevent polluting the CSV file with other junk
-     *
-     * @param resource $fh filehandle where we're writing the CSV to
-     */
-    public function end_sending_csv($fh)
-    {
-        fclose($fh);
-        exit(0);
-    }
-
-    /**
-     * Given an open file, writes all the model data to it in the format the importer expects.
-     * Usually preceded by begin_sending_csv($filename), and followed by end_sending_csv($filehandle).
-     *
-     * @param resource $filehandle
-     * @param array    $model_data_array is assumed to be a 3d array: 1st layer has keys of model names (eg 'Event'),
-     *                                   next layer is numerically indexed to represent each model object (eg, each
-     *                                   individual event), and the last layer has all the attributes o fthat model
-     *                                   object (eg, the event's id, name, etc)
-     * @return boolean success
-     */
-    public function write_model_data_to_csv($filehandle, $model_data_array)
-    {
-        $this->write_metadata_to_csv($filehandle);
-        foreach ($model_data_array as $model_name => $model_instance_arrays) {
-            // first: output a special row stating the model
-            echo $this->fputcsv2($filehandle, array('MODEL', $model_name));
-            // if we have items to put in the CSV, do it normally
-
-            if (! empty($model_instance_arrays)) {
-                $this->write_data_array_to_csv($filehandle, $model_instance_arrays);
-            } else {
-                // echo "no data to write... so just write the headers";
-                // so there's actually NO model objects for that model.
-                // probably still want to show the columns
-                $model = EE_Registry::instance()->load_model($model_name);
-                $column_names = array();
-                foreach ($model->field_settings() as $field) {
-                    $column_names[ $field->get_nicename() . "[" . $field->get_name() . "]" ] = null;
-                }
-                $this->write_data_array_to_csv($filehandle, array($column_names));
-            }
-        }
-    }
-
-    /**
-     * Writes the CSV file to the output buffer, with rows corresponding to $model_data_array,
-     * and dies (in order to avoid other plugins from messing up the csv output)
-     *
-     * @param string $filename         the filename you want to give the file
-     * @param array  $model_data_array 3d array, as described in EE_CSV::write_model_data_to_csv()
-     * @return bool | void writes CSV file to output and dies
-     */
-    public function export_multiple_model_data_to_csv($filename, $model_data_array)
-    {
-        $filehandle = $this->begin_sending_csv($filename);
-        $this->write_model_data_to_csv($filehandle, $model_data_array);
-        $this->end_sending_csv($filehandle);
-    }
-
-    /**
-     * @Export contents of an array to csv file
-     * @access public
-     * @param array  $data     - the array of data to be converted to csv and exported
-     * @param string $filename - name for newly created csv file
-     * @return TRUE on success, FALSE on fail
-     */
-    public function export_array_to_csv($data = false, $filename = false)
-    {
-
-        // no data file?? get outta here
-        if (! $data or ! is_array($data) or empty($data)) {
-            return false;
-        }
-
-        // no filename?? get outta here
-        if (! $filename) {
-            return false;
-        }
-
-
-        // somebody told me i might need this ???
-        global $wpdb;
-        $prefix = $wpdb->prefix;
-
-
-        $fh = $this->begin_sending_csv($filename);
-
-
-        $this->end_sending_csv($fh);
-    }
-
-
-    /**
-     * @Determine the maximum upload file size based on php.ini settings
-     * @access    public
-     * @param int $percent_of_max - desired percentage of the max upload_mb
-     * @return int KB
-     */
-    public function get_max_upload_size($percent_of_max = false)
-    {
-
-        $max_upload = (int) (ini_get('upload_max_filesize'));
-        $max_post = (int) (ini_get('post_max_size'));
-        $memory_limit = (int) (ini_get('memory_limit'));
-
-        // determine the smallest of the three values from above
-        $upload_mb = min($max_upload, $max_post, $memory_limit);
-
-        // convert MB to KB
-        $upload_mb = $upload_mb * 1024;
-
-        // don't want the full monty? then reduce the max uplaod size
-        if ($percent_of_max) {
-            // is percent_of_max like this -> 50 or like this -> 0.50 ?
-            if ($percent_of_max > 1) {
-                // chnages 50 to 0.50
-                $percent_of_max = $percent_of_max / 100;
-            }
-            // make upload_mb a percentage of the max upload_mb
-            $upload_mb = $upload_mb * $percent_of_max;
-        }
-
-        return $upload_mb;
+            ],
+        ];
+        $this->write_data_array_to_csv($file_handle, $meta_data);
     }
 
 
@@ -618,7 +476,7 @@ class EE_CSV
         $delimiter_esc = preg_quote($delimiter, '/');
         $enclosure_esc = preg_quote($enclosure, '/');
 
-        $output = array();
+        $output = [];
         foreach ($row as $field_value) {
             if (is_object($field_value) || is_array($field_value)) {
                 $field_value = serialize($field_value);
@@ -628,8 +486,8 @@ class EE_CSV
                 continue;
             }
 
-            $output[] = preg_match("/(?:${delimiter_esc}|${enclosure_esc}|\s)/", $field_value) ?
-                ($enclosure . str_replace($enclosure, $enclosure . $enclosure, $field_value) . $enclosure)
+            $output[] = preg_match("/(?:${delimiter_esc}|${enclosure_esc}|\s)/", $field_value)
+                ? ($enclosure . str_replace($enclosure, $enclosure . $enclosure, $field_value) . $enclosure)
                 : $field_value;
         }
 
@@ -637,32 +495,122 @@ class EE_CSV
     }
 
 
-    // /**
-    //  * @CSV    Import / Export messages
-    //  * @access public
-    //  * @return void
-    //  */
-    // public function csv_admin_notices()
-    // {
-    //
-    //     // We play both kinds of music here! Country AND Western! - err... I mean, cycle through both types of notices
-    //     foreach (array('updates', 'errors') as $type) {
-    //
-    //         // if particular notice type is not empty, then "You've got Mail"
-    //         if (! empty($this->_notices[ $type ])) {
-    //
-    //             // is it an update or an error ?
-    //             $msg_class = $type == 'updates' ? 'updated' : 'error';
-    //             echo '<div id="message" class="' . $msg_class . '">';
-    //             // display each notice, however many that may be
-    //             foreach ($this->_notices[ $type ] as $message) {
-    //                 echo '<p>' . $message . '</p>';
-    //             }
-    //             // wrap it up
-    //             echo '</div>';
-    //         }
-    //     }
-    // }
+    /**
+     * Writes $data to the csv file open in $file_handle. uses the array indices of $data for column headers
+     *
+     * @param resource $file_handle
+     * @param array    $data        2D array, first numerically-indexed,
+     *                              and next-level-down preferably indexed by string
+     * @return boolean              if we successfully wrote to the CSV or not.
+     *                              If there's no $data, we consider that a success
+     *                              (because we wrote everything there was...nothing)
+     * @throws EE_Error
+     * @throws EE_Error
+     */
+    public function write_data_array_to_csv($file_handle, $data)
+    {
+        // determine if $data is actually a 2d array
+        if ($data && is_array($data) && is_array(EEH_Array::get_one_item_from_array($data))) {
+            // make sure top level is numerically indexed,
+
+            if (EEH_Array::is_associative_array($data)) {
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__(
+                            "top-level array must be numerically indexed. Does these look like numbers to you? %s",
+                            "event_espresso"
+                        ),
+                        implode(",", array_keys($data))
+                    )
+                );
+            }
+            $item_in_top_level_array = EEH_Array::get_one_item_from_array($data);
+            // now, is the last item in the top-level array of $data an associative or numeric array?
+            if (EEH_Array::is_associative_array($item_in_top_level_array)) {
+                // its associative, so we want to output its keys as column headers
+                $keys = array_keys($item_in_top_level_array);
+                $this->fputcsv2($file_handle, $keys);
+            }
+            // start writing data
+            foreach ($data as $data_row) {
+                $this->fputcsv2($file_handle, $data_row);
+            }
+            return true;
+        }
+        // no data TO write... so we can assume that's a success
+        return true;
+    }
+
+
+    /**
+     * Should be called after begin_sending_csv(), and one or more write_data_array_to_csv()s.
+     * Calls exit to prevent polluting the CSV file with other junk
+     *
+     * @param resource $fh file_handle where we're writing the CSV to
+     */
+    public function end_sending_csv($fh)
+    {
+        fclose($fh);
+        exit(0);
+    }
+
+
+    /**
+     * @Export contents of an array to csv file
+     * @access public
+     * @param array  $data     - the array of data to be converted to csv and exported
+     * @param string $filename - name for newly created csv file
+     * @return bool TRUE on success, FALSE on fail
+     */
+    public function export_array_to_csv($data = false, $filename = false)
+    {
+        // no data file?? get outta here
+        if (! $data or ! is_array($data) or empty($data)) {
+            return false;
+        }
+
+        // no filename?? get outta here
+        if (! $filename) {
+            return false;
+        }
+        $fh = $this->begin_sending_csv($filename);
+        $this->end_sending_csv($fh);
+        return true;
+    }
+
+
+    /**
+     * @Determine the maximum upload file size based on php.ini settings
+     * @access    public
+     * @param int $percent_of_max - desired percentage of the max upload_mb
+     * @return int KB
+     */
+    public function get_max_upload_size($percent_of_max = false)
+    {
+        $max_upload   = (int) (ini_get('upload_max_filesize'));
+        $max_post     = (int) (ini_get('post_max_size'));
+        $memory_limit = (int) (ini_get('memory_limit'));
+
+        // determine the smallest of the three values from above
+        $upload_mb = min($max_upload, $max_post, $memory_limit);
+
+        // convert MB to KB
+        $upload_mb = $upload_mb * 1024;
+
+        // don't want the full monty? then reduce the max upload size
+        if ($percent_of_max) {
+            // is percent_of_max like this -> 50 or like this -> 0.50 ?
+            if ($percent_of_max > 1) {
+                // changes 50 to 0.50
+                $percent_of_max = $percent_of_max / 100;
+            }
+            // make upload_mb a percentage of the max upload_mb
+            $upload_mb = $upload_mb * $percent_of_max;
+        }
+
+        return $upload_mb;
+    }
+
 
     /**
      * Gets the date format to use in teh csv. filterable
@@ -674,6 +622,7 @@ class EE_CSV
     {
         return apply_filters('FHEE__EE_CSV__get_date_format_for_csv__format', 'Y-m-d', $current_format);
     }
+
 
     /**
      * Gets the time format we want to use in CSV reports. Filterable

--- a/core/db_classes/EE_Change_Log.class.php
+++ b/core/db_classes/EE_Change_Log.class.php
@@ -3,24 +3,24 @@
 /**
  * EE_Change_Log
  *
- * @package               Event Espresso
+ * @package     Event Espresso
  * @subpackage
- * @author                Mike Nelson
- * ------------------------------------------------------------------------
+ * @author      Mike Nelson
  */
 class EE_Change_Log extends EE_Base_Class
 {
 
     /**
-     * @param array  $props_n_values          incoming values
-     * @param string $timezone                incoming timezone (if not set the timezone set for the website will be
-     *                                        used.)
-     * @param array  $date_formats            incoming date_formats in an array where the first value is the
-     *                                        date_format and the second value is the time format
+     * @param array  $props_n_values    incoming values
+     * @param string $timezone          incoming timezone
+     *                                  If not set the timezone for the website will be used.
+     * @param array  $date_formats      incoming date_formats in an array where the first value is the
+     *                                  date_format and the second value is the time format
      * @return EE_Change_Log
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -29,14 +29,17 @@ class EE_Change_Log extends EE_Base_Class
 
     /**
      * @param array  $props_n_values  incoming values from the database
-     * @param string $timezone        incoming timezone as set by the model.  If not set the timezone for
-     *                                the website will be used.
+     * @param string $timezone        incoming timezone as set by the model.
+     *                                If not set the timezone for the website will be used.
      * @return EE_Change_Log
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = null)
     {
         return new self($props_n_values, true, $timezone);
     }
+
 
     /**
      * Gets message
@@ -49,16 +52,19 @@ class EE_Change_Log extends EE_Base_Class
         return $this->get('LOG_message');
     }
 
+
     /**
      * Sets message
      *
      * @param mixed $message
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_message($message)
     {
         $this->set('LOG_message', $message);
     }
+
 
     /**
      * Gets time
@@ -71,26 +77,17 @@ class EE_Change_Log extends EE_Base_Class
         return $this->get('LOG_time');
     }
 
+
     /**
      * Sets time
      *
      * @param string $time
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_time($time)
     {
         $this->set('LOG_time', $time);
-    }
-
-    /**
-     * Gets log_type
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function log_type()
-    {
-        return $this->get('LOG_type');
     }
 
 
@@ -105,38 +102,31 @@ class EE_Change_Log extends EE_Base_Class
         return EEM_Change_Log::get_pretty_label_for_type($this->log_type());
     }
 
+
+    /**
+     * Gets log_type
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function log_type()
+    {
+        return $this->get('LOG_type');
+    }
+
+
     /**
      * Sets log_type
      *
      * @param string $log_type
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_log_type($log_type)
     {
         $this->set('LOG_type', $log_type);
     }
 
-    /**
-     * Gets type of the model object related to this log
-     *
-     * @return string
-     * @throws EE_Error
-     */
-    public function OBJ_type()
-    {
-        return $this->get('OBJ_type');
-    }
-
-    /**
-     * Sets type
-     *
-     * @param string $type
-     * @throws EE_Error
-     */
-    public function set_OBJ_type($type)
-    {
-        $this->set('OBJ_type', $type);
-    }
 
     /**
      * Gets OBJ_ID (the ID of the item related to this log)
@@ -149,16 +139,6 @@ class EE_Change_Log extends EE_Base_Class
         return $this->get('OBJ_ID');
     }
 
-    /**
-     * Sets OBJ_ID
-     *
-     * @param mixed $OBJ_ID
-     * @throws EE_Error
-     */
-    public function set_OBJ_ID($OBJ_ID)
-    {
-        $this->set('OBJ_ID', $OBJ_ID);
-    }
 
     /**
      * Gets wp_user
@@ -171,33 +151,49 @@ class EE_Change_Log extends EE_Base_Class
         return $this->get('LOG_wp_user');
     }
 
+
     /**
      * Sets wp_user
      *
      * @param int $wp_user_id
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_wp_user($wp_user_id)
     {
         $this->set('LOG_wp_user', $wp_user_id);
     }
 
+
     /**
      * Gets the model object attached to this log
      *
      * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function object()
     {
         $model_name_of_related_obj = $this->OBJ_type();
-        $is_model_name = EE_Registry::instance()->is_model_name($model_name_of_related_obj);
+        $is_model_name             = EE_Registry::instance()->is_model_name($model_name_of_related_obj);
         if (! $is_model_name) {
             return null;
-        } else {
-            return $this->get_first_related($model_name_of_related_obj);
         }
+        return $this->get_first_related($model_name_of_related_obj);
     }
+
+
+    /**
+     * Gets type of the model object related to this log
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function OBJ_type()
+    {
+        return $this->get('OBJ_type');
+    }
+
 
     /**
      * Shorthand for setting the OBJ_ID and OBJ_type. Slightly handier than using
@@ -208,6 +204,7 @@ class EE_Change_Log extends EE_Base_Class
      * @param boolean       $save
      * @return bool if $save=true, NULL is $save=false
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_object($object, $save = true)
     {
@@ -220,8 +217,33 @@ class EE_Change_Log extends EE_Base_Class
         }
         if ($save) {
             return $this->save();
-        } else {
-            return null;
         }
+        return null;
+    }
+
+
+    /**
+     * Sets type
+     *
+     * @param string $type
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function set_OBJ_type($type)
+    {
+        $this->set('OBJ_type', $type);
+    }
+
+
+    /**
+     * Sets OBJ_ID
+     *
+     * @param mixed $OBJ_ID
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function set_OBJ_ID($OBJ_ID)
+    {
+        $this->set('OBJ_ID', $OBJ_ID);
     }
 }

--- a/core/db_classes/EE_Checkin.class.php
+++ b/core/db_classes/EE_Checkin.class.php
@@ -3,9 +3,9 @@
 /**
  * EE_Checkin class
  *
- * @package            Event Espresso
- * @subpackage         includes/classes/EE_Checkin.class.php
- * @author             Darren Ethier
+ * @package     Event Espresso
+ * @subpackage  includes/classes/EE_Checkin.class.php
+ * @author      Darren Ethier
  */
 class EE_Checkin extends EE_Base_Class
 {
@@ -34,7 +34,6 @@ class EE_Checkin extends EE_Base_Class
 
 
     /**
-     *
      * @param array  $props_n_values    incoming values
      * @param string $timezone          incoming timezone (if not set the timezone set for the website will be used.)
      * @param array  $date_formats      incoming date_formats in an array
@@ -42,8 +41,9 @@ class EE_Checkin extends EE_Base_Class
      *                                  and the second value is the time format
      * @return EE_Checkin
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object
@@ -58,37 +58,58 @@ class EE_Checkin extends EE_Base_Class
      *                                the website will be used.
      * @return EE_Checkin
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = null)
     {
         return new self($props_n_values, true, $timezone);
     }
 
 
+    /**
+     * @return mixed
+     * @throws EE_Error
+     */
     public function ID()
     {
         return $this->get('CHK_ID');
     }
 
 
+    /**
+     * @return mixed
+     * @throws EE_Error
+     */
     public function registration_id()
     {
         return $this->get('REG_ID');
     }
 
 
+    /**
+     * @return mixed
+     * @throws EE_Error
+     */
     public function datetime_id()
     {
         return $this->get('DTT_ID');
     }
 
 
+    /**
+     * @return mixed
+     * @throws EE_Error
+     */
     public function status()
     {
         return $this->get('CHK_in');
     }
 
 
+    /**
+     * @return mixed
+     * @throws EE_Error
+     */
     public function timestamp()
     {
         return $this->get('CHK_timestamp');

--- a/core/db_classes/EE_Country.class.php
+++ b/core/db_classes/EE_Country.class.php
@@ -3,9 +3,9 @@
 /**
  * EE_Country class
  *
- * @package               Event Espresso
- * @subpackage            includes/classes/EE_Country.class.php
- * @author                Brent Christensen
+ * @package     Event Espresso
+ * @subpackage  includes/classes/EE_Country.class.php
+ * @author      Brent Christensen
  */
 class EE_Country extends EE_Base_Class
 {
@@ -13,8 +13,10 @@ class EE_Country extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Country|mixed
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array())
+    public static function new_instance($props_n_values = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__);
         return $has_object ? $has_object : new self($props_n_values);
@@ -24,8 +26,10 @@ class EE_Country extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Country
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array())
+    public static function new_instance_from_db($props_n_values = [])
     {
         return new self($props_n_values, true);
     }
@@ -35,6 +39,7 @@ class EE_Country extends EE_Base_Class
      * Gets the country name
      *
      * @return string
+     * @throws EE_Error
      */
     public function name()
     {
@@ -46,6 +51,7 @@ class EE_Country extends EE_Base_Class
      * gets the country's currency code
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_code()
     {
@@ -57,6 +63,7 @@ class EE_Country extends EE_Base_Class
      * gets the country's currency sign/symbol
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_sign()
     {
@@ -69,6 +76,7 @@ class EE_Country extends EE_Base_Class
      * Currency name singular
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_name_single()
     {
@@ -80,6 +88,7 @@ class EE_Country extends EE_Base_Class
      * Currency name plural
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_name_plural()
     {
@@ -91,6 +100,7 @@ class EE_Country extends EE_Base_Class
      * currency_sign_before - ie: $TRUE  or  FALSE$
      *
      * @return boolean
+     * @throws EE_Error
      */
     public function currency_sign_before()
     {
@@ -102,6 +112,7 @@ class EE_Country extends EE_Base_Class
      * currency_decimal_places : 2 = 0.00   3 = 0.000
      *
      * @return integer
+     * @throws EE_Error
      */
     public function currency_decimal_places()
     {
@@ -113,6 +124,7 @@ class EE_Country extends EE_Base_Class
      * currency_decimal_mark :   (comma) ',' = 0,01   or   (decimal) '.' = 0.01
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_decimal_mark()
     {
@@ -124,6 +136,7 @@ class EE_Country extends EE_Base_Class
      * currency thousands separator:   (comma) ',' = 1,000   or   (decimal) '.' = 1.000
      *
      * @return string
+     * @throws EE_Error
      */
     public function currency_thousands_separator()
     {

--- a/core/db_classes/EE_Currency.class.php
+++ b/core/db_classes/EE_Currency.class.php
@@ -3,39 +3,63 @@
 /**
  * EE_Currency
  *
- * @package               Event Espresso
+ * @package     Event Espresso
  * @subpackage
- * @author                Mike Nelson
- *
- * ------------------------------------------------------------------------
+ * @author      Mike Nelson
  */
 class EE_Currency extends EE_Base_Class
 {
 
-    /** Currency COde @var CUR_code */
+    /** Currency COde
+     *
+     * @var CUR_code
+     */
     protected $_CUR_code = null;
-    /** Currency Name Singular @var CUR_single */
+
+    /** Currency Name Singular
+     *
+     * @var CUR_single
+     */
     protected $_CUR_single = null;
-    /** Currency Name Plural @var CUR_plural */
+
+    /** Currency Name Plural
+     *
+     * @var CUR_plural
+     */
     protected $_CUR_plural = null;
-    /** Currency Sign @var CUR_sign */
+
+    /** Currency Sign
+     *
+     * @var CUR_sign
+     */
     protected $_CUR_sign = null;
-    /** Currency Decimal Places @var CUR_dec_plc */
+
+    /** Currency Decimal Places
+     *
+     * @var CUR_dec_plc
+     */
     protected $_CUR_dec_plc = null;
-    /** Active? @var CUR_active */
+
+    /** Active?
+     *
+     * @var CUR_active
+     */
     protected $_CUR_active = null;
+
     protected $_Payment_Method;
 
+
     /**
-     *
      * @param array  $props_n_values          incoming values
-     * @param string $timezone                incoming timezone (if not set the timezone set for the website will be
-     *                                        used.)
+     * @param string $timezone                incoming timezone
+     *                                        (if not set the timezone set for the website will be used.)
      * @param array  $date_formats            incoming date_formats in an array where the first value is the
      *                                        date_format and the second value is the time format
-     * @return EE_Attendee
+     * @return EE_Currency
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -44,148 +68,180 @@ class EE_Currency extends EE_Base_Class
 
     /**
      * @param array  $props_n_values  incoming values from the database
-     * @param string $timezone        incoming timezone as set by the model.  If not set the timezone for
-     *                                the website will be used.
-     * @return EE_Attendee
+     * @param string $timezone        incoming timezone as set by the model.
+     *                                If not set the timezone for the website will be used.
+     * @return EE_Currency
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = null)
     {
         return new self($props_n_values, true, $timezone);
     }
 
-    /**
-     * Gets code
-     *
-     * @return string
-     */
-    public function code()
-    {
-        return $this->get('CUR_code');
-    }
 
     /**
      * Sets code
      *
      * @param string $code
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_code($code)
     {
-        return $this->set('CUR_code', $code);
+        $this->set('CUR_code', $code);
     }
+
 
     /**
      * Gets active
      *
      * @return boolean
+     * @throws EE_Error
      */
     public function active()
     {
         return $this->get('CUR_active');
     }
 
+
     /**
      * Sets active
      *
      * @param boolean $active
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_active($active)
     {
-        return $this->set('CUR_active', $active);
+        $this->set('CUR_active', $active);
     }
+
 
     /**
      * Gets dec_plc
      *
      * @return int
+     * @throws EE_Error
      */
     public function dec_plc()
     {
         return $this->get('CUR_dec_plc');
     }
 
+
     /**
      * Sets dec_plc
      *
      * @param int $dec_plc
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_dec_plc($dec_plc)
     {
-        return $this->set('CUR_dec_plc', $dec_plc);
+        $this->set('CUR_dec_plc', $dec_plc);
     }
 
-    /**
-     * Gets plural
-     *
-     * @return string
-     */
-    public function plural_name()
-    {
-        return $this->get('CUR_plural');
-    }
 
     /**
      * Sets plural
      *
      * @param string $plural
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_plural_name($plural)
     {
-        return $this->set('CUR_plural', $plural);
+        $this->set('CUR_plural', $plural);
     }
+
 
     /**
      * Gets sign
      *
      * @return string
+     * @throws EE_Error
      */
     public function sign()
     {
         return $this->get('CUR_sign');
     }
 
+
     /**
      * Sets sign
      *
      * @param string $sign
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_sign($sign)
     {
-        return $this->set('CUR_sign', $sign);
+        $this->set('CUR_sign', $sign);
     }
+
 
     /**
      * Gets single
      *
      * @return string
+     * @throws EE_Error
      */
     public function singular_name()
     {
         return $this->get('CUR_single');
     }
 
+
     /**
      * Sets single
      *
      * @param string $single
-     * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function set_singular_name($single)
     {
-        return $this->set('CUR_single', $single);
+        $this->set('CUR_single', $single);
     }
+
 
     /**
      * Gets a prettier name
      *
      * @return string
+     * @throws EE_Error
      */
     public function name()
     {
-        return sprintf(__("%s (%s)", "event_espresso"), $this->code(), $this->plural_name());
+        return sprintf(
+            esc_html__("%s (%s)", "event_espresso"),
+            $this->code(),
+            $this->plural_name()
+        );
+    }
+
+
+    /**
+     * Gets code
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function code()
+    {
+        return $this->get('CUR_code');
+    }
+
+
+    /**
+     * Gets plural
+     *
+     * @return string
+     * @throws EE_Error
+     */
+    public function plural_name()
+    {
+        return $this->get('CUR_plural');
     }
 }


### PR DESCRIPTION
This PR essentially applies PSR12 formatting & phpdoc fixes to the model object classes whose names start with A, B, or C (ignoring the `EE_` prefix).