### PR TITLE
Fix Feature Flag Parsing

### DIFF
--- a/core/domain/services/capabilities/FeatureFlags.php
+++ b/core/domain/services/capabilities/FeatureFlags.php
@@ -63,11 +63,11 @@ class FeatureFlags
      */
     public function featureAllowed(string $feature): bool
     {
-        $flag = isset($this->feature_flags[ $feature ]) ?? false;
+        $flag = $this->feature_flags[ $feature ] ?? false;
         try {
             return is_object($flag) && $flag instanceof CapCheck
                 ? $this->capabilities_checker->processCapCheck($flag)
-                : $flag;
+                : filter_var($flag, FILTER_VALIDATE_BOOLEAN);
         } catch (InsufficientPermissionsException $e) {
             // eat the exception
         }


### PR DESCRIPTION
Seth noticed that some EDTR features were appearing when they _should_ have been hidden behind a feature flag

This PR:

- fixes null coalescing operator (`??` shortcut)
- ensures bool values are bools