### PR TITLE
Cast global $post_type to string when running add_meta_boxes hook.

### DIFF
--- a/core/admin/templates/admin_details_wrapper.template.php
+++ b/core/admin/templates/admin_details_wrapper.template.php
@@ -4,7 +4,7 @@
 /** @var string|WP_Screen $current_page */
 global $post_type, $post;
 // action for registering metaboxes
-do_action('add_meta_boxes', $post_type, $post);
+do_action('add_meta_boxes', (string) $post_type, $post);
 ?>
 <?php if (! empty($admin_page_header)) : ?>
     <div id="admin-page-header">


### PR DESCRIPTION
Spoke about this in Slack, this cases the `$post_type` global variable to a string when running the add_meta_boxes hook on EE admin pages to prevent fatal's from other plugins expecting a string (that variable is null on EE admin pages).

## Problem this Pull Request solves
See: #3360 

## How has this been tested
Using SearchWP master will fatal when you view an EE admin page (Event Espresso -> General Settings)

With this fix, no more fatal.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
