### PR TITLE
Set GRP_ID from the EE_Message in the message queue... on the EE_Message that is used.

### DIFF
--- a/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
+++ b/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
@@ -32,7 +32,7 @@ class EE_Message_To_Generate_From_Queue extends EE_Message_To_Generate
         if ($this->valid()) {
             $this->_message->set_content($this->_get_content());
             $this->_message->set_subject($this->_get_subject($custom_subject));
-            $this->_message->set_GRP_ID($this->_get_GRP_ID());
+            $this->_message->set_GRP_ID($this->getGroupIdFromMessageRepo());
         }
     }
 
@@ -92,7 +92,7 @@ class EE_Message_To_Generate_From_Queue extends EE_Message_To_Generate
      * for the single EE_Message aggregate object returned by get_EE_Message
      * @return int;
      */
-    protected function _get_GRP_ID()
+    protected function getGroupIdFromMessageRepo()
     {
         $this->queue->get_message_repository()->rewind();
         if ($this->queue->get_message_repository()->valid()) {

--- a/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
+++ b/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
@@ -32,6 +32,7 @@ class EE_Message_To_Generate_From_Queue extends EE_Message_To_Generate
         if ($this->valid()) {
             $this->_message->set_content($this->_get_content());
             $this->_message->set_subject($this->_get_subject($custom_subject));
+            $this->_message->set_GRP_ID($this->_get_GRP_ID());
         }
     }
 
@@ -83,5 +84,19 @@ class EE_Message_To_Generate_From_Queue extends EE_Message_To_Generate
             $count_of_items
         );
         // phpcs:enable
+    }
+
+
+    /**
+     * Uses the EE_Messages_Queue currently set on this object to set the GRP_ID
+     * for the single EE_Message aggregate object returned by get_EE_Message
+     * @return int;
+     */
+    protected function _get_GRP_ID()
+    {
+        $this->queue->get_message_repository()->rewind();
+        if($this->queue->get_message_repository()->valid()) {
+            return $this->queue->get_message_repository()->current()->GRP_ID();
+        }
     }
 }

--- a/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
+++ b/core/libraries/messages/EE_Message_To_Generate_From_Queue.php
@@ -95,7 +95,7 @@ class EE_Message_To_Generate_From_Queue extends EE_Message_To_Generate
     protected function _get_GRP_ID()
     {
         $this->queue->get_message_repository()->rewind();
-        if($this->queue->get_message_repository()->valid()) {
+        if ($this->queue->get_message_repository()->valid()) {
             return $this->queue->get_message_repository()->current()->GRP_ID();
         }
     }


### PR DESCRIPTION
See this thread: https://eventespresso.com/topic/stylesheets-not-loaded-for-emailed-tickets-but-loaded-in-wp-backend/

If you have a custom message pack set on a custom message template, EE doesn't load that template pack when viewing the front end ticket links.

In the admin, when you view the tickets you'll get a link like this:

http://ee4.test/?ee=msg_url_trigger&snd_msgr=html&gen_msgr=html&message_type=ticketing&context=registrant&token=1-d463d9fb18eefea75cc536d2eb6f77c9&GRP_ID=27&id=0

The above works because it sets the GRP_ID, however, the user gets a link like this:

http://ee4.test/?ee=ee-txn-tickets-approved-url&token=1-d463d9fb18eefea75cc536d2eb6f77c9

That uses the registration to work out what is needed and for the most part, it works, in fact, it pulls all of the correct details and sets up the data in a 'message queue' in the background. However, the message queue system then basically reuses the details from that message queue (which is a bunch of EE_Message objects) to recreate EE_Message objects from and set values..... GRP_ID is NOT one of those values set and this fixes that.

@tn3rb when I mentioned this in slack you mentioned it didn't sound right and I agree, this could do with some refactoring as it just seems really inefficient currently. Maybe I'm missing something with it all but for now, this fixes the above.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
