### PR TITLE
PHP8 Fix - Remove FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED

### DIFF
--- a/core/domain/values/Url.php
+++ b/core/domain/values/Url.php
@@ -53,8 +53,7 @@ class Url
     {
         if (! filter_var(
             $url,
-            FILTER_VALIDATE_URL,
-            array(FILTER_FLAG_SCHEME_REQUIRED, FILTER_FLAG_HOST_REQUIRED)
+            FILTER_VALIDATE_URL
         )) {
             throw new InvalidArgumentException(
                 esc_html__(


### PR DESCRIPTION
FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED have been deprecated in PHP7.3.0 and remove in PHP8 which causes this function to throw a fatal.

Apparently, they haven't done anything since PHP5.2.1, see:

https://stackoverflow.com/a/47006079

Removed the constants and confirmed the fix in PHP8.

## Problem this Pull Request solves
Whilst logged **out**, register onto an Event with the WP User integration add-on active.

Use attendee details that match your WP user account so that the add-on checks for a current user and finds one.

On master you should get a fatal and EE will show your reg step could not be completed.

On this branch you'll see a notice about already having an account.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
