### PR TITLE
Fix Delete Event Logic

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2045,9 +2045,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     * _trash_or_restore_events
-     *
-     * @access  private
      * @param  int    $EVT_ID
      * @param  string $event_status
      * @return bool
@@ -2104,22 +2101,37 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     }
 
 
-    private function getEventIdsFromRequest(): array
+    /**
+     * @param array $event_ids
+     * @return array
+     * @since   $VID:$
+     */
+    private function cleanEventIds(array $event_ids)
     {
-        $event_ids = $this->_req_data['EVT_ID'] ?? [];
-        return (array) $event_ids;
+        return array_map('absint', $event_ids);
     }
 
+
     /**
-     * _delete_event
-     *
+     * @return array
+     * @since   $VID:$
+     */
+    private function getEventIdsFromRequest()
+    {
+        $event_ids = isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : [];
+        return $this->cleanEventIds($event_ids);
+    }
+
+
+    /**
      * @param bool $preview_delete
      * @throws EE_Error
      */
-    protected function _delete_event(bool $preview_delete = true)
+    protected function _delete_event($preview_delete = true)
     {
         $this->_delete_events($preview_delete);
     }
+
 
     /**
      * Gets the tree traversal batch persister.
@@ -2139,16 +2151,13 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     * _delete_events
-     *
      * @param bool $preview_delete
      * @return void
      * @throws EE_Error
      */
-    protected function _delete_events(bool $preview_delete = true)
+    protected function _delete_events($preview_delete = true)
     {
         $event_ids = $this->getEventIdsFromRequest();
-        $event_ids = array_map('absint', $event_ids);
         if ($preview_delete) {
             $this->generateDeletionPreview($event_ids);
         } else {
@@ -2156,8 +2165,13 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         }
     }
 
+
+    /**
+     * @param array $event_ids
+     */
     protected function generateDeletionPreview(array $event_ids)
     {
+        $event_ids = $this->cleanEventIds($event_ids);
         // Set a code we can use to reference this deletion task in the batch jobs and preview page.
         $deletion_job_code = $this->getModelObjNodeGroupPersister()->generateGroupCode();
         $return_url = EE_Admin_Page::add_query_args_and_nonce(
@@ -2167,7 +2181,6 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             ],
             $this->_admin_base_url
         );
-        $event_ids = array_map('absint', $event_ids);
         EEH_URL::safeRedirectAndExit(
             EE_Admin_Page::add_query_args_and_nonce(
                 [

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2119,7 +2119,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     private function getEventIdsFromRequest()
     {
         $event_ids = isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : [];
-        $event_ids = is_string($event_ids) ? explode(',', $event_ids) : $event_ids;
+        $event_ids = is_string($event_ids) ? explode(',', $event_ids) : (array) $event_ids;
         return $this->cleanEventIds($event_ids);
     }
 

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -2119,6 +2119,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
     private function getEventIdsFromRequest()
     {
         $event_ids = isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : [];
+        $event_ids = is_string($event_ids) ? explode(',', $event_ids) : $event_ids;
         return $this->cleanEventIds($event_ids);
     }
 

--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -952,9 +952,9 @@ class EEM_Event extends EEM_CPT_Base
         if ($deleted) {
             // get list of events with no prices
             $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);
-            $where = $query_params[0] ?? [];
-            $where_event = $where['EVT_ID'] ?? ['', ''];
-            $where_event_ids = $where_event[1] ?? '';
+            $where = isset($query_params[0]) ? $query_params[0] : [];
+            $where_event = isset($where['EVT_ID']) ? $where['EVT_ID'] : ['', ''];
+            $where_event_ids = isset($where_event[1]) ? $where_event[1] : '';
             $event_ids = is_string($where_event_ids)
                 ? explode(',', $where_event_ids)
                 : (array) $where_event_ids;

--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -930,4 +930,40 @@ class EEM_Event extends EEM_CPT_Base
         }
         return $classInstance;
     }
+
+
+    /**
+     * Deletes the model objects that meet the query params. Note: this method is overridden
+     * in EEM_Soft_Delete_Base so that soft-deleted model objects are instead only flagged
+     * as archived, not actually deleted
+     *
+     * @param array   $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param boolean $allow_blocking if TRUE, matched objects will only be deleted if there is no related model info
+     *                                that blocks it (ie, there' sno other data that depends on this data); if false,
+     *                                deletes regardless of other objects which may depend on it. Its generally
+     *                                advisable to always leave this as TRUE, otherwise you could easily corrupt your
+     *                                DB
+     * @return int                    number of rows deleted
+     * @throws EE_Error
+     */
+    public function delete_permanently($query_params, $allow_blocking = true)
+    {
+        $deleted = parent::delete_permanently($query_params, $allow_blocking);
+        if ($deleted) {
+            // get list of events with no prices
+            $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);
+            $where = $query_params[0] ?? [];
+            $where_event = $where['EVT_ID'] ?? ['', ''];
+            $where_event_ids = $where_event[1] ?? '';
+            $event_ids = is_string($where_event_ids)
+                ? explode(',', $where_event_ids)
+                : (array) $where_event_ids;
+            array_walk($event_ids, 'trim');
+            $event_ids = array_filter($event_ids);
+            // remove events from list of events with no prices
+            $espresso_no_ticket_prices = array_diff($espresso_no_ticket_prices, $event_ids);
+            update_option('ee_no_ticket_prices', $espresso_no_ticket_prices);
+        }
+        return $deleted;
+    }
 }

--- a/core/db_models/EEM_Soft_Delete_Base.model.php
+++ b/core/db_models/EEM_Soft_Delete_Base.model.php
@@ -267,9 +267,10 @@ abstract class EEM_Soft_Delete_Base extends EEM_Base
      * @param boolean $allow_blocking if TRUE, matched objects will only be deleted if there is no related model info
      *                                that blocks it (ie, there' sno other data that depends on this data); if false, deletes regardless of other objects
      *                                which may depend on it. Its generally advisable to always leave this as TRUE, otherwise you could easily corrupt your DB
-     * @return boolean success
+     * @return int                    number of rows deleted
+     * @throws EE_Error
      */
-    public function delete_permanently($query_params = array(), $allow_blocking = true)
+    public function delete_permanently($query_params, $allow_blocking = true)
     {
         $query_params = $this->_alter_query_params_so_deleted_and_undeleted_items_included($query_params);
         return parent::delete_permanently($query_params, $allow_blocking);

--- a/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
@@ -6,77 +6,83 @@ use EventEspresso\core\services\loaders\LoaderFactory;
  *
  * This class contains all tests for the Events Admin Page (non decaf).
  *
- * @package		Event Espresso
- * @subpackage	tests
- * @author		Darren Ethier
- * @since 4.9
- * @group admin
- * @group ppt
- *
+ * @package        Event Espresso
+ * @subpackage     tests
+ * @author         Darren Ethier
+ * @since          4.9
+ * @group          admin
+ * @group          ppt
  */
-class Events_Admin_Page_Test extends EE_UnitTestCase {
+class Events_Admin_Page_Test extends EE_UnitTestCase
+{
 
-	/**
-	 * Holds the Events_Admin_Page Mock class
-	 * @var Events_Admin_Page_Mock
-	 */
-	protected $_admin_page;
-
-
-	/**
-	 * This holds the EE_Event object for testing with
-	 * @var EE_Event
-	 */
-	protected $_event;
-	
-	
-	
-	public function setUp() {
-		parent::setUp();
-		$this->delayedAdminPageMocks( 'events' );
-	}
+    /**
+     * Holds the Events_Admin_Page Mock class
+     *
+     * @var Events_Admin_Page_Mock
+     */
+    protected $_admin_page;
 
 
     /**
-     * @throws EE_Error
+     * This holds the EE_Event object for testing with
+     *
+     * @var EE_Event
      */
+    protected $_event;
+
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->delayedAdminPageMocks('events');
+    }
+
+
     public function tearDown()
     {
         unset($this->_admin_page);
         unset($this->_event);
         parent::tearDown();
     }
-	
-	
-	
-	protected function _load_requirements( $timezone = 'America/Vancouver' ) {
+
+
+    /**
+     * @param string $timezone
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    protected function _load_requirements($timezone = 'America/Vancouver')
+    {
         $this->_admin_page = LoaderFactory::getLoader()->getNew('Events_Admin_Page_Mock');
-		$this->_event = $this->factory->event->create();
-		$this->_event->set_timezone( $timezone );
-		$this->_event->save();
-		$this->_set_default_dates( $timezone );
-	}
+        $this->_event      = $this->factory->event->create();
+        $this->_event->set_timezone($timezone);
+        $this->_event->save();
+        $this->_set_default_dates($timezone);
+    }
 
 
+    /**
+     * Tests the _delete_event method via the mock
+     *
+     * @see   https://events.codebasehq.com/projects/event-espresso/tickets/9699
+     * @group 9699
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_delete_event()
+    {
+        $this->_load_requirements();
+        $EVT_ID = $this->_event->ID();
 
-
-	/**
-	 * Tests the _delete_event method via the mock
-	 * @see https://events.codebasehq.com/projects/event-espresso/tickets/9699
-	 * @group 9699
-	 */
-	public function test_delete_event() {
-		$this->_load_requirements();
-		$EVT_ID = $this->_event->ID();
-
-		// creates and saves an array of integers including EVT_ID plus 2 sequential entries before and after
+        // creates and saves an array of integers including EVT_ID plus 2 sequential entries before and after
         update_option('ee_no_ticket_prices', range($EVT_ID - 2, $EVT_ID + 2));
         $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);
         // verify that EVT_ID is now in the array
         $this->assertArrayContains($EVT_ID, $espresso_no_ticket_prices);
 
-		$this->_admin_page->delete_event($EVT_ID);
-		$this->assertEmpty( EEM_Event::instance()->get_one_by_ID($EVT_ID ) );
+        $this->_admin_page->delete_event($EVT_ID);
+        $this->assertEmpty(EEM_Event::instance()->get_one_by_ID($EVT_ID));
 
         // verify that EVT_ID is no longer in the 'ee_no_ticket_prices' array
         $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);

--- a/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
@@ -1,0 +1,86 @@
+<?php
+
+use EventEspresso\core\services\loaders\LoaderFactory;
+
+/**
+ *
+ * This class contains all tests for the Events Admin Page (non decaf).
+ *
+ * @package		Event Espresso
+ * @subpackage	tests
+ * @author		Darren Ethier
+ * @since 4.9
+ * @group admin
+ * @group ppt
+ *
+ */
+class Events_Admin_Page_Test extends EE_UnitTestCase {
+
+	/**
+	 * Holds the Events_Admin_Page Mock class
+	 * @var Events_Admin_Page_Mock
+	 */
+	protected $_admin_page;
+
+
+	/**
+	 * This holds the EE_Event object for testing with
+	 * @var EE_Event
+	 */
+	protected $_event;
+	
+	
+	
+	public function setUp() {
+		parent::setUp();
+		$this->delayedAdminPageMocks( 'events' );
+	}
+
+
+    /**
+     * @throws EE_Error
+     */
+    public function tearDown()
+    {
+        unset($this->_admin_page);
+        unset($this->_event);
+        parent::tearDown();
+    }
+	
+	
+	
+	protected function _load_requirements( $timezone = 'America/Vancouver' ) {
+        $this->_admin_page = LoaderFactory::getLoader()->getNew('Events_Admin_Page_Mock');
+		$this->_event = $this->factory->event->create();
+		$this->_event->set_timezone( $timezone );
+		$this->_event->save();
+		$this->_set_default_dates( $timezone );
+	}
+
+
+
+
+	/**
+	 * Tests the _delete_event method via the mock
+	 * @see https://events.codebasehq.com/projects/event-espresso/tickets/9699
+	 * @group 9699
+	 */
+	public function test_delete_event() {
+		$this->_load_requirements();
+		$EVT_ID = $this->_event->ID();
+
+		// creates and saves an array of integers including EVT_ID plus 2 sequential entries before and after
+        update_option('ee_no_ticket_prices', range($EVT_ID - 2, $EVT_ID + 2));
+        $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);
+        // verify that EVT_ID is now in the array
+        $this->assertArrayContains($EVT_ID, $espresso_no_ticket_prices);
+
+		$this->_admin_page->delete_event($EVT_ID);
+		$this->assertEmpty( EEM_Event::instance()->get_one_by_ID($EVT_ID ) );
+
+        // verify that EVT_ID is no longer in the 'ee_no_ticket_prices' array
+        $espresso_no_ticket_prices = get_option('ee_no_ticket_prices', []);
+        $this->assertArrayDoesNotContain($EVT_ID, $espresso_no_ticket_prices);
+    }
+}
+// tests/testcases/admin_pages/events/Events_Admin_Page_Test.php


### PR DESCRIPTION
Encountered an error recently in the event admin, where previewing an event deletion failed because of an issue with a system that tracks events with tickets that have no prices (can't remember atm why we even do that).

This PR fixes that by updating the list of "tickets with no prices" when deleting an event.