### PR TITLE
Use getType() in place of getClass(), then use the getName() method.

### DIFF
--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -150,7 +150,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
     protected $_hook_obj;
 
     // for holding incoming request data
-    protected $_req_data;
+    protected $_req_data = [];
 
     // yes / no array for admin form fields
     protected $_yes_no_values = array();

--- a/core/services/container/Mirror.php
+++ b/core/services/container/Mirror.php
@@ -158,8 +158,8 @@ class Mirror
         if (! isset($this->parameter_classes[ $class_name ][ $index ])) {
             $this->parameter_classes[ $class_name ][ $index ] = array();
         }
-        $this->parameter_classes[ $class_name ][ $index ]['param_class_name'] = $param->getClass()
-            ? $param->getClass()->name
+        $this->parameter_classes[ $class_name ][ $index ]['param_class_name'] = $param->getType()
+            ? $param->getType()->getName()
             : null;
         return $this->parameter_classes[ $class_name ][ $index ]['param_class_name'];
     }

--- a/core/services/container/Mirror.php
+++ b/core/services/container/Mirror.php
@@ -158,9 +158,17 @@ class Mirror
         if (! isset($this->parameter_classes[ $class_name ][ $index ])) {
             $this->parameter_classes[ $class_name ][ $index ] = array();
         }
-        $this->parameter_classes[ $class_name ][ $index ]['param_class_name'] = $param->getType()
-            ? $param->getType()->getName()
-            : null;
+        // ReflectionParameter::getClass() is deprecated in PHP 8+
+        if (PHP_VERSION_ID >= 80000) {
+            $this->parameter_classes[$class_name][$index]['param_class_name'] =
+                $param->getType() instanceof ReflectionNamedType
+                    ? $param->getType()->getName()
+                    : null;
+        } else {
+            $this->parameter_classes[$class_name][$index]['param_class_name'] = $param->getClass()
+                    ? $param->getClass()->getName()
+                    : null;
+        }
         return $this->parameter_classes[ $class_name ][ $index ]['param_class_name'];
     }
 

--- a/core/services/container/Mirror.php
+++ b/core/services/container/Mirror.php
@@ -160,12 +160,12 @@ class Mirror
         }
         // ReflectionParameter::getClass() is deprecated in PHP 8+
         if (PHP_VERSION_ID >= 80000) {
-            $this->parameter_classes[$class_name][$index]['param_class_name'] =
+            $this->parameter_classes[ $class_name ][ $index ]['param_class_name'] =
                 $param->getType() instanceof ReflectionNamedType
                     ? $param->getType()->getName()
                     : null;
         } else {
-            $this->parameter_classes[$class_name][$index]['param_class_name'] = $param->getClass()
+            $this->parameter_classes[ $class_name ][ $index ]['param_class_name'] = $param->getClass()
                     ? $param->getClass()->getName()
                     : null;
         }


### PR DESCRIPTION
I was testing PHP8 and my logs start filling with tons of these, so fixed it and figured I might as push the change.


## How has this been tested
Use PHP8 and confirm no more of these notices are shown:

`PHP Deprecated:  Method ReflectionParameter::getClass() is deprecated in /wp-content/plugins/event-espresso-core-reg/core/services/container/Mirror.php on line 162`

If this broke something I think we'd know pretty quick, so that's it.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
