### PR TITLE
Check Ticket Visibility in Queries and Ticket Selector

### DIFF
--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -1708,6 +1708,81 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
 
 
     /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isHidden(): int
+    {
+        return $this->visibility() === EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE;
+    }
+
+
+    /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isNotHidden(): int
+    {
+        return $this->visibility() > EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE;
+    }
+
+
+    /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isPublicOnly(): int
+    {
+        return $this->isNotHidden() && $this->visibility() <= EEM_Ticket::TICKET_VISIBILITY_PUBLIC_VALUE;
+    }
+
+
+    /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isMembersOnly(): int
+    {
+        return $this->visibility() > EEM_Ticket::TICKET_VISIBILITY_PUBLIC_VALUE
+               && $this->visibility() <= EEM_Ticket::TICKET_VISIBILITY_MEMBERS_ONLY_VALUE;
+    }
+
+
+    /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isAdminsOnly(): int
+    {
+        return $this->visibility() > EEM_Ticket::TICKET_VISIBILITY_MEMBERS_ONLY_VALUE
+               && $this->visibility() <= EEM_Ticket::TICKET_VISIBILITY_ADMINS_ONLY_VALUE;
+    }
+
+
+    /**
+     * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since   $VID:$
+     */
+    public function isAdminUiOnly(): int
+    {
+        return $this->visibility() > EEM_Ticket::TICKET_VISIBILITY_ADMINS_ONLY_VALUE
+               && $this->visibility() <= EEM_Ticket::TICKET_VISIBILITY_ADMIN_UI_ONLY_VALUE;
+    }
+
+
+    /**
      * @param int $visibility
      * @throws EE_Error
      * @throws ReflectionException
@@ -1717,7 +1792,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
     {
 
         $ticket_visibility_options = $this->_model->ticketVisibilityOptions();
-        $ticket_visibility = -1;
+        $ticket_visibility         = -1;
         foreach ($ticket_visibility_options as $ticket_visibility_option) {
             if ($visibility === $ticket_visibility_option) {
                 $ticket_visibility = $visibility;

--- a/core/db_models/EEM_Ticket.model.php
+++ b/core/db_models/EEM_Ticket.model.php
@@ -277,11 +277,20 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
      *
      * @return EE_Ticket[]
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function get_all_default_tickets()
+    public function get_all_default_tickets(): array
     {
         /** @type EE_Ticket[] $tickets */
-        $tickets = $this->get_all([['TKT_is_default' => 1], 'order_by' => ['TKT_ID' => 'ASC']]);
+        $tickets = $this->get_all(
+            [
+                [
+                    'TKT_is_default' => 1,
+                    'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
+                ],
+                'order_by' => ['TKT_ID' => 'ASC'],
+            ]
+        );
         // we need to set the start date and end date to today's date and the start of the default dtt
         return $this->_set_default_dates($tickets);
     }
@@ -293,8 +302,9 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
      * @param EE_Ticket[] $tickets
      * @return EE_Ticket[]
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    private function _set_default_dates($tickets)
+    private function _set_default_dates(array $tickets): array
     {
         foreach ($tickets as $ticket) {
             $ticket->set(
@@ -325,9 +335,12 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
      * @param int   $DTT_ID
      * @param array $query_params
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function sum_tickets_currently_available_at_datetime($DTT_ID, $query_params = [])
+    public function sum_tickets_currently_available_at_datetime(int $DTT_ID, array $query_params = []): int
     {
+        $query_params += [['TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE]]];
         return EEM_Datetime::instance()->sum_tickets_currently_available_at_datetime($DTT_ID, $query_params);
     }
 
@@ -338,11 +351,11 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
      * @param EE_Ticket[] $tickets
      * @return void
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function update_tickets_sold($tickets)
+    public function update_tickets_sold(array $tickets)
     {
         foreach ($tickets as $ticket) {
-            /* @var  $ticket EE_Ticket */
             $ticket->update_tickets_sold();
         }
     }
@@ -359,7 +372,8 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
         return $this->get_all(
             [
                 [
-                    'TKT_reserved' => ['>', 0],
+                    'TKT_reserved'   => ['>', 0],
+                    'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
                 ],
             ]
         );

--- a/core/db_models/EEM_Ticket.model.php
+++ b/core/db_models/EEM_Ticket.model.php
@@ -13,12 +13,16 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
     /**
      * the following constants define where tickets can be viewed throughout the UI
      *
+     *  TICKET_VISIBILITY_NONE          - will not be displayed anywhere
      *  TICKET_VISIBILITY_PUBLIC        - displayed basically anywhere
      *  TICKET_VISIBILITY_MEMBERS_ONLY  - displayed to any logged in user
      *  TICKET_VISIBILITY_ADMINS_ONLY   - displayed to any logged in user that is an admin
      *  TICKET_VISIBILITY_ADMIN_UI_ONLY - only displayed in the admin, never publicly
-     *  TICKET_VISIBILITY_NONE          - will not be displayed anywhere
      */
+    public const TICKET_VISIBILITY_NONE_KEY            = 'NONE';
+
+    public const TICKET_VISIBILITY_NONE_VALUE          = 0;
+
     public const TICKET_VISIBILITY_PUBLIC_KEY          = 'PUBLIC';
 
     public const TICKET_VISIBILITY_PUBLIC_VALUE        = 100;
@@ -34,10 +38,6 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
     public const TICKET_VISIBILITY_ADMIN_UI_ONLY_KEY   = 'ADMIN_UI_ONLY';
 
     public const TICKET_VISIBILITY_ADMIN_UI_ONLY_VALUE = 400;
-
-    public const TICKET_VISIBILITY_NONE_KEY            = 'NONE';
-
-    public const TICKET_VISIBILITY_NONE_VALUE          = 500;
 
 
     /**
@@ -286,7 +286,7 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
             [
                 [
                     'TKT_is_default' => 1,
-                    'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
+                    'TKT_visibility' => ['>', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
                 ],
                 'order_by' => ['TKT_ID' => 'ASC'],
             ]
@@ -340,7 +340,7 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
      */
     public function sum_tickets_currently_available_at_datetime(int $DTT_ID, array $query_params = []): int
     {
-        $query_params += [['TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE]]];
+        $query_params += [['TKT_visibility' => ['>', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE]]];
         return EEM_Datetime::instance()->sum_tickets_currently_available_at_datetime($DTT_ID, $query_params);
     }
 
@@ -373,7 +373,7 @@ class EEM_Ticket extends EEM_Soft_Delete_Base
             [
                 [
                     'TKT_reserved'   => ['>', 0],
-                    'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
+                    'TKT_visibility' => ['>', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
                 ],
             ]
         );

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -307,6 +307,12 @@ class Ticket extends TypeBase
                 null,
                 esc_html__('Ticket Creator ID', 'event_espresso')
             ),
+            new GraphQLField(
+                'visibility',
+                'Int',
+                'visibility',
+                esc_html__('Where the ticket can be viewed throughout the UI', 'event_espresso')
+            ),
         ];
 
         return apply_filters(

--- a/core/domain/services/graphql/types/Ticket.php
+++ b/core/domain/services/graphql/types/Ticket.php
@@ -307,12 +307,6 @@ class Ticket extends TypeBase
                 null,
                 esc_html__('Ticket Creator ID', 'event_espresso')
             ),
-            new GraphQLField(
-                'visibility',
-                'Int',
-                'visibility',
-                esc_html__('Where the ticket can be viewed throughout the UI', 'event_espresso')
-            ),
         ];
 
         return apply_filters(

--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -408,7 +408,7 @@ class DisplayTicketSelector
         $ticket_query_args = [
             [
                 'Datetime.EVT_ID' => $this->event->ID(),
-                'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE],
+                'TKT_visibility' => ['<', EEM_Ticket::TICKET_VISIBILITY_NONE_VALUE],
             ],
             'order_by' => [
                 'TKT_order'              => 'ASC',


### PR DESCRIPTION
This PR:

- adds visibility checks to queries in EEM_Ticket

- filters tickets displayed in the ticket selector based on ticket visibility and the current user's access rights

---

with the following values in the tickets table in the db (manually entered):

![ScreenShot_20210506173504](https://user-images.githubusercontent.com/1751030/117381678-7ae12b00-ae91-11eb-9273-f3d2acc37657.png)


### logged in as admin adding tickets via the registrations admin page

![ScreenShot_20210506173300](https://user-images.githubusercontent.com/1751030/117381531-23db5600-ae91-11eb-864b-0c02046300c1.png)


### logged in as admin & adding tickets via the public event post

![ScreenShot_20210506172820](https://user-images.githubusercontent.com/1751030/117381378-cba45400-ae90-11eb-9f40-8d86dfeea244.png)


### logged in as subscriber & adding tickets via the public event post

![ScreenShot_20210506172850](https://user-images.githubusercontent.com/1751030/117381401-d6f77f80-ae90-11eb-866f-5f5d4e72e212.png)

### NOT logged in & adding tickets via the public event post

![ScreenShot_20210506172915](https://user-images.githubusercontent.com/1751030/117381432-ed9dd680-ae90-11eb-9860-e0d84e8473ab.png)


