### PR TITLE
Request Routing Fixes

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -766,14 +766,6 @@ class EE_Dependency_Map
             'EventEspresso\core\services\addon\api\ThirdPartyPluginHandler' => [
                 'EventEspresso\core\services\request\Request'  => EE_Dependency_Map::load_from_cache,
             ],
-            'EventEspresso\core\libraries\rest_api\CalculatedModelFields' => [
-                'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => EE_Dependency_Map::load_from_cache
-            ],
-            'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => [
-                'EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache
-            ],
-            'EventEspresso\core\libraries\rest_api\controllers\model\Read' => [
-                'EventEspresso\core\libraries\rest_api\CalculatedModelFields' => EE_Dependency_Map::load_from_cache]
         ];
     }
 
@@ -847,6 +839,7 @@ class EE_Dependency_Map
             'EE_DMS_Core_4_8_0'                            => 'load_dms',
             'EE_DMS_Core_4_9_0'                            => 'load_dms',
             'EE_DMS_Core_4_10_0'                           => 'load_dms',
+            'EE_DMS_Core_4_11_0'                           => 'load_dms',
             'EE_Messages_Generator'                        => static function () {
                 return EE_Registry::instance()->load_lib(
                     'Messages_Generator',

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -477,6 +477,7 @@ final class EE_System implements ResettableInterface
      *                                       so we prefer to only do it when necessary
      * @return void
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function initialize_db_if_no_migrations_required($initialize_addons_too = false, $verify_schema = true)
     {
@@ -516,6 +517,7 @@ final class EE_System implements ResettableInterface
      * Initializes the db for all registered addons
      *
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function initialize_addons()
     {

--- a/core/domain/entities/routing/handlers/shared/RestApiRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RestApiRequests.php
@@ -25,7 +25,7 @@ class RestApiRequests extends Route
      */
     public function matchesCurrentRequest(): bool
     {
-        return $this->request->isApi() || $this->request->isWordPressApi();
+        return $this->request->isAdmin() || $this->request->isApi() || $this->request->isWordPressApi();
     }
 
 

--- a/core/domain/entities/routing/handlers/shared/RestApiRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RestApiRequests.php
@@ -35,6 +35,18 @@ class RestApiRequests extends Route
     protected function registerDependencies()
     {
         $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\CalculatedModelFields',
+            ['EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\calculations\CalculatedModelFieldsFactory',
+            ['EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\libraries\rest_api\controllers\model\Read',
+            ['EventEspresso\core\libraries\rest_api\CalculatedModelFields' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
             'EventEspresso\core\libraries\rest_api\calculations\Datetime',
             [
                 'EEM_Datetime'     => EE_Dependency_Map::load_from_cache,

--- a/core/domain/entities/routing/specifications/admin/WordPressPluginsPage.php
+++ b/core/domain/entities/routing/specifications/admin/WordPressPluginsPage.php
@@ -20,6 +20,6 @@ class WordPressPluginsPage extends RouteMatchSpecification
      */
     public function isMatchingRoute()
     {
-        return $this->request->currentPageIs('plugins.php');
+        return $this->request->isAdmin() && $this->request->currentPageIs('plugins.php');
     }
 }

--- a/core/domain/entities/routing/specifications/admin/WordPressPluginsPage.php
+++ b/core/domain/entities/routing/specifications/admin/WordPressPluginsPage.php
@@ -20,7 +20,6 @@ class WordPressPluginsPage extends RouteMatchSpecification
      */
     public function isMatchingRoute()
     {
-        global $pagenow;
-        return $this->request->isAdmin() && $pagenow && $pagenow === 'plugins.php';
+        return $this->request->currentPageIs('plugins.php');
     }
 }

--- a/core/libraries/rest_api/calculations/CalculatedModelFieldsFactory.php
+++ b/core/libraries/rest_api/calculations/CalculatedModelFieldsFactory.php
@@ -2,7 +2,6 @@
 
 namespace EventEspresso\core\libraries\rest_api\calculations;
 
-use EventEspresso\core\domain\services\factories\FactoryInterface;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\loaders\LoaderInterface;
 

--- a/core/services/request/Request.php
+++ b/core/services/request/Request.php
@@ -178,11 +178,7 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
     public function setRequestParam($key, $value, $override_ee = false)
     {
         // don't allow "ee" to be overwritten unless explicitly instructed to do so
-        if (
-            $key !== 'ee'
-            || ($key === 'ee' && empty($this->request['ee']))
-            || ($key === 'ee' && ! empty($this->request['ee']) && $override_ee)
-        ) {
+        if ($key !== 'ee' || empty($this->request['ee']) || $override_ee) {
             $this->request[ $key ] = $value;
         }
     }
@@ -435,12 +431,14 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
 
     /**
      * Gets the request's literal URI. Related to `requestUriAfterSiteHomeUri`, see its description for a comparison.
-     * @param boolean $relativeToWpRoot If home_url() is "http://mysite.com/wp/", and a request comes to
-     *                                  "http://mysite.com/wp/wp-json", setting $relativeToWpRoot=true will return
-     *                                  "/wp-json", whereas $relativeToWpRoot=false will return "/wp/wp-json/".
+     *
+     * @param boolean $relativeToWpRoot    If home_url() is "http://mysite.com/wp/", and a request comes to
+     *                                     "http://mysite.com/wp/wp-json", setting $relativeToWpRoot=true will return
+     *                                     "/wp-json", whereas $relativeToWpRoot=false will return "/wp/wp-json/".
+     * @param boolean $remove_query_params whether or not to return the uri with all query params removed.
      * @return string
      */
-    public function requestUri($relativeToWpRoot = false)
+    public function requestUri($relativeToWpRoot = false, $remove_query_params = false)
     {
         $request_uri = filter_input(
             INPUT_SERVER,
@@ -451,6 +449,10 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
         if (empty($request_uri)) {
             // fallback sanitization if the above fails
             $request_uri = wp_sanitize_redirect($this->server['REQUEST_URI']);
+        }
+        if($remove_query_params) {
+            $request_uri_parts = explode('?', $request_uri);
+            $request_uri = reset($request_uri_parts);
         }
         if ($relativeToWpRoot) {
             $home_path = untrailingslashit(
@@ -688,5 +690,32 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
     public function slug()
     {
         return $this->request_type->slug();
+    }
+
+
+    /**
+     * returns the path portion of the current request URI with both the WP Root (home_url()) and query params removed
+     *
+     * @return string
+     * @since   $VID:$
+     */
+    public function requestPath()
+    {
+        return $this->requestUri(true, true);
+    }
+
+
+    /**
+     * returns true if the last segment of the current request path (without params) matches the provided string
+     *
+     * @param string $uri_segment
+     * @return bool
+     * @since   $VID:$
+     */
+    public function currentPageIs($uri_segment)
+    {
+        $request_path = $this->requestPath();
+        $current_page = explode('/', $request_path);
+        return end($current_page) === $uri_segment;
     }
 }

--- a/core/services/request/Request.php
+++ b/core/services/request/Request.php
@@ -450,7 +450,7 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
             // fallback sanitization if the above fails
             $request_uri = wp_sanitize_redirect($this->server['REQUEST_URI']);
         }
-        if($remove_query_params) {
+        if ($remove_query_params) {
             $request_uri_parts = explode('?', $request_uri);
             $request_uri = reset($request_uri_parts);
         }

--- a/core/services/request/RequestInterface.php
+++ b/core/services/request/RequestInterface.php
@@ -139,10 +139,11 @@ interface RequestInterface extends RequestTypeContextCheckerInterface
 
 
     /**
-     * @param boolean $relativeToWpRoot whether to return the uri relative to WordPress' home URL, or not.
+     * @param boolean $relativeToWpRoot    whether or not to return the uri relative to WordPress' home URL.
+     * @param boolean $remove_query_params whether or not to return the uri with all query params removed.
      * @return string
      */
-    public function requestUri($relativeToWpRoot = false);
+    public function requestUri($relativeToWpRoot = false, $remove_query_params = false);
 
 
     /**
@@ -167,4 +168,23 @@ interface RequestInterface extends RequestTypeContextCheckerInterface
      * @param bool $is_bot
      */
     public function setIsBot($is_bot);
+
+
+    /**
+     * returns the path portion of the current request URI with both the WP Root (home_url()) and query params removed
+     *
+     * @return string
+     * @since   $VID:$
+     */
+    public function requestPath();
+
+
+    /**
+     * returns true if the last segment of the current request path (without params) matches the provided string
+     *
+     * @param string $uri_segment
+     * @return bool
+     * @since   $VID:$
+     */
+    public function currentPageIs($uri_segment);
 }

--- a/core/services/routing/RouteHandler.php
+++ b/core/services/routing/RouteHandler.php
@@ -49,7 +49,7 @@ class RouteHandler
     /**
      * @var string $route_request_type
      */
-    protected $route_request_type;
+    protected $route_request_type = '';
 
 
     /**

--- a/tests/includes/EE_REST_TestCase.php
+++ b/tests/includes/EE_REST_TestCase.php
@@ -37,7 +37,6 @@ abstract class EE_REST_TestCase extends EE_UnitTestCase
 
         $this->setupRequest(RequestTypeContext::WP_API);
         RestApiRequestsMock::register();
-        EED_Core_Rest_Api::set_hooks_both();
 
         add_filter('rest_url', array($this, 'filter_rest_url_for_leading_slash'), 10, 2);
         /** @var WP_REST_Server $wp_rest_server */

--- a/tests/mocks/core/domain/entities/routing/handlers/shared/RestApiRequestsMock.php
+++ b/tests/mocks/core/domain/entities/routing/handlers/shared/RestApiRequestsMock.php
@@ -27,8 +27,10 @@ class RestApiRequestsMock extends RestApiRequests
                 'EventEspresso\core\domain\entities\routing\specifications\RouteMatchSpecificationInterface' => EE_Dependency_Map::load_from_cache,
             ]
         );
+        /** @var RestApiRequestsMock $self */
         $self = LoaderFactory::getLoader()->getShared(RestApiRequestsMock::class);
         $self->registerDependencies();
+        $self->requestHandler();
     }
 
 

--- a/tests/mocks/core/services/request/RequestMock.php
+++ b/tests/mocks/core/services/request/RequestMock.php
@@ -207,9 +207,10 @@ class RequestMock extends Request
 
     /**
      * @param bool $relativeToWpRoot
+     * @param bool $remove_query_params
      * @return string
      */
-    public function requestUri($relativeToWpRoot = false)
+    public function requestUri($relativeToWpRoot = false, $remove_query_params = false)
     {
         return isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
     }

--- a/tests/testcases/core/EE_Dependency_Map_Test.php
+++ b/tests/testcases/core/EE_Dependency_Map_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use EventEspresso\core\domain\entities\contexts\RequestTypeContext;
+use EventEspresso\tests\mocks\core\domain\entities\routing\handlers\shared\RestApiRequestsMock;
 
 /**
  * Class EE_Dependency_Map_Test
@@ -80,6 +81,7 @@ class EE_Dependency_Map_Test extends EE_UnitTestCase {
         ];
         $request_types = [
             'EE_Front_Controller' => RequestTypeContext::FRONTEND,
+            'EED_Core_Rest_Api' => RequestTypeContext::WP_API,
         ];
         //loop through and verify the class loader can successfully load the class it is set for
 		foreach ( $this->dependency_map->class_loaders() as $class => $loader ) {
@@ -88,6 +90,9 @@ class EE_Dependency_Map_Test extends EE_UnitTestCase {
 			}
 			if (isset($request_types[ $class ])) {
                 $this->setupRequest($request_types[ $class ]);
+            }
+			if ($class === 'EED_Core_Rest_Api') {
+                RestApiRequestsMock::register();
             }
             $dependency = $loader instanceof Closure ? $loader() : EE_Registry::instance()->$loader( $class );
 			// helpers are simply loaded and do not return an instance

--- a/tests/testcases/core/libraries/rest_api/controllers/Checkin_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Checkin_Test.php
@@ -5,19 +5,11 @@ namespace EventEspresso\core\libraries\rest_api\controllers\rpc;
 use EE_Error;
 use EE_UnitTestCase;
 use EED_Core_Rest_Api;
-use EEH_Debug_Tools;
 use EEM_Checkin;
 use EEM_Registration;
 use EventEspresso\tests\mocks\core\domain\entities\routing\handlers\shared\RestApiRequestsMock;
-
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- * @group rest_api
- */
-
 use EventEspresso\core\domain\entities\contexts\RequestTypeContext;
+use Exception;
 use ReflectionException;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -26,6 +18,7 @@ class Checkin_Test extends EE_UnitTestCase
 {
 
     /**
+     * @throws Exception
      * @since $VID:$
      */
     public function setUp()
@@ -38,7 +31,6 @@ class Checkin_Test extends EE_UnitTestCase
         }
         $this->setupRequest(RequestTypeContext::WP_API);
         RestApiRequestsMock::register();
-        EED_Core_Rest_Api::set_hooks_both();
     }
 
 
@@ -61,7 +53,7 @@ class Checkin_Test extends EE_UnitTestCase
      * @param string $force
      * @return WP_REST_Response
      */
-    protected function executeRestRequest($reg_id, $dtt_id, $force = "false")
+    protected function executeRestRequest(int $reg_id, int $dtt_id, $force = "false"): WP_REST_Response
     {
         $req = new WP_REST_Request(
             'POST',
@@ -78,7 +70,7 @@ class Checkin_Test extends EE_UnitTestCase
                 'force' => $force,
             )
         );
-        return rest_do_request($req);;
+        return rest_do_request($req);
     }
 
 
@@ -181,7 +173,7 @@ class Checkin_Test extends EE_UnitTestCase
         $dtt2 = $this->new_model_obj_with_dependencies('Datetime');
         $dtt2->_add_relation_to($reg->get('TKT_ID'), 'Ticket');
         //create a previous checkin entry, so the reg shouldn't be allowed to checkin more
-        $old_checkin = $this->new_model_obj_with_dependencies(
+        $this->new_model_obj_with_dependencies(
             'Checkin',
             array(
                 'REG_ID' => $reg->ID(),


### PR DESCRIPTION
While trying to figure out what was wrong in https://github.com/eventespresso/eea-automated-upcoming-event-notifications/pull/19 I discovered that the way a "previous dev" was doing things caused some issues with some of the request routing logic in core.

To protect against misuse I added some fixes to some of the request routing logic, but ended up settling on a better solution for the AUEN plugin. The changes I made here, although not necessary anymore, are still good so I would like to keep them.

I also discovered a couple other issues while going through error logs which I've also fixed here.

The changes include:

- loading the REST API module on all admin routes because the data nodes used for generating GQL data reference that class.

- fixed a minor data type error for the default value of `$route_request_type` in `core/services/routing/RouteHandler.php`

- added a couple of new methods to the Request class for resolving paths as well as a couple of other tweaks