### PR TITLE
Form Builder | Fix sanitization for HTML elements

### DIFF
--- a/core/domain/services/graphql/data/mutations/FormElementMutation.php
+++ b/core/domain/services/graphql/data/mutations/FormElementMutation.php
@@ -37,7 +37,7 @@ class FormElementMutation
         }
 
         if (isset($input['attributes'])) {
-            $args['FIN_attributes'] = Attributes::fromJson(sanitize_text_field($input['attributes']))->toJson();
+            $args['FIN_attributes'] = Attributes::fromJson($input['attributes'])->toJson();
         }
 
         if (isset($input['belongsTo'])) {

--- a/core/domain/services/graphql/data/mutations/FormElementMutation.php
+++ b/core/domain/services/graphql/data/mutations/FormElementMutation.php
@@ -37,7 +37,7 @@ class FormElementMutation
         }
 
         if (isset($input['attributes'])) {
-            $args['FIN_attributes'] = Attributes::fromJson($input['attributes'])->toJson();
+            $args['FIN_attributes'] = Attributes::fromJson(sanitize_text_field($input['attributes']))->toJson();
         }
 
         if (isset($input['belongsTo'])) {
@@ -49,7 +49,7 @@ class FormElementMutation
         }
 
         if (isset($input['label'])) {
-            $args['FIN_label'] = FormLabel::fromJson(sanitize_text_field($input['label']))->toJson();
+            $args['FIN_label'] = FormLabel::fromJson($input['label'])->toJson();
         }
 
         if (isset($input['mapsTo'])) {

--- a/core/services/form/meta/Attributes.php
+++ b/core/services/form/meta/Attributes.php
@@ -74,6 +74,8 @@ class Attributes implements JsonableInterface
         'type'            => 'string',
         'value'           => 'string',
         'width'           => 'string',
+        // HTML content displayed in block type elements
+        'html'            => 'html',
     ];
 
 
@@ -144,6 +146,8 @@ class Attributes implements JsonableInterface
                 return filter_var($value, FILTER_SANITIZE_NUMBER_INT);
             case 'float':
                 return filter_var($value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+            case 'html':
+                return wp_kses_post($value);
             case 'string':
             default:
                 return filter_var(

--- a/core/services/form/meta/Attributes.php
+++ b/core/services/form/meta/Attributes.php
@@ -74,8 +74,6 @@ class Attributes implements JsonableInterface
         'type'            => 'string',
         'value'           => 'string',
         'width'           => 'string',
-        // HTML content displayed in block type elements
-        'html'            => 'html',
     ];
 
 
@@ -146,8 +144,6 @@ class Attributes implements JsonableInterface
                 return filter_var($value, FILTER_SANITIZE_NUMBER_INT);
             case 'float':
                 return filter_var($value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
-            case 'html':
-                return wp_kses_post($value);
             case 'string':
             default:
                 return filter_var(

--- a/core/services/form/meta/FormLabel.php
+++ b/core/services/form/meta/FormLabel.php
@@ -169,7 +169,7 @@ class FormLabel implements JsonableInterface
 
 
     /**
-     * @return bool
+     * @return string
      */
     public function html(): string
     {
@@ -178,7 +178,7 @@ class FormLabel implements JsonableInterface
 
 
     /**
-     * @param string $showLabel
+     * @param string $html
      */
     public function setHtml($html): void
     {

--- a/core/services/form/meta/FormLabel.php
+++ b/core/services/form/meta/FormLabel.php
@@ -39,6 +39,13 @@ class FormLabel implements JsonableInterface
      */
     private $showLabel;
 
+    /**
+     * The HTML block displayed for block elements.
+     *
+     * @var string
+     */
+    private $html;
+
 
     /**
      * FormLabel constructor.
@@ -52,12 +59,14 @@ class FormLabel implements JsonableInterface
         JsonDataHandler $json_data_handler,
         string $adminLabel,
         string $publicLabel,
-        bool $showLabel
+        bool $showLabel,
+        string $html
     ) {
         $this->json_data_handler = $json_data_handler;
         $this->setAdminLabel($adminLabel);
         $this->setPublicLabel($publicLabel);
         $this->setShowLabel($showLabel);
+        $this->setHtml($html);
     }
 
 
@@ -73,7 +82,8 @@ class FormLabel implements JsonableInterface
         $adminLabel  = $data->adminLabel ?? '';
         $publicLabel = $data->publicLabel ?? '';
         $showLabel   = $data->showLabel ?? false;
-        return new FormLabel($json_data_handler, $adminLabel, $publicLabel, $showLabel);
+        $html        = $data->html ?? '';
+        return new FormLabel($json_data_handler, $adminLabel, $publicLabel, $showLabel, $html);
     }
 
 
@@ -86,6 +96,7 @@ class FormLabel implements JsonableInterface
             'adminLabel'  => $this->adminLabel,
             'publicLabel' => $this->publicLabel,
             'showLabel'   => $this->showLabel,
+            'html'        => $this->html,
         ];
     }
 
@@ -154,5 +165,23 @@ class FormLabel implements JsonableInterface
     public function setShowLabel($showLabel): void
     {
         $this->showLabel = filter_var($showLabel, FILTER_VALIDATE_BOOLEAN);
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function html(): string
+    {
+        return $this->html;
+    }
+
+
+    /**
+     * @param string $showLabel
+     */
+    public function setHtml($html): void
+    {
+        $this->html = wp_kses_post($html);
     }
 }

--- a/core/services/form/meta/FormLabel.php
+++ b/core/services/form/meta/FormLabel.php
@@ -180,7 +180,7 @@ class FormLabel implements JsonableInterface
     /**
      * @param string $html
      */
-    public function setHtml($html): void
+    public function setHtml(string $html): void
     {
         $this->html = wp_kses_post($html);
     }

--- a/core/services/form/meta/inputs/Input.php
+++ b/core/services/form/meta/inputs/Input.php
@@ -41,6 +41,11 @@ class Input
     public const TYPE_PASSWORD = 'password';
 
     /**
+     * indicates that the input is used to confirm a password
+     */
+    public const TYPE_PASSWORD_CONFIRMATION = 'password-confirmation';
+
+    /**
      * indicates that the HTML input type is 'radio'
      */
     public const TYPE_RADIO = 'radio';
@@ -61,15 +66,16 @@ class Input
         $this->valid_type_options = apply_filters(
             'FHEE__EventEspresso_core_services_form_meta_inputs_Input__valid_type_options',
             [
-                Input::TYPE_CHECKBOX       => esc_html__('Checkbox', 'event_espresso'),
-                Input::TYPE_CHECKBOX_MULTI => esc_html__('Multi Checkbox', 'event_espresso'),
-                Input::TYPE_COLOR          => esc_html__('Color Picker', 'event_espresso'),
-                Input::TYPE_FILE           => esc_html__('File Upload', 'event_espresso'),
-                Input::TYPE_HIDDEN         => esc_html__('Hidden', 'event_espresso'),
-                Input::TYPE_IMAGE          => esc_html__('Image Upload', 'event_espresso'),
-                Input::TYPE_PASSWORD       => esc_html__('Password', 'event_espresso'),
-                Input::TYPE_RADIO          => esc_html__('Radio Button', 'event_espresso'),
-                Input::TYPE_URL            => esc_html__('URL', 'event_espresso'),
+                Input::TYPE_CHECKBOX              => esc_html__('Checkbox', 'event_espresso'),
+                Input::TYPE_CHECKBOX_MULTI        => esc_html__('Multi Checkbox', 'event_espresso'),
+                Input::TYPE_COLOR                 => esc_html__('Color Picker', 'event_espresso'),
+                Input::TYPE_FILE                  => esc_html__('File Upload', 'event_espresso'),
+                Input::TYPE_HIDDEN                => esc_html__('Hidden', 'event_espresso'),
+                Input::TYPE_IMAGE                 => esc_html__('Image Upload', 'event_espresso'),
+                Input::TYPE_PASSWORD              => esc_html__('Password', 'event_espresso'),
+                Input::TYPE_PASSWORD_CONFIRMATION => esc_html__('Password confirmation', 'event_espresso'),
+                Input::TYPE_RADIO                 => esc_html__('Radio Button', 'event_espresso'),
+                Input::TYPE_URL                   => esc_html__('URL', 'event_espresso'),
             ]
         );
     }

--- a/core/services/form/meta/inputs/Input.php
+++ b/core/services/form/meta/inputs/Input.php
@@ -73,7 +73,7 @@ class Input
                 Input::TYPE_HIDDEN                => esc_html__('Hidden', 'event_espresso'),
                 Input::TYPE_IMAGE                 => esc_html__('Image Upload', 'event_espresso'),
                 Input::TYPE_PASSWORD              => esc_html__('Password', 'event_espresso'),
-                Input::TYPE_PASSWORD_CONFIRMATION => esc_html__('Password confirmation', 'event_espresso'),
+                Input::TYPE_PASSWORD_CONFIRMATION => esc_html__('Password Confirmation', 'event_espresso'),
                 Input::TYPE_RADIO                 => esc_html__('Radio Button', 'event_espresso'),
                 Input::TYPE_URL                   => esc_html__('URL', 'event_espresso'),
             ]

--- a/core/services/form/meta/inputs/Text.php
+++ b/core/services/form/meta/inputs/Text.php
@@ -12,7 +12,7 @@ class Text
     /**
      * indicates that the input is used to confirm an email address
      */
-    public const TYPE_EMAIL_CONFIRM = 'email-confirmation';
+    public const TYPE_EMAIL_CONFIRMATION = 'email-confirmation';
 
     /**
      * indicates that the HTML input type is 'text'
@@ -41,11 +41,11 @@ class Text
         $this->valid_type_options = apply_filters(
             'FHEE__EventEspresso_core_services_form_meta_inputs_Text__valid_type_options',
             [
-                Text::TYPE_EMAIL         => esc_html__('Email', 'event_espresso'),
-                Text::TYPE_EMAIL_CONFIRM => esc_html__('Email Confirmation', 'event_espresso'),
-                Text::TYPE_TEXT          => esc_html__('Plain Text', 'event_espresso'),
-                Text::TYPE_TEXTAREA      => esc_html__('Plain Textarea', 'event_espresso'),
-                Text::TYPE_TEXTAREA_HTML => esc_html__('Simple HTML Textarea', 'event_espresso'),
+                Text::TYPE_EMAIL              => esc_html__('Email', 'event_espresso'),
+                Text::TYPE_EMAIL_CONFIRMATION => esc_html__('Email Confirmation', 'event_espresso'),
+                Text::TYPE_TEXT               => esc_html__('Plain Text', 'event_espresso'),
+                Text::TYPE_TEXTAREA           => esc_html__('Plain Textarea', 'event_espresso'),
+                Text::TYPE_TEXTAREA_HTML      => esc_html__('Simple HTML Textarea', 'event_espresso'),
             ]
         );
     }


### PR DESCRIPTION
This PR fixes the sanitization of HTML elements for form builder by using a special attribute named `html` to store the HTML content and passing it through `wp_kses_post`.
It also adds `Password confirmation` to the form inputs.