### PR TITLE
Form Builder | Add GraphQL schema for Form Section queries

### DIFF
--- a/core/db_classes/EE_Form_Section.class.php
+++ b/core/db_classes/EE_Form_Section.class.php
@@ -225,7 +225,7 @@ class EE_Form_Section extends EE_Base_Class
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function wpUser(): int
+    public function wp_user(): int
     {
         return $this->get('FSC_wpUser');
     }

--- a/core/db_models/EEM_Form_Section.model.php
+++ b/core/db_models/EEM_Form_Section.model.php
@@ -88,7 +88,7 @@ class EEM_Form_Section extends EEM_Form_Element
                 'FSC_appliesTo' => new EE_Enum_Text_Field(
                     'FSC_appliesTo',
                     esc_html__(
-                        'Form user types that this form section should be presented to. Values correspond to the EEM_Form_Section::APPLIES_TO_* constants.',
+                        'Form user type that this form section should be presented to. Values correspond to the EEM_Form_Section::APPLIES_TO_* constants.',
                         'event_espresso'
                     ),
                     false,
@@ -133,7 +133,7 @@ class EEM_Form_Section extends EEM_Form_Element
                 'FSC_status'    => new EE_Enum_Text_Field(
                     'FSC_status',
                     esc_html__(
-                        'Whether form section is active, archived, trashed, or used as a default on new forms. Values correspond to the EEM_Form_Section::STATUS_TO_* constants.',
+                        'Whether form section is active, archived, shared, trashed, or used as a default on new forms. Values correspond to the EEM_Form_Section::STATUS_TO_* constants.',
                         'event_espresso'
                     ),
                     false,

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -136,6 +136,10 @@ class GQLRequests extends Route
             ['EEM_Event' => EE_Dependency_Map::load_from_cache]
         );
         $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\types\FormSection',
+            ['EEM_Form_Section' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\types\Ticket',
             ['EEM_Ticket' => EE_Dependency_Map::load_from_cache]
         );
@@ -170,6 +174,10 @@ class GQLRequests extends Route
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\connections\RootQueryAttendeesConnection',
             ['EEM_Attendee' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryFormSectionsConnection',
+            ['EEM_Form_Section' => EE_Dependency_Map::load_from_cache]
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\connections\DatetimeTicketsConnection',

--- a/core/domain/services/graphql/connection_resolvers/FormSectionConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/FormSectionConnectionResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connection_resolvers;
+
+use EE_Error;
+use EEM_Form_Section;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class FormSectionConnectionResolver
+ */
+class FormSectionConnectionResolver extends AbstractConnectionResolver
+{
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_loader_name()
+    {
+        return 'espresso_formSection';
+    }
+
+    /**
+     * @return EEM_Form_Section
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query()
+    {
+        return EEM_Form_Section::instance();
+    }
+
+
+    /**
+     * Return an array of item IDs from the query
+     *
+     * @return array
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_ids()
+    {
+        $results = $this->query->get_col($this->query_args);
+
+        return ! empty($results) ? $results : [];
+    }
+
+
+    /**
+     * Here, we map the args from the input, then we make sure that we're only querying
+     * for IDs. The IDs are then passed down the resolve tree, and deferred resolvers
+     * handle batch resolution of the posts.
+     *
+     * @return array
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query_args()
+    {
+        $where_params = [];
+        $query_args   = [];
+
+        $query_args['limit'] = $this->getLimit();
+
+        // Avoid multiple entries by join.
+        $query_args['group_by'] = 'FSC_UUID';
+
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__form_section_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
+        if (! empty($where_params)) {
+            $query_args[] = $where_params;
+        }
+
+
+        /**
+         * Return the $query_args
+         */
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__form_section_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
+    }
+}

--- a/core/domain/services/graphql/connections/RootQueryFormSectionsConnection.php
+++ b/core/domain/services/graphql/connections/RootQueryFormSectionsConnection.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connections;
+
+use EEM_Form_Section;
+use EventEspresso\core\domain\services\graphql\connection_resolvers\FormSectionConnectionResolver;
+use EventEspresso\core\domain\services\graphql\abstracts\AbstractRootQueryConnection;
+use Exception;
+
+/**
+ * Class RootQueryFormSectionsConnection
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\connections
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class RootQueryFormSectionsConnection extends AbstractRootQueryConnection
+{
+
+
+    /**
+     * FormSectionConnection constructor.
+     *
+     * @param EEM_Form_Section               $model
+     */
+    public function __construct(EEM_Form_Section $model)
+    {
+        $this->model = $model;
+    }
+
+
+    /**
+     * @return array
+     * @since $VID:$
+     */
+    public function config()
+    {
+        return [
+            'fromType'           => 'RootQuery',
+            'toType'             => $this->namespace . 'FormSection',
+            'fromFieldName'      => lcfirst($this->namespace) . 'FormSections',
+            'connectionTypeName' => "{$this->namespace}RootQueryFormSectionsConnection",
+            'resolve'            => [$this, 'resolveConnection'],
+        ];
+    }
+
+
+    /**
+     * @param $entity
+     * @param $args
+     * @param $context
+     * @param $info
+     * @return FormSectionConnectionResolver
+     * @throws Exception
+     * @since $VID:$
+     */
+    public function getConnectionResolver($entity, $args, $context, $info)
+    {
+        return new FormSectionConnectionResolver($entity, $args, $context, $info);
+    }
+}

--- a/core/domain/services/graphql/data/domains/EspressoEditor.php
+++ b/core/domain/services/graphql/data/domains/EspressoEditor.php
@@ -27,12 +27,13 @@ class EspressoEditor implements GQLDataDomainInterface
     public function registerLoaders(array $loaders, AppContext $context)
     {
         $newLoaders = [
-            'espresso_attendee'  => new Loaders\AttendeeLoader($context),
-            'espresso_datetime'  => new Loaders\DatetimeLoader($context),
-            'espresso_price'     => new Loaders\PriceLoader($context),
-            'espresso_priceType' => new Loaders\PriceTypeLoader($context),
-            'espresso_ticket'    => new Loaders\TicketLoader($context),
-            'espresso_venue'     => new Loaders\VenueLoader($context),
+            'espresso_attendee'    => new Loaders\AttendeeLoader($context),
+            'espresso_datetime'    => new Loaders\DatetimeLoader($context),
+            'espresso_price'       => new Loaders\PriceLoader($context),
+            'espresso_priceType'   => new Loaders\PriceTypeLoader($context),
+            'espresso_formSection' => new Loaders\FormSectionLoader($context),
+            'espresso_ticket'      => new Loaders\TicketLoader($context),
+            'espresso_venue'       => new Loaders\VenueLoader($context),
         ];
 
         return array_merge($loaders, $newLoaders);

--- a/core/domain/services/graphql/data/loaders/FormSectionLoader.php
+++ b/core/domain/services/graphql/data/loaders/FormSectionLoader.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\data\loaders;
+
+use EE_Error;
+use EEM_Base;
+use EEM_Form_Section;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+
+/**
+ * Class FormSectionLoader
+ */
+class FormSectionLoader extends AbstractLoader
+{
+    /**
+     * @return EEM_Base
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    protected function getQuery(): EEM_Base
+    {
+        return EEM_Form_Section::instance();
+    }
+
+    /**
+     * @param array $keys
+     * @return array
+     */
+    protected function getWhereParams(array $keys): array
+    {
+        return [
+            'FSC_UUID' => ['IN', $keys],
+        ];
+    }
+}

--- a/core/domain/services/graphql/enums/FormSectionAppliesToEnum.php
+++ b/core/domain/services/graphql/enums/FormSectionAppliesToEnum.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\enums;
+
+use EEM_Form_Section;
+use EventEspresso\core\services\graphql\enums\EnumBase;
+
+/**
+ * Class FormSectionAppliesToEnum
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\enums
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class FormSectionAppliesToEnum extends EnumBase
+{
+
+    /**
+     * FormSectionAppliesToEnum constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'FormSectionAppliesToEnum');
+        $this->setDescription(esc_html__(
+            'Form user type that this form section should be presented to.',
+            'event_espresso'
+        ));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return array
+     */
+    protected function getValues(): array
+    {
+        return [
+            'ALL'         => [
+                'value' => EEM_Form_Section::APPLIES_TO_ALL,
+            ],
+            'PRIMARY'     => [
+                'value' => EEM_Form_Section::APPLIES_TO_PRIMARY,
+            ],
+            'PURCHASER'   => [
+                'value' => EEM_Form_Section::APPLIES_TO_PURCHASER,
+            ],
+            'REGISTRANTS' => [
+                'value' => EEM_Form_Section::APPLIES_TO_REGISTRANTS,
+            ],
+        ];
+    }
+}

--- a/core/domain/services/graphql/enums/FormSectionStatusEnum.php
+++ b/core/domain/services/graphql/enums/FormSectionStatusEnum.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\enums;
+
+use EE_Form_Section;
+use EventEspresso\core\services\graphql\enums\EnumBase;
+use EventEspresso\core\services\form\meta\Element;
+
+/**
+ * Class FormSectionStatusEnum
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\enums
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class FormSectionStatusEnum extends EnumBase
+{
+
+    /**
+     * FormSectionStatusEnum constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'FormSectionStatusEnum');
+        $this->setDescription(esc_html__(
+            'Whether form section is active, archived, shared, trashed, or used as a default on new forms.',
+            'event_espresso'
+        ));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return array
+     */
+    protected function getValues(): array
+    {
+        return [
+            'ACTIVE'   => [
+                'value' => Element::STATUS_ACTIVE,
+            ],
+            'ARCHIVED' => [
+                'value' => Element::STATUS_ARCHIVED,
+            ],
+            'DEFAULT'  => [
+                'value' => Element::STATUS_DEFAULT,
+            ],
+            'SHARED'   => [
+                'value' => Element::STATUS_SHARED,
+            ],
+            'TRASHED'  => [
+                'value' => Element::STATUS_TRASHED,
+            ],
+        ];
+    }
+}

--- a/core/domain/services/graphql/resolvers/FieldResolver.php
+++ b/core/domain/services/graphql/resolvers/FieldResolver.php
@@ -133,9 +133,15 @@ class FieldResolver extends ResolverBase
      */
     public function resolveId($source)
     {
-        $ID = $source instanceof EE_Base_Class ? $source->ID() : 0;
+        if (!$source instanceof EE_Base_Class) {
+            return null;
+        }
+        // If the model has a UUID method
+        if (is_callable([$source, 'UUID'])) {
+            return $source->UUID();
+        }
 
-        return $ID ? Relay::toGlobalId($this->model->item_name(), $ID) : null;
+        return Relay::toGlobalId($this->model->item_name(), $source->ID());
     }
 
 

--- a/core/domain/services/graphql/types/FormSection.php
+++ b/core/domain/services/graphql/types/FormSection.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\types;
+
+use EEM_Form_Section;
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\types\TypeBase;
+use EventEspresso\core\services\graphql\fields\GraphQLField;
+use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
+
+/**
+ * Class FormSection
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\types
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class FormSection extends TypeBase
+{
+
+    /**
+     * FormSection constructor.
+     *
+     * @param EEM_Form_Section $form_section_model
+     */
+    public function __construct(EEM_Form_Section $form_section_model)
+    {
+        $this->model = $form_section_model;
+        $this->setName($this->namespace . 'FormSection');
+        $this->setDescription(__('A form section', 'event_espresso'));
+        $this->setIsCustomPostType(false);
+
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     * @since $VID:$
+     */
+    public function getFields()
+    {
+        $fields = [
+            new GraphQLField(
+                'id',
+                ['non_null' => 'ID'],
+                null,
+                esc_html__('The globally unique ID for the object.', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'dbId',
+                ['non_null' => 'Int'],
+                'ID',
+                esc_html__('Form section ID', 'event_espresso')
+            ),
+            new GraphQLField(
+                'appliesTo',
+                $this->namespace . 'FormSectionAppliesToEnum',
+                'appliesTo',
+                esc_html__('Form user type that this form section should be presented to.', 'event_espresso')
+            ),
+            /* new GraphQLField(
+                'adminLabel',
+                'String',
+                'adminLabel',
+                esc_html__('The form section label that should be show to the admins.', 'event_espresso')
+            ), */
+            new GraphQLField(
+                'belongsTo',
+                'String',
+                'belongsTo',
+                esc_html__('UUID or ID of related entity this form section belongs to.', 'event_espresso')
+            ),
+            /* new GraphQLField(
+                'description',
+                'String',
+                'description',
+                esc_html__('Description of the form section.', 'event_espresso')
+            ), */
+            new GraphQLField(
+                'htmlClass',
+                'String',
+                'htmlClass',
+                esc_html__('HTML classes to be applied to this form section\'s container.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'order',
+                'Int',
+                'order',
+                esc_html__('Order in which form section appears in a form.', 'event_espresso')
+            ),
+            /* new GraphQLField(
+                'showDescription',
+                'Boolean',
+                'showDescription',
+                esc_html__('Whether to display description of the form section.', 'event_espresso')
+            ),
+            new GraphQLField(
+                'showName',
+                'Boolean',
+                'showName',
+                esc_html__('Whether to display the admin label to non-admin users.', 'event_espresso')
+            ), */
+            new GraphQLField(
+                'status',
+                $this->namespace . 'FormSectionStatusEnum',
+                'status',
+                esc_html__(
+                    'Whether form section is active, archived, shared, trashed, or used as a default on new forms.',
+                    'event_espresso'
+                )
+            ),
+            new GraphQLOutputField(
+                'wpUser',
+                'User',
+                null,
+                esc_html__('WP User that created this form section.', 'event_espresso')
+            ),
+        ];
+
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_types__form_section_fields',
+            $fields,
+            $this->name,
+            $this->model
+        );
+    }
+}

--- a/core/services/form/meta/Element.php
+++ b/core/services/form/meta/Element.php
@@ -45,7 +45,7 @@ class Element
                 Element::STATUS_ACTIVE   => esc_html__('Active', 'event_espresso'),
                 Element::STATUS_ARCHIVED => esc_html__('Archived', 'event_espresso'),
                 Element::STATUS_DEFAULT  => esc_html__('Default', 'event_espresso'),
-                Element::STATUS_DEFAULT  => esc_html__('Shared', 'event_espresso'),
+                Element::STATUS_SHARED   => esc_html__('Shared', 'event_espresso'),
                 Element::STATUS_TRASHED  => esc_html__('Trashed', 'event_espresso'),
             ]
         );

--- a/core/services/form/meta/Element.php
+++ b/core/services/form/meta/Element.php
@@ -22,6 +22,11 @@ class Element
     public const STATUS_DEFAULT = 'default';
 
     /**
+     * indicates that a copy of the form section will be saved for use in other events but not loaded by default
+     */
+    public const STATUS_SHARED = 'shared';
+
+    /**
      * indicates that element is no longer needed, has no existing answers, and can be moved to the trash
      */
     public const STATUS_TRASHED = 'trashed';
@@ -40,6 +45,7 @@ class Element
                 Element::STATUS_ACTIVE   => esc_html__('Active', 'event_espresso'),
                 Element::STATUS_ARCHIVED => esc_html__('Archived', 'event_espresso'),
                 Element::STATUS_DEFAULT  => esc_html__('Default', 'event_espresso'),
+                Element::STATUS_DEFAULT  => esc_html__('Shared', 'event_espresso'),
                 Element::STATUS_TRASHED  => esc_html__('Trashed', 'event_espresso'),
             ]
         );


### PR DESCRIPTION
This PR adds the GQL schema for Form Builder section queries.

Next steps:
- Add the missing fields to `Form_Section` model - `adminLabel`, `description`, `showDescription`, `showName`
- Remove unnecessary fields - `FSC_relation`


![image](https://user-images.githubusercontent.com/18226415/122933441-49aeb280-d38c-11eb-92c4-758fea879fbf.png)
