### PR TITLE
Add Form Section Admin Label Field

### DIFF
--- a/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
@@ -265,6 +265,7 @@ class EE_DMS_Core_4_12_0 extends EE_Data_Migration_Script_Base
 
         $table_name = 'esp_form_section';
         $sql        = "FSC_UUID varchar(25) NOT NULL,
+				FSC_adminLabel tinytext NOT NULL,
 				FSC_appliesTo tinytext NOT NULL,
 				FSC_belongsTo varchar(25) DEFAULT NULL,
 				FSC_htmlClass text DEFAULT NULL,

--- a/core/db_classes/EE_Form_Section.class.php
+++ b/core/db_classes/EE_Form_Section.class.php
@@ -88,6 +88,30 @@ class EE_Form_Section extends EE_Base_Class
 
 
     /**
+     * Form Section label displayed in the admin to help differentiate it from others
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function adminLabel(): string
+    {
+        return $this->get('FSC_adminLabel');
+    }
+
+
+    /**
+     * @param string $admin_label
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function setAdminLabel(string $admin_label)
+    {
+        $this->set('FSC_adminLabel', $admin_label);
+    }
+
+
+    /**
      * Form user types that this form section should be presented to.
      * Values correspond to the EEM_Form_Section::APPLIES_TO_* constants.
      *

--- a/core/db_models/EEM_Form_Section.model.php
+++ b/core/db_models/EEM_Form_Section.model.php
@@ -69,6 +69,15 @@ class EEM_Form_Section extends EEM_Form_Element
                     'FSC_UUID',
                     esc_html__('Form Section UUID (universally unique identifier)', 'event_espresso')
                 ),
+                'FSC_adminLabel' => new EE_Plain_Text_Field(
+                    'FSC_adminLabel',
+                    esc_html__(
+                        'Form Section label displayed in the admin to help differentiate it from others.',
+                        'event_espresso'
+                    ),
+                    true,
+                    null
+                ),
                 'FSC_appliesTo' => new EE_Enum_Text_Field(
                     'FSC_appliesTo',
                     esc_html__(
@@ -79,15 +88,6 @@ class EEM_Form_Section extends EEM_Form_Element
                     EEM_Form_Section::APPLIES_TO_ALL,
                     $this->valid_applies_to_options
                 ),
-                // 'FSC_attributes' => new EE_Serialized_Text_Field(
-                //     'FSC_attributes',
-                //     esc_html__(
-                //         'Array of HTML attributes that apply to this form section.',
-                //         'event_espresso'
-                //     ),
-                //     true,
-                //     []
-                // ),
                 'FSC_belongsTo' => new EE_Plain_Text_Field(
                     'FSC_belongsTo',
                     esc_html__('UUID of parent form section that this one belongs to.', 'event_espresso'),

--- a/core/domain/services/graphql/types/FormSection.php
+++ b/core/domain/services/graphql/types/FormSection.php
@@ -7,6 +7,7 @@ use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
 use EventEspresso\core\services\graphql\types\TypeBase;
 use EventEspresso\core\services\graphql\fields\GraphQLField;
 use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
+use EventEspresso\core\services\graphql\fields\GraphQLInputField;
 use EventEspresso\core\domain\services\graphql\mutators\FormSectionCreate;
 use EventEspresso\core\domain\services\graphql\mutators\FormSectionDelete;
 use EventEspresso\core\domain\services\graphql\mutators\FormSectionUpdate;
@@ -58,24 +59,18 @@ class FormSection extends TypeBase
                 'appliesTo',
                 esc_html__('Form user type that this form section should be presented to.', 'event_espresso')
             ),
-            /* new GraphQLField(
+            new GraphQLField(
                 'adminLabel',
                 'String',
                 'adminLabel',
-                esc_html__('The form section label that should be show to the admins.', 'event_espresso')
-            ), */
+                esc_html__('The form section label that should be shown to the admins.', 'event_espresso')
+            ),
             new GraphQLField(
                 'belongsTo',
                 'String',
                 'belongsTo',
                 esc_html__('UUID or ID of related entity this form section belongs to.', 'event_espresso')
             ),
-            /* new GraphQLField(
-                'description',
-                'String',
-                'description',
-                esc_html__('Description of the form section.', 'event_espresso')
-            ), */
             new GraphQLField(
                 'htmlClass',
                 'String',
@@ -88,18 +83,21 @@ class FormSection extends TypeBase
                 'order',
                 esc_html__('Order in which form section appears in a form.', 'event_espresso')
             ),
-            /* new GraphQLField(
-                'showDescription',
-                'Boolean',
-                'showDescription',
-                esc_html__('Whether to display description of the form section.', 'event_espresso')
+            new GraphQLField(
+                'publicLabel',
+                'String',
+                'publicLabel',
+                esc_html__('Form Section label displayed on public forms as a heading.', 'event_espresso')
             ),
             new GraphQLField(
-                'showName',
+                'showLabel',
                 'Boolean',
-                'showName',
-                esc_html__('Whether to display the admin label to non-admin users.', 'event_espresso')
-            ), */
+                'showLabel',
+                esc_html__(
+                    'Whether or not to display the Form Section name (Public Label) on public forms.',
+                    'event_espresso'
+                )
+            ),
             new GraphQLField(
                 'status',
                 $this->namespace . 'FormSectionStatusEnum',
@@ -114,6 +112,12 @@ class FormSection extends TypeBase
                 'User',
                 null,
                 esc_html__('WP User that created this form section.', 'event_espresso')
+            ),
+            new GraphQLInputField(
+                'wpUser',
+                'Int',
+                null,
+                esc_html__('ID of the WP User that created the form section.', 'event_espresso')
             ),
         ];
 

--- a/core/domain/services/graphql/types/FormSection.php
+++ b/core/domain/services/graphql/types/FormSection.php
@@ -63,7 +63,10 @@ class FormSection extends TypeBase
                 'adminLabel',
                 'String',
                 'adminLabel',
-                esc_html__('The form section label that should be shown to the admins.', 'event_espresso')
+                esc_html__(
+                    'Form Section label displayed in the admin to help differentiate it from others.',
+                    'event_espresso'
+                )
             ),
             new GraphQLField(
                 'belongsTo',


### PR DESCRIPTION
this PR:

- adds the missing `FSC_adminLabel` field to the Form Section model
- adds the `FSC_adminLabel` field to the DMS table declaration
- adds a getter and setter to the Form Section model object