### PR TITLE
Make WP Users Add-on Work

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -985,25 +985,24 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _events_overview_list_table()
     {
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-        $this->_template_args['after_list_table']                           =
-            ! empty($this->_template_args['after_list_table'])
-                ? (array) $this->_template_args['after_list_table']
-                : [];
-        $this->_template_args['after_list_table']['view_event_list_button'] = EEH_HTML::br()
-                                                                              . EEH_Template::get_button_or_link(
-                get_post_type_archive_link('espresso_events'),
-                esc_html__('View Event Archive Page', 'event_espresso'),
-                'button'
-            );
-        $this->_template_args['after_list_table']['legend']                 =
-            $this->_display_legend($this->_event_legend_items());
-        $this->_admin_page_title                                            .= ' '
-                                                                               . $this->get_action_link_or_button(
+        $after_list_table                           = [];
+        $after_list_table['view_event_list_button'] = EEH_HTML::br();
+        $after_list_table['view_event_list_button'] .= EEH_Template::get_button_or_link(
+            get_post_type_archive_link('espresso_events'),
+            esc_html__('View Event Archive Page', 'event_espresso'),
+            'button'
+        );
+        $after_list_table['legend'] = $this->_display_legend($this->_event_legend_items());
+        $this->_admin_page_title    .= ' ' . $this->get_action_link_or_button(
                 'create_new',
                 'add',
                 [],
                 'add-new-h2'
             );
+        $this->_template_args['after_list_table']   = array_merge(
+            $this->_template_args['after_list_table'],
+            $after_list_table
+        );
         $this->display_admin_list_table_page_with_no_sidebar();
     }
 
@@ -1355,26 +1354,26 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                   ->get_one_by_ID($tkt['TKT_ID']);
                 if ($TKT instanceof EE_Ticket) {
                     $ticket_sold = $TKT->count_related(
-                            'Registration',
+                        'Registration',
+                        [
                             [
-                                [
-                                    'STS_ID' => [
-                                        'NOT IN',
-                                        [EEM_Registration::status_id_incomplete],
-                                    ],
+                                'STS_ID' => [
+                                    'NOT IN',
+                                    [EEM_Registration::status_id_incomplete],
                                 ],
-                            ]
-                        ) > 0;
+                            ],
+                        ]
+                    ) > 0;
                     // let's just check the total price for the existing ticket and determine if it matches the new
                     // total price.  if they are different then we create a new ticket (if tickets sold)
                     // if they aren't different then we go ahead and modify existing ticket.
                     $create_new_TKT = $ticket_sold
                                       && ! $TKT->deleted()
                                       && EEH_Money::compare_floats(
-                            $ticket_price,
-                            $TKT->get('TKT_price'),
-                            '!=='
-                        );
+                                          $ticket_price,
+                                          $TKT->get('TKT_price'),
+                                          '!=='
+                                      );
                     $TKT->set_date_format($incoming_date_formats[0]);
                     $TKT->set_time_format($incoming_date_formats[1]);
                     // set new values
@@ -2504,8 +2503,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                     : EEM_Registration::status_id_pending_payment,
                                 'html_label_text' => esc_html__('Default Registration Status', 'event_espresso')
                                                      . EEH_Template::get_help_tab_link(
-                                        'default_settings_status_help_tab'
-                                    ),
+                                                         'default_settings_status_help_tab'
+                                                     ),
                                 'html_help_text'  => esc_html__(
                                     'This setting allows you to preselect what the default registration status setting is when creating an event.  Note that changing this setting does NOT retroactively apply it to existing events.',
                                     'event_espresso'
@@ -2522,8 +2521,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                                          'event_espresso'
                                                      )
                                                      . EEH_Template::get_help_tab_link(
-                                        'default_maximum_tickets_help_tab"'
-                                    ),
+                                                         'default_maximum_tickets_help_tab"'
+                                                     ),
                                 'html_help_text'  => esc_html__(
                                     'This setting allows you to indicate what will be the default for the maximum number of tickets per order when creating new events.',
                                     'event_espresso'

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -292,8 +292,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 //     'Event_Overview_Help_Tour',
                 //     // 'New_Features_Test_Help_Tour' for testing multiple help tour
                 // ],
-                'qtips'         => ['EE_Event_List_Table_Tips'],
                 'require_nonce' => false,
+                'qtips'         => ['EE_Event_List_Table_Tips'],
             ],
             'create_new'             => [
                 'nav'           => [
@@ -990,7 +990,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 ? (array) $this->_template_args['after_list_table']
                 : [];
         $this->_template_args['after_list_table']['view_event_list_button'] = EEH_HTML::br()
-            . EEH_Template::get_button_or_link(
+                                                                              . EEH_Template::get_button_or_link(
                 get_post_type_archive_link('espresso_events'),
                 esc_html__('View Event Archive Page', 'event_espresso'),
                 'button'
@@ -998,7 +998,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         $this->_template_args['after_list_table']['legend']                 =
             $this->_display_legend($this->_event_legend_items());
         $this->_admin_page_title                                            .= ' '
-            . $this->get_action_link_or_button(
+                                                                               . $this->get_action_link_or_button(
                 'create_new',
                 'add',
                 [],
@@ -1176,9 +1176,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     protected function _default_venue_update(EE_Event $evtobj, $data)
     {
         require_once(EE_MODELS . 'EEM_Venue.model.php');
-        $venue_model   = EE_Registry::instance()->load_model('Venue');
-        $rows_affected = null;
-        $venue_id      = ! empty($data['venue_id']) ? $data['venue_id'] : null;
+        $venue_model = EE_Registry::instance()->load_model('Venue');
+        $venue_id    = ! empty($data['venue_id']) ? $data['venue_id'] : null;
         // very important.  If we don't have a venue name...
         // then we'll get out because not necessary to create empty venue
         if (empty($data['venue_title'])) {
@@ -1356,26 +1355,26 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                   ->get_one_by_ID($tkt['TKT_ID']);
                 if ($TKT instanceof EE_Ticket) {
                     $ticket_sold = $TKT->count_related(
-                        'Registration',
-                        [
+                            'Registration',
                             [
-                                'STS_ID' => [
-                                    'NOT IN',
-                                    [EEM_Registration::status_id_incomplete],
+                                [
+                                    'STS_ID' => [
+                                        'NOT IN',
+                                        [EEM_Registration::status_id_incomplete],
+                                    ],
                                 ],
-                            ],
-                        ]
-                    ) > 0;
+                            ]
+                        ) > 0;
                     // let's just check the total price for the existing ticket and determine if it matches the new
                     // total price.  if they are different then we create a new ticket (if tickets sold)
                     // if they aren't different then we go ahead and modify existing ticket.
                     $create_new_TKT = $ticket_sold
                                       && ! $TKT->deleted()
                                       && EEH_Money::compare_floats(
-                                          $ticket_price,
-                                          $TKT->get('TKT_price'),
-                                          '!=='
-                                      );
+                            $ticket_price,
+                            $TKT->get('TKT_price'),
+                            '!=='
+                        );
                     $TKT->set_date_format($incoming_date_formats[0]);
                     $TKT->set_time_format($incoming_date_formats[1]);
                     // set new values
@@ -1721,7 +1720,11 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
          * 2. Fore each datetime get related tickets
          * 3. For each ticket get related prices
          */
-        $times = EE_Registry::instance()->load_model('Datetime')->get_all_event_dates($event_id);
+        /** @var EEM_Datetime $datetime_model */
+        $datetime_model = EE_Registry::instance()->load_model('Datetime');
+        /** @var EEM_Ticket $datetime_model */
+        $ticket_model = EE_Registry::instance()->load_model('Ticket');
+        $times        = $datetime_model->get_all_event_dates($event_id);
         /** @type EE_Datetime $first_datetime */
         $first_datetime = reset($times);
         // do we get related tickets?
@@ -1753,9 +1756,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             }
         } else {
             $template_args['time'] = $times[0];
-            /** @type EE_Ticket $ticket */
-            $ticket                       = EE_Registry::instance()->load_model('Ticket')->get_all_default_tickets();
-            $template_args['ticket_rows'] .= $this->_get_ticket_row($ticket[1]);
+            /** @type EE_Ticket[] $tickets */
+            $tickets                      = $ticket_model->get_all_default_tickets();
+            $template_args['ticket_rows'] .= $this->_get_ticket_row($tickets[1]);
             // NOTE: we're just sending the first default row
             // (decaf can't manage default tickets so this should be sufficient);
         }
@@ -1766,7 +1769,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         $template_args['existing_datetime_ids']    = implode(',', $existing_datetime_ids);
         $template_args['existing_ticket_ids']      = implode(',', $existing_ticket_ids);
         $template_args['ticket_js_structure']      = $this->_get_ticket_row(
-            EE_Registry::instance()->load_model('Ticket')->create_default_object(),
+            $ticket_model->create_default_object(),
             true
         );
         $template                                  = apply_filters(
@@ -1937,6 +1940,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         $limit   = $count ? null : $offset . ',' . $per_page;
         $orderby = isset($this->_req_data['orderby']) ? $this->_req_data['orderby'] : 'EVT_ID';
         $order   = isset($this->_req_data['order']) ? $this->_req_data['order'] : 'DESC';
+        $month_r = '';
+        $year_r  = '';
         if (isset($this->_req_data['month_range'])) {
             $pieces = explode(' ', $this->_req_data['month_range'], 3);
             // simulate the FIRST day of the month, that fixes issues for months like February
@@ -2283,8 +2288,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     * _delete_event
-     *
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
@@ -2315,9 +2318,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     * _delete_events
-     *
-     * @access protected
      * @return void
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -2503,9 +2503,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                     ? sanitize_text_field($registration_config->default_STS_ID)
                                     : EEM_Registration::status_id_pending_payment,
                                 'html_label_text' => esc_html__('Default Registration Status', 'event_espresso')
-                                                        . EEH_Template::get_help_tab_link(
-                                                            'default_settings_status_help_tab'
-                                                        ),
+                                                     . EEH_Template::get_help_tab_link(
+                                        'default_settings_status_help_tab'
+                                    ),
                                 'html_help_text'  => esc_html__(
                                     'This setting allows you to preselect what the default registration status setting is when creating an event.  Note that changing this setting does NOT retroactively apply it to existing events.',
                                     'event_espresso'
@@ -2518,12 +2518,12 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                     ? $registration_config->default_maximum_number_of_tickets
                                     : EEM_Event::get_default_additional_limit(),
                                 'html_label_text' => esc_html__(
-                                    'Default Maximum Tickets Allowed Per Order:',
-                                    'event_espresso'
-                                )
-                                . EEH_Template::get_help_tab_link(
-                                    'default_maximum_tickets_help_tab"'
-                                ),
+                                                         'Default Maximum Tickets Allowed Per Order:',
+                                                         'event_espresso'
+                                                     )
+                                                     . EEH_Template::get_help_tab_link(
+                                        'default_maximum_tickets_help_tab"'
+                                    ),
                                 'html_help_text'  => esc_html__(
                                     'This setting allows you to indicate what will be the default for the maximum number of tickets per order when creating new events.',
                                     'event_espresso'
@@ -2576,7 +2576,10 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     }
 
 
-    /*************        Templates        *************/
+    /*************        Templates        *************
+     *
+     * @throws EE_Error
+     */
     protected function _template_settings()
     {
         $this->_admin_page_title              = esc_html__('Template Settings (Preview)', 'event_espresso');
@@ -2738,6 +2741,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
     /**
      * Handles deleting categories.
+     *
+     * @throws EE_Error
      */
     protected function _delete_categories()
     {
@@ -2873,6 +2878,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     }
 
     /* end category stuff */
+
+
     /**************/
 
 

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1000,7 +1000,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'add-new-h2'
         );
         $this->_template_args['after_list_table']   = array_merge(
-            $this->_template_args['after_list_table'],
+            (array) $this->_template_args['after_list_table'],
             $after_list_table
         );
         $this->display_admin_list_table_page_with_no_sidebar();

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -994,11 +994,11 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         );
         $after_list_table['legend'] = $this->_display_legend($this->_event_legend_items());
         $this->_admin_page_title    .= ' ' . $this->get_action_link_or_button(
-                'create_new',
-                'add',
-                [],
-                'add-new-h2'
-            );
+            'create_new',
+            'add',
+            [],
+            'add-new-h2'
+        );
         $this->_template_args['after_list_table']   = array_merge(
             $this->_template_args['after_list_table'],
             $after_list_table
@@ -2517,12 +2517,12 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                                     ? $registration_config->default_maximum_number_of_tickets
                                     : EEM_Event::get_default_additional_limit(),
                                 'html_label_text' => esc_html__(
-                                                         'Default Maximum Tickets Allowed Per Order:',
-                                                         'event_espresso'
-                                                     )
-                                                     . EEH_Template::get_help_tab_link(
-                                                         'default_maximum_tickets_help_tab"'
-                                                     ),
+                                    'Default Maximum Tickets Allowed Per Order:',
+                                    'event_espresso'
+                                )
+                                . EEH_Template::get_help_tab_link(
+                                    'default_maximum_tickets_help_tab"'
+                                ),
                                 'html_help_text'  => esc_html__(
                                     'This setting allows you to indicate what will be the default for the maximum number of tickets per order when creating new events.',
                                     'event_espresso'

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -3283,17 +3283,16 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
 
 
     /**
-     *    generates HTML for the forms used on admin pages
+     * generates HTML for the forms used on admin pages
      *
-     * @param    array $input_vars - array of input field details
-     * @param string   $generator  (options are 'string' or 'array', basically use this to indicate which generator to
-     *                             use)
-     * @param bool     $id
-     * @return string
+     * @param array  $input_vars - array of input field details
+     * @param string $generator  indicates which generator to use: options are 'string' or 'array'
+     * @param bool   $id
+     * @return array|string
      * @uses   EEH_Form_Fields::get_form_fields (/helper/EEH_Form_Fields.helper.php)
      * @uses   EEH_Form_Fields::get_form_fields_array (/helper/EEH_Form_Fields.helper.php)
      */
-    protected function _generate_admin_form_fields($input_vars = array(), $generator = 'string', $id = false)
+    protected function _generate_admin_form_fields($input_vars = [], $generator = 'string', $id = false)
     {
         return $generator === 'string'
             ? EEH_Form_Fields::get_form_fields($input_vars, $id)

--- a/core/libraries/plugin_api/EE_Register_Message_Type.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Message_Type.lib.php
@@ -45,7 +45,8 @@ class EE_Register_Message_Type implements EEI_Plugin_API
     public static function register(string $addon_name = '', array $setup_args = []): bool
     {
         // required fields MUST be present, so let's make sure they are.
-        if (! isset($addon_name)
+        if (
+            ! isset($addon_name)
             || ! is_array($setup_args)
             || empty($setup_args['mtfilename'])
             || empty($setup_args['autoloadpaths'])
@@ -157,10 +158,12 @@ class EE_Register_Message_Type implements EEI_Plugin_API
         ];
         // add filters but only if they haven't already been set (these filters only need to be registered ONCE because
         // the callback handles all registered message types.
-        if (false === has_filter(
+        if (
+            has_filter(
                 'FHEE__EED_Messages___set_messages_paths___MSG_PATHS',
                 ['EE_Register_Message_Type', 'register_msgs_autoload_paths']
-            )) {
+            ) === false
+        ) {
             add_filter(
                 'FHEE__EED_Messages___set_messages_paths___MSG_PATHS',
                 ['EE_Register_Message_Type', 'register_msgs_autoload_paths'],
@@ -235,10 +238,11 @@ class EE_Register_Message_Type implements EEI_Plugin_API
             if ($settings['force_activation']) {
                 foreach ($settings['messengers_to_activate_with'] as $messenger) {
                     // DO not force activation if this message type has already been activated in the system
-                    if (! $message_resource_manager->has_message_type_been_activated_for_messenger(
-                        $addon_name,
-                        $messenger
-                    )
+                    if (
+                        ! $message_resource_manager->has_message_type_been_activated_for_messenger(
+                            $addon_name,
+                            $messenger
+                        )
                     ) {
                         $message_resource_manager->ensure_message_type_is_active($addon_name, $messenger);
                     }
@@ -423,13 +427,15 @@ class EE_Register_Message_Type implements EEI_Plugin_API
         string $context,
         EE_Messages_Template_Pack $template_pack
     ): string {
-        if (! $template_pack instanceof EE_Messages_Template_Pack_Default
+        if (
+            ! $template_pack instanceof EE_Messages_Template_Pack_Default
             || ! $message_type instanceof EE_message_type
         ) {
             return $base_path;
         }
         foreach (self::$_ee_message_type_registry as $addon_name => $mt_reg) {
-            if ($message_type->name === $addon_name
+            if (
+                $message_type->name === $addon_name
                 && ! empty($mt_reg['base_path_for_default_templates'])
             ) {
                 return $mt_reg['base_path_for_default_templates'];
@@ -470,17 +476,11 @@ class EE_Register_Message_Type implements EEI_Plugin_API
             return $base_path_or_url;
         }
         foreach (self::$_ee_message_type_registry as $addon_name => $mt_reg) {
-            if ($addon_name === $message_type_slug
-            ) {
-                if (
-                    $url
-                    && ! empty($mt_reg['base_url_for_default_variation'])
-                ) {
+            if ($addon_name === $message_type_slug) {
+                if ($url && ! empty($mt_reg['base_url_for_default_variation'])) {
                     return $mt_reg['base_url_for_default_variation'];
-                } elseif (
-                    ! $url
-                    && ! empty($mt_reg['base_path_for_default_variation'])
-                ) {
+                }
+                if (! $url && ! empty($mt_reg['base_path_for_default_variation'])) {
                     return $mt_reg['base_path_for_default_variation'];
                 }
             }

--- a/core/libraries/plugin_api/EE_Register_Messages_Template_Pack.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Messages_Template_Pack.lib.php
@@ -157,7 +157,7 @@ class EE_Register_Messages_Template_Pack implements EEI_Plugin_API
 
             // check again!
             if (class_exists($args['classname'])) {
-                $template_pack                           = new $args['classname'];
+                $template_pack                           = new $args['classname']();
                 $template_packs[ $template_pack->dbref ] = $template_pack;
             }
         }

--- a/core/libraries/plugin_api/EE_Register_Model.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Model.lib.php
@@ -82,8 +82,10 @@ class EE_Register_Model implements EEI_Plugin_API
         }
         self::$_model_registry[ $addon_name ] = $setup_args;
 
-        if ((isset($setup_args['model_paths']) && ! isset($setup_args['class_paths']))
-            || (! isset($setup_args['model_paths']) && isset($setup_args['class_paths']))) {
+        if (
+            (isset($setup_args['model_paths']) && ! isset($setup_args['class_paths']))
+            || (! isset($setup_args['model_paths']) && isset($setup_args['class_paths']))
+        ) {
             throw new EE_Error(
                 sprintf(
                     __(

--- a/core/libraries/plugin_api/EE_Register_Model_Extensions.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Model_Extensions.lib.php
@@ -54,7 +54,8 @@ class EE_Register_Model_Extensions implements EEI_Plugin_API
     public static function register(string $addon_name = '', array $setup_args = []): bool
     {
         // required fields MUST be present, so let's make sure they are.
-        if (empty($addon_name)
+        if (
+            empty($addon_name)
             || ! is_array($setup_args)
             || (empty($setup_args['model_extension_paths']) && empty($setup_args['class_extension_paths']))
         ) {
@@ -102,7 +103,7 @@ class EE_Register_Model_Extensions implements EEI_Plugin_API
             }
             EEH_Autoloader::register_autoloader($class_to_filepath_map);
             foreach (array_keys($class_to_filepath_map) as $classname) {
-                self::$_extensions[ $addon_name ]['models'][ $classname ] = new $classname;
+                self::$_extensions[ $addon_name ]['models'][ $classname ] = new $classname();
             }
             unset($setup_args['model_extension_paths']);
         }
@@ -111,7 +112,7 @@ class EE_Register_Model_Extensions implements EEI_Plugin_API
             $class_to_filepath_map = EEH_File::get_contents_of_folders($setup_args['class_extension_paths']);
             EEH_Autoloader::register_autoloader($class_to_filepath_map);
             foreach (array_keys($class_to_filepath_map) as $classname) {
-                self::$_extensions[ $addon_name ]['classes'][ $classname ] = new $classname;
+                self::$_extensions[ $addon_name ]['classes'][ $classname ] = new $classname();
             }
             unset($setup_args['class_extension_paths']);
         }

--- a/core/libraries/plugin_api/EE_Register_Shortcode.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Shortcode.lib.php
@@ -45,7 +45,8 @@ class EE_Register_Shortcode implements EEI_Plugin_API
     public static function register(string $addon_name = '', array $setup_args = []): bool
     {
         // required fields MUST be present, so let's make sure they are.
-        if (empty($addon_name)
+        if (
+            empty($addon_name)
             || ! is_array($setup_args)
             || (
                empty($setup_args['shortcode_paths']))

--- a/core/services/addon/api/IncompatibleAddonHandler.php
+++ b/core/services/addon/api/IncompatibleAddonHandler.php
@@ -25,13 +25,13 @@ class IncompatibleAddonHandler
             'load_espresso_automated_upcoming_event_notification',
             'EE_AUTOMATED_UPCOMING_EVENT_NOTIFICATION_PLUGIN_FILE'
         );
-        $this->deactivateIncompatibleAddon(
-            'WP Users Integration',
-            'EE_WPUSERS_VERSION',
-            '2.1.0.rc.003',
-            'load_ee_core_wpusers',
-            'EE_WPUSERS_PLUGIN_FILE'
-        );
+        // $this->deactivateIncompatibleAddon(
+        //     'WP Users Integration',
+        //     'EE_WPUSERS_VERSION',
+        //     '2.1.0.rc.003',
+        //     'load_ee_core_wpusers',
+        //     'EE_WPUSERS_PLUGIN_FILE'
+        // );
     }
 
 

--- a/core/services/addon/api/IncompatibleAddonHandler.php
+++ b/core/services/addon/api/IncompatibleAddonHandler.php
@@ -28,7 +28,7 @@ class IncompatibleAddonHandler
         $this->deactivateIncompatibleAddon(
             'WP Users Integration',
             'EE_WPUSERS_VERSION',
-            '2.1.1.rc.001',
+            '2.1.0.rc.003',
             'load_ee_core_wpusers',
             'EE_WPUSERS_PLUGIN_FILE'
         );

--- a/core/services/orm/tree_traversal/NodeGroupDao.php
+++ b/core/services/orm/tree_traversal/NodeGroupDao.php
@@ -45,6 +45,7 @@ class NodeGroupDao
     /**
      * @param $code
      * @return ModelObjNode[]
+     * @throws Exception
      * @throws UnexpectedEntityException
      * @throws Exception
      */
@@ -97,6 +98,7 @@ class NodeGroupDao
      * @param string $code
      * @return array
      * @throws EE_Error
+     * @throws Exception
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException

--- a/core/services/orm/tree_traversal/RelationNode.php
+++ b/core/services/orm/tree_traversal/RelationNode.php
@@ -51,6 +51,7 @@ class RelationNode extends BaseNode
     protected $related_model;
 
 
+
     /**
      * RelationNode constructor.
      *
@@ -199,7 +200,6 @@ class RelationNode extends BaseNode
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
-     * @throws ReflectionException
      */
     protected function discover()
     {


### PR DESCRIPTION
This PR simply reduces the min add-on version required set in the `IncompatibleAddonHandler`.
This allows older versions of WP User to continue working with the EDTR...

### **HOWEVER**...

PLEASE NOTE that NONE of the WP User Event Editor functionality (assigning caps to tickets) will work if the user has activated the Advanced Editor (EDTR). So in other words, they can use WP Users version `2.1.0.rc.003` with core dev branch (EDTR) and everything will work the same as long as they also continue to use the Legacy Event Editor. If the switch to use the new EDTR, then they just won't be able to set caps on tickets, but everything else _should_ work as SPCO remains unchanged.