### PR TITLE
Fix Model Timezone Setting 

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -34,17 +34,25 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     * This will hold the event model instance
-     *
      * @var EEM_Event $_event_model
      */
     protected $_event_model;
+
+    /**
+     * @var EEM_Datetime $datetime_model
+     */
+    protected $datetime_model;
+
+    /**
+     * @var EEM_Ticket $ticket_model
+     */
+    protected $ticket_model;
 
 
     /**
      * @var EE_Event
      */
-    protected $_cpt_model_obj = false;
+    protected $_cpt_model_obj;
 
 
     /**
@@ -768,11 +776,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      * When a user is creating a new event, notify them if they haven't set their timezone.
      * Otherwise, do the normal logic
      *
-     * @return string
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
      */
     protected function _create_new_cpt_item()
     {
@@ -898,17 +904,41 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     /**
      * @return EEM_Event
      * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
-     * @throws ReflectionException
      */
-    private function _event_model()
+    private function eventModel()
     {
         if (! $this->_event_model instanceof EEM_Event) {
-            $this->_event_model = EE_Registry::instance()->load_model('Event');
+            $this->_event_model = EEM_Event::instance();
         }
         return $this->_event_model;
+    }
+
+
+    /**
+     * @param string $event_timezone_string
+     * @return EEM_Datetime
+     * @throws EE_Error
+     */
+    private function datetimeModel($event_timezone_string = '')
+    {
+        if (! $this->datetime_model instanceof EEM_Datetime) {
+            $this->datetime_model = EEM_Datetime::instance($event_timezone_string);
+        }
+        return $this->datetime_model;
+    }
+
+
+    /**
+     * @param string $event_timezone_string
+     * @return EEM_Ticket
+     * @throws EE_Error
+     */
+    private function ticketModel($event_timezone_string = '')
+    {
+        if (! $this->ticket_model instanceof EEM_Ticket) {
+            $this->ticket_model = EEM_Ticket::instance($event_timezone_string);
+        }
+        return $this->ticket_model;
     }
 
 
@@ -1049,18 +1079,21 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 : null;
         }
         // update event
-        $success = $this->_event_model()->update_by_ID($event_values, $post_id);
-        // get event_object for other metaboxes... though it would seem to make sense to just use $this->_event_model()->get_one_by_ID( $post_id ).. i have to setup where conditions to override the filters in the model that filter out autodraft and inherit statuses so we GET the inherit id!
+        $success = $this->eventModel()->update_by_ID($event_values, $post_id);
+        // get event_object for other metaboxes...
+        // though it would seem to make sense to just use $this->eventModel()->get_one_by_ID( $post_id )..
+        // i have to setup where conditions to override the filters in the model
+        // that filter out autodraft and inherit statuses so we GET the inherit id!
         $get_one_where = [
-            $this->_event_model()->primary_key_name() => $post_id,
-            'OR'                                      => [
+            $this->eventModel()->primary_key_name() => $post_id,
+            'OR'                                    => [
                 'status'   => $post->post_status,
                 // if trying to "Publish" a sold out event, it's status will get switched back to "sold_out" in the db,
                 // but the returned object here has a status of "publish", so use the original post status as well
                 'status*1' => $this->_req_data['original_post_status'],
             ],
         ];
-        $event = $this->_event_model()->get_one([$get_one_where]);
+        $event = $this->eventModel()->get_one([$get_one_where]);
         // the following are default callbacks for event attachment updates that can be overridden by caffeinated functionality and/or addons.
         $event_update_callbacks = apply_filters(
             'FHEE__Events_Admin_Page___insert_update_cpt_item__event_update_callbacks',
@@ -1112,7 +1145,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _restore_cpt_item($post_id, $revision_id)
     {
         // copy existing event meta to new post
-        $post_evt = $this->_event_model()->get_one_by_ID($post_id);
+        $post_evt = $this->eventModel()->get_one_by_ID($post_id);
         if ($post_evt instanceof EE_Event) {
             // meta revision restore
             $post_evt->restore_revision($revision_id);
@@ -1137,7 +1170,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _default_venue_update(EE_Event $evtobj, $data)
     {
         require_once(EE_MODELS . 'EEM_Venue.model.php');
-        $venue_model = EE_Registry::instance()->load_model('Venue');
+        $venue_model = EEM_Venue::instance();
         $rows_affected = null;
         $venue_id = ! empty($data['venue_id']) ? $data['venue_id'] : null;
         // very important.  If we don't have a venue name...
@@ -1200,14 +1233,18 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         if ($this->admin_config->useAdvancedEditor()) {
             return [];
         }
-        $success = true;
         $saved_dtt = null;
         $saved_tickets = [];
         $incoming_date_formats = ['Y-m-d', 'h:i a'];
+        $event_timezone_string = $evtobj->get_timezone();
+        $event_timezone = new DateTimeZone($event_timezone_string);
+        // let's use now in the set timezone.
+        $now = new DateTime('now', $event_timezone);
         foreach ($data['edit_event_datetimes'] as $row => $dtt) {
             // trim all values to ensure any excess whitespace is removed.
             $dtt = array_map('trim', $dtt);
-            $dtt['DTT_EVT_end'] = isset($dtt['DTT_EVT_end']) && ! empty($dtt['DTT_EVT_end']) ? $dtt['DTT_EVT_end']
+            $dtt['DTT_EVT_end'] = isset($dtt['DTT_EVT_end']) && ! empty($dtt['DTT_EVT_end'])
+                ? $dtt['DTT_EVT_end']
                 : $dtt['DTT_EVT_start'];
             $datetime_values = [
                 'DTT_ID'        => ! empty($dtt['DTT_ID']) ? $dtt['DTT_ID'] : null,
@@ -1218,9 +1255,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             ];
             // if we have an id then let's get existing object first and then set the new values.  Otherwise we instantiate a new object for save.
             if (! empty($dtt['DTT_ID'])) {
-                $DTM = EE_Registry::instance()
-                                  ->load_model('Datetime', [$evtobj->get_timezone()])
-                                  ->get_one_by_ID($dtt['DTT_ID']);
+                $DTM = $this->datetimeModel($event_timezone_string)->get_one_by_ID($dtt['DTT_ID']);
                 $DTM->set_date_format($incoming_date_formats[0]);
                 $DTM->set_time_format($incoming_date_formats[1]);
                 foreach ($datetime_values as $field => $value) {
@@ -1231,7 +1266,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             } else {
                 $DTM = EE_Registry::instance()->load_class(
                     'Datetime',
-                    [$datetime_values, $evtobj->get_timezone(), $incoming_date_formats],
+                    [$datetime_values, $event_timezone_string, $incoming_date_formats],
                     false,
                     false
                 );
@@ -1240,17 +1275,17 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 }
             }
             $DTM->save();
-            $DTT = $evtobj->_add_relation_to($DTM, 'Datetime');
+            $DTM = $evtobj->_add_relation_to($DTM, 'Datetime');
             // load DTT helper
             // before going any further make sure our dates are setup correctly so that the end date is always equal or greater than the start date.
-            if ($DTT->get_raw('DTT_EVT_start') > $DTT->get_raw('DTT_EVT_end')) {
-                $DTT->set('DTT_EVT_end', $DTT->get('DTT_EVT_start'));
-                $DTT = EEH_DTT_Helper::date_time_add($DTT, 'DTT_EVT_end', 'days');
-                $DTT->save();
+            if ($DTM->get_raw('DTT_EVT_start') > $DTM->get_raw('DTT_EVT_end')) {
+                $DTM->set('DTT_EVT_end', $DTM->get('DTT_EVT_start'));
+                $DTM = EEH_DTT_Helper::date_time_add($DTM, 'DTT_EVT_end', 'days');
+                $DTM->save();
             }
-            // now we got to make sure we add the new DTT_ID to the $saved_dtts array  because it is possible there was a new one created for the autosave.
-            $saved_dtt = $DTT;
-            $success = ! $success ? $success : $DTT;
+            // now we got to make sure we add the new DTT_ID to the $saved_dtts array
+            //  because it is possible there was a new one created for the autosave.
+            $saved_dtt = $DTM;
             // if ANY of these updates fail then we want the appropriate global error message.
             // //todo this is actually sucky we need a better error message but this is what it is for now.
         }
@@ -1265,8 +1300,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             // trim inputs to ensure any excess whitespace is removed.
             $tkt = array_map('trim', $tkt);
             if (empty($tkt['TKT_start_date'])) {
-                // let's use now in the set timezone.
-                $now = new DateTime('now', new DateTimeZone($evtobj->get_timezone()));
                 $tkt['TKT_start_date'] = $now->format($incoming_date_formats[0] . ' ' . $incoming_date_formats[1]);
             }
             if (empty($tkt['TKT_end_date'])) {
@@ -1303,9 +1336,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             // we actually do our saves a head of doing any add_relations to because its entirely possible that this ticket didn't removed or added to any datetime in the session but DID have it's items modified.
             // keep in mind that if the TKT has been sold (and we have changed pricing information), then we won't be updating the tkt but instead a new tkt will be created and the old one archived.
             if (! empty($tkt['TKT_ID'])) {
-                $TKT = EE_Registry::instance()
-                                  ->load_model('Ticket', [$evtobj->get_timezone()])
-                                  ->get_one_by_ID($tkt['TKT_ID']);
+                $TKT = $this->ticketModel($event_timezone_string)->get_one_by_ID($tkt['TKT_ID']);
                 if ($TKT instanceof EE_Ticket) {
                     $ticket_sold = $TKT->count_related(
                         'Registration',
@@ -1398,7 +1429,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         foreach ($tickets_removed as $id) {
             $id = absint($id);
             // get the ticket for this id
-            $tkt_to_remove = EE_Registry::instance()->load_model('Ticket')->get_one_by_ID($id);
+            $tkt_to_remove = $this->ticketModel($event_timezone_string)->get_one_by_ID($id);
             // need to get all the related datetimes on this ticket and remove from every single one of them (remember this process can ONLY kick off if there are NO tkts_sold)
             $dtts = $tkt_to_remove->get_many_related('Datetime');
             foreach ($dtts as $dtt) {
@@ -1446,7 +1477,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 $PRC_values['PRC_ID'] = 0;
                 $PRC = EE_Registry::instance()->load_class('Price', [$PRC_values], false, false);
             } else {
-                $PRC = EE_Registry::instance()->load_model('Price')->get_one_by_ID($prc['PRC_ID']);
+                $PRC = EEM_Price::instance()->get_one_by_ID($prc['PRC_ID']);
                 // update this price with new values
                 foreach ($PRC_values as $field => $newprc) {
                     $PRC->set($field, $newprc);
@@ -1655,14 +1686,17 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'trash_icon'               => 'ee-lock-icon',
             'disabled'                 => '',
         ];
-        $event_id = is_object($this->_cpt_model_obj) ? $this->_cpt_model_obj->ID() : null;
+        $event_id = $this->_cpt_model_obj instanceof EE_Event ? $this->_cpt_model_obj->ID() : 0;
+        $event_timezone_string = $this->_cpt_model_obj instanceof EE_Event
+            ? $this->_cpt_model_obj->timezone_string()
+            : '';
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         /**
          * 1. Start with retrieving Datetimes
          * 2. Fore each datetime get related tickets
          * 3. For each ticket get related prices
          */
-        $times = EE_Registry::instance()->load_model('Datetime')->get_all_event_dates($event_id);
+        $times = $this->datetimeModel($event_timezone_string)->get_all_event_dates($event_id);
         /** @type EE_Datetime $first_datetime */
         $first_datetime = reset($times);
         // do we get related tickets?
@@ -1689,13 +1723,13 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             } else {
                 $template_args['total_ticket_rows'] = 1;
                 /** @type EE_Ticket $ticket */
-                $ticket = EE_Registry::instance()->load_model('Ticket')->create_default_object();
+                $ticket = $this->ticketModel($event_timezone_string)->create_default_object();
                 $template_args['ticket_rows'] .= $this->_get_ticket_row($ticket);
             }
         } else {
             $template_args['time'] = $times[0];
             /** @type EE_Ticket $ticket */
-            $ticket = EE_Registry::instance()->load_model('Ticket')->get_all_default_tickets();
+            $ticket = $this->ticketModel($event_timezone_string)->get_all_default_tickets();
             $template_args['ticket_rows'] .= $this->_get_ticket_row($ticket[1]);
             // NOTE: we're just sending the first default row
             // (decaf can't manage default tickets so this should be sufficient);
@@ -1707,7 +1741,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         $template_args['existing_datetime_ids'] = implode(',', $existing_datetime_ids);
         $template_args['existing_ticket_ids'] = implode(',', $existing_ticket_ids);
         $template_args['ticket_js_structure'] = $this->_get_ticket_row(
-            EE_Registry::instance()->load_model('Ticket')->create_default_object(),
+            $this->ticketModel($event_timezone_string)->create_default_object(),
             true
         );
         $template = apply_filters(
@@ -1756,7 +1790,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         ];
         $price = $ticket->ID() !== 0
             ? $ticket->get_first_related('Price', ['default_where_conditions' => 'none'])
-            : EE_Registry::instance()->load_model('Price')->create_default_object();
+            : EEM_Price::instance()->create_default_object();
         $price_args = [
             'price_currency_symbol' => EE_Registry::instance()->CFG->currency->sign,
             'PRC_amount'            => $price->get('PRC_amount'),
@@ -1873,7 +1907,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
      */
     public function get_events($per_page = 10, $current_page = 1, $count = false)
     {
-        $EEME = $this->_event_model();
+        $EEME = $this->eventModel();
         $offset = ($current_page - 1) * $per_page;
         $limit = $count ? null : $offset . ',' . $per_page;
         $orderby = isset($this->_req_data['orderby']) ? $this->_req_data['orderby'] : 'EVT_ID';

--- a/core/EE_Registry.core.php
+++ b/core/EE_Registry.core.php
@@ -1625,6 +1625,8 @@ class EE_Registry implements ResettableInterface
         $instance->_cache_on = true;
         // reset some "special" classes
         EEH_Activation::reset();
+        EEH_DTT_Helper::resetDefaultTimezoneString();
+
         $hard = apply_filters('FHEE__EE_Registry__reset__hard', $hard);
         $instance->CFG = EE_Config::reset($hard, $reinstantiate);
         $instance->CART = null;

--- a/core/db_classes/EE_Attendee.class.php
+++ b/core/db_classes/EE_Attendee.class.php
@@ -23,7 +23,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * @throws EE_Error
      * @throws ReflectionException
      */
-    protected function __construct($fieldValues = null, $bydb = false, $timezone = null, $date_formats = [])
+    protected function __construct($fieldValues = null, $bydb = false, $timezone = '', $date_formats = [])
     {
         if (! isset($fieldValues['ATT_full_name'])) {
             $fname                        = isset($fieldValues['ATT_fname']) ? $fieldValues['ATT_fname'] . ' ' : '';
@@ -51,7 +51,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
+    public static function new_instance($props_n_values = [], $timezone = '', $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -67,7 +67,7 @@ class EE_Attendee extends EE_CPT_Base implements EEI_Contact, EEI_Address, EEI_A
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = [], $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Change_Log.class.php
+++ b/core/db_classes/EE_Change_Log.class.php
@@ -20,7 +20,7 @@ class EE_Change_Log extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
+    public static function new_instance($props_n_values = [], $timezone = '', $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -35,7 +35,7 @@ class EE_Change_Log extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = [], $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Checkin.class.php
+++ b/core/db_classes/EE_Checkin.class.php
@@ -43,7 +43,7 @@ class EE_Checkin extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
+    public static function new_instance($props_n_values = [], $timezone = '', $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object
@@ -60,7 +60,7 @@ class EE_Checkin extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = [], $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Currency.class.php
+++ b/core/db_classes/EE_Currency.class.php
@@ -59,7 +59,7 @@ class EE_Currency extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
+    public static function new_instance($props_n_values = [], $timezone = '', $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -74,7 +74,7 @@ class EE_Currency extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = [], $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Currency_Payment_Method.class.php
+++ b/core/db_classes/EE_Currency_Payment_Method.class.php
@@ -33,7 +33,7 @@ class EE_Currency_Payment_Method extends EE_Base_Class
      *                                        date_format and the second value is the time format
      * @return EE_Attendee
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -46,7 +46,7 @@ class EE_Currency_Payment_Method extends EE_Base_Class
      *                                the website will be used.
      * @return EE_Attendee
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Datetime.class.php
+++ b/core/db_classes/EE_Datetime.class.php
@@ -62,7 +62,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object(
             $props_n_values,
@@ -87,7 +87,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Datetime_Ticket.class.php
+++ b/core/db_classes/EE_Datetime_Ticket.class.php
@@ -19,7 +19,7 @@ class EE_Datetime_Ticket extends EE_Base_Class
      *                                        date_format and the second value is the time format
      * @return EE_Attendee
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -32,7 +32,7 @@ class EE_Datetime_Ticket extends EE_Base_Class
      *                                the website will be used.
      * @return EE_Attendee
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Event.class.php
+++ b/core/db_classes/EE_Event.class.php
@@ -45,7 +45,7 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      * @return EE_Event
      * @throws EE_Error
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -59,7 +59,7 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      * @return EE_Event
      * @throws EE_Error
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Event_Message_Template.class.php
+++ b/core/db_classes/EE_Event_Message_Template.class.php
@@ -17,7 +17,7 @@ class EE_Event_Message_Template extends EE_Base_Class
      * @param null  $timezone
      * @return EE_Event_Message_Template|mixed
      */
-    public static function new_instance($props_n_values = array(), $timezone = null)
+    public static function new_instance($props_n_values = array(), $timezone = '')
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone);
@@ -29,7 +29,7 @@ class EE_Event_Message_Template extends EE_Base_Class
      * @param null  $timezone
      * @return EE_Event_Message_Template
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Extra_Join.class.php
+++ b/core/db_classes/EE_Extra_Join.class.php
@@ -17,7 +17,7 @@ class EE_Extra_Join extends EE_Base_Class
      * @param null  $timezone
      * @return EE_Extra_Join|mixed
      */
-    public static function new_instance($props_n_values = array(), $timezone = null)
+    public static function new_instance($props_n_values = array(), $timezone = '')
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone);
@@ -29,7 +29,7 @@ class EE_Extra_Join extends EE_Base_Class
      * @param null  $timezone
      * @return EE_Extra_Join
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Line_Item.class.php
+++ b/core/db_classes/EE_Line_Item.class.php
@@ -42,7 +42,7 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object(
             $props_n_values,
@@ -67,7 +67,7 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Message.class.php
+++ b/core/db_classes/EE_Message.class.php
@@ -47,7 +47,7 @@ class EE_Message extends EE_Base_Class implements EEI_Admin_Links
      *                             format.
      * @return EE_Message
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__);
         // if object doesn't exist, let's generate a unique token on instantiation so that its available even before saving to db.
@@ -64,7 +64,7 @@ class EE_Message extends EE_Base_Class implements EEI_Admin_Links
      * @param string $timezone
      * @return EE_Message
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Payment.class.php
+++ b/core/db_classes/EE_Payment.class.php
@@ -19,7 +19,7 @@ class EE_Payment extends EE_Base_Class implements EEI_Payment
      * @return EE_Payment
      * @throws \EE_Error
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -33,7 +33,7 @@ class EE_Payment extends EE_Base_Class implements EEI_Payment
      * @return EE_Payment
      * @throws \EE_Error
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Price.class.php
+++ b/core/db_classes/EE_Price.class.php
@@ -26,7 +26,7 @@ class EE_Price extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -44,7 +44,7 @@ class EE_Price extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Question.class.php
+++ b/core/db_classes/EE_Question.class.php
@@ -23,7 +23,7 @@ class EE_Question extends EE_Soft_Delete_Base_Class implements EEI_Duplicatable
      *                                        date_format and the second value is the time format
      * @return EE_Question
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -36,7 +36,7 @@ class EE_Question extends EE_Soft_Delete_Base_Class implements EEI_Duplicatable
      *                                the website will be used.
      * @return EE_Question
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Question_Option.class.php
+++ b/core/db_classes/EE_Question_Option.class.php
@@ -28,7 +28,7 @@ class EE_Question_Option extends EE_Soft_Delete_Base_Class implements EEI_Duplic
      *                                        date_format and the second value is the time format
      * @return EE_Attendee
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -41,7 +41,7 @@ class EE_Question_Option extends EE_Soft_Delete_Base_Class implements EEI_Duplic
      *                                the website will be used.
      * @return EE_Attendee
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Registration.class.php
+++ b/core/db_classes/EE_Registration.class.php
@@ -68,7 +68,7 @@ class EE_Registration extends EE_Soft_Delete_Base_Class implements EEI_Registrat
      * @return EE_Registration
      * @throws EE_Error
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -81,7 +81,7 @@ class EE_Registration extends EE_Soft_Delete_Base_Class implements EEI_Registrat
      *                                the website will be used.
      * @return EE_Registration
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -74,7 +74,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = [], $timezone = null, $date_formats = [])
+    public static function new_instance($props_n_values = [], $timezone = '', $date_formats = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -89,7 +89,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = [], $timezone = null)
+    public static function new_instance_from_db($props_n_values = [], $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_classes/EE_Transaction.class.php
+++ b/core/db_classes/EE_Transaction.class.php
@@ -40,7 +40,7 @@ class EE_Transaction extends EE_Base_Class implements EEI_Transaction
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         $txn = $has_object
@@ -64,7 +64,7 @@ class EE_Transaction extends EE_Base_Class implements EEI_Transaction
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         $txn = new self($props_n_values, true, $timezone);
         $txn->set_old_txn_status($txn->status_ID());

--- a/core/db_classes/EE_Venue.class.php
+++ b/core/db_classes/EE_Venue.class.php
@@ -19,7 +19,7 @@ class EE_Venue extends EE_CPT_Base implements EEI_Address
      *                                        date_format and the second value is the time format
      * @return EE_Attendee
      */
-    public static function new_instance($props_n_values = array(), $timezone = null, $date_formats = array())
+    public static function new_instance($props_n_values = array(), $timezone = '', $date_formats = array())
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__, $timezone, $date_formats);
         return $has_object ? $has_object : new self($props_n_values, false, $timezone, $date_formats);
@@ -32,7 +32,7 @@ class EE_Venue extends EE_CPT_Base implements EEI_Address
      *                                the website will be used.
      * @return EE_Attendee
      */
-    public static function new_instance_from_db($props_n_values = array(), $timezone = null)
+    public static function new_instance_from_db($props_n_values = array(), $timezone = '')
     {
         return new self($props_n_values, true, $timezone);
     }

--- a/core/db_models/EEM_Answer.model.php
+++ b/core/db_models/EEM_Answer.model.php
@@ -35,11 +35,13 @@ class EEM_Answer extends EEM_Base
     );
 
 
-
     /**
      *  constructor
+     *
+     * @param string $timezone
+     * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Answer', 'event_espresso');
         $this->plural_item = __('Answers', 'event_espresso');

--- a/core/db_models/EEM_Attendee.model.php
+++ b/core/db_models/EEM_Attendee.model.php
@@ -135,7 +135,7 @@ class EEM_Attendee extends EEM_CPT_Base
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function __construct($timezone = null, ModelFieldFactory $model_field_factory)
+    protected function __construct($timezone = '', ModelFieldFactory $model_field_factory)
     {
         $this->singular_item = esc_html__('Attendee', 'event_espresso');
         $this->plural_item = esc_html__('Attendees', 'event_espresso');

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -561,10 +561,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * the array key ('Event_Post_Table'), instead of repeating it. The model fields and model relations
      * do something similar.
      *
-     * @param null $timezone
+     * @param string $timezone
      * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         // check that the model has not been loaded too soon
         if (! did_action('AHEE__EE_System__load_espresso_addons')) {
@@ -744,13 +744,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                Note this just sends the timezone info to the date time model field objects.
      *                                Default is NULL
      *                                (and will be assumed using the set timezone in the 'timezone_string' wp option)
-     * @return static (as in the concrete child class)
+     * @return EEM_Base (as in the concrete child class)
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public static function instance($timezone = null)
+    public static function instance($timezone = '')
     {
         // check if instance of Espresso_model already exists
         if (! static::$_instance instanceof static) {
@@ -760,9 +760,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 LoaderFactory::getLoader()->load('EventEspresso\core\services\orm\ModelFieldFactory')
             );
         }
-        // we might have a timezone set, let set_timezone decide what to do with it
-        static::$_instance->set_timezone($timezone);
-        // Espresso_model object
+        // Espresso model object
         return static::$_instance;
     }
 
@@ -770,7 +768,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * resets the model and returns it
      *
-     * @param null | string $timezone
+     * @param string $timezone
      * @return EEM_Base|null (if the model was already instantiated, returns it, with
      * all its properties reset; if it wasn't instantiated, returns null)
      * @throws EE_Error
@@ -779,7 +777,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public static function reset($timezone = null)
+    public static function reset($timezone = '')
     {
         if (static::$_instance instanceof EEM_Base) {
             // let's try to NOT swap out the current instance for a new one
@@ -795,12 +793,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     static::$_instance->{$property} = $value;
                 }
             }
+            EEH_DTT_Helper::resetDefaultTimezoneString();
             // and then directly call its constructor again, like we would if we were creating a new one
             static::$_instance->__construct(
                 $timezone,
                 LoaderFactory::getLoader()->load('EventEspresso\core\services\orm\ModelFieldFactory')
             );
-            return self::instance();
+            return static::instance();
         }
         return null;
     }
@@ -1421,13 +1420,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string|null $timezone valid PHP DateTimeZone timezone string
      */
-    public function set_timezone($timezone)
+    public function set_timezone($timezone = '')
     {
-        // don't set the timezone if the incoming value is the same
-        if (! empty($timezone) && $timezone === $this->_timezone) {
+        static $set_in_progress = false;
+        // if incoming timezone string is empty, then use the existing
+        $valid_timezone = ! empty($timezone) && $timezone !== $this->_timezone
+            ? EEH_DTT_Helper::get_valid_timezone_string($timezone)
+            : $this->_timezone;
+        // do NOT set the timezone if we are already in the process of setting the timezone
+        // OR the existing timezone is already set and the incoming value is nothing (which gets set to default TZ)
+        // OR the existing timezone is already set and the validated value is the same as the existing timezone
+        if (
+            $set_in_progress
+            || (
+                ! empty($this->_timezone)
+                && (
+                    empty($timezone) || $valid_timezone === $this->_timezone
+                )
+            )
+        ) {
             return;
         }
-        $this->_timezone = EEH_DTT_Helper::get_valid_timezone_string($timezone);
+        $set_in_progress = true;
+        $this->_timezone = $valid_timezone ? $valid_timezone : EEH_DTT_Helper::get_valid_timezone_string();
         // note we need to loop through relations and set the timezone on those objects as well.
         foreach ($this->_model_relations as $relation) {
             $relation->set_timezone($this->_timezone);
@@ -1438,6 +1453,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $field->set_timezone($this->_timezone);
             }
         }
+        $set_in_progress = false;
     }
 
 
@@ -1449,18 +1465,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function get_timezone()
     {
-        // first validate if timezone is set.  If not, then let's set it be whatever is set on the model fields.
         if (empty($this->_timezone)) {
-            foreach ($this->_fields as $field) {
-                if ($field instanceof EE_Datetime_Field) {
-                    $this->set_timezone($field->get_timezone());
-                    break;
-                }
-            }
-        }
-        // if timezone STILL empty then return the default timezone for the site.
-        if (empty($this->_timezone)) {
-            $this->set_timezone(EEH_DTT_Helper::get_timezone());
+            $this->set_timezone();
         }
         return $this->_timezone;
     }
@@ -1491,9 +1497,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 )
             );
         }
-        // while we are here, let's make sure the timezone internally in EEM_Base matches what is stored on
-        // the field.
-        $this->_timezone = $field_settings->get_timezone();
+        // while we are here, let's make sure the timezone internally in EEM_Base matches what is stored on the field.
+        $field_timezone = $field_settings->get_timezone();
+        if (empty($this->_timezone && $field_timezone)) {
+            $this->set_timezone();
+        } else {
+            // or vice versa if the field TZ isn't set
+            $model_timezone = $this->get_timezone();
+            $field_settings->set_timezone($model_timezone);
+        }
+
         return [$field_settings->get_date_format($pretty), $field_settings->get_time_format($pretty)];
     }
 
@@ -1523,7 +1536,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function current_time_for_query($field_name, $timestamp = false, $what = 'both')
     {
         $formats  = $this->get_formats_for($field_name);
-        $DateTime = new DateTime("now", new DateTimeZone($this->_timezone));
+        $DateTime = new DateTime("now", new DateTimeZone($this->get_timezone()));
         if ($timestamp) {
             return $DateTime->format('U');
         }
@@ -1546,25 +1559,24 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * (functionally the equivalent of UTC+0).  So when you send it in, whatever timezone string you include is
      * ignored.
      *
-     * @param string $field_name      The field being setup.
-     * @param string $timestring      The date time string being used.
-     * @param string $incoming_format The format for the time string.
-     * @param string $timezone        By default, it is assumed the incoming time string is in timezone for
-     *                                the blog.  If this is not the case, then it can be specified here.  If incoming
-     *                                format is
-     *                                'U', this is ignored.
-     * @return DateTime
+     * @param string $field_name    The field being setup.
+     * @param string $timestring    The date time string being used.
+     * @param string $format        The format for the time string.
+     * @param string $timezone      By default, it is assumed the incoming time string is in timezone for
+     *                              the blog.  If this is not the case, then it can be specified here.
+     *                              If incoming format is 'U', this is ignored.
+     * @return DbSafeDateTime
      * @throws EE_Error
+     * @throws Exception
      */
-    public function convert_datetime_for_query($field_name, $timestring, $incoming_format, $timezone = '')
+    public function convert_datetime_for_query($field_name, $timestring, $format, $timezone = '')
     {
         // just using this to ensure the timezone is set correctly internally
         $this->get_formats_for($field_name);
-        // load EEH_DTT_Helper
-        $set_timezone     = empty($timezone) ? EEH_DTT_Helper::get_timezone() : $timezone;
-        $incomingDateTime = date_create_from_format($incoming_format, $timestring, new DateTimeZone($set_timezone));
-        EEH_DTT_Helper::setTimezone($incomingDateTime, new DateTimeZone($this->_timezone));
-        return DbSafeDateTime::createFromDateTime($incomingDateTime);
+        $timezone         = ! empty($timezone) ? $timezone : EEH_DTT_Helper::get_timezone();
+        $db_safe_datetime = DbSafeDateTime::createFromFormat($format, $timestring, new DateTimeZone($timezone));
+        EEH_DTT_Helper::setTimezone($db_safe_datetime, new DateTimeZone($this->get_timezone()));
+        return $db_safe_datetime;
     }
 
 
@@ -1711,12 +1723,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     }
                 }
             }
-            //              //and now check that if we have cached any models by that ID on the model, that
-            //              //they also get updated properly
-            //              $model_object = $this->get_from_entity_map( $main_table_pk_value );
-            //              if( $model_object ){
-            //                  foreach( $fields_n_values as $field => $value ){
-            //                      $model_object->set($field, $value);
             // let's make sure default_where strategy is followed now
             $this->_ignore_where_strategy = false;
         }
@@ -1759,12 +1765,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
-        $SQL              = "UPDATE "
-                            . $model_query_info->get_full_join_sql()
-                            . " SET "
-                            . $this->_construct_update_sql($fields_n_values)
-                            . $model_query_info->get_where_sql(
-            );// note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
+        $SQL              = "UPDATE " . $model_query_info->get_full_join_sql()
+                            . " SET " . $this->_construct_update_sql($fields_n_values)
+                            . $model_query_info->get_where_sql();
+        // note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
         $rows_affected    = $this->_do_wpdb_query('query', [$SQL]);
         /**
          * Action called after a model update call has been made.
@@ -1806,8 +1810,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         $model_query_info   = $this->_create_model_query_info_carrier($query_params);
         $select_expressions = $field->get_qualified_column();
-        $SQL                =
-            "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
+        $SQL = "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
         return $this->_do_wpdb_query('get_col', [$SQL]);
     }
 
@@ -1854,7 +1857,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // if the value is NULL, we want to assign the value to that.
             // wpdb->prepare doesn't really handle that properly
             $prepared_value  = $this->_prepare_value_or_use_default($field_obj, $fields_n_values);
-            $value_sql       = $prepared_value === null ? 'NULL'
+            $value_sql       = $prepared_value === null
+                ? 'NULL'
                 : $wpdb->prepare($field_obj->get_wpdb_data_type(), $prepared_value);
             $cols_n_values[] = $field_obj->get_qualified_column() . "=" . $value_sql;
         }
@@ -1985,13 +1989,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         if ($deletion_where_query_part) {
             $model_query_info = $this->_create_model_query_info_carrier($query_params);
-            $table_aliases    = array_keys($this->_tables);
-            $SQL              = "DELETE "
-                                . implode(", ", $table_aliases)
-                                . " FROM "
-                                . $model_query_info->get_full_join_sql()
-                                . " WHERE "
-                                . $deletion_where_query_part;
+            $table_aliases    = implode(', ', array_keys($this->_tables));
+            $SQL              = "DELETE " . $table_aliases
+                                . " FROM " . $model_query_info->get_full_join_sql()
+                                . " WHERE " . $deletion_where_query_part;
             $rows_deleted     = $this->_do_wpdb_query('query', [$SQL]);
         } else {
             $rows_deleted = 0;
@@ -2211,9 +2212,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 foreach ($ids_to_delete_indexed_by_column_for_each_row as $column => $id) {
                     $values_for_each_combined_primary_key_for_a_row[] = $column . '=' . $id;
                 }
-                $ways_to_identify_a_row[] = '('
-                                            . implode(' AND ', $values_for_each_combined_primary_key_for_a_row)
-                                            . ')';
+                $value_and_value_and_value = implode(' AND ', $values_for_each_combined_primary_key_for_a_row);
+                $ways_to_identify_a_row[]  = "({$value_and_value_and_value})";
             }
             $query_part = implode(' OR ', $ways_to_identify_a_row);
         }
@@ -2309,8 +2309,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $field_obj = $this->get_primary_key_field();
         }
         $column_to_count = $field_obj->get_qualified_column();
-        $SQL             =
-            "SELECT SUM(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
+        $SQL             = "SELECT SUM(" . $column_to_count . ")"
+                           . $this->_construct_2nd_half_of_select_query($model_query_info);
         $return_value    = $this->_do_wpdb_query('get_var', [$SQL]);
         $data_type       = $field_obj->get_wpdb_data_type();
         if ($data_type === '%d' || $data_type === '%s') {
@@ -5200,7 +5200,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 );
             }
             // set the timezone on the instantiated objects
-            $classInstance->set_timezone($this->_timezone);
+            $classInstance->set_timezone($this->get_timezone(), true);
             // make sure if there is any timezone setting present that we set the timezone for the object
             $key                      = $has_primary_key ? $classInstance->ID() : $count_if_model_has_no_primary_key++;
             $array_of_objects[ $key ] = $classInstance;
@@ -5217,7 +5217,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     // if we managed to make a model object from the results, cache it on the main model object
                     if ($other_model_obj_maybe) {
                         // set timezone on these other model objects if they are present
-                        $other_model_obj_maybe->set_timezone($this->_timezone);
+                        $other_model_obj_maybe->set_timezone($this->get_timezone(), true);
                         $classInstance->cache($modelName, $other_model_obj_maybe);
                     }
                 }
@@ -5343,7 +5343,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if (! $classInstance) {
                 $classInstance = EE_Registry::instance()->load_class(
                     $className,
-                    [$this_model_fields_n_values, $this->_timezone],
+                    [$this_model_fields_n_values, $this->get_timezone()],
                     true,
                     false
                 );
@@ -5353,7 +5353,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } else {
             $classInstance = EE_Registry::instance()->load_class(
                 $className,
-                [$this_model_fields_n_values, $this->_timezone],
+                [$this_model_fields_n_values, $this->get_timezone()],
                 true,
                 false
             );
@@ -5371,7 +5371,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function get_from_entity_map($id)
     {
         return isset($this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $id ])
-            ? $this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $id ] : null;
+            ? $this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $id ]
+            : null;
     }
 
 
@@ -5389,7 +5390,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param EE_Base_Class $object
      * @return EE_Base_Class
      * @throws EE_Error
-     * @throws ReflectionException
      */
     public function add_to_entity_map(EE_Base_Class $object)
     {
@@ -5743,7 +5743,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param EE_Base_Class|int|string $base_class_obj_or_id
      * @return int|string depending on the type of this model object's ID
      * @throws EE_Error
-     * @throws ReflectionException
      */
     public function ensure_is_ID($base_class_obj_or_id)
     {
@@ -6141,7 +6140,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                               in the returned array
      * @return array
      * @throws EE_Error
-     * @throws ReflectionException
      */
     public function get_IDs($model_objects, $filter_out_empty_ids = false)
     {

--- a/core/db_models/EEM_CPT_Base.model.php
+++ b/core/db_models/EEM_CPT_Base.model.php
@@ -68,7 +68,7 @@ abstract class EEM_CPT_Base extends EEM_Soft_Delete_Base
      * @param string $timezone
      * @throws \EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         // adds a relationship to Term_Taxonomy for all these models. For this to work
         // Term_Relationship must have a relation to each model subclassing EE_CPT_Base explicitly

--- a/core/db_models/EEM_Change_Log.model.php
+++ b/core/db_models/EEM_Change_Log.model.php
@@ -54,7 +54,7 @@ class EEM_Change_Log extends EEM_Base
      * @param null $timezone
      * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         global $current_user;
         $this->singular_item       = esc_html__('Log', 'event_espresso');

--- a/core/db_models/EEM_Checkin.model.php
+++ b/core/db_models/EEM_Checkin.model.php
@@ -26,7 +26,7 @@ class EEM_Checkin extends EEM_Base
      *      @param string $timezone string representing the timezone we want to set for returned Date Time Strings (and any incoming timezone data that gets saved).  Note this just sends the timezone info to the date time model field objects.  Default is NULL (and will be assumed using the set timezone in the 'timezone_string' wp option)
      *      @return void
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Check-In', 'event_espresso');
         $this->plural_item = __('Check-Ins', 'event_espresso');

--- a/core/db_models/EEM_Country.model.php
+++ b/core/db_models/EEM_Country.model.php
@@ -25,14 +25,14 @@ class EEM_Country extends EEM_Base
      * Resets the country
      * @return EEM_Country
      */
-    public static function reset($timezone = null)
+    public static function reset($timezone = '')
     {
         self::$_active_countries = null;
         self::$_all_countries = null;
         return parent::reset($timezone);
     }
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = esc_html__('Country', 'event_espresso');
         $this->plural_item = esc_html__('Countries', 'event_espresso');

--- a/core/db_models/EEM_Currency.model.php
+++ b/core/db_models/EEM_Currency.model.php
@@ -14,7 +14,7 @@ class EEM_Currency extends EEM_Base
         // private instance of the Attendee object
     protected static $_instance = null;
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Currency', 'event_espresso');
         $this->plural_item = __('Currencies', 'event_espresso');

--- a/core/db_models/EEM_Currency_Payment_Method.model.php
+++ b/core/db_models/EEM_Currency_Payment_Method.model.php
@@ -15,7 +15,7 @@ class EEM_Currency_Payment_Method extends EEM_Base
     protected static $_instance = null;
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Currency Usable by Payment Method', 'event_espresso');
         $this->plural_item = __('Currencies Usable by Payment Methods', 'event_espresso');

--- a/core/db_models/EEM_Datetime.model.php
+++ b/core/db_models/EEM_Datetime.model.php
@@ -31,7 +31,7 @@ class EEM_Datetime extends EEM_Soft_Delete_Base
      * @throws InvalidArgumentException
      * @throws InvalidArgumentException
      */
-    protected function __construct($timezone)
+    protected function __construct($timezone = '')
     {
         $this->singular_item           = esc_html__('Datetime', 'event_espresso');
         $this->plural_item             = esc_html__('Datetimes', 'event_espresso');

--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -54,15 +54,14 @@ class EEM_Event extends EEM_CPT_Base
     protected static $_instance;
 
 
-
-
     /**
      * Adds a relationship to Term_Taxonomy for each CPT_Base
      *
      * @param string $timezone
      * @throws \EE_Error
+     * @throws ReflectionException
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         EE_Registry::instance()->load_model('Registration');
         $this->singular_item = esc_html__('Event', 'event_espresso');
@@ -284,9 +283,10 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * @param string $default_reg_status
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public static function set_default_reg_status($default_reg_status)
     {
@@ -349,6 +349,7 @@ class EEM_Event extends EEM_CPT_Base
      *
      * @return array
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_all_question_groups()
     {
@@ -361,13 +362,13 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * get_question_groups
      *
      * @param int $EVT_ID
      * @return array|bool
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_all_event_question_groups($EVT_ID = 0)
     {
@@ -475,13 +476,13 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * get_question_target_db_column
      *
      * @param string $QSG_IDs csv list of $QSG IDs
      * @return array|bool
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_questions_in_groups($QSG_IDs = '')
     {
@@ -507,13 +508,13 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * get_options_for_question
      *
      * @param string $QST_IDs csv list of $QST IDs
      * @return array|bool
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_options_for_question($QST_IDs)
     {
@@ -538,20 +539,16 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
-
-
-
-
     /**
      * Gets all events that are published
      * and have event start time earlier than now and an event end time later than now
      *
-     * @param  array $query_params An array of query params to further filter on
+     * @param array $query_params  An array of query params to further filter on
      *                             (note that status and DTT_EVT_start and DTT_EVT_end will be overridden)
-     * @param bool   $count        whether to return the count or not (default FALSE)
+     * @param bool  $count         whether to return the count or not (default FALSE)
      * @return EE_Event[]|int
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_active_events($query_params, $count = false)
     {
@@ -600,15 +597,15 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * get all events that are published and have an event start time later than now
      *
-     * @param  array $query_params An array of query params to further filter on
+     * @param array $query_params  An array of query params to further filter on
      *                             (Note that status and DTT_EVT_start will be overridden)
-     * @param bool   $count        whether to return the count or not (default FALSE)
+     * @param bool  $count         whether to return the count or not (default FALSE)
      * @return EE_Event[]|int
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_upcoming_events($query_params, $count = false)
     {
@@ -652,16 +649,16 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * Gets all events that are published
      * and have an event end time later than now
      *
-     * @param  array $query_params An array of query params to further filter on
+     * @param array $query_params  An array of query params to further filter on
      *                             (note that status and DTT_EVT_end will be overridden)
-     * @param bool   $count        whether to return the count or not (default FALSE)
+     * @param bool  $count         whether to return the count or not (default FALSE)
      * @return EE_Event[]|int
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_active_and_upcoming_events($query_params, $count = false)
     {
@@ -699,16 +696,16 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * This only returns events that are expired.
      * They may still be published but all their datetimes have expired.
      *
-     * @param  array $query_params An array of query params to further filter on
+     * @param array $query_params  An array of query params to further filter on
      *                             (note that status and DTT_EVT_end will be overridden)
-     * @param bool   $count        whether to return the count or not (default FALSE)
+     * @param bool  $count         whether to return the count or not (default FALSE)
      * @return EE_Event[]|int
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_expired_events($query_params, $count = false)
     {
@@ -763,15 +760,15 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * This basically just returns the events that do not have the publish status.
      *
-     * @param  array   $query_params An array of query params to further filter on
+     * @param array   $query_params  An array of query params to further filter on
      *                               (note that status will be overwritten)
-     * @param  boolean $count        whether to return the count or not (default FALSE)
+     * @param boolean $count         whether to return the count or not (default FALSE)
      * @return EE_Event[]|int
      * @throws \EE_Error
+     * @throws ReflectionException
      */
     public function get_inactive_events($query_params, $count = false)
     {
@@ -807,7 +804,6 @@ class EEM_Event extends EEM_CPT_Base
     }
 
 
-
     /**
      * This is just injecting into the parent add_relationship_to so we do special handling on price relationships
      * because we don't want to override any existing global default prices but instead insert NEW prices that get
@@ -819,6 +815,7 @@ class EEM_Event extends EEM_CPT_Base
      * @param array  $where_query
      * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function add_relationship_to($id_or_obj, $other_model_id_or_obj, $relationName, $where_query = array())
     {
@@ -842,19 +839,18 @@ class EEM_Event extends EEM_CPT_Base
     /******************** DEPRECATED METHODS ********************/
 
 
-
     /**
      * _get_question_target_db_column
      *
-     * @deprecated as of 4.8.32.rc.001. Instead consider using
-     *             EE_Registration_Custom_Questions_Form located in
-     *             admin_pages/registrations/form_sections/EE_Registration_Custom_Questions_Form.form.php
-     * @access     public
-     * @param    EE_Registration $registration (so existing answers for registration are included)
-     * @param    int             $EVT_ID       so all question groups are included for event (not just answers from
+     * @param EE_Registration $registration    (so existing answers for registration are included)
+     * @param int             $EVT_ID          so all question groups are included for event (not just answers from
      *                                         registration).
-     * @throws EE_Error
      * @return    array
+     * @throws ReflectionException
+     * @throws EE_Error*@deprecated as of 4.8.32.rc.001. Instead consider using
+     *                                         EE_Registration_Custom_Questions_Form located in
+     *                                         admin_pages/registrations/form_sections/EE_Registration_Custom_Questions_Form.form.php
+     * @access     public
      */
     public function assemble_array_of_groups_questions_and_options(EE_Registration $registration, $EVT_ID = 0)
     {
@@ -919,7 +915,8 @@ class EEM_Event extends EEM_CPT_Base
      * @param mixed $cols_n_values either an array of where each key is the name of a field, and the value is its value
      *                             or an stdClass where each property is the name of a column,
      * @return EE_Base_Class
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function instantiate_class_from_array_or_object($cols_n_values)
     {

--- a/core/db_models/EEM_Event_Message_Template.model.php
+++ b/core/db_models/EEM_Event_Message_Template.model.php
@@ -22,7 +22,7 @@ class EEM_Event_Message_Template extends EEM_Base
      * @param null $timezone
      * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = esc_html__('Event Message Template', 'event_espresso');
         $this->plural_item = esc_html__('Event Message Templates', 'event_espresso');

--- a/core/db_models/EEM_Event_Question_Group.model.php
+++ b/core/db_models/EEM_Event_Question_Group.model.php
@@ -29,7 +29,7 @@ class EEM_Event_Question_Group extends EEM_Base
     protected static $_instance = null;
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item    = __('Event to Question Group Link', 'event_espresso');
         $this->plural_item      = __('Event to Question Group Links', 'event_espresso');

--- a/core/db_models/EEM_Event_Venue.model.php
+++ b/core/db_models/EEM_Event_Venue.model.php
@@ -11,7 +11,7 @@ class EEM_Event_Venue extends EEM_Base
     // private instance of the Attendee object
     protected static $_instance = null;
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Event to Question Group Link', 'event_espresso');
         $this->plural_item = __('Event to Question Group Links', 'event_espresso');

--- a/core/db_models/EEM_Extra_Join.model.php
+++ b/core/db_models/EEM_Extra_Join.model.php
@@ -26,7 +26,7 @@ class EEM_Extra_Join extends EEM_Base
     // private instance of the Extra Join object
     protected static $_instance = null;
 
-    public function __construct($timezone = null)
+    public function __construct($timezone = '')
     {
         $models_this_can_join = array_keys(EE_Registry::instance()->non_abstract_db_models);
         $this->_tables = array(

--- a/core/db_models/EEM_Extra_Meta.model.php
+++ b/core/db_models/EEM_Extra_Meta.model.php
@@ -20,7 +20,7 @@ class EEM_Extra_Meta extends EEM_Base
     // private instance of the Attendee object
     protected static $_instance = null;
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Extra Meta', 'event_espresso');
         $this->plural_item = __('Extra Metas', 'event_espresso');

--- a/core/db_models/EEM_Message.model.php
+++ b/core/db_models/EEM_Message.model.php
@@ -107,7 +107,7 @@ class EEM_Message extends EEM_Base implements EEI_Query_Filter
      *                         timezone in the 'timezone_string' wp option)
      * @return EEM_Message
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Message', 'event_espresso');
         $this->plural_item   = __('Messages', 'event_espresso');

--- a/core/db_models/EEM_Message_Template.model.php
+++ b/core/db_models/EEM_Message_Template.model.php
@@ -27,7 +27,7 @@ class EEM_Message_Template extends EEM_Base
      * @param string $timezone
      * @throws \EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Message Template', 'event_espresso');
         $this->plural_item = __('Message Templates', 'event_espresso');

--- a/core/db_models/EEM_Message_Template_Group.model.php
+++ b/core/db_models/EEM_Message_Template_Group.model.php
@@ -17,7 +17,7 @@ class EEM_Message_Template_Group extends EEM_Soft_Delete_Base
 
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Message Template Group', 'event_espresso');
         $this->plural_item = __('Message Template Groups', 'event_espresso');

--- a/core/db_models/EEM_Payment_Method.model.php
+++ b/core/db_models/EEM_Payment_Method.model.php
@@ -35,7 +35,7 @@ class EEM_Payment_Method extends EEM_Base
      * @param null $timezone
      * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = esc_html__('Payment Method', 'event_espresso');
         $this->plural_item = esc_html__('Payment Methods', 'event_espresso');

--- a/core/db_models/EEM_Post_Meta.model.php
+++ b/core/db_models/EEM_Post_Meta.model.php
@@ -24,7 +24,7 @@ class EEM_Post_Meta extends EEM_Base
 
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Post Meta', 'event_espresso');
         $this->plural_item = __('Post Metas', 'event_espresso');

--- a/core/db_models/EEM_Price_Type.model.php
+++ b/core/db_models/EEM_Price_Type.model.php
@@ -66,7 +66,7 @@ class EEM_Price_Type extends EEM_Soft_Delete_Base
      *      @access protected
      *      @return void
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->base_types = array(
             EEM_Price_Type::base_type_base_price => __('Price', 'event_espresso'),

--- a/core/db_models/EEM_Question.model.php
+++ b/core/db_models/EEM_Question.model.php
@@ -106,7 +106,7 @@ class EEM_Question extends EEM_Soft_Delete_Base
      *
      * @param null $timezone
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item                  = esc_html__('Question', 'event_espresso');
         $this->plural_item                    = esc_html__('Questions', 'event_espresso');

--- a/core/db_models/EEM_Question_Group.model.php
+++ b/core/db_models/EEM_Question_Group.model.php
@@ -27,7 +27,7 @@ class EEM_Question_Group extends EEM_Soft_Delete_Base
      *
      * @param string|null $timezone
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = esc_html__('Question Group', 'event_espresso');
         $this->plural_item   = esc_html__('Question Groups', 'event_espresso');

--- a/core/db_models/EEM_Question_Group_Question.model.php
+++ b/core/db_models/EEM_Question_Group_Question.model.php
@@ -18,7 +18,7 @@ class EEM_Question_Group_Question extends EEM_Base
     protected static $_instance = null;
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item    = esc_html__('Question Group to Question Link', 'event_espresso');
         $this->plural_item      = esc_html__('Question Group to Question Links', 'event_espresso');

--- a/core/db_models/EEM_Question_Option.model.php
+++ b/core/db_models/EEM_Question_Option.model.php
@@ -14,7 +14,7 @@ class EEM_Question_Option extends EEM_Soft_Delete_Base
     protected static $_instance = null;
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = esc_html__('Question Option', 'event_espresso');
         $this->plural_item   = esc_html__('Question Options', 'event_espresso');

--- a/core/db_models/EEM_Registration.model.php
+++ b/core/db_models/EEM_Registration.model.php
@@ -110,7 +110,7 @@ class EEM_Registration extends EEM_Soft_Delete_Base
      *                         timezone in the 'timezone_string' wp option)
      * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->_table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
         $this->singular_item = esc_html__('Registration', 'event_espresso');

--- a/core/db_models/EEM_Registration_Payment.model.php
+++ b/core/db_models/EEM_Registration_Payment.model.php
@@ -17,7 +17,7 @@ class EEM_Registration_Payment extends EEM_Base
     protected static $_instance = null;
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
 
         $this->singular_item = __('Registration Payment', 'event_espresso');

--- a/core/db_models/EEM_Soft_Delete_Base.model.php
+++ b/core/db_models/EEM_Soft_Delete_Base.model.php
@@ -28,9 +28,10 @@ abstract class EEM_Soft_Delete_Base extends EEM_Base
 {
 
     /**
-     * @param null $timezone
+     * @param string $timezone
+     * @throws EE_Error
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         if (! $this->_default_where_conditions_strategy instanceof EE_Default_Where_Conditions) {
             $this->_default_where_conditions_strategy = new EE_Soft_Delete_Where_Conditions();

--- a/core/db_models/EEM_State.model.php
+++ b/core/db_models/EEM_State.model.php
@@ -19,7 +19,7 @@ class EEM_State extends EEM_Base
     // array of all active states
     private static $_active_states = false;
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('State/Province', 'event_espresso');
         $this->plural_item = __('States/Provinces', 'event_espresso');

--- a/core/db_models/EEM_Status.model.php
+++ b/core/db_models/EEM_Status.model.php
@@ -18,7 +18,7 @@ class EEM_Status extends EEM_Base
     /**
      * @return EEM_Status
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item    = __('Status', 'event_espresso');
         $this->plural_item      = __('Stati', 'event_espresso');

--- a/core/db_models/EEM_Term.model.php
+++ b/core/db_models/EEM_Term.model.php
@@ -24,7 +24,7 @@ class EEM_Term extends EEM_Base
      *
      * @param string $timezone
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Term', 'event_espresso');
         $this->plural_item = __('Terms', 'event_espresso');

--- a/core/db_models/EEM_Term_Relationship.model.php
+++ b/core/db_models/EEM_Term_Relationship.model.php
@@ -20,7 +20,7 @@ class EEM_Term_Relationship extends EEM_Base
      *
      * @param string $timezone
      */
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Term Relationship', 'event_espresso');
         $this->plural_item = __('Term Relationships', 'event_espresso');

--- a/core/db_models/EEM_Term_Taxonomy.model.php
+++ b/core/db_models/EEM_Term_Taxonomy.model.php
@@ -16,7 +16,7 @@ class EEM_Term_Taxonomy extends EEM_Base
 
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Term Taxonomy', 'event_espresso');
         $this->plural_item = __('Term Taxonomy', 'event_espresso');

--- a/core/db_models/EEM_Venue.model.php
+++ b/core/db_models/EEM_Venue.model.php
@@ -16,7 +16,7 @@ class EEM_Venue extends EEM_CPT_Base
 
 
 
-    protected function __construct($timezone = null)
+    protected function __construct($timezone = '')
     {
         $this->singular_item = __('Venue', 'event_espresso');
         $this->plural_item = __('Venues', 'event_espresso');

--- a/core/db_models/EEM_WP_User.model.php
+++ b/core/db_models/EEM_WP_User.model.php
@@ -29,7 +29,7 @@ class EEM_WP_User extends EEM_Base
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function __construct($timezone = null, ModelFieldFactory $model_field_factory)
+    protected function __construct($timezone = '', ModelFieldFactory $model_field_factory)
     {
         $this->singular_item = esc_html__('WP_User', 'event_espresso');
         $this->plural_item = esc_html__('WP_Users', 'event_espresso');

--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -249,7 +249,7 @@ class EE_Datetime_Field extends EE_Model_Field_Base
      */
     public function set_timezone($timezone_string)
     {
-        if (empty($timezone_string) && $this->_timezone_string !== null) {
+        if (empty($timezone_string) && ! empty($this->_timezone_string)) {
             // leave the timezone AS-IS if we already have one and
             // the function arg didn't provide one
             return;

--- a/core/db_models/relations/EE_Model_Relation_Base.php
+++ b/core/db_models/relations/EE_Model_Relation_Base.php
@@ -117,11 +117,18 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
      *
      * @param string $model_name like Event, Question_Group, etc. omit the EEM_
      * @return EEM_Base
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_model($model_name)
     {
         $modelInstance = EE_Registry::instance()->load_model($model_name);
-        $modelInstance->set_timezone($this->_timezone);
+        // if the timezone is NOT set on the model but IS set for this relation
+        // (which seems really unlikely to ever happen, but whatever)
+        // make sure the model timezone is set
+        if ($this->_timezone && ! $modelInstance->get_timezone()) {
+            $modelInstance->set_timezone($this->_timezone);
+        }
         return $modelInstance;
     }
 
@@ -134,7 +141,7 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
      */
     public function set_timezone($timezone)
     {
-        if ($timezone !== null) {
+        if (! empty($timezone)) {
             $this->_timezone = $timezone;
         }
     }
@@ -169,10 +176,11 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
      * EE_Belongs_To_Relation doesn't need to be saved before querying.
      *
      * @param EE_Base_Class|int $model_object_or_id                      or the primary key of this model
-     * @param array             $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array             $query_params                            @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param boolean           $values_already_prepared_by_model_object @deprecated since 4.8.1
      * @return EE_Base_Class[]
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_all_related(
         $model_object_or_id,
@@ -199,7 +207,7 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
     /**
      * Alters the $query_params to disable default where conditions, unless otherwise specified
      *
-     * @param string $query_params
+     * @param array $query_params
      * @return array
      */
     protected function _disable_default_where_conditions_on_query_param($query_params)
@@ -220,7 +228,8 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
      * @param EE_Base_Class|int|string $model_object_or_id
      * @param array                    $query_params
      * @return int of how many related models got deleted
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function delete_all_related($model_object_or_id, $query_params = array())
     {
@@ -253,7 +262,8 @@ abstract class EE_Model_Relation_Base implements HasSchemaInterface
      * @param EE_Base_Class|int|string $model_object_or_id
      * @param array                    $query_params
      * @return int of how many related models got deleted
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function delete_related_permanently($model_object_or_id, $query_params = array())
     {

--- a/core/helpers/EEH_DTT_Helper.helper.php
+++ b/core/helpers/EEH_DTT_Helper.helper.php
@@ -16,7 +16,6 @@ use EventEspresso\core\services\loaders\LoaderFactory;
 class EEH_DTT_Helper
 {
 
-
     /**
      * return the timezone set for the WP install
      *
@@ -36,14 +35,21 @@ class EEH_DTT_Helper
      *    ensures that a valid timezone string is returned
      *
      * @param string $timezone_string
+     * @param bool   $throw_error
      * @return string
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public static function get_valid_timezone_string($timezone_string = '')
+    public static function get_valid_timezone_string($timezone_string = '', $throw_error = false)
     {
-        return self::getHelperAdapter()->getValidTimezoneString($timezone_string);
+        return self::getHelperAdapter()->getValidTimezoneString($timezone_string, $throw_error);
+    }
+
+
+    public static function resetDefaultTimezoneString()
+    {
+        self::getHelperAdapter()->resetDefaultTimezoneString();
     }
 
 

--- a/core/services/helpers/datetime/HelperInterface.php
+++ b/core/services/helpers/datetime/HelperInterface.php
@@ -21,9 +21,10 @@ interface HelperInterface
      *
      * @param string $timezone_string  When not provided then attempt to use the timezone_string set in the WP Time
      *                                 settings (or derive from set UTC offset).
+     * @param bool   $throw_error
      * @return string
      */
-    public function getValidTimezoneString($timezone_string = '');
+    public function getValidTimezoneString($timezone_string = '', $throw_error = false);
 
 
     /**

--- a/core/services/helpers/datetime/PhpCompatGreaterFiveSixHelper.php
+++ b/core/services/helpers/datetime/PhpCompatGreaterFiveSixHelper.php
@@ -28,6 +28,7 @@ class PhpCompatGreaterFiveSixHelper extends AbstractHelper
                 )
             );
         }
+        parent::__construct();
     }
 
     /**

--- a/core/services/helpers/datetime/PhpCompatLessFiveSixHelper.php
+++ b/core/services/helpers/datetime/PhpCompatLessFiveSixHelper.php
@@ -38,6 +38,7 @@ class PhpCompatLessFiveSixHelper extends AbstractHelper
                 )
             );
         }
+        parent::__construct();
     }
 
     /**

--- a/tests/includes/factories/EE_UnitTest_Factory.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory.class.php
@@ -104,11 +104,16 @@ class EE_UnitTest_Factory extends WP_UnitTest_Factory {
 	 */
 	public $complex_factory;
 
+    /**
+     * @var string
+     */
+    private $timezone;
 
 
 
 
 	public function __construct() {
+        $this->setTimezone(get_option('timezone_string'));
 		parent::__construct();
 
 		//simple factories
@@ -140,6 +145,37 @@ class EE_UnitTest_Factory extends WP_UnitTest_Factory {
 		$this->complex_factory = new EE_UnitTest_Factory_for_Specific_Builds( $this );
 
 	}
+
+
+    /**
+     * @return string
+     */
+    public function timezone()
+    {
+        return $this->timezone;
+    }
+
+
+    /**
+     * @param string $timezone
+     * @throws EE_Error
+     */
+    public function setTimezone($timezone)
+    {
+        if (! $timezone || ($timezone === $this->timezone && $this->timezone)) {
+            return;
+        }
+        $this->timezone = $timezone;
+        EEM_Event::instance()->set_timezone($timezone);
+        EEM_Datetime::instance()->set_timezone($timezone);
+        EEM_Ticket::instance()->set_timezone($timezone);
+        EEM_Registration::instance()->set_timezone($timezone);
+        EEM_Transaction::instance()->set_timezone($timezone);
+        EEM_Payment::instance()->set_timezone($timezone);
+        EEM_Message::instance()->set_timezone($timezone);
+    }
+
+
 }
 
 

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Datetime.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Datetime.class.php
@@ -116,9 +116,9 @@ class EE_UnitTest_Factory_For_Datetime extends WP_UnitTest_Factory_For_Thing {
 			$timezone = $args[ 'timezone' ];
 			unset( $args[ 'timezone' ] );
 		} else {
-			$timezone = null;
+			$timezone = '';
 		}
-		//date formats?
+        //date formats?
 		if ( isset( $args[ 'formats' ] ) && is_array( $args[ 'formats' ] ) ) {
 			$formats = $args[ 'formats' ];
 			unset( $args[ 'formats' ] );

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Payment.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Payment.class.php
@@ -35,7 +35,7 @@ class EE_UnitTest_Factory_For_Payment extends WP_UnitTest_Factory_For_Thing {
 			$timezone = $args[ 'timezone' ];
 			unset( $args[ 'timezone' ] );
 		} else {
-			$timezone = null;
+			$timezone = '';
 		}
 		//date_formats?
 		if ( isset( $args[ 'formats' ] ) && is_array( $args[ 'formats' ] ) ) {

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Registration.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Registration.class.php
@@ -180,7 +180,7 @@ class EE_UnitTest_Factory_For_Registration extends WP_UnitTest_Factory_For_Thing
             $timezone = $args['timezone'];
             unset($args['timezone']);
         } else {
-            $timezone = null;
+            $timezone = '';
         }
         //date_formats?
         if (isset($args['formats']) && is_array($args['formats'])) {
@@ -197,10 +197,11 @@ class EE_UnitTest_Factory_For_Registration extends WP_UnitTest_Factory_For_Thing
         //only run finalize if $chained because it requires EE_Transaction
         if ($this->_chained) {
             $att_nmbr++;
-            $registration->set_reg_url_link(new RegUrlLink($att_nmbr, md5('ticket' . $registrationID . time())));
+            $reg_url_link = new RegUrlLink($att_nmbr, md5('ticket' . $registrationID . time()));
+            $registration->set_reg_url_link($reg_url_link);
             $registration->set_reg_code(
                 new RegCode(
-                    RegUrlLink::fromRegistration($registration),
+                    $reg_url_link,
                     $registration->transaction(),
                     $registration->ticket()
                 )

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Ticket.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Ticket.class.php
@@ -158,7 +158,7 @@ class EE_UnitTest_Factory_For_Ticket extends WP_UnitTest_Factory_For_Thing {
 			$timezone = $args[ 'timezone' ];
 			unset( $args[ 'timezone' ] );
 		} else {
-			$timezone = null;
+			$timezone = '';
 		}
 		//date_formats?
 		if ( isset( $args[ 'formats' ] ) && is_array( $args[ 'formats' ] ) ) {

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Transaction.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Transaction.class.php
@@ -144,7 +144,7 @@ class EE_UnitTest_Factory_For_Transaction extends WP_UnitTest_Factory_For_Thing 
 			$timezone = $args[ 'timezone' ];
 			unset( $args[ 'timezone' ] );
 		} else {
-			$timezone = null;
+			$timezone = '';
 		}
 		//date_formats?
 		if ( isset( $args[ 'formats' ] ) && is_array( $args[ 'formats' ] ) ) {

--- a/tests/mocks/addons/eea-new-addon/core/db_models/EEM_New_Addon_Thing.model.php
+++ b/tests/mocks/addons/eea-new-addon/core/db_models/EEM_New_Addon_Thing.model.php
@@ -16,7 +16,7 @@ class EEM_New_Addon_Thing extends EEM_Base{
 	// private instance of the EEM_New_Addon_Thing object
 	protected static $_instance = null;
 
-	protected function __construct($timezone = null) {
+	protected function __construct($timezone = '') {
 		$this->_tables = array(
 			'New_Addon_Thing'=>new EE_Primary_Table('esp_new_addon_thing', 'NEW_ID')
 		);

--- a/tests/mocks/admin/events/Events_Admin_Page_Mock.php
+++ b/tests/mocks/admin/events/Events_Admin_Page_Mock.php
@@ -31,8 +31,8 @@ class Events_Admin_Page_Mock extends Events_Admin_Page {
 	}
 
 
-	public function default_tickets_update( $evtobj, $data ) {
-		return $this->_default_tickets_update( $evtobj, $data );
+	public function default_tickets_update( EE_Event $event, $data ) {
+		return $this->_default_tickets_update( $event, $data );
 	}
 
 

--- a/tests/mocks/core/db_models/EEM_Mock.model.php
+++ b/tests/mocks/core/db_models/EEM_Mock.model.php
@@ -22,7 +22,7 @@ class EEM_Mock extends EEM_Base
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    public function __construct($timezone = null)
+    public function __construct($timezone = '')
     {
         $this->_tables = array(
             'Mock' => new EE_Primary_Table('esp_mock', 'MCK_ID'),

--- a/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
@@ -31,10 +31,15 @@ class Events_Admin_Page_Test extends EE_UnitTestCase {
 		parent::setUp();
 		$this->delayedAdminPageMocks( 'events' );
 	}
-	
-	
-	
-	protected function _load_requirements( $timezone = 'America/Vancouver' ) {
+
+
+    /**
+     * @param string $timezone
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    protected function _load_requirements( $timezone = 'America/Vancouver' ) {
+        $this->loadFactories();
 		$this->_admin_page = new Events_Admin_Page_Mock();
 		$this->_event = $this->factory->event->create();
 		$this->_event->set_timezone( $timezone );

--- a/tests/testcases/admin_pages/events_decaf/Events_Admin_Page_Decaf_Test.php
+++ b/tests/testcases/admin_pages/events_decaf/Events_Admin_Page_Decaf_Test.php
@@ -56,13 +56,16 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 	}
 
 
-	/**
-	 * loader for setting the $_admin_page_property
-	 *
-	 * @param string $timezone Timezone string to initialize the times in.
-	 * @since 4.6
-	 */
+    /**
+     * loader for setting the $_admin_page_property
+     *
+     * @param string $timezone Timezone string to initialize the times in.
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.6
+     */
 	protected function _load_requirements( $timezone = 'America/Vancouver' ) {
+        $this->loadFactories();
 		$this->_admin_page = new Events_Admin_Page_Mock();
 		$this->_event = $this->factory->event->create();
 		$this->_event->set_timezone( $timezone );
@@ -74,28 +77,42 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 
 
 	/**
+	 * tests the decaf datetime and tickets update method for Events Admin Page with default data.
+	 *
+	 *@since 4.6
+	 */
+	public function test_tickets_update_with_default_data() {
+		$this->_load_requirements();
+		$this->_testing_updates( "Tests with Default Data\n" );
+	}
+
+
+
+
+	/**
 	 * tests the decaf datetime and tickets update method for Events Admin Page.
 	 *
 	 *@since 4.6
 	 */
-	public function test_default_tickets_update() {
-		//first test is just with default data
+	public function test_tickets_update() {
 		$this->_load_requirements();
-		$this->_testing_updates( "Tests with Default Data\n" );
 
 		//next test is with empty TKT_start and TKT_end dates.
 		$replacement['edit_tickets']['1']['TKT_start_date'] = null;
 		$replacement['edit_tickets']['1']['TKT_end_date'] = null;
 
-		//override _default_dates because we expect something different.
-		$this->_default_dates = array();
-		$this->_load_requirements();
-		$this->_default_dates['TKT_start'] = new DateTime( 'now', new DateTimeZone( 'America/Vancouver' ) );
+        update_option('timezone_string', 'America/Vancouver');
+        $tz = new DateTimeZone('America/Vancouver');
 
+        //override _default_dates because we expect something different.
+		$this->_default_dates['TKT_start'] = new DateTime( 'now', $tz );
 		/**
 		 *  TKT_start is set in the decaf ticket saves without seconds, so we need to set the seconds to zero as well for comparison.
 		 */
-		$this->_default_dates['TKT_start']->setTime( $this->_default_dates['TKT_start']->format( 'H' ), $this->_default_dates['TKT_start']->format( 'i' ), 0 );
+		$this->_default_dates['TKT_start']->setTime(
+		    $this->_default_dates['TKT_start']->format( 'H' ),
+            $this->_default_dates['TKT_start']->format( 'i' )
+        );
 		/**
 		 * tkt end date is the same as start date because here's the code execution in Events_Admin_page::default_tickets_update:
 		 * 1. If no TKT_end_date, then set to DTT_EVT_start.
@@ -105,23 +122,62 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 		$this->_default_dates['TKT_end'] = clone $this->_default_dates['TKT_start'];
 		$this->_default_dates['TKT_end'] = $this->_default_dates['TKT_end']->add( new DateInterval( 'P1D' ) );
 		$this->_testing_updates( "Tests with unset tkt start and end date\n", $replacement );
-
 	}
 
 
+    protected function prepareSaveData(array $data_to_replace, $decaf_date_format)
+    {
+        $data = $this->_get_save_data($decaf_date_format);
+
+        //is there any data to unset/replace?
+        if (! empty($data_to_replace)) {
+            //any data to unset?
+            foreach ($data_to_replace as $top_level => $second_level) {
+                if (is_array($second_level)) {
+                    foreach ($second_level as $third_level => $fourth_level) {
+                        if (is_array($fourth_level)) {
+                            foreach ($fourth_level as $fifth_level => $sixth_level) {
+                                if (is_null($sixth_level)) {
+                                    unset($data_to_replace[ $top_level ][ $third_level ][ $fifth_level ]);
+                                    unset($data[ $top_level ][ $third_level ][ $fifth_level ]);
+                                }
+                            }
+                        } elseif (is_null($fourth_level)) {
+                            unset($data_to_replace[ $top_level ][ $third_level ]);
+                            unset($data[ $top_level ][ $third_level ]);
+                        }
+                    }
+                } else {
+                    if (is_null($second_level)) {
+                        unset($data_to_replace[ $top_level ]);
+                        unset($data[ $top_level ]);
+                    }
+                }
+            }
+            //moige
+            $data = array_merge($data, $data_to_replace);
+        }
+        return $data;
+	}
 
 
-	/**
-	 * This is a common looped to test saves of ticket and datetime data.
-	 *
-	 * @param string $context_for_error_messages Used this to add context to any failed tests so
-	 *                                           you can easily verify what triggered it.
-	 * @param array  $data_to_replace            An array of replacements for the default data.
-	 *                                           Use null to indicate you want the key unset.
-	 * @since 4.6
-	 */
+    /**
+     * This is a common looped to test saves of ticket and datetime data.
+     *
+     * @param string $context_for_error_messages Used this to add context to any failed tests so
+     *                                           you can easily verify what triggered it.
+     * @param array  $data_to_replace            An array of replacements for the default data.
+     *                                           Use null to indicate you want the key unset.
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.6
+     */
 	protected function _testing_updates( $context_for_error_messages, $data_to_replace = array() ) {
-		$formats_to_test = $this->date_formats_to_test();
+
+        $decaf_date_format = 'Y-m-d h:i a';
+        $data = $this->prepareSaveData($data_to_replace, $decaf_date_format);
+
+        $formats_to_test = $this->date_formats_to_test();
 
 		$saved_dtts_for_tickets = $formats_for_compare = $saved_tkts = array();
 
@@ -132,74 +188,70 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 		 * on the decaf editor form.  So we make sure the all the dates going in for the data are in the same format.
 		 */
 
-		foreach( $formats_to_test['date'] as $date_format ) {
-			foreach( $formats_to_test['time'] as $time_format ) {
-				$full_format = $date_format . ' ' . $time_format;
-				$decaf_date_format = 'Y-m-d h:i a';
-				$data = $this->_get_save_data( $decaf_date_format );
+        foreach ($formats_to_test['date'] as $date_format) {
+            foreach ($formats_to_test['time'] as $time_format) {
+                $full_format = $date_format . ' ' . $time_format;
+                $saved_data = $this->_admin_page->default_tickets_update($this->_event, $data);
+                /** @var EE_Datetime $dtt */
+                $dtt  = $saved_data[0];
 
-				//is there any data to unset/replace?
-				if ( ! empty( $data_to_replace ) ) {
-					//any data to unset?
-					foreach( $data_to_replace as $top_level => $second_level ) {
-						if ( is_array( $second_level ) ) {
-							foreach ( $second_level as $third_level => $fourth_level )
-								if ( is_array( $fourth_level ) ) {
-									foreach ( $fourth_level as $fifth_level => $sixth_level ) {
-										if ( is_null( $sixth_level ) ) {
-											unset( $data_to_replace[$top_level][$third_level][$fifth_level] );
-											unset( $data[$top_level][$third_level][$fifth_level] );
+                //verify datetime.
+                $this->assertInstanceof('EE_Datetime', $dtt);
+                //verify start and date
+                $this->assertEquals(
+                    $dtt->start_date_and_time($date_format, $time_format),
+                    $this->_default_dates['DTT_start']->format($full_format),
+                    $context_for_error_messages . sprintf('Start Date Format Tested: %s', $full_format)
+                );
+                $this->assertEquals(
+                    $dtt->end_date_and_time($date_format, $time_format),
+                    $this->_default_dates['DTT_end']->format($full_format),
+                    $context_for_error_messages . sprintf('End Date Format Tested: %s', $full_format)
+                );
 
-										}
-									}
-								} else if ( is_null( $fourth_level ) ) {
-									unset( $data_to_replace[$top_level][$third_level] );
-									unset( $data[$top_level][$third_level] );
-								}
-						} else {
-							if ( is_null( $second_level ) ) {
-								unset( $data_to_replace[$top_level] );
-								unset( $data[$top_level] );
-							}
-						}
-					}
-					//moige
-					$data = array_merge( $data, $data_to_replace );
-				}
+                $saved_dtts_for_tickets[ $full_format ] = $dtt;
+                $formats_for_compare[ $dtt->ID() ]      = [$date_format, $time_format];
 
+                //verify tkts
+                /** @var EE_Ticket[] $tkts */
+                $tkts = $saved_data[1];
+                foreach ($tkts as $tkt) {
+                    $this->assertInstanceof(
+                        'EE_Ticket',
+                        $tkt,
+                        $context_for_error_messages . sprintf('Format: %s', $full_format)
+                    );
 
+                    //verify start and date
+                    //Note: currently this test sometimes fails depending on the timing of when it happens and how fast
+                    // the server is. Whenever I've seen this fail its been off by 1 minute and that's because when the
+                    // default dates for testing were created, they likely happened at the second turnover.
+                    $this->assertDateWithinOneMinute(
+                        $tkt->start_date($date_format, $time_format),
+                        $this->_default_dates['TKT_start']->format($full_format),
+                        $full_format,
+                        $context_for_error_messages . sprintf(
+                            'Start Ticket DateFormat Tested: %s',
+                            $full_format
+                        )
+                    );
+                    $this->assertDateWithinOneMinute(
+                        $tkt->end_date($date_format, $time_format),
+                        $this->_default_dates['TKT_end']->format($full_format),
+                        $full_format,
+                        $context_for_error_messages . sprintf(
+                            'End Ticket Date Format Tested: %s',
+                            $full_format
+                        )
+                    );
 
-				$saved_data = $this->_admin_page->default_tickets_update( $this->_event, $data );
-				$dtt = $saved_data[0];
-				$tkts = $saved_data[1];
-
-				//verify datetime.
-				$this->assertInstanceof( 'EE_Datetime', $dtt );
-				//verify start and date
-				$this->assertEquals( $dtt->start_date_and_time( $date_format, $time_format ), $this->_default_dates['DTT_start']->format( $full_format ), $context_for_error_messages . sprintf( 'Start Date Format Tested: %s', $full_format ) );
-				$this->assertEquals( $dtt->end_date_and_time( $date_format, $time_format ), $this->_default_dates['DTT_end']->format( $full_format ), $context_for_error_messages . sprintf( 'End Date Format Tested: %s', $full_format ) );
-
-				$saved_dtts_for_tickets[$full_format] = $dtt;
-				$formats_for_compare[$dtt->ID()] = array( $date_format, $time_format );
-
-				//verify tkts
-				foreach ( $tkts as $tkt ) {
-					$this->assertInstanceof( 'EE_Ticket', $tkt, $context_for_error_messages . sprintf( 'Format: %s', $full_format ) );
-
-					//verify start and date
-					//Note: currently this test sometimes fails depending on the timing of when it happens and how fast
-					// the server is. Whenever I've seen this fail its been off by 1 minute and that's because when the
-					// default dates for testing were created, they likely happened at the second turnover.
-					$this->assertDateWithinOneMinute( $tkt->start_date( $date_format, $time_format ), $this->_default_dates['TKT_start']->format( $full_format ), $full_format, $context_for_error_messages . sprintf( 'Start Ticket DateFormat Tested: %s', $full_format ) );
-					$this->assertDateWithinOneMinute( $tkt->end_date( $date_format, $time_format ), $this->_default_dates['TKT_end']->format( $full_format ), $full_format, $context_for_error_messages . sprintf( 'End Ticket Date Format Tested: %s', $full_format ) );
-
-					$saved_tkts[$full_format] = $tkt;
-				}
-			}
-		}
+                    $saved_tkts[ $full_format ] = $tkt;
+                }
+            }
+        }
 
 
-		//now let's verify these items were saved corectly in the db.
+        //now let's verify these items were saved corectly in the db.
 		/*$new_tkts = $new_dtts = array();
 		foreach ( $tkt as $format => $tkt ) {
 			$new_tkts[$format] = EEM_Ticket::instance()->refresh_entity_map_from_db( $tkt->ID() );
@@ -214,22 +266,83 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 
 		$evt_dtts = $new_event->datetimes_ordered();
 
-		//now let's do comparisons.
-		foreach( $evt_dtts as  $edtt ) {
-			$formats = $formats_for_compare[$edtt->ID()];
-			$format = $formats[0] . ' ' . $formats[1];
-			$this->assertEquals( $edtt->start_date_and_time( $formats[0], $formats[1] ), $this->_default_dates['DTT_start']->format( $format), $context_for_error_messages . sprintf( 'DB DTT/Default DTT Start Date Format Checked: %s', $format ) );
-			$this->assertEquals( $edtt->end_date_and_time( $formats[0], $formats[1] ), $this->_default_dates['DTT_end']->format( $format ), $context_for_error_messages . sprintf( 'DB DTT/Default DTT End Date Format Checked: %s', $format ) );
-			$this->assertEquals( $edtt->start_date_and_time( $formats[0], $formats[1] ), $saved_dtts_for_tickets[$format]->start_date_and_time( $formats[0], $formats[1] ), $context_for_error_messages . sprintf( 'DB DTT/Orig DTT Start Date Format Checked: %s', $format ) );
-			$this->assertEquals( $edtt->end_date_and_time( $formats[0], $formats[1] ), $saved_dtts_for_tickets[$format]->end_date_and_time( $formats[0], $formats[1] ), $context_for_error_messages . sprintf( 'DB DTT/Orig DTT End Date Format Checked: %s', $format ) );
+        //now let's do comparisons.
+        foreach ($evt_dtts as $edtt) {
+            $this->assertInstanceOf('EE_Datetime', $edtt);
+            $formats = $formats_for_compare[ $edtt->ID() ];
+            $format  = $formats[0] . ' ' . $formats[1];
+            $this->assertEquals(
+                $edtt->start_date_and_time($formats[0], $formats[1]),
+                $this->_default_dates['DTT_start']->format($format),
+                $context_for_error_messages . sprintf(
+                    'DB DTT/Default DTT Start Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertEquals(
+                $edtt->end_date_and_time($formats[0], $formats[1]),
+                $this->_default_dates['DTT_end']->format($format),
+                $context_for_error_messages . sprintf(
+                    'DB DTT/Default DTT End Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertEquals(
+                $edtt->start_date_and_time($formats[0], $formats[1]),
+                $saved_dtts_for_tickets[ $format ]->start_date_and_time($formats[0], $formats[1]),
+                $context_for_error_messages . sprintf(
+                    'DB DTT/Orig DTT Start Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertEquals(
+                $edtt->end_date_and_time($formats[0], $formats[1]),
+                $saved_dtts_for_tickets[ $format ]->end_date_and_time($formats[0], $formats[1]),
+                $context_for_error_messages . sprintf(
+                    'DB DTT/Orig DTT End Date Format Checked: %s',
+                    $format
+                )
+            );
 
-			//get related ticket on this $edtt
-			$evt_tkt = $edtt->get_first_related( 'Ticket' );
-			$this->assertDateWithinOneMinute( $evt_tkt->start_date( $formats[0], $formats[1] ), $this->_default_dates['TKT_start']->format( $format ), $format, $context_for_error_messages . sprintf( 'DB TKT/Default TKT Start Date Format Checked: %s', $format ) );
-			$this->assertDateWithinOneMinute( $evt_tkt->end_date( $formats[0], $formats[1] ), $this->_default_dates['TKT_end']->format( $format ), $format, $context_for_error_messages . sprintf( 'DB TKT/Default TKT End Date Format Checked: %s', $format ) );
-			$this->assertDateWithinOneMinute( $evt_tkt->start_date( $formats[0], $formats[1] ), $saved_tkts[$format]->start_date( $formats[0], $formats[1] ), $format, $context_for_error_messages . sprintf( 'DB TKT/Orig TKT Start Date Format Checked: %s', $format ) );
-			$this->assertDateWithinOneMinute( $evt_tkt->end_date( $formats[0], $formats[1] ), $saved_tkts[$format]->end_date( $formats[0], $formats[1] ), $format, $context_for_error_messages . sprintf( 'DB TKT/Orig TKT End Date Format Checked: %s', $format ) );
-		}
+            //get related ticket on this $edtt
+            $evt_tkt = $edtt->get_first_related('Ticket');
+            $this->assertDateWithinOneMinute(
+                $evt_tkt->start_date($formats[0], $formats[1]),
+                $this->_default_dates['TKT_start']->format($format),
+                $format,
+                $context_for_error_messages . sprintf(
+                    'DB TKT/Default TKT Start Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertDateWithinOneMinute(
+                $evt_tkt->end_date($formats[0], $formats[1]),
+                $this->_default_dates['TKT_end']->format($format),
+                $format,
+                $context_for_error_messages . sprintf(
+                    'DB TKT/Default TKT End Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertDateWithinOneMinute(
+                $evt_tkt->start_date($formats[0], $formats[1]),
+                $saved_tkts[ $format ]->start_date($formats[0], $formats[1]),
+                $format,
+                $context_for_error_messages . sprintf(
+                    'DB TKT/Orig TKT Start Date Format Checked: %s',
+                    $format
+                )
+            );
+            $this->assertDateWithinOneMinute(
+                $evt_tkt->end_date($formats[0], $formats[1]),
+                $saved_tkts[ $format ]->end_date($formats[0], $formats[1]),
+                $format,
+                $context_for_error_messages . sprintf(
+                    'DB TKT/Orig TKT End Date Format Checked: %s',
+                    $format
+                )
+            );
+        }
 	}
 
 

--- a/tests/testcases/admin_pages/pricing/espresso_events_Pricing_Hooks_Test.php
+++ b/tests/testcases/admin_pages/pricing/espresso_events_Pricing_Hooks_Test.php
@@ -50,6 +50,7 @@ class espresso_events_Pricing_Hooks_Test extends EE_UnitTestCase
      */
     protected function _load_pricing_mock($timezone = 'America/Vancouver')
     {
+        $this->loadFactories();
         $this->_pricingMock = new espresso_events_Pricing_Hooks_Mock();
         $this->_event = $this->factory->event->create();
         $this->_event->set_timezone($timezone);

--- a/tests/testcases/admin_pages/registrations/EE_Registrations_List_Table_Test.php
+++ b/tests/testcases/admin_pages/registrations/EE_Registrations_List_Table_Test.php
@@ -25,6 +25,7 @@ class EE_Registrations_List_Table_Test extends EE_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
+        $this->loadFactories();
 		$this->loadAdminMocks();
 	}
 

--- a/tests/testcases/admin_pages/registrations/form_sections/EERegistrationCustomQuestionsFormTest.php
+++ b/tests/testcases/admin_pages/registrations/form_sections/EERegistrationCustomQuestionsFormTest.php
@@ -16,6 +16,7 @@ class EERegistrationCustomQuestionsFormTest extends EE_UnitTestCase
     {
         parent::setUp();
         $this->delayedAdminPageMocks('registrations');
+        $this->loadFactories();
 
     }
 

--- a/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
@@ -42,6 +42,7 @@ class Transactions_Admin_Page_Test extends EE_UnitTestCase
     {
         parent::setUp();
         $this->delayedAdminPageMocks('transactions');
+        $this->loadFactories();
     }
 
 

--- a/tests/testcases/core/EE_Capabilities_Test.php
+++ b/tests/testcases/core/EE_Capabilities_Test.php
@@ -33,6 +33,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     {
         parent::setUp();
         $this->CAPS = EE_Registry::instance()->CAP;
+        $this->loadFactories();
     }
 
 

--- a/tests/testcases/core/EE_Maintenance_Mode_Test.php
+++ b/tests/testcases/core/EE_Maintenance_Mode_Test.php
@@ -15,6 +15,16 @@ if (!defined('EVENT_ESPRESSO_VERSION')) {
  */
 class EE_Maintenance_Mode_Test extends EE_UnitTestCase{
 
+
+    /**
+     * the DMS manager maintains a bit of state in order to be more efficient, which we want to lose between tests
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        EE_Data_Migration_Manager::reset();
+        $this->loadFactories();
+    }
 	public function test_set_mm_if_db_old__no_need(){
 		//we should start off out of maintenance mode
 		$this->assertEquals( EE_Maintenance_Mode::level_0_not_in_maintenance,  EE_Maintenance_Mode::instance()->level() );
@@ -86,14 +96,6 @@ class EE_Maintenance_Mode_Test extends EE_UnitTestCase{
 		}else{
 			delete_option(EE_Data_Migration_Manager::current_database_state);
 		}
-	}
-
-	/**
-	 * the DMS manager maintains a bit of state in order to be more efficient, which we want to lose between tests
-	 */
-	public function setUp(){
-        parent::setUp();
-	    EE_Data_Migration_Manager::reset();
 	}
 }
 

--- a/tests/testcases/core/EE_Payment_Processor_Test.php
+++ b/tests/testcases/core/EE_Payment_Processor_Test.php
@@ -94,6 +94,7 @@ class EE_Payment_Processor_Test extends EE_UnitTestCase {
 	 * @return \WP_User
 	 */
 	public function get_wp_user_mock( $role = 'administrator' ) {
+        $this->loadFactories();
 		/** @type WP_User $user */
 		$user = $this->factory->user->create_and_get();
 		$user->add_role( $role );

--- a/tests/testcases/core/EE_Registry_Test.php
+++ b/tests/testcases/core/EE_Registry_Test.php
@@ -520,6 +520,7 @@ class EE_Registry_Test extends EE_UnitTestCase{
 	 * @author    Mike Nelson
 	 */
 	public function test_reset_model(){
+        $original_timezone = get_option('timezone_string');
 		$model_a = EE_Registry_Mock::instance()->load_model('Event');
 		$model_a2 = EE_Registry_Mock::instance()->load_model('Event');
 		$model_a3 = EEM_Event::instance();
@@ -528,11 +529,12 @@ class EE_Registry_Test extends EE_UnitTestCase{
 		$this->assertNotNull( $model_a->get_from_entity_map( $e->ID() ) );
 		$this->assertEquals($model_a, $model_a2);
 		$this->assertEquals($model_a2, $model_a3);
-		//let's set a differnet WP timezone. When the model is reset, it
+		//let's set a different WP timezone. When the model is reset, it
 		//should automatically use this new timezone
 		$new_timezone_string = 'America/Detroit';
 		update_option( 'timezone_string', $new_timezone_string );
 		$model_b1 = EEM_Event::reset();
+		$this->assertEquals($new_timezone_string, EEH_DTT_Helper::get_valid_timezone_string());
 		$this->assertEquals( $model_a, $model_b1);
 		$model_b2 = EE_Registry_Mock::instance()->reset_model('Event');
 		$this->assertEquals( $model_a, $model_b2);
@@ -540,6 +542,7 @@ class EE_Registry_Test extends EE_UnitTestCase{
 		$this->assertEquals( $new_timezone_string, $model_b1->get_timezone() );
 		//and that the model's entity map has been reset
 		$this->assertNull( $model_b1->get_from_entity_map( $e->ID() ) );
+        update_option('timezone_string', $original_timezone);
 	}
 
 
@@ -780,7 +783,6 @@ class EE_Registry_Test extends EE_UnitTestCase{
         EE_Registry_Mock::instance()->removeAddon('foobar');
         $this->assertTrue(true);
     }
-
 }
 // End of file EE_Registry_Test.php
 // Location: /tests/testcases/core/EE_Registry_Test.php

--- a/tests/testcases/core/admin/EE_Admin_Tests.php
+++ b/tests/testcases/core/admin/EE_Admin_Tests.php
@@ -30,6 +30,7 @@ class EE_Admin_Tests extends EE_UnitTestCase {
         $this->loader->getShared('EE_Admin');
         $this->setupRequest();
         $this->admin = EE_Admin::reset();
+        $this->loadFactories();
     }
 	/**
 	 * test whether EE_Admin is loaded correctly

--- a/tests/testcases/core/db_classes/EE_Base_Class_Test.php
+++ b/tests/testcases/core/db_classes/EE_Base_Class_Test.php
@@ -1,7 +1,11 @@
 <?php
 
+/** @noinspection PhpParamsInspection */
+/** @noinspection PhpUndefinedClassInspection */
+
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+
 
 /**
  * EE_Base_Class_Test
@@ -52,7 +56,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
 
     /**
-     * @return \EE_Attendee
+     * @return EE_Attendee
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_new_instance()
     {
@@ -66,6 +72,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * @group 9273
      * @see   https://events.codebasehq.com/projects/event-espresso/tickets/9273
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_new_instance_with_existing_object_and_incoming_date_formats()
     {
@@ -88,32 +96,44 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_set_and_get()
     {
         $a = EE_Attendee::new_instance();
         $a->set('ATT_fname', 'value1');
-        $this->assertEquals($a->get('ATT_fname'), 'value1');
+        $this->assertEquals('value1', $a->get('ATT_fname'));
         //verify that we can change it
         $a->set('ATT_fname', 'value2');
-        $this->assertEquals($a->get('ATT_fname'), 'value2');
+        $this->assertEquals('value2', $a->get('ATT_fname'));
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_set_and_get_with_caching()
     {
         $t = EE_Transaction::new_instance();
         $t->set('TXN_total', 10.53);
-        $this->assertEquals($t->get('TXN_total'), 10.53);
-        $this->assertEquals($t->get_pretty('TXN_total'), '$10.53 <span class="currency-code">(USD)</span>');
+        $this->assertEquals(10.53, $t->get('TXN_total'));
+        $this->assertEquals('$10.53 <span class="currency-code">(USD)</span>', $t->get_pretty('TXN_total'));
         //make sure the caching of pretty and normal fields doesn't mess us up
-        $this->assertEquals($t->get('TXN_total'), 10.53);
+        $this->assertEquals(10.53, $t->get('TXN_total'));
         $t->set('TXN_total', 0.00);
-        $this->assertEquals($t->get('TXN_total'), 0);
-        $this->assertEquals($t->get_pretty('TXN_total'), '$0.00 <span class="currency-code">(USD)</span>');
-        $this->assertEquals($t->get('TXN_total'), 0);
+        $this->assertEquals(0, $t->get('TXN_total'));
+        $this->assertEquals('$0.00 <span class="currency-code">(USD)</span>', $t->get_pretty('TXN_total'));
+        $this->assertEquals(0, $t->get('TXN_total'));
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_save_string_pk()
     {
         //test saving something with an auto-increment PK
@@ -126,6 +146,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_save_autoincrement_pk()
     {
         //test saving something with an auto-increment PK
@@ -143,6 +167,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8622
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_save__allow_persist_changed()
     {
@@ -164,7 +190,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * @throws InvalidInterfaceException
      */
    	function test_save_no_pk(){
-        $term_taxonomy = $this->new_model_obj_with_dependencies('Term_Taxonomy', array('taxonomy'=>'monkeys'));
+        $this->new_model_obj_with_dependencies('Term_Taxonomy', array('taxonomy'=>'monkeys'));
         $e = $this->new_model_obj_with_dependencies('Event');
         $tr = EE_Term_Relationship::new_instance(array('object_id'=>$e->ID()));
         $results = $tr->save();
@@ -172,6 +198,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_add_relation_to()
     {
@@ -268,6 +296,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_add_relation_to__unsaved()
     {
@@ -283,6 +313,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 7084
+     * @throws EE_Error
      */
     function test_set_defaults_on_unspecified_fields()
     {
@@ -294,6 +325,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_get_first_related()
     {
         $t = EE_Transaction::new_instance();
@@ -308,6 +343,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_get_many_related()
     {
         $t = EE_Transaction::new_instance();
@@ -326,14 +365,18 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_cache_related()
     {
         $t = EE_Transaction::new_instance();
         //note that we did NOT save it
         $r = EE_Registration::new_instance();
         $t->_add_relation_to($r, 'Registration');
-        $this->assertEquals($t->ID(), 0);
-        $this->assertEquals($r->ID(), 0);
+        $this->assertEquals(0, $t->ID());
+        $this->assertEquals(0, $r->ID());
         //get the registration cached on the transaction
         $r_from_t = $t->get_first_related('Registration');
         $this->assertEquals($r, $r_from_t);
@@ -342,6 +385,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_remove_relation_to()
     {
@@ -366,6 +411,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_remove_relations()
     {
@@ -387,24 +434,32 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_count_related()
     {
         $e1 = EE_Event::new_instance(array('EVT_name' => '1'));
         $e1->save();
-        $this->assertNotEquals($e1->ID(), 0);
+        $this->assertNotEquals(0, $e1->ID());
         $e2 = EE_Event::new_instance(array('EVT_name' => '2'));
         $e2->save();
-        $this->assertNotEquals($e2->ID(), 0);
+        $this->assertNotEquals(0, $e2->ID());
         $e3 = EE_Event::new_instance(array('EVT_name' => '3'));
         $e3->save();
         $v = EE_Venue::new_instance(array('VNU_name' => 'v1'));
         $v->save();
         $v->_add_relation_to($e1, 'Event');
         $v->_add_relation_to($e2, 'Event');
-        $this->assertEquals($v->count_related('Event'), 2);
+        $this->assertEquals(2, $v->count_related('Event'));
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_sum_related()
     {
         $t = EE_Transaction::new_instance();
@@ -415,12 +470,16 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         $p2->save();
         $p1 = EE_Payment::new_instance(array('PAY_amount' => 1000, 'TXN_ID' => 0));
         $p1->save();
-        $this->assertEquals($t->sum_related('Payment', array(), 'PAY_amount'), 3);
+        $this->assertEquals(3, $t->sum_related('Payment', array(), 'PAY_amount'));
         $t->_remove_relation_to($p2, 'Payment');
-        $this->assertEquals($t->sum_related('Payment', array(), 'PAY_amount'), 1);
+        $this->assertEquals(1, $t->sum_related('Payment', array(), 'PAY_amount'));
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_cache_specifying_id()
     {
         $t = EE_Transaction::new_instance();
@@ -439,6 +498,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_update_cache_after_save()
     {
         $t = EE_Transaction::new_instance();
@@ -454,6 +517,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_is_set()
     {
         $t = EE_Transaction::new_instance();
@@ -464,6 +531,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * tests that clearing all from a cache works as expected
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_clear_cache__all()
     {
@@ -495,6 +565,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * test that after we've cached something, we can remove it specifically
      * by only knowing the object
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_clear_cache__specific_object()
     {
@@ -520,6 +593,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * test that after we've cached something using a specific index,
      * we can remove it using a specific index
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_clear_cache__specific_index()
     {
@@ -542,6 +618,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * tests that clearing the cache on a belongsTo relation works
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     function test_clear_cache__belongs_to()
     {
@@ -558,6 +637,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     function test_set_and_get_extra_meta()
     {
         $e = EE_Event::new_instance();
@@ -573,10 +656,13 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * Created to attempt to reproduce a bug found when fixing
      * https://events.codebasehq.com/projects/event-espresso/tickets/6373
      *
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.5.0
      */
     function test_set_primary_key_clear_relations()
     {
+        $this->loadFactories();
         /** @type EE_Event $event */
         $event = $this->factory->event->create();
         /** @type EE_Datetime $datetime */
@@ -620,6 +706,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 7151
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_in_entity_map()
     {
@@ -650,6 +738,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 7151
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_refresh_from_db()
     {
@@ -670,6 +760,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function test_delete_permanently_with_extra_meta()
     {
         $attendee = EE_Attendee::new_instance(array(
@@ -687,6 +781,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 7358
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_get_raw()
     {
@@ -708,6 +804,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * Tests when we set a field to INFINITY, it stays that way even after we re-fetch it from the db
      *
      * @group 7358
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_infinite_fields_stay_that_way()
     {
@@ -722,6 +820,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
 
     /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @throws Exception
      * @since 4.6.12+
      */
     public function test_get_i18n_datetime()
@@ -729,6 +830,12 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         //setup a datetime object with some known values for testing with.
         $original_timezone = get_option('timezone_string');
         update_option('timezone_string', 'America/Toronto');
+        $this->loadFactories();
+        $this->assertEquals(
+            'America/Toronto',
+            EEM_Datetime::instance()->get_timezone(),
+            'Timezones for EEM_Datetime has not been set correctly'
+        );
         $dateTimeZone = new DateTimeZone('America/Toronto');
         $currentTime = new DateTime("now", $dateTimeZone);
         $futureTime = clone $currentTime;
@@ -738,8 +845,16 @@ class EE_Base_Class_Test extends EE_UnitTestCase
             'DTT_EVT_start' => $currentTime->format('Y-m-d H:i:s'),
             'DTT_EVT_end'   => $futureTime->format('Y-m-d H:i:s'),
             'formats'       => array('Y-m-d', 'H:i:s'),
+            'timezone'      => 'America/Toronto'
         ));
+        $this->assertEquals(
+            'America/Toronto',
+            $datetime->get_timezone(),
+            'Timezone on EE_Datetime factory object has not been set correctly'
+        );
         $this->assertInstanceOf('EE_Datetime', $datetime);
+        $this->assertInstanceOf('DateTime', $datetime->get_DateTime_object('DTT_EVT_start'));
+        $this->assertInstanceOf('DateTime', $datetime->get_DateTime_object('DTT_EVT_end'));
         //test get_i18n_datetime
         $this->assertEquals($currentTime->format('Y-m-d H:i:s'), $datetime->get_i18n_datetime('DTT_EVT_start'));
         $this->assertEquals($futureTime->format('Y-m-d H:i:s'), $datetime->get_i18n_datetime('DTT_EVT_end'));
@@ -758,6 +873,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
 
     /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @throws Exception
      * @since 4.7.0
      * Note: in this test we're using EE_Datetime methods that utilize this method on
      * EE_Base_Class
@@ -767,6 +885,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         //setup a datetime object with some known values for testing with.
         $original_timezone = get_option('timezone_string');
         update_option('timezone_string', 'America/Toronto');
+        $this->loadFactories();
         $dateTimeZone = new DateTimeZone('America/Toronto');
         $currentTime = new DateTime("now", $dateTimeZone);
         $futureTime = clone $currentTime;
@@ -791,9 +910,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         );
         //test setting the time to 8am using a time string.
         $datetime->set_start_time('8:00:00');
-        $this->assertEquals($currentTime->setTime(8, 0, 0)->format('Y-m-d H:i:s'), $datetime->get('DTT_EVT_start'));
+        $this->assertEquals($currentTime->setTime(8, 0)->format('Y-m-d H:i:s'), $datetime->get('DTT_EVT_start'));
         //test setting the time to 11pm using a date object
-        $currentTime->setTime(23, 0, 0);
+        $currentTime->setTime(23, 0);
         $datetime->set_start_time($currentTime);
         $this->assertEquals($currentTime->format('Y-m-d H:i:s'), $datetime->get('DTT_EVT_start'));
         //test setting the date to 12-31-2012 on start date using a date string.
@@ -814,6 +933,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      */
     public function test_next_x()
     {
+        $this->loadFactories();
         //create 5 events for testing with.
         $events = $this->factory->event->create_many(5);
         //grab the first event in the list as the reference
@@ -837,7 +957,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         //loop through and verify the IDS returned are correct.
         $pointer = 1;
         foreach ($next_events as $next_event) {
-            $this->assertTrue(array_key_exists('EVT_ID', $next_event));
+            $this->assertArrayHasKey('EVT_ID', $next_event);
             $this->assertEquals($event->ID() + $pointer, $next_event['EVT_ID']);
             $pointer++;
         }
@@ -849,6 +969,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      */
     public function test_previous_x()
     {
+        $this->loadFactories();
         //create 5 events for testing with.
         $events = $this->factory->event->create_many(5);
         //grab the last event in the list as the reference
@@ -872,7 +993,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         //loop through and verify the IDS returned are correct.
         $pointer = 1;
         foreach ($previous_events as $next_event) {
-            $this->assertTrue(array_key_exists('EVT_ID', $next_event));
+            $this->assertArrayHasKey('EVT_ID', $next_event);
             $this->assertEquals($event->ID() - $pointer, $next_event['EVT_ID']);
             $pointer++;
         }
@@ -884,6 +1005,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      */
     public function test_next()
     {
+        $this->loadFactories();
         //create 5 events for testing with.
         $events = $this->factory->event->create_many(5);
         //grab the first event in the list as the reference
@@ -898,7 +1020,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         $next_event = $event->next('EVT_ID', array(), 'EVT_ID');
         //verify the returned array has the right key and value.
         $this->assertTrue(is_array($next_event));
-        $this->assertTrue(array_key_exists('EVT_ID', $next_event));
+        $this->assertArrayHasKey('EVT_ID', $next_event);
         $this->assertEquals($event->ID() + 1, $next_event['EVT_ID']);
     }
 
@@ -908,6 +1030,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      */
     public function test_previous()
     {
+        $this->loadFactories();
         //create 5 events for testing with.
         $events = $this->factory->event->create_many(5);
         //grab the last event in the list as the reference
@@ -922,7 +1045,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         $previous_event = $event->previous('EVT_ID', array(), 'EVT_ID');
         //verify the returned array has the right key and value.
         $this->assertTrue(is_array($previous_event));
-        $this->assertTrue(array_key_exists('EVT_ID', $previous_event));
+        $this->assertArrayHasKey('EVT_ID', $previous_event);
         $this->assertEquals($event->ID() - 1, $previous_event['EVT_ID']);
     }
 
@@ -930,6 +1053,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * @group github-102
      * @group 8589
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_get__serialized_data__once()
     {
@@ -956,6 +1081,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * @group github-102
      * @group 8589
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_get__serialized_data__twice()
     {
@@ -981,10 +1108,14 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_delete__remove_from_related_items_in_entity_mapper()
     {
+        /** @var EE_Payment $p */
         $p = $this->new_model_obj_with_dependencies('Payment');
+        /** @var EE_Registration $r */
         $r = $this->new_model_obj_with_dependencies('Registration');
         $p->_add_relation_to($r, 'Registration');
         $reg_payments = $p->registration_payments();
@@ -1003,6 +1134,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
 
     /**
      * @group 8686
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_remove_relation_to__reciprocal()
     {
@@ -1019,7 +1152,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
                 $this->assertEquals($registration, $p->_remove_relation_to($registration, 'Registration'));
             }
         }
-        //now there shoudl eb no more relations between those two right?
+        //now there should eb no more relations between those two right?
         $regs_on_p = $p->get_many_related('Registration');
         $pays_on_r = $r->get_many_related('Payment');
         $this->assertTrue(empty($regs_on_p));
@@ -1032,6 +1165,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      *
      * @group 10751
      * @group 10905
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_automatically_set_timezone_on_related_model_obj__same_request()
     {
@@ -1039,6 +1174,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
         $dtt = $this->new_model_obj_with_dependencies('Datetime');
         $event = EEM_Event::instance()->get_one_by_ID($dtt->get('EVT_ID'));
         $event->set_timezone('Europe/London');
+        //first check we haven't accidentally changed the event's timezone
+        $this->assertEquals('Europe/London', $event->get_timezone());
         $dtt = $event->get_first_related('Datetime');
         //first check we haven't accidentally changed the event's timezone
         $this->assertEquals('Europe/London', $event->get_timezone());
@@ -1051,8 +1188,10 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * Verifies that when we set the timezone on a model object, related objects adopt that same timezone
      *
      * @group 10905
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function setTimezone()
+    public function testSetTimezone()
     {
         $t = $this->new_typical_transaction();
         $datetime = EEM_Datetime::instance()->get_one(array(array('EVT_ID' => $t->primary_registration()->event_ID())));
@@ -1078,6 +1217,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * across multiple requests.
      *
      * @group 10751
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function test_automatically_set_timezone_on_related_model_obj__separate_requests()
     {
@@ -1101,6 +1242,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * Tests that the f() function correctly escapes the value for display in a form input's value.
      *
      * @group 11195
+     * @throws EE_Error
      */
     public function testF()
     {
@@ -1126,6 +1268,8 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * when the form is submitted, that we end up with the same content that we started with.
      *
      * @group 11195
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function testFThenSetRoundTrip()
     {
@@ -1159,7 +1303,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
      * @throws ReflectionException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
-     * @throws \PHPUnit\Framework\Exception
+     * @throws PHPUnit\Framework\Exception
      */
     public function testGetDateTimeObject()
     {
@@ -1217,6 +1361,7 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     {
         $original_sold_count = 5;
         $original_reserved_count = 10;
+        /** @var EE_Datetime $d */
         $d = $this->new_model_obj_with_dependencies(
             'Datetime',
             [

--- a/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
+++ b/tests/testcases/core/db_classes/EE_CPT_Base_Test.php
@@ -153,6 +153,7 @@ class EE_CPT_Base_Test extends EE_UnitTestCase{
      */
     public function testAddEventCategoryNoDuplicates()
     {
+        $this->loadFactories();
         $e = $this->new_model_obj_with_dependencies('Event');
         $wp_term = $this->factory()->term->create_and_get(
             array(

--- a/tests/testcases/core/db_classes/EE_Datetime_Test.php
+++ b/tests/testcases/core/db_classes/EE_Datetime_Test.php
@@ -151,6 +151,7 @@ class EE_Datetime_Test extends EE_UnitTestCase{
 		//setup some dates we'll use for testing with.
 		$timezone = new DateTimeZone( 'America/Toronto' );
         $now_for_test = new DateTime( 'now', $timezone );
+        $this->loadFactories();
         // set time explicitly
         $now_for_test->setTime(14, 00);
         $upcoming_start_date = clone $now_for_test;
@@ -213,6 +214,7 @@ class EE_Datetime_Test extends EE_UnitTestCase{
 		//setup a datetime for testing
 		$start_date = new DateTime( 'now' );
 		$end_date = new DateTime( 'now + 3 hours' );
+        $this->loadFactories();
 		$datetime = $this->factory->datetime->create(
 			array(
 				'DTT_EVT_start' => $start_date->format( 'Y-m-d H:i:s' ),

--- a/tests/testcases/core/db_classes/EE_Ticket_Test.php
+++ b/tests/testcases/core/db_classes/EE_Ticket_Test.php
@@ -137,6 +137,7 @@ class EE_Ticket_Test extends EE_UnitTestCase
      */
     public function test_get_related_event_exception()
     {
+        $this->loadFactories();
         //create a ticket (it won't have any datetime).
         /** @var EE_Ticket $ticket */
         $ticket = $this->factory->ticket->create();

--- a/tests/testcases/core/db_classes/EE_Transaction_Test.php
+++ b/tests/testcases/core/db_classes/EE_Transaction_Test.php
@@ -69,6 +69,7 @@ class EE_Transaction_Test extends EE_UnitTestCase {
 	 */
 	public function test_datetime() {
 		$now = new DateTime( "now", new DateTimeZone( 'America/Vancouver' ) );
+        $this->loadFactories();
 		$DateTimeZoneAbbr = $now->format( 'T' );
 		// Now get the transaction's time
 		$format_to_use = get_option( 'date_format' ) . ' ' . 'H:i:s';
@@ -111,6 +112,7 @@ class EE_Transaction_Test extends EE_UnitTestCase {
 	 * @throws \EE_Error
 	 */
 	public function test_is_locked() {
+        $this->loadFactories();
 		/** @type EE_Transaction $transaction */
 		$transaction = $this->factory->transaction->create();
 		// initial state should be unlocked
@@ -133,6 +135,7 @@ class EE_Transaction_Test extends EE_UnitTestCase {
 
 
 	public function test_lock() {
+        $this->loadFactories();
 		/** @type EE_Transaction $transaction */
 		$transaction = $this->factory->transaction->create();
 		// initial state should be unlocked
@@ -160,6 +163,7 @@ class EE_Transaction_Test extends EE_UnitTestCase {
 	 * @throws \EE_Error
 	 */
 	public function test_unlock() {
+        $this->loadFactories();
 		/** @type EE_Transaction $transaction */
 		$transaction = $this->factory->transaction->create();
 		// initial state should be unlocked

--- a/tests/testcases/core/db_classes/EE_Venue_Test.php
+++ b/tests/testcases/core/db_classes/EE_Venue_Test.php
@@ -1,72 +1,102 @@
 <?php
 
-if (!defined('EVENT_ESPRESSO_VERSION'))
-	exit('No direct script access allowed');
+if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
+}
 
 /**
  *
  * EE_Venue_Test
  *
- * @package		Event Espresso
- * @subpackage  	tests
- * @author		Darren Ethier
- * @since 4.6
+ * @package        Event Espresso
+ * @subpackage     tests
+ * @author         Darren Ethier
+ * @since          4.6
  */
+
 /**
  * @group core/db_classes
  */
-class EE_Venue_Test extends EE_UnitTestCase{
+class EE_Venue_Test extends EE_UnitTestCase
+{
 
 
+    /**
+     * Test the events() method
+     *
+     * @since 4.6
+     */
+    public function test_events()
+    {
+        $this->loadFactories();
+        $timezone_string = 'America/Toronto';
+        update_option('timezone_string', $timezone_string);
+        //setup some dates we'll use for testing with.
+        $timezone            = new DateTimeZone($timezone_string);
+        $upcoming_start_date = new DateTime("now +2hours", $timezone);
+        $past_start_date     = new DateTime("now -5days", $timezone);
+        $current_end_date    = new DateTime("now +2hours", $timezone);
+        $current             = new DateTime("now", $timezone);
+        $formats             = ['d/m Y', 'h:i:s a'];
+        $full_format         = implode(' ', $formats);
+
+        //setup some datetimes for event testing.
+        $datetimes = [
+            'expired_datetime'  => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $past_start_date->format($full_format),
+                    'DTT_EVT_end'   => $past_start_date->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'upcoming_datetime' => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'active_datetime'   => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $current->format($full_format),
+                    'DTT_EVT_end'   => $current_end_date->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'sold_out_datetime' => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'DTT_reg_limit' => 10,
+                    'DTT_sold'      => 10,
+                    'formats'       => $formats,
+                ]
+            ),
+        ];
 
 
-	/**
-	 * Test the events() method
-	 * @since 4.6
-	 */
-	public function test_events() {
-		//setup some dates we'll use for testing with.
-		$timezone = new DateTimeZone( 'America/Toronto' );
-		$upcoming_start_date = new DateTime( "now +2hours", $timezone );
-		$past_start_date = new DateTime( "now -5days", $timezone );
-		$current_end_date = new DateTime( "now +2hours", $timezone );
-		$current = new DateTime( "now", $timezone );
-		$formats = array( 'd/m Y',  'h:i:s a' );
-		$full_format = implode( ' ', $formats );
+        $venue = $this->factory->venue->create();
+        //assign events to the datetimes and then the events to the venue.
+        foreach ($datetimes as $type => $datetime) {
+            $event = $this->factory->event->create();
+            $event->set_timezone($timezone_string);
+            $event->set('status', 'publish');
+            $event->_add_relation_to($datetime, 'Datetime');
+            $event->save();
+            $venue->_add_relation_to($event, 'Event');
+            $venue->save();
+        }
 
-		//setup some datetimes for event testing.
-		$datetimes = array(
-			'expired_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $past_start_date->format( $full_format ), 'DTT_EVT_end' => $past_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'upcoming_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' => $formats ) ),
-			'active_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $current->format( $full_format ), 'DTT_EVT_end' => $current_end_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'sold_out_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'DTT_reg_limit' => 10, 'DTT_sold' => 10,  'timezone' => 'America/Toronto', 'formats' =>  $formats ) )
-			);
+        //test with upcoming as false.  Should return 4 events.
+        $events = $venue->events();
+        $this->assertEquals(4, count($events));
+        $this->assertInstanceOf('EE_Event', reset($events));
 
-
-		$venue = $this->factory->venue->create();
-		//assign events to the datetimes and then the events to the venue.
-		foreach ( $datetimes as $type => $datetime ) {
-			$event = $this->factory->event->create();
-			$event->set_timezone( 'America/Toronto' );
-			$event->set('status', 'publish');
-			$event->_add_relation_to( $datetime, 'Datetime' );
-			$event->save();
-			$venue->_add_relation_to($event, 'Event');
-			$venue->save();
-		}
-
-		//test with upcoming as false.  Should return 4 events.
-		$events = $venue->events();
-		$this->assertEquals( 4, count($events) );
-		$this->assertInstanceOf( 'EE_Event', reset($events) );
-
-		//test with upcoming as true.  Should return 2 events.
-		$events = $venue->events(array(), true);
-		$this->assertEquals( 2, count($events) );
-		$this->assertInstanceOf( 'EE_Event', reset($events) );
-
-	}
-
+        //test with upcoming as true.  Should return 2 events.
+        $events = $venue->events([], true);
+        $this->assertEquals(2, count($events));
+        $this->assertInstanceOf('EE_Event', reset($events));
+    }
 
 
 }// end class EE_Venue_Test

--- a/tests/testcases/core/db_models/EEM_Attendee_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Attendee_Caps_Test.php
@@ -26,6 +26,7 @@ class EEM_Attendee_Caps_Test extends EE_UnitTestCase
      */
     function test_get_all__caps()
     {
+        $this->loadFactories();
         $query_params_with_read_caps = ['caps' => EEM_Base::caps_read];
 
         global $current_user;

--- a/tests/testcases/core/db_models/EEM_CPT_Base_Test.php
+++ b/tests/testcases/core/db_models/EEM_CPT_Base_Test.php
@@ -26,6 +26,7 @@ class EEM_CPT_Base_Test extends EE_UnitTestCase
      */
     public function test_get_minimum_where_conditions_during_query()
     {
+        $this->loadFactories();
         $this->assertEquals(0, EEM_Event::instance()->count(array('default_where_conditions' => 'none')));
         $e_normal = $this->new_model_obj_with_dependencies('Event',
             array('status' => EEM_CPT_Base::post_status_publish));

--- a/tests/testcases/core/db_models/EEM_Datetime_Test.php
+++ b/tests/testcases/core/db_models/EEM_Datetime_Test.php
@@ -16,16 +16,20 @@
  */
 class EEM_Datetime_Test extends EE_UnitTestCase {
 
+    private $original_timezone = '';
+
     public function setUp() {
+        $this->original_timezone = get_option('timezone_string');
         parent::setUp();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option( 'timezone_string', 'Australia/Sydney' );
+        $this->loadFactories();
     }
 
 
 	public function tearDown(){
 		//restore the timezone string to the default
-		update_option( 'timezone_string', '' );
+		update_option( 'timezone_string', $this->original_timezone );
 		parent::tearDown();
 	}
 
@@ -364,8 +368,10 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
 
 
 	public function test_get_dtt_months_and_years() {
+        $timezone_string = 'America/Toronto';
+        update_option('timezone_string', $timezone_string);
 		//setup some dates we'll use for testing with.
-		$timezone = new DateTimeZone( 'America/Toronto' );
+		$timezone = new DateTimeZone($timezone_string );
 		$upcoming_start_date = new DateTime( "now +2hours", $timezone );
 		$past_start_date = new DateTime( "now -2days", $timezone );
 		$current_end_date = new DateTime( "now +2days", $timezone );
@@ -379,7 +385,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
                 array(
                     'DTT_EVT_start' => $past_start_date->format($full_format),
                     'DTT_EVT_end'   => $past_start_date->format($full_format),
-                    'timezone'      => 'America/Toronto',
                     'formats'       => $formats,
                 )
             ),
@@ -387,7 +392,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
                 array(
                     'DTT_EVT_start' => $upcoming_start_date->format($full_format),
                     'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
-                    'timezone'      => 'America/Toronto',
                     'formats'       => $formats,
                 )
             ),
@@ -395,7 +399,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
                 array(
                     'DTT_EVT_start' => $current->sub(new DateInterval("PT2H"))->format($full_format),
                     'DTT_EVT_end'   => $current_end_date->add(new DateInterval("PT2H"))->format($full_format),
-                    'timezone'      => 'America/Toronto',
                     'formats'       => $formats,
                 )
             ),
@@ -405,7 +408,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
                     'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
                     'DTT_reg_limit' => 10,
                     'DTT_sold'      => 10,
-                    'timezone'      => 'America/Toronto',
                     'formats'       => $formats,
                 )
             ),
@@ -413,7 +415,6 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
                 array(
                     'DTT_EVT_start' => $current->format($full_format),
                     'DTT_EVT_end'   => $current_end_date->format($full_format),
-                    'timezone'      => 'America/Toronto',
                     'formats'       => $formats,
                 )
             ),

--- a/tests/testcases/core/db_models/EEM_Event_Test.php
+++ b/tests/testcases/core/db_models/EEM_Event_Test.php
@@ -2,9 +2,9 @@
 /**
  * Contains test class for /core/db_models/EEM_Event.model.php
  *
- * @since  		4.6.x
- * @package 		Event Espresso
- * @subpackage 	tests
+ * @since          4.6.x
+ * @package        Event Espresso
+ * @subpackage     tests
  */
 
 use EventEspresso\core\exceptions\InvalidDataTypeException;
@@ -13,162 +13,218 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 /**
  * All tests for the EEM_Event class.
  *
- * @since 		4.6.x
- * @package 		Event Espresso
- * @subpackage 	tests
- * @group core/db_models
+ * @since          4.6.x
+ * @package        Event Espresso
+ * @subpackage     tests
+ * @group          core/db_models
  */
-class EEM_Event_Test extends EE_UnitTestCase {
+class EEM_Event_Test extends EE_UnitTestCase
+{
+
+    private $original_timezone = '';
 
 
-    public function setUp() {
+    public function setUp()
+    {
+        $this->original_timezone = get_option('timezone_string');
         parent::setUp();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
-        update_option( 'timezone_string', 'Australia/Sydney' );
+        update_option('timezone_string', 'Australia/Sydney');
+        $this->loadFactories();
     }
 
 
-	public function tearDown() {
-		//restore the timezone string to the default
-		update_option( 'timezone_string', '' );
-		parent::tearDown();
-	}
+    public function tearDown()
+    {
+        //restore the timezone string to the default
+        update_option('timezone_string', $this->original_timezone);
+        parent::tearDown();
+    }
 
-
-
-	/**
-	 * This just sets up some events in the db for running certain tests that query getting events back.
-	 * @since 4.6.x
-	 */
-	protected function _setup_events() {
-		//setup some dates we'll use for testing with.
-		$timezone = new DateTimeZone( 'America/Toronto' );
-		$upcoming_start_date = new DateTime( "now +2hours", $timezone );
-		$past_start_date = new DateTime( "now -2days", $timezone );
-		$current_end_date = new DateTime( "now +2days", $timezone );
-		$current = new DateTime( "now", $timezone );
-		$formats = array( 'Y-d-m',  'h:i a' );
-		$full_format = implode( ' ', $formats );
-
-		//setup some datetimes to attach to events.
-		$datetimes = array(
-			'expired_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $past_start_date->format( $full_format ), 'DTT_EVT_end' => $past_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'upcoming_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'timezone' => 'America/Toronto', 'formats' => $formats ) ),
-			'active_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $current->sub( new DateInterval( "PT2H") )->format( $full_format ), 'DTT_EVT_end' => $current_end_date->add( new DateInterval( "PT2H" ) )->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'sold_out_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $upcoming_start_date->format( $full_format ), 'DTT_EVT_end' => $upcoming_start_date->format( $full_format), 'DTT_reg_limit' => 10, 'DTT_sold' => 10,  'timezone' => 'America/Toronto', 'formats' =>  $formats ) ),
-			'inactive_datetime' => $this->factory->datetime->create( array( 'DTT_EVT_start' => $current->sub( new DateInterval( "PT2H") )->format( $full_format ), 'DTT_EVT_end' => $current_end_date->add( new DateInterval( "PT2H" ) )->format( $full_format), 'timezone' => 'America/Toronto', 'formats' =>  $formats ) )
-			);
-
-		//setup some events
-        /** @var EE_Event[] $events */
-        $events = $this->factory->event->create_many( '4' );
-
-		//add datetimes to the events.
-		$events[0]->_add_relation_to( $datetimes['expired_datetime'], 'Datetime' );
-		$events[0]->save();
-		$events[1]->_add_relation_to( $datetimes['upcoming_datetime'], 'Datetime' );
-		$events[1]->save();
-		$events[2]->_add_relation_to( $datetimes['active_datetime'], 'Datetime' );
-		$events[2]->save();
-		$events[3]->_add_relation_to( $datetimes['sold_out_datetime'], 'Datetime' );
-		$events[3]->save();
-
-		foreach( $events as $event ) {
-			$event->set('status', 'publish');
-			$event->save();
-		}
-
-		//one more event that is just going to be inactive
-        /** @var EE_Event $final_event */
-        $final_event = $this->factory->event->create();
-		$final_event->_add_relation_to( $datetimes['inactive_datetime'], 'Datetime' );
-		$final_event->save();
-
-	}
-
-
-
-	/**
-	 * This tests getting active events.
-	 * @since 4.6.x
-	 */
-	public function test_get_active_events() {
-		$this->_setup_events();
-		//now do our tests
-		$this->assertEquals( 1, EEM_Event::instance()->get_active_events( array(), true ) );
-	}
-
-
-	public function test_get_upcoming_events() {
-		$this->_setup_events();
-		//now do our tests
-		$this->assertEquals( 2, EEM_Event::instance()->get_upcoming_events( array(), true ) );
-	}
-
-
-	public function test_get_expired_events() {
-		$this->_setup_events();
-		//now do our tests
-		$this->assertEquals( 1, EEM_Event::instance()->get_expired_events( array(), true ) );
-	}
-
-	public function test_get_inactive_events() {
-		$this->_setup_events();
-		//now do our tests
-		$this->assertEquals( 1, EEM_Event::instance()->get_inactive_events( array(), true ) );
-	}
-
-	public function test_get_active_and_upcoming_events() {
-		$this->_setup_events();
-		//now do our tests
-		$this->assertEquals( 3, EEM_Event::instance()->get_active_and_upcoming_events( array(), true ) );
-	}
-
-
-	/**
-	 * @see https://events.codebasehq.com/projects/event-espresso/tickets/8799
-	 * @group 8799
-	 * @since 4.8.8.rc.019
-	 */
-	public function test_default_reg_status() {
-		//first verify the default reg status on config is pending payment
-		$this->assertEquals( EEM_Registration::status_id_pending_payment, EE_Registry::instance()->CFG->registration->default_STS_ID );
-
-		//verify creating default event from the model has that default reg status
-		/** @type EE_Event $event */
-		$event = EEM_Event::instance()->create_default_object();
-		$this->assertEquals( EEM_Registration::status_id_pending_payment, $event->default_registration_status() );
-
-		//let's update config in the db to have default reg status of approved
-		EE_Registry::instance()->CFG->registration->default_STS_ID = EEM_Registration::status_id_approved;
-		EE_Registry::instance()->CFG->update_espresso_config();
-
-		//let's reset for new test
-		EEM_Event::reset();
-		EE_Registry::reset();
-
-		//k NOW the default reg status in config should be approved
-		$this->assertEquals( EEM_Registration::status_id_approved, EE_Registry::instance()->CFG->registration->default_STS_ID );
-
-		//new default event should have approved as the default reg status
-		$event = EEM_Event::instance()->create_default_object();
-		$this->assertEquals( EEM_Registration::status_id_approved, $event->default_registration_status() );
-	}
 
     /**
-     * @since 4.10.0.p
+     * This just sets up some events in the db for running certain tests that query getting events back.
+     *
+     * @since 4.6.x
+     */
+    protected function _setup_events()
+    {
+        $timezone_string = 'America/Toronto';
+        update_option('timezone_string', $timezone_string);
+        //setup some dates we'll use for testing with.
+        $timezone            = new DateTimeZone($timezone_string);
+        $upcoming_start_date = new DateTime("now +2hours", $timezone);
+        $past_start_date     = new DateTime("now -2days", $timezone);
+        $current_end_date    = new DateTime("now +2days", $timezone);
+        $current             = new DateTime("now", $timezone);
+        $formats             = ['Y-d-m', 'h:i a'];
+        $full_format         = implode(' ', $formats);
+
+        //setup some datetimes to attach to events.
+        $datetimes = [
+            'expired_datetime'  => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $past_start_date->format($full_format),
+                    'DTT_EVT_end'   => $past_start_date->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'upcoming_datetime' => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'active_datetime'   => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $current->sub(new DateInterval("PT2H"))->format($full_format),
+                    'DTT_EVT_end'   => $current_end_date->add(new DateInterval("PT2H"))->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+            'sold_out_datetime' => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $upcoming_start_date->format($full_format),
+                    'DTT_EVT_end'   => $upcoming_start_date->format($full_format),
+                    'DTT_reg_limit' => 10,
+                    'DTT_sold'      => 10,
+                    'formats'       => $formats,
+                ]
+            ),
+            'inactive_datetime' => $this->factory->datetime->create(
+                [
+                    'DTT_EVT_start' => $current->sub(new DateInterval("PT2H"))->format($full_format),
+                    'DTT_EVT_end'   => $current_end_date->add(new DateInterval("PT2H"))->format($full_format),
+                    'formats'       => $formats,
+                ]
+            ),
+        ];
+
+        //setup some events
+        /** @var EE_Event[] $events */
+        $events = $this->factory->event->create_many('4');
+
+        //add datetimes to the events.
+        $events[0]->_add_relation_to($datetimes['expired_datetime'], 'Datetime');
+        $events[0]->save();
+        $events[1]->_add_relation_to($datetimes['upcoming_datetime'], 'Datetime');
+        $events[1]->save();
+        $events[2]->_add_relation_to($datetimes['active_datetime'], 'Datetime');
+        $events[2]->save();
+        $events[3]->_add_relation_to($datetimes['sold_out_datetime'], 'Datetime');
+        $events[3]->save();
+
+        foreach ($events as $event) {
+            $event->set('status', 'publish');
+            $event->save();
+        }
+
+        //one more event that is just going to be inactive
+        /** @var EE_Event $final_event */
+        $final_event = $this->factory->event->create();
+        $final_event->_add_relation_to($datetimes['inactive_datetime'], 'Datetime');
+        $final_event->save();
+    }
+
+
+    /**
+     * This tests getting active events.
+     *
+     * @since 4.6.x
+     */
+    public function test_get_active_events()
+    {
+        $this->_setup_events();
+        //now do our tests
+        $this->assertEquals(1, EEM_Event::instance()->get_active_events([], true));
+    }
+
+
+    public function test_get_upcoming_events()
+    {
+        $this->_setup_events();
+        //now do our tests
+        $this->assertEquals(2, EEM_Event::instance()->get_upcoming_events([], true));
+    }
+
+
+    public function test_get_expired_events()
+    {
+        $this->_setup_events();
+        //now do our tests
+        $this->assertEquals(1, EEM_Event::instance()->get_expired_events([], true));
+    }
+
+
+    public function test_get_inactive_events()
+    {
+        $this->_setup_events();
+        //now do our tests
+        $this->assertEquals(1, EEM_Event::instance()->get_inactive_events([], true));
+    }
+
+
+    public function test_get_active_and_upcoming_events()
+    {
+        $this->_setup_events();
+        //now do our tests
+        $this->assertEquals(3, EEM_Event::instance()->get_active_and_upcoming_events([], true));
+    }
+
+
+    /**
+     * @see   https://events.codebasehq.com/projects/event-espresso/tickets/8799
+     * @group 8799
+     * @since 4.8.8.rc.019
+     */
+    public function test_default_reg_status()
+    {
+        //first verify the default reg status on config is pending payment
+        $this->assertEquals(
+            EEM_Registration::status_id_pending_payment,
+            EE_Registry::instance()->CFG->registration->default_STS_ID
+        );
+
+        //verify creating default event from the model has that default reg status
+        /** @type EE_Event $event */
+        $event = EEM_Event::instance()->create_default_object();
+        $this->assertEquals(EEM_Registration::status_id_pending_payment, $event->default_registration_status());
+
+        //let's update config in the db to have default reg status of approved
+        EE_Registry::instance()->CFG->registration->default_STS_ID = EEM_Registration::status_id_approved;
+        EE_Registry::instance()->CFG->update_espresso_config();
+
+        //let's reset for new test
+        EEM_Event::reset();
+        EE_Registry::reset();
+
+        //k NOW the default reg status in config should be approved
+        $this->assertEquals(
+            EEM_Registration::status_id_approved,
+            EE_Registry::instance()->CFG->registration->default_STS_ID
+        );
+
+        //new default event should have approved as the default reg status
+        $event = EEM_Event::instance()->create_default_object();
+        $this->assertEquals(EEM_Registration::status_id_approved, $event->default_registration_status());
+    }
+
+
+    /**
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @since 4.10.0.p
      */
-	public function testGetQuestionGroupsForEvent()
+    public function testGetQuestionGroupsForEvent()
     {
         $r = $this->new_model_obj_with_dependencies(
             'Registration',
             [
-                'REG_count' => 1
+                'REG_count' => 1,
             ]
         );
         $r->event_obj()->add_question_group(EEM_Question_Group::system_personal, true);

--- a/tests/testcases/core/db_models/EEM_Message_Template_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Message_Template_Caps_Test.php
@@ -24,6 +24,7 @@ class EEM_Message_Template_Caps_Test extends EE_UnitTestCase{
 	 * and then you can edit others if you have that cap
 	 */
 	function test_get_all__caps() {
+        $this->loadFactories();
 		//remove all questions currently existing
 		EEM_Message_Template::instance()->delete( array(), false );
 		$this->assertEquals( 0, EEM_Message_Template::instance()->count() );

--- a/tests/testcases/core/db_models/EEM_Payment_Test.php
+++ b/tests/testcases/core/db_models/EEM_Payment_Test.php
@@ -10,25 +10,6 @@
 class EEM_Payment_Test extends EE_UnitTestCase
 {
 
-
-    public function setUp()
-    {
-        parent::setUp();
-        //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
-        update_option('timezone_string', 'Australia/Sydney');
-    }
-
-
-
-    public function tearDown()
-    {
-        //restore the timezone string to the default
-        update_option('timezone_string', '');
-        parent::tearDown();
-    }
-
-
-
     /**
      * This sets up some payments in the db for testing with.
      *
@@ -38,8 +19,12 @@ class EEM_Payment_Test extends EE_UnitTestCase
      */
     public function _setup_payments(DateTime $now = null, DateTimeZone $timezone = null)
     {
+        // this is purposely a high positive timezone string because it works better for testing expiry times.
+        $timezone_string = 'Australia/Sydney';
+        update_option('timezone_string', $timezone_string);
+        $this->loadFactories();
         // setup DateTimeZone
-        $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone('America/Toronto');
+        $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone_string);
         // and base DateTime for now
         $now = $now instanceof DateTime ? $now : new DateTime('now', $timezone);
         //setup some dates we'll use for testing with.
@@ -59,27 +44,22 @@ class EEM_Payment_Test extends EE_UnitTestCase
         $payment_args = array(
             array(
                 'PAY_timestamp' => $two_days_ago->format(\EE_Datetime_Field::mysql_timestamp_format),
-                'timezone'      => 'America/Toronto',
                 'formats'       => $formats,
             ),
             array(
                 'PAY_timestamp' => $one_hour_from_now->format(\EE_Datetime_Field::mysql_timestamp_format),
-                'timezone'      => 'America/Toronto',
                 'formats'       => $formats,
             ),
             array(
                 'PAY_timestamp' => $two_hours_ago->format(\EE_Datetime_Field::mysql_timestamp_format),
-                'timezone'      => 'America/Toronto',
                 'formats'       => $formats,
             ),
             array(
                 'PAY_timestamp' => $two_days_from_now->format(\EE_Datetime_Field::mysql_timestamp_format),
-                'timezone'      => 'America/Toronto',
                 'formats'       => $formats,
             ),
             array(
                 'PAY_timestamp' => $two_days_ago->format(\EE_Datetime_Field::mysql_timestamp_format),
-                'timezone'      => 'America/Toronto',
                 'formats'       => $formats,
             ),
         );
@@ -96,7 +76,10 @@ class EEM_Payment_Test extends EE_UnitTestCase
      */
     public function test_get_payments_between_dates()
     {
-        $timezone = new DateTimeZone('America/Toronto');
+        // this is purposely a high positive timezone string because it works better for testing expiry times.
+        $timezone_string = 'Australia/Sydney';
+        update_option('timezone_string', $timezone_string);
+        $timezone = new DateTimeZone($timezone_string);
         // set $test_time in the timezone being tested.
         $test_time = new DateTime('now', $timezone);
         $test_time->setTime(14, 00);
@@ -109,7 +92,7 @@ class EEM_Payment_Test extends EE_UnitTestCase
             $test_time->sub(new DateInterval('P2D'))->format('d/m/Y'),
             '',
             'd/m/Y',
-            'America/Toronto'
+            $timezone_string
         );
         $this->assertCount(4, $payments);
         //test including a date from past date for end date.
@@ -117,7 +100,7 @@ class EEM_Payment_Test extends EE_UnitTestCase
             '',
             $test_time->format('d/m/Y'),
             'd/m/Y',
-            'America/Toronto'
+            $timezone_string
         );
         $this->assertCount(4, $payments);
         //test including a date from upcoming date for start date
@@ -125,7 +108,7 @@ class EEM_Payment_Test extends EE_UnitTestCase
             $test_time->add(new DateInterval('P4D'))->format('d/m/Y'),
             '',
             'd/m/Y',
-            'America/Toronto'
+            $timezone_string
         );
         $this->assertCount(3, $payments);
         //test including a date from upcoming date for end date
@@ -133,7 +116,7 @@ class EEM_Payment_Test extends EE_UnitTestCase
             '',
             $test_time->format('d/m/Y'),
             'd/m/Y',
-            'America/Toronto'
+            $timezone_string
         );
         $this->assertCount(3, $payments);
         //test exception

--- a/tests/testcases/core/db_models/EEM_Price_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Price_Caps_Test.php
@@ -89,6 +89,7 @@ class EEM_Price_Caps_Test extends EE_UnitTestCase{
 	public $e_private;
 	public function setUp(){
 		parent::setUp();
+        $this->loadFactories();
 		//let's make sure we start off with NO tickets in the DB
 		EEM_Price::instance()->delete_permanently( EEM_Price::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Price::instance()->count( EEM_Price::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_Question_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Question_Caps_Test.php
@@ -31,6 +31,7 @@ class EEM_Question_Caps_Test extends EE_UnitTestCase{
 	 * and then you can edit others if you have that cap
 	 */
 	function test_get_all__caps__edit() {
+        $this->loadFactories();
 		//remove all questions currently existing
 		EEM_Question::instance()->delete_permanently( EEM_Question::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Question::instance()->count( EEM_Question::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_Question_Group_Question_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Question_Group_Question_Caps_Test.php
@@ -25,6 +25,7 @@ class EEM_Question_Group_Question_Caps_Test extends EE_UnitTestCase{
 	 * and then you can edit others if you have that cap
 	 */
 	function test_get_all__caps__edit() {
+        $this->loadFactories();
 		//verify we only start off with NO question gruops or question group questions
 		EEM_Question_Group::instance()->delete_permanently( EEM_Question_Group::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Question_Group::instance()->count( EEM_Question_Group::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_Registration_Test.php
+++ b/tests/testcases/core/db_models/EEM_Registration_Test.php
@@ -18,16 +18,20 @@
 class EEM_Registration_Test extends EE_UnitTestCase {
 
 
+    private $original_timezone = '';
+
 	public function setUp() {
+        $this->original_timezone = get_option('timezone_string');
 		parent::setUp();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option( 'timezone_string', 'Australia/Sydney' );
+        $this->loadFactories();
 	}
 
 
 	public function tearDown() {
 		//restore the timezone string to the default
-		update_option( 'timezone_string', '' );
+        update_option('timezone_string', $this->original_timezone);
 		parent::tearDown();
 	}
 

--- a/tests/testcases/core/db_models/EEM_Term_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Term_Caps_Test.php
@@ -31,6 +31,7 @@ class EEM_Term_Caps_Test extends EE_UnitTestCase{
 
 	public function setUp(){
 		parent::setUp();
+        $this->loadFactories();
 		$this->event_term = $this->new_model_obj_with_dependencies('Term' );
 		$this->new_model_obj_with_dependencies( 'Term_Taxonomy', array(
 			'term_id' => $this->event_term->ID(),

--- a/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
@@ -41,6 +41,7 @@ class EEM_Term_Relationship_Caps_Test extends EE_UnitTestCase {
 	//don't bother with a private term relationship.
 	public function setUp(){
 		parent::setUp();
+        $this->loadFactories();
 		$this->user = $this->factory->user->create_and_get();
 		$this->my_event = $this->new_model_obj_with_dependencies( 'Event', array( 'EVT_wp_user' => $this->user->ID ) );
 		$term_id_and_taxonomy_id = wp_insert_term('term_r_for_my_event', 'espresso_event_categories' );

--- a/tests/testcases/core/db_models/EEM_Ticket_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Ticket_Caps_Test.php
@@ -71,6 +71,7 @@ class EEM_Ticket_Caps_Test extends EE_UnitTestCase{
 	public $e_private;
 	public function setUp(){
 		parent::setUp();
+        $this->loadFactories();
 		//let's make sure we start off with NO tickets in the DB
 		EEM_Ticket::instance()->delete_permanently( EEM_Ticket::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Ticket::instance()->count( EEM_Ticket::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_Transaction_Test.php
+++ b/tests/testcases/core/db_models/EEM_Transaction_Test.php
@@ -19,6 +19,7 @@ class EEM_Transaction_Test extends EE_UnitTestCase
      */
     public function test_delete_junk_transactions()
     {
+        $this->loadFactories();
         $pretend_bot_creations    = 9;
         $pretend_real_recent_txns = 3;
         $pretend_real_good_txns   = 5;

--- a/tests/testcases/core/db_models/EEM_WP_User_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_WP_User_Caps_Test.php
@@ -32,6 +32,7 @@ class EEM_WP_User_Caps_Test extends EE_UnitTestCase{
 
 	public function setUp(){
 		parent::setUp();
+        $this->loadFactories();
 		//clean out hte WP User table for these tests
 		EEM_WP_User::instance()->delete( array(), false );
 		$this->me = $this->factory->user->create_and_get();

--- a/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
@@ -72,7 +72,7 @@ class EE_Datetime_Field_Test extends EE_UnitTestCase
         $nice_name = 'Start Date',
         $nullable = false,
         $default_value = '',
-        $timezone = null,
+        $timezone = '',
         $date_format = null,
         $time_format = null,
         $pretty_date_format = null,

--- a/tests/testcases/core/db_models/strategies/EE_Default_Where_Conditions_Test.php
+++ b/tests/testcases/core/db_models/strategies/EE_Default_Where_Conditions_Test.php
@@ -21,6 +21,7 @@ class EE_Default_Where_Conditions_Test extends EE_UnitTestCase
      */
     function test_add_model_relation_chain_onto_where_conditions()
     {
+        $this->loadFactories();
         global $current_user;
         $current_user             = $this->factory->user->create_and_get();
         $value1                   = 12;

--- a/tests/testcases/core/db_models/strategies/EE_Restriciton_Generator_Protected_Test.php
+++ b/tests/testcases/core/db_models/strategies/EE_Restriciton_Generator_Protected_Test.php
@@ -30,6 +30,7 @@ class EE_Restriction_Generator_Protected_Test extends EE_UnitTestCase {
 	}
 
 	function test_generate_restrictions__basic_and_others() {
+        $this->loadFactories();
 		global $current_user;
 		$current_user = $this->factory->user->create_and_get();
 		//currently registrations have the 'ee_read_registrations' and 'ee_read_others_registrations' permissions

--- a/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
@@ -24,6 +24,7 @@ class BaseQueriesTest extends GraphQLUnitTestCase
         if (!$this->model_name) {
             return;
         }
+        $this->loadFactories();
 
         $this->admin      = $this->factory()->user->create(
             [

--- a/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
@@ -30,6 +30,7 @@ class EventConnectionQueriesTest extends BaseQueriesTest
 
     public function createPostObject($args)
     {
+        $this->loadFactories();
 
         /**
          * Set up the $defaults

--- a/tests/testcases/core/domain/services/graphql/mutators/BaseMutationTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/BaseMutationTest.php
@@ -21,6 +21,7 @@ class BaseMutationTest extends GraphQLUnitTestCase
         if (!$this->model_name) {
             return;
         }
+        $this->loadFactories();
 
         $this->name               = 'some name';
         $this->description        = 'some description';

--- a/tests/testcases/core/helpers/EEH_Activation_Test.php
+++ b/tests/testcases/core/helpers/EEH_Activation_Test.php
@@ -142,6 +142,7 @@ class EEH_Activation_Test extends EE_UnitTestCase {
 	 * @since 4.6.0
 	 */
 	public function test_get_default_creator_id() {
+        $this->loadFactories();
 		//clear out any previous users that may be lurking in teh system
 		foreach( get_users() as $wp_user ){
 			wp_delete_user( $wp_user->ID );

--- a/tests/testcases/core/helpers/EEH_DTT_Helper_Test.php
+++ b/tests/testcases/core/helpers/EEH_DTT_Helper_Test.php
@@ -42,7 +42,7 @@ class EEH_DTT_Helper_Test extends EE_UnitTestCase
         $nice_name = 'Start Date',
         $nullable = false,
         $default_value = '',
-        $timezone = null,
+        $timezone = '',
         $date_format = null,
         $time_format = null,
         $pretty_date_format = null,
@@ -68,7 +68,6 @@ class EEH_DTT_Helper_Test extends EE_UnitTestCase
      */
     public function test_get_valid_timezone_string()
     {
-
         $original_timezone_string = get_option('timezone_string');
         // TEST 1: retrieval of WP timezone string
         $expected_timezone_string = 'UTC';
@@ -82,7 +81,10 @@ class EEH_DTT_Helper_Test extends EE_UnitTestCase
         $this->assertEquals($timezone_string, $expected_timezone_string);
         // TEST 3: bogus timezone string
         try {
-            $timezone_string = EEH_DTT_Helper::get_valid_timezone_string('me got funky pants and like to dance');
+            $timezone_string = EEH_DTT_Helper::get_valid_timezone_string(
+                'me got funky pants and like to dance',
+                true
+            );
             $this->fail(
                 sprintf(
                     __(

--- a/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
+++ b/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
@@ -62,6 +62,7 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
     {
         parent::setUp();
 
+        $this->loadFactories();
         //all shortcode parse tests will require a full event to be setup with some datetimes and tickets.
         $price         = $this->factory->price_chained->create_object(array(
             'PRC_name'   => 'Not Free Price',

--- a/tests/testcases/core/libraries/batch/JobHandlers/DatetimeOffsetFixTest.php
+++ b/tests/testcases/core/libraries/batch/JobHandlers/DatetimeOffsetFixTest.php
@@ -32,6 +32,7 @@ class DatetimeOffsetFixTest extends EE_UnitTestCase
      */
     public function testProcessModel()
     {
+        $this->loadFactories();
         $original_date_and_time = new DateTime('now');
         $expected_positive_offset_datetime = clone $original_date_and_time;
         $test_offsets = array(

--- a/tests/testcases/core/libraries/messages/EE_Message_Repository_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Message_Repository_Test.php
@@ -22,6 +22,7 @@ class EE_Message_Repository_Test extends EE_UnitTestCase {
 	 * @return EE_Message_Repository
 	 */
 	function test_add() {
+        $this->loadFactories();
 		$message = $this->factory->message->create( array( 'nosave' => 1 ) );
 		$test_repo = new EE_Message_Repository();
 		$this->assertInstanceOf( 'EE_Message_Repository', $test_repo );
@@ -67,6 +68,7 @@ class EE_Message_Repository_Test extends EE_UnitTestCase {
 	 * @return EE_Message_Repository
 	 */
 	function test_saveAll() {
+        $this->loadFactories();
 		//create a bunch of message objects and add to repo.
 		$test_repo = new EE_Message_Repository();
 		$generation_data = array( 'MSG_generation_data' => array(
@@ -132,6 +134,7 @@ class EE_Message_Repository_Test extends EE_UnitTestCase {
 
 
 	function test__maybe_persist_generation_data() {
+        $this->loadFactories();
 		$test_repo = new EE_Message_Repository();
 		$message = $this->factory->message->create();
 		$actual_generation_data = array( 'MSG_generation_data' => array(
@@ -151,6 +154,7 @@ class EE_Message_Repository_Test extends EE_UnitTestCase {
 
 
 	function test_count_by_priority_and_status() {
+        $this->loadFactories();
 		$test_repo = new EE_Message_Repository();
 		//let's setup some message objects with a variety of priorities and statuses.
 		//high priority, idle  (invoice is high priority hence it is used as a message type).

--- a/tests/testcases/core/libraries/messages/EE_Messages_Generator_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Generator_Test.php
@@ -43,6 +43,7 @@ class EE_Messages_Generator_Test extends EE_UnitTestCase
      */
     function test_generate_only_incomplete_messages()
     {
+        $this->loadFactories();
         $message_processor = EE_Registry::instance()->load_lib('Messages_Processor');
         //make sure there is nothing in the queue
         $this->assertFalse($message_processor->batch_generate_from_queue(array(), true));

--- a/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
@@ -80,6 +80,7 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
      */
     function test_batch_generate_from_queue(EE_Messages_Processor $message_proc)
     {
+        $this->loadFactories();
         //first we know there is nothing in the db, so let's verify that returns false. (this also verifies the clear param)
         $this->assertFalse($message_proc->batch_generate_from_queue(array(), true));
 
@@ -102,6 +103,7 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
      */
     function test_batch_generate_from_queue_with_messages(EE_Messages_Processor $message_proc)
     {
+        $this->loadFactories();
         //make sure clear works
         $this->assertFalse($message_proc->batch_generate_from_queue(array(), true));
 
@@ -135,7 +137,7 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
      */
     function test_batch_send_from_queue(EE_Messages_Processor $message_proc)
     {
-
+        $this->loadFactories();
         //create messages ready to send.
         $this->factory->message->create_many(5, array('STS_ID' => EEM_Message::status_idle));
 
@@ -160,6 +162,7 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
      */
     function test_batch_send_from_queue_with_messages(EE_Messages_Processor $messages_proc)
     {
+        $this->loadFactories();
         //create messages we're going to use for sending
         $messages_to_send = $this->factory->message->create_many(5, array('STS_ID' => EEM_Message::status_idle));
 
@@ -298,6 +301,7 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
 
     function test_setup_messages_from_ids_and_send()
     {
+        $this->loadFactories();
         //setup processor to work with
         /** @type EE_Messages_Processor $proc */
         $proc = EE_Registry::instance()->load_lib('Messages_Processor');

--- a/tests/testcases/core/libraries/messages/EE_Messages_Queue_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Queue_Test.php
@@ -37,6 +37,7 @@ class EE_Messages_Queue_Test extends EE_UnitTestCase {
 	 * @return EE_Messages_Queue
 	 */
 	function test_add_and_get_queue() {
+        $this->loadFactories();
 		$queue = $this->_get_queue();
 		$message = $this->factory->message->create(array('nosave'=> 1));
 
@@ -146,6 +147,7 @@ class EE_Messages_Queue_Test extends EE_UnitTestCase {
 	 * @return EE_Messages_Queue
 	 */
 	function test_get_batch_to_generate() {
+        $this->loadFactories();
 		//grab a bunch of message objects and add to queue.
 		$queue = $this->_get_queue();
 		for ( $i=0;$i<5;$i++ ) {
@@ -174,6 +176,7 @@ class EE_Messages_Queue_Test extends EE_UnitTestCase {
 
 
 	function test_get_to_send_batch_and_send() {
+        $this->loadFactories();
 		//grab a bunch of message objects and add to queue.
 		$queue = $this->_get_queue();
 		for ( $i=0;$i<5;$i++ ) {
@@ -212,6 +215,7 @@ class EE_Messages_Queue_Test extends EE_UnitTestCase {
 	 * @group 9787
 	 */
 	public function test_send_only_ready_to_send_messages() {
+        $this->loadFactories();
 		//get some messages ready for the test and add to queue
 		$queue = $this->_get_queue();
 		for ( $i = 0; $i < 5; $i++ ) {

--- a/tests/testcases/core/libraries/messages/EE_Messages_Scheduler_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Scheduler_Test.php
@@ -45,6 +45,7 @@ class EE_Messages_Scheduler_Test extends EE_UnitTestCase
 
     protected function addSomeMessagesForTesting()
     {
+        $this->loadFactories();
         $messages_to_create = array(
             array(
                 'STS_ID' => EEM_Message::status_idle,

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
@@ -163,6 +163,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
 
     public function test_register_mock_addon_success()
     {
+        $this->loadFactories();
         //ensure model and class extensions weren't setup beforehand
         $this->assertFalse($this->_class_has_been_extended());
         $this->assertFalse($this->_model_has_been_extended());

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
@@ -96,6 +96,7 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
      */
     private function setupUser()
     {
+        $this->loadFactories();
         //create a user for checking caps on.
         $user_id     = $this->factory->user->create();
         $this->_user = $this->factory->user->get_object_by_id($user_id);
@@ -322,6 +323,7 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
 
     public function test_capability_maps_registered_non_numeric()
     {
+        $this->loadFactories();
         $this->_pretend_capabilities_registered();
         //the best way to test this is to ensure the registered maps work.  So let's author an event by the user.
 
@@ -351,6 +353,7 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
 
     public function test_capability_maps_registered_numeric()
     {
+        $this->loadFactories();
         $this->_pretend_capabilities_registered(false);
         //the best way to test this is to ensure the registered maps work.  So let's author an event by the user.
 

--- a/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Read_Test.php
@@ -836,6 +836,7 @@ class Read_Test extends EE_REST_TestCase
      */
     public function get_wp_user_mock($role = 'administrator')
     {
+        $this->loadFactories();
         /** @type \WP_User $user */
         $user = $this->factory->user->create_and_get();
         $user->add_role($role);

--- a/tests/testcases/core/libraries/rest_api/controllers/WriteAddRelationTest.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/WriteAddRelationTest.php
@@ -287,6 +287,7 @@ class WriteAddRelationTest extends EE_REST_TestCase
      */
     public function testAddRelationInsufficientPrivileges()
     {
+        $this->loadFactories();
         global $current_user;
         //setup our user and set as current user.
         $current_user = $this->factory->user->create_and_get();

--- a/tests/testcases/core/libraries/rest_api/controllers/WriteRemoveRelationTest.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/WriteRemoveRelationTest.php
@@ -301,6 +301,7 @@ class WriteRemoveRelationTest extends EE_REST_TestCase
      */
     public function testRemoveRelationInsufficientPrivileges()
     {
+        $this->loadFactories();
         global $current_user;
         //setup our user and set as current user.
         $current_user = $this->factory->user->create_and_get();

--- a/tests/testcases/core/libraries/rest_api/controllers/WriteTest.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/WriteTest.php
@@ -45,6 +45,7 @@ class WriteTest extends EE_REST_TestCase
      */
     public function testNoInsertLimitedUser()
     {
+        $this->loadFactories();
         $user = $this->factory->user->create_and_get(array('role' => 'subscriber'));
         $user->add_cap('ee_edit_events');
         $user->add_cap('ee_read_events');

--- a/tests/testcases/core/libraries/shortcodes/VenueShortcodesTest.php
+++ b/tests/testcases/core/libraries/shortcodes/VenueShortcodesTest.php
@@ -103,6 +103,7 @@ class VenueShortcodesTest extends EE_UnitTestCase
      */
     protected function getDataForShortcodes()
     {
+        $this->loadFactories();
         //setup a venue for the event for our tests.
         $venue = $this->factory->venue->create($this->getVenueTestValues());
         /** @var EE_Event $event */

--- a/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
+++ b/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
@@ -27,6 +27,7 @@ class EED_Single_Page_Checkout_Test extends EE_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
+        $this->loadFactories();
 		$this->loadModuleMocks( array( 'EED_Single_Page_Checkout' ) );
 		$this->spco_mock = EED_Single_Page_Checkout_Mock::instance();
 		//add filter on permalink to add some noise

--- a/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
+++ b/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
@@ -582,6 +582,7 @@ class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
      */
     public function testReleaseReservationForTicketsAllValid()
     {
+        $this->loadFactories();
         EEM_Ticket::instance()->delete_permanently(
             [
                 [


### PR DESCRIPTION
This PR fixes a whole bunch of nonsense that I noticed happening in the models with respect to timezones. There appeared to be no sane / logical approach to ensuring that timezones were set properly and efficiently. To be honest, I'm not even sure how some of it wasn't completely crashing things because there appeared to be a lot recursion happening where setting a models' timezone would result in it setting the timezone for its related fields, which in turn would set their related models timezone, which included the original timezone that started the entire update stampede. This resulted in the timezone for a model getting updated hundreds upon hundreds (thousands maybe?) of times during a simple request.

With the changes in this PR< timezones should only get set once and only update related objects if the timezone has yet to be set or their is an obviously intentional change occurring.

My apologies for the big PR< but the timezone stuff need to all be changed in one fell swoop