### PR TITLE
Fix PUE Stats Nonce closes #3429

### DIFF
--- a/core/domain/services/pue/Stats.php
+++ b/core/domain/services/pue/Stats.php
@@ -191,7 +191,7 @@ class Stats
     public function ajaxHandler()
     {
         // verify nonce
-        if (isset($_POST['nonce']) && ! wp_verify_nonce($_POST['nonce'], 'ee-data-optin')) {
+        if (! isset($_POST['nonce']) || ! wp_verify_nonce($_POST['nonce'], 'ee-data-optin')) {
             exit();
         }
 


### PR DESCRIPTION
plz see #3429

This PR changes the conditional in `EventEspresso\core\domain\services\pue\Stats::ajaxHandler()` so that the code in that method does not run if no nonce is set.