### PR TITLE
Replace EE_Request

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -444,7 +444,7 @@ class EE_Dependency_Map
     {
         $this->_dependency_map = array(
             'EE_Request_Handler'                                                                                          => array(
-                'EE_Request' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
             ),
             'EE_System'                                                                                                   => array(
                 'EE_Registry'                                 => EE_Dependency_Map::load_from_cache,
@@ -656,10 +656,10 @@ class EE_Dependency_Map
                 'EventEspresso\core\services\database\ModelFieldFactory' => EE_Dependency_Map::load_from_cache,
             ),
             'EE_Module_Request_Router'                                                                                    => array(
-                'EE_Request' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
             ),
             'EE_Registration_Processor'                                                                                   => array(
-                'EE_Request' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
             ),
             'EventEspresso\core\services\notifications\PersistentAdminNoticeManager'                                      => array(
                 null,

--- a/core/EE_Module_Request_Router.core.php
+++ b/core/EE_Module_Request_Router.core.php
@@ -1,6 +1,7 @@
 <?php
 
 use EventEspresso\core\interfaces\InterminableInterface;
+use EventEspresso\core\services\request\RequestInterface;
 
 /**
  *  Class EE_Module_Request_Router
@@ -16,7 +17,7 @@ final class EE_Module_Request_Router implements InterminableInterface
 {
 
     /**
-     * @var EE_Request $request
+     * @var RequestInterface $request
      */
     private $request;
 
@@ -34,9 +35,9 @@ final class EE_Module_Request_Router implements InterminableInterface
     /**
      * EE_Module_Request_Router constructor.
      *
-     * @param EE_Request $request
+     * @param RequestInterface $request
      */
-    public function __construct(EE_Request $request)
+    public function __construct(RequestInterface $request)
     {
         $this->request = $request;
     }
@@ -97,11 +98,11 @@ final class EE_Module_Request_Router implements InterminableInterface
                 // check request for module route
                 $route_found = $uses_wildcards
                     ? $this->request->matches($key)
-                    : $this->request->is_set($key);
+                    : $this->request->requestParamIsSet($key);
                 if ($route_found) {
                     $current_route = $uses_wildcards
                         ? $this->request->getMatch($key)
-                        : $this->request->get($key);
+                        : $this->request->getRequestParam($key);
                     $current_route = sanitize_text_field($current_route);
                     if ($current_route) {
                         $current_route = array($key, $current_route);
@@ -125,7 +126,7 @@ final class EE_Module_Request_Router implements InterminableInterface
      *
      * @param string $key
      * @param string $current_route
-     * @return mixed EED_Module | boolean
+     * @return EED_Module|object|boolean|null
      * @throws EE_Error
      * @throws ReflectionException
      */
@@ -187,7 +188,6 @@ final class EE_Module_Request_Router implements InterminableInterface
      *
      * @param string $module_name
      * @return EED_Module|object|null
-     * @throws ReflectionException
      */
     public static function module_factory($module_name)
     {
@@ -238,7 +238,7 @@ final class EE_Module_Request_Router implements InterminableInterface
         if ($module instanceof EED_Module) {
             // and call whatever action the route was for
             try {
-                call_user_func(array($module, $method), $this->WP_Query);
+                $module->{$method}($this->WP_Query);
             } catch (EE_Error $e) {
                 $e->get_error();
                 return null;

--- a/core/Factory.php
+++ b/core/Factory.php
@@ -2,7 +2,9 @@
 
 namespace EventEspresso\core;
 
+use EE_Error;
 use EventEspresso\core\libraries\iframe_display\Iframe;
+use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
  * Class Factory
@@ -20,28 +22,19 @@ class Factory
      * @param string $class_name
      * @param array  $arguments
      * @return mixed|null
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public static function create($class_name, $arguments = array())
     {
         if (empty($class_name)) {
-            throw new \EE_Error(
+            throw new EE_Error(
                 __('You must provide a class name in order to instantiate it.', 'event_espresso')
             );
         }
-        // if ( ! class_exists( $class_name ) ) {
-        //     throw new \EE_Error(
-        //         sprintf(
-        //             __('The "%1$s" class was not found. Please include the correct file or set an autoloader for it',
-        //                 'event_espresso'),
-        //             $class_name
-        //         )
-        //     );
-        // }
-        $object = null;
         switch ($class_name) {
+            case 'Request':
             case 'EE_Request':
-                $object = new \EE_Request($_GET, $_POST, $_COOKIE);
+                $object = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\Request');
                 break;
             case 'Iframe':
                 $title = isset($arguments['title']) ? $arguments['title'] : null;
@@ -51,19 +44,6 @@ class Factory
             default:
                 $object = new $class_name($arguments);
         }
-
-        // if ( ! $object instanceof $class_name ) {
-        //     throw new \EE_Error(
-        //         sprintf(
-        //             __(
-        //                 'An error occurred during class instantiation and the requested object could not be created. The result was: %1$s %2$s',
-        //                 'event_espresso'
-        //             ),
-        //             '<br />',
-        //             var_export($object, true)
-        //         )
-        //     );
-        // }
         return $object;
     }
 }

--- a/core/business/EE_Registration_Processor.class.php
+++ b/core/business/EE_Registration_Processor.class.php
@@ -7,7 +7,9 @@ use EventEspresso\core\domain\services\registration\CreateRegistrationService;
 use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\request\RequestInterface;
 
 EE_Registry::instance()->load_class('Processor_Base');
 
@@ -36,7 +38,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      *
      * @var array
      */
-    protected $_old_reg_status = array();
+    protected $_old_reg_status = [];
 
     /**
      * reg status at the end of the request after all processing.
@@ -44,7 +46,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      *
      * @var array
      */
-    protected $_new_reg_status = array();
+    protected $_new_reg_status = [];
 
     /**
      * amounts paid at the end of the request after all processing.
@@ -52,7 +54,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      *
      * @var array
      */
-    protected static $_amount_paid = array();
+    protected static $_amount_paid = [];
 
     /**
      * Cache of the reg final price for registrations corresponding to a ticket line item
@@ -63,25 +65,25 @@ class EE_Registration_Processor extends EE_Processor_Base
     protected $_reg_final_price_per_tkt_line_item;
 
     /**
-     * @var EE_Request $request
+     * @var RequestInterface $request
      */
     protected $request;
 
 
     /**
      * @singleton method used to instantiate class object
-     * @param EE_Request|null $request
+     * @param RequestInterface|null $request
      * @return EE_Registration_Processor instance
-     * @throws \InvalidArgumentException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @throws InvalidArgumentException
+     * @throws InvalidInterfaceException
+     * @throws InvalidDataTypeException
      */
-    public static function instance(EE_Request $request = null)
+    public static function instance(RequestInterface $request = null)
     {
         // check if class object is instantiated
         if (! self::$_instance instanceof EE_Registration_Processor) {
-            if (! $request instanceof EE_Request) {
-                $request = LoaderFactory::getLoader()->getShared('EE_Request');
+            if (! $request instanceof RequestInterface) {
+                $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\Request');
             }
             self::$_instance = new self($request);
         }
@@ -92,9 +94,9 @@ class EE_Registration_Processor extends EE_Processor_Base
     /**
      * EE_Registration_Processor constructor.
      *
-     * @param EE_Request $request
+     * @param RequestInterface $request
      */
-    public function __construct(EE_Request $request)
+    public function __construct(RequestInterface $request)
     {
         $this->request = $request;
     }
@@ -369,14 +371,14 @@ class EE_Registration_Processor extends EE_Processor_Base
     public function toggle_registration_status_if_no_monies_owing(
         EE_Registration $registration,
         $save = true,
-        array $additional_details = array()
+        array $additional_details = []
     ) {
         // set initial REG_Status
         $this->set_old_reg_status($registration->ID(), $registration->status_ID());
         // was a payment just made ?
-        $payment = isset($additional_details['payment_updates'], $additional_details['last_payment'])
-                   && $additional_details['payment_updates']
-                   && $additional_details['last_payment'] instanceof EE_Payment
+        $payment    = isset($additional_details['payment_updates'], $additional_details['last_payment'])
+                      && $additional_details['payment_updates']
+                      && $additional_details['last_payment'] instanceof EE_Payment
             ? $additional_details['last_payment']
             : null;
         $total_paid = array_sum(self::$_amount_paid);
@@ -445,7 +447,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      * @param array           $additional_details
      * @return void
      */
-    public function trigger_registration_update_notifications($registration, array $additional_details = array())
+    public function trigger_registration_update_notifications($registration, array $additional_details = [])
     {
         try {
             if (! $registration instanceof EE_Registration) {
@@ -492,7 +494,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      */
     public function update_registration_after_checkout_or_payment(
         EE_Registration $registration,
-        array $additional_details = array()
+        array $additional_details = []
     ) {
         // set initial REG_Status
         $this->set_old_reg_status($registration->ID(), $registration->status_ID());
@@ -525,6 +527,7 @@ class EE_Registration_Processor extends EE_Processor_Base
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws RuntimeException
+     * @throws ReflectionException
      */
     public function update_registration_final_prices($transaction, $save_regs = true)
     {
@@ -563,30 +566,30 @@ class EE_Registration_Processor extends EE_Processor_Base
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     public function fix_reg_final_price_rounding_issue($transaction)
     {
         $reg_final_price_sum = EEM_Registration::instance()->sum(
-            array(
-                array(
+            [
+                [
                     'TXN_ID' => $transaction->ID(),
-                ),
-            ),
+                ],
+            ],
             'REG_final_price'
         );
-        $diff = $transaction->total() - $reg_final_price_sum;
+        $diff                = $transaction->total() - $reg_final_price_sum;
         // ok then, just grab one of the registrations
-        if ($diff !== 0) {
+        if ($diff !== (float) 0) {
             $a_reg = EEM_Registration::instance()->get_one(
-                array(
-                    array(
+                [
+                    [
                         'TXN_ID' => $transaction->ID(),
-                    ),
-                )
+                    ],
+                ]
             );
             return $a_reg instanceof EE_Registration
-                ? (bool) $a_reg->save(array('REG_final_price' => $a_reg->final_price() + $diff))
-                : false;
+                   && $a_reg->save(['REG_final_price' => $a_reg->final_price() + $diff]);
         }
         return true;
     }
@@ -601,10 +604,11 @@ class EE_Registration_Processor extends EE_Processor_Base
      * @return bool
      * @throws EE_Error
      * @throws RuntimeException
+     * @throws ReflectionException
      */
     public function update_registration_after_being_canceled_or_declined(
         EE_Registration $registration,
-        array $closed_reg_statuses = array(),
+        array $closed_reg_statuses = [],
         $update_reg = true
     ) {
         // these reg statuses should not be considered in any calculations involving monies owing
@@ -633,10 +637,11 @@ class EE_Registration_Processor extends EE_Processor_Base
      * @return bool
      * @throws EE_Error
      * @throws RuntimeException
+     * @throws ReflectionException
      */
     public function update_canceled_or_declined_registration_after_being_reinstated(
         EE_Registration $registration,
-        array $closed_reg_statuses = array(),
+        array $closed_reg_statuses = [],
         $update_reg = true
     ) {
         // these reg statuses should not be considered in any calculations involving monies owing
@@ -677,16 +682,17 @@ class EE_Registration_Processor extends EE_Processor_Base
      * after SPCO has already been initialized. So if an additional ticket was added to the cart, you can simply pass
      * the line item to this method to add a second ticket, and in this case, you would not want to add 2 tickets.
      *
+     * @param EE_Line_Item   $line_item
+     * @param EE_Transaction $transaction
+     * @param int            $att_nmbr
+     * @param int            $total_ticket_count
+     * @return EE_Registration | null
+     * @throws OutOfRangeException
+     * @throws UnexpectedEntityException
+     * @throws EE_Error
+     * @throws ReflectionException
      * @deprecated
      * @since 4.9.1
-     * @param EE_Line_Item    $line_item
-     * @param \EE_Transaction $transaction
-     * @param int             $att_nmbr
-     * @param int             $total_ticket_count
-     * @return EE_Registration | null
-     * @throws \OutOfRangeException
-     * @throws \EventEspresso\core\exceptions\UnexpectedEntityException
-     * @throws \EE_Error
      */
     public function generate_ONE_registration_from_line_item(
         EE_Line_Item $line_item,
@@ -733,12 +739,12 @@ class EE_Registration_Processor extends EE_Processor_Base
     /**
      * generates reg_url_link
      *
-     * @deprecated
-     * @since 4.9.1
      * @param int                   $att_nmbr
      * @param EE_Line_Item | string $item
-     * @return string
+     * @return RegUrlLink
      * @throws InvalidArgumentException
+     * @deprecated
+     * @since 4.9.1
      */
     public function generate_reg_url_link($att_nmbr, $item)
     {
@@ -758,13 +764,13 @@ class EE_Registration_Processor extends EE_Processor_Base
     /**
      * generates reg code
      *
-     * @deprecated
-     * @since 4.9.1
      * @param EE_Registration $registration
-     * @return string
+     * @return RegCode
      * @throws EE_Error
      * @throws EntityNotFoundException
      * @throws InvalidArgumentException
+     * @since 4.9.1
+     * @deprecated
      */
     public function generate_reg_code(EE_Registration $registration)
     {

--- a/core/libraries/form_sections/form_handlers/SequentialStepFormManager.php
+++ b/core/libraries/form_sections/form_handlers/SequentialStepFormManager.php
@@ -3,8 +3,7 @@
 namespace EventEspresso\core\libraries\form_sections\form_handlers;
 
 use EE_Error;
-use EE_Request;
-use EventEspresso\core\exceptions\ExceptionStackTraceDisplay;
+use EventEspresso\core\services\request\RequestInterface;
 use EventEspresso\core\exceptions\InvalidClassException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
@@ -68,7 +67,7 @@ abstract class SequentialStepFormManager
     private $progress_step_style = '';
 
     /**
-     * @var EE_Request $request
+     * @var RequestInterface $request
      */
     private $request;
 
@@ -96,7 +95,7 @@ abstract class SequentialStepFormManager
      * @param string     $default_form_step
      * @param string     $form_action
      * @param string     $form_config
-     * @param EE_Request $request
+     * @param RequestInterface $request
      * @param string     $progress_step_style
      * @throws InvalidDataTypeException
      * @throws InvalidArgumentException
@@ -107,7 +106,7 @@ abstract class SequentialStepFormManager
         $form_action = '',
         $form_config = FormHandler::ADD_FORM_TAGS_AND_SUBMIT,
         $progress_step_style = 'number_bubbles',
-        EE_Request $request
+        RequestInterface $request = null
     ) {
         $this->setBaseUrl($base_url);
         $this->setDefaultFormStep($default_form_step);
@@ -203,21 +202,18 @@ abstract class SequentialStepFormManager
 
     /**
      * @return void
-     * @throws \EventEspresso\core\exceptions\InvalidIdentifierException
+     * @throws InvalidIdentifierException
      * @throws InvalidDataTypeException
      */
     protected function setCurrentStepFromRequest()
     {
-        $current_step_slug = $this->request()->get($this->formStepUrlKey(), $this->defaultFormStep());
+        $current_step_slug = $this->request()->getRequestParam($this->formStepUrlKey(), $this->defaultFormStep());
         if (! $this->form_steps->setCurrent($current_step_slug)) {
             throw new InvalidIdentifierException(
                 $current_step_slug,
                 $this->defaultFormStep(),
-                $message = sprintf(
-                    esc_html__(
-                        'The "%1$s" form step could not be set.',
-                        'event_espresso'
-                    ),
+                sprintf(
+                    esc_html__('The "%1$s" form step could not be set.', 'event_espresso'),
                     $current_step_slug
                 )
             );
@@ -226,7 +222,7 @@ abstract class SequentialStepFormManager
 
 
     /**
-     * @return object|SequentialStepFormInterface
+     * @return SequentialStepFormInterface|object
      * @throws InvalidFormHandlerException
      */
     public function getCurrentStep()
@@ -321,7 +317,7 @@ abstract class SequentialStepFormManager
 
 
     /**
-     * @return EE_Request
+     * @return RequestInterface
      */
     public function request()
     {
@@ -587,7 +583,6 @@ abstract class SequentialStepFormManager
                 // going somewhere else, so just check out now
                 wp_safe_redirect($redirect_step->redirectUrl());
                 exit();
-                break;
             case SequentialStepForm::REDIRECT_TO_PREV_STEP:
                 $redirect_step = $this->form_steps->previous();
                 break;

--- a/core/services/progress_steps/ProgressStepManager.php
+++ b/core/services/progress_steps/ProgressStepManager.php
@@ -2,14 +2,15 @@
 
 namespace EventEspresso\core\services\progress_steps;
 
-use EE_Request;
+use EEH_Template;
 use EventEspresso\core\exceptions\InvalidClassException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidIdentifierException;
-use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\collections\Collection;
 use EventEspresso\core\services\collections\CollectionInterface;
+use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\progress_steps\display_strategies\ProgressStepsDisplayInterface;
+use EventEspresso\core\services\request\RequestInterface;
 
 /**
  * Class ProgressStepManager
@@ -27,12 +28,12 @@ class ProgressStepManager
 {
 
     /**
-     * @var ProgressStepInterface[] $collection
+     * @var ProgressStepInterface[]
      */
     private $collection;
 
     /**
-     * @var string $default_step
+     * @var string
      */
     private $default_step;
 
@@ -40,17 +41,17 @@ class ProgressStepManager
      * the key used for the URL param that denotes the current form step
      * defaults to 'ee-form-step'
      *
-     * @var string $form_step_url_key
+     * @var string
      */
     private $form_step_url_key = '';
 
     /**
-     * @var ProgressStepsDisplayInterface $display_strategy
+     * @var ProgressStepsDisplayInterface
      */
     private $display_strategy;
 
     /**
-     * @var EE_Request $request
+     * @var RequestInterface
      */
     private $request;
 
@@ -62,17 +63,14 @@ class ProgressStepManager
      * @param string              $default_step
      * @param string              $form_step_url_key
      * @param CollectionInterface $collection
-     * @param \EE_Request         $request
-     * @throws InvalidClassException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
+     * @param RequestInterface    $request
      */
     public function __construct(
         $display_strategy_name = 'number_bubbles',
         $default_step = '',
         $form_step_url_key = '',
         CollectionInterface $collection = null,
-        EE_Request $request = null
+        RequestInterface $request = null
     ) {
         $this->setDisplayStrategy($display_strategy_name);
         $this->setDefaultStep($default_step);
@@ -81,8 +79,9 @@ class ProgressStepManager
             $collection = new Collection('\EventEspresso\core\services\progress_steps\ProgressStepInterface');
         }
         $this->collection = $collection;
-        if (! $request instanceof EE_Request) {
-            $request = \EE_Registry::instance()->load_core('Request');
+        if (! $request instanceof RequestInterface) {
+            /** @var RequestInterface $request */
+            $request = LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\Request');
         }
         $this->request = $request;
     }
@@ -160,7 +159,7 @@ class ProgressStepManager
         // use incoming value if it's set, otherwise use request param if it's set, otherwise use default
         $step = ! empty($step)
             ? $step
-            : $this->request->get($this->form_step_url_key, $this->default_step);
+            : $this->request->getRequestParam($this->form_step_url_key, $this->default_step);
         // grab the step previously known as current, in case we need to revert
         $current_current_step = $this->collection->current();
         // verify that requested step exists
@@ -233,7 +232,7 @@ class ProgressStepManager
      */
     public function displaySteps()
     {
-        return \EEH_Template::display_template(
+        return EEH_Template::display_template(
             $this->display_strategy->getTemplate(),
             array('progress_steps' => $this->collection),
             true
@@ -243,7 +242,7 @@ class ProgressStepManager
 
     /**
      * @param bool $completed
-     * @return \EventEspresso\core\services\progress_steps\ProgressStepInterface
+     * @return ProgressStepInterface
      */
     public function setCurrentStepCompleted($completed = true)
     {

--- a/tests/testcases/core/services/request/RequestTest.php
+++ b/tests/testcases/core/services/request/RequestTest.php
@@ -1,0 +1,479 @@
+<?php
+
+namespace EventEspresso\tests\testcases\core\services\request;
+
+use EventEspresso\core\services\request\Request;
+use PHPUnit_Framework_TestCase;
+
+
+/**
+ * Class RequestTest
+ * Description
+ *
+ * @package EventEspresso\tests\testcases\core\request_stack
+ * @author  Brent Christensen
+ *
+ */
+class RequestTest extends PHPUnit_Framework_TestCase
+{
+
+    public function getParams(array $params = array())
+    {
+        return $params + array(
+            'action'         => 'edit',
+            'id'             => 123,
+            'event-name-123' => 'Event 123',
+        );
+    }
+
+    public function postParams(array $params = array())
+    {
+        return $params + array(
+            'input-a' => 'A',
+            'input-b' => 'B',
+            'sub' => array(
+                'sub-a'   => 'AA',
+                'sub-b'   => 'BB',
+                'sub-sub' => array(
+                    'sub-sub-a'   => 'AAA',
+                    'sub-sub-b'   => 'BBB',
+                )
+            ),
+        );
+    }
+
+    public function cookieParams(array $params = array())
+    {
+        return $params + array(
+            'PHPSESSID'   => 'abcdefghijklmnopqrstuvwxyz',
+            'cookie_test' => 'a1b2c3d4e5f6g7h8i9j0.12345678',
+        );
+    }
+
+
+    /**
+     * @param array $get
+     * @param array $post
+     * @param array $cookie
+     * @param array $server
+     * @param array $files
+     * @return Request
+     */
+    private function getRequest(array $get, array $post, array $cookie, array $server, array $files = array())
+    {
+        return new Request($get, $post, $cookie, $server, $files);
+    }
+
+
+    public function testGetParams()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $this->assertEquals(
+            $this->getParams(),
+            $request->getParams()
+        );
+    }
+
+    public function testPostParams()
+    {
+        $request = $this->getRequest(
+            array(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        $this->assertEquals(
+            $this->postParams(),
+            $request->postParams()
+        );
+    }
+
+    public function testCookieParams()
+    {
+        $request = $this->getRequest(
+            array(),
+            array(),
+            $this->cookieParams(),
+            array()
+        );
+        $this->assertEquals(
+            $this->cookieParams(),
+            $request->cookieParams()
+        );
+    }
+
+    public function testParams()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        $this->assertEquals(
+            array_merge($this->getParams(), $this->postParams()),
+            $request->getParams()
+        );
+    }
+
+    public function testSet()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $key = 'new-key';
+        $value = 'ima noob';
+        $request->setRequestParam($key, $value);
+        $params = $request->getParams();
+        $this->assertArrayHasKey($key, $params);
+        $this->assertEquals($value, $params[$key]);
+    }
+
+    public function testSetEE()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $request->setRequestParam('ee', 'module-route');
+        $params = $request->getParams();
+        $this->assertArrayHasKey('ee', $params);
+        $this->assertEquals('module-route', $params['ee']);
+    }
+
+    public function testAlreadySetEE()
+    {
+        $request = $this->getRequest(
+            $this->getParams(array('ee' => 'existing-route')),
+            array(),
+            array(),
+            array()
+        );
+        $request->setRequestParam('ee', 'module-route');
+        $params = $request->getParams();
+        $this->assertArrayHasKey('ee', $params);
+        $this->assertNotEquals('module-route', $params['ee']);
+        $this->assertEquals('existing-route', $params['ee']);
+    }
+
+    public function testOverrideAlreadySetEE()
+    {
+        $request = $this->getRequest(
+            $this->getParams(array('ee' => 'existing-route')),
+            array(),
+            array(),
+            array()
+        );
+        $request->setRequestParam('ee', 'module-route', true);
+        $params = $request->getParams();
+        $this->assertArrayHasKey('ee', $params);
+        $this->assertEquals('module-route', $params['ee']);
+    }
+
+
+
+    public function testGet()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        // key exists
+        $this->assertEquals('edit', $request->getRequestParam('action'));
+        // key does NOT exist and no default value set
+        $this->assertNotEquals('edit', $request->getRequestParam('me-no-key'));
+        $this->assertNull($request->getRequestParam('me-no-key'));
+        // key does NOT exist but default value set
+        $this->assertNotEquals(
+            'edit',
+            $request->getRequestParam('me-no-key', 'me-default')
+        );
+        $this->assertEquals(
+            'me-default',
+            $request->getRequestParam('me-no-key', 'me-default')
+        );
+    }
+
+
+
+    public function testGetWithDrillDown()
+    {
+        $request = $this->getRequest(
+            array(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        // our post data looks like this:
+        //  array(
+        //    'input-a' => 'A',
+        //    'input-b' => 'B',
+        //    'sub' => array(
+        //        'sub-a'   => 'AA',
+        //        'sub-b'   => 'BB',
+        //        'sub-sub' => array(
+        //            'sub-sub-a'   => 'AAA',
+        //            'sub-sub-b'   => 'BBB',
+        //          )
+        //      )
+        //  );
+        // top-level value
+        $this->assertEquals('A', $request->getRequestParam('input-a'));
+        $this->assertEquals('B', $request->getRequestParam('input-b'));
+        // second level
+        $this->assertEquals('AA', $request->getRequestParam('sub[sub-a]'));
+        $this->assertEquals('BB', $request->getRequestParam('sub[sub-b]'));
+        // third level
+        $this->assertEquals('AAA', $request->getRequestParam('sub[sub-sub][sub-sub-a]'));
+        $this->assertEquals('BBB', $request->getRequestParam('sub[sub-sub][sub-sub-b]'));
+        // does not exist
+        $this->assertNull($request->getRequestParam('input-c'));
+        $this->assertNull($request->getRequestParam('sub[sub-c]'));
+        $this->assertNull($request->getRequestParam('sub[sub-sub][sub-sub-c]'));
+    }
+
+
+
+    public function testIsSet()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $this->assertTrue($request->requestParamIsSet('action'));
+        $this->assertFalse($request->requestParamIsSet('me-no-key'));
+    }
+
+
+
+    public function testIsSetWithDrillDown()
+    {
+        $request = $this->getRequest(
+            array(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        // our post data looks like this:
+        //  array(
+        //    'input-a' => 'A',
+        //    'input-b' => 'B',
+        //    'sub' => array(
+        //        'sub-a'   => 'AA',
+        //        'sub-b'   => 'BB',
+        //        'sub-sub' => array(
+        //            'sub-sub-a'   => 'AAA',
+        //            'sub-sub-b'   => 'BBB',
+        //          )
+        //      )
+        //  );
+        // top-level value
+        $this->assertTrue($request->requestParamIsSet('input-a'));
+        $this->assertTrue($request->requestParamIsSet('input-b'));
+        // second level
+        $this->assertTrue($request->requestParamIsSet('sub[sub-a]'));
+        $this->assertTrue($request->requestParamIsSet('sub[sub-b]'));
+        // third level
+        $this->assertTrue($request->requestParamIsSet('sub[sub-sub][sub-sub-a]'));
+        $this->assertTrue($request->requestParamIsSet('sub[sub-sub][sub-sub-b]'));
+        // not set
+        $this->assertFalse($request->requestParamIsSet('input-c'));
+        $this->assertFalse($request->requestParamIsSet('sub[sub-c]'));
+        $this->assertFalse($request->requestParamIsSet('sub[sub-sub][sub-sub-c]'));
+    }
+
+
+
+    public function testUnSet()
+    {
+        // do the chevy shuffle with the $_REQUEST global
+        // in case it's needed by other tests
+        $EXISTING_REQUEST = $_REQUEST;
+        $_REQUEST = $this->getParams();
+        $request = $this->getRequest(
+            $_REQUEST,
+            array(),
+            array(),
+            array()
+        );
+        $this->assertTrue($request->requestParamIsSet('action'));
+        $request->unSetRequestParam('action');
+        $this->assertFalse($request->requestParamIsSet('action'));
+        $this->assertTrue(isset($_REQUEST['action']));
+        // unset 'id' param but from GLOBAL too
+        $this->assertTrue($request->requestParamIsSet('id'));
+        $request->unSetRequestParam('id', true);
+        $this->assertFalse($request->requestParamIsSet('id'));
+        $this->assertFalse(isset($_REQUEST['id']));
+        // reinstate $_REQUEST global
+        $_REQUEST = $EXISTING_REQUEST;
+    }
+
+
+
+    public function testIpAddress()
+    {
+        // do the chevy shuffle with the $_SERVER global
+        // in case it's needed by other tests
+        $EXISTING_SERVER = $_SERVER;
+        $server_keys = array(
+            'HTTP_CLIENT_IP',
+            'HTTP_X_FORWARDED_FOR',
+            'HTTP_X_FORWARDED',
+            'HTTP_X_CLUSTER_CLIENT_IP',
+            'HTTP_FORWARDED_FOR',
+            'HTTP_FORWARDED',
+            'REMOTE_ADDR',
+        );
+        $x = 0;
+        // let's test 100 random IP addresses
+        while ($x < 100) {
+            // first clear out entries from previous test
+            foreach ($server_keys as $server_key) {
+                unset($_SERVER[$server_key]);
+            }
+            // randomly generate IP address. plz see: https://stackoverflow.com/a/39846883
+            $ip_address = long2ip(mt_rand() + mt_rand() + mt_rand(0, 1));
+            // then randomly populate one of the $_SERVER keys used to determine the IP
+            $_SERVER[$server_keys[mt_rand(0, 6)]] = $ip_address;
+            $request = $this->getRequest(array(), array(), array(), $_SERVER);
+            $this->assertEquals($ip_address, $request->ipAddress());
+            unset($request);
+            $x++;
+        }
+        // reinstate $_SERVER global
+        $_SERVER = $EXISTING_SERVER;
+    }
+
+
+    public function testMatches()
+    {
+        $request = $this->getRequest(
+            $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $this->assertTrue($request->matches('event-*'));
+        $this->assertTrue($request->matches('*-name-*'));
+        $this->assertTrue($request->matches('event-name-*'));
+        $this->assertTrue($request->matches('event*name*'));
+        $this->assertTrue($request->matches('event?name*'));
+        $this->assertTrue($request->matches('event-name-123'));
+        $this->assertFalse($request->matches('event-name-?'));
+    }
+
+
+    public function testMatchesWithDrillDown()
+    {
+        $request = $this->getRequest(
+        array(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        // our post data looks like this:
+        //  array(
+        //    'input-a' => 'A',
+        //    'input-b' => 'B',
+        //    'sub' => array(
+        //        'sub-a'   => 'AA',
+        //        'sub-b'   => 'BB',
+        //        'sub-sub' => array(
+        //            'sub-sub-a'   => 'AAA',
+        //            'sub-sub-b'   => 'BBB',
+        //          )
+        //      )
+        //  );
+        // top-level value
+        $this->assertTrue($request->matches('input-?'));
+        $this->assertTrue($request->matches('input-*'));
+        // second level
+        $this->assertTrue($request->matches('sub[sub-?]'));
+        $this->assertTrue($request->matches('sub[sub-*]'));
+        // third level
+        $this->assertTrue($request->matches('sub[sub-sub][sub-sub-?]'));
+        $this->assertTrue($request->matches('sub[sub-sub][sub-sub-*]'));
+        // not set
+        $this->assertFalse($request->matches('input-c-*'));
+        $this->assertFalse($request->matches('sub[sub-c-*]'));
+        $this->assertFalse($request->matches('sub[sub-sub-*][sub-sub-c]'));
+    }
+
+    public function testGetMatch()
+    {
+        $request = $this->getRequest(
+        $this->getParams(),
+            array(),
+            array(),
+            array()
+        );
+        $this->assertEquals('Event 123', $request->getMatch('event-*'));
+        $this->assertEquals('Event 123', $request->getMatch('*-name-*'));
+        $this->assertEquals('Event 123', $request->getMatch('event-name-*'));
+        $this->assertEquals('Event 123', $request->getMatch('event*name*'));
+        $this->assertEquals('Event 123', $request->getMatch('event?name*'));
+        $this->assertEquals('Event 123', $request->getMatch('event-name-123'));
+        $this->assertNull($request->getMatch('event-name-?'));
+        // with default
+        $this->assertEquals('default', $request->getMatch('event-name-?', 'default'));
+    }
+
+
+    public function testGetMatchWithDrillDown()
+    {
+        $request = $this->getRequest(
+        array(),
+            $this->postParams(),
+            array(),
+            array()
+        );
+        // our post data looks like this:
+        //  array(
+        //    'input-a' => 'A',
+        //    'input-b' => 'B',
+        //    'sub' => array(
+        //        'sub-a'   => 'AA',
+        //        'sub-b'   => 'BB',
+        //        'sub-sub' => array(
+        //            'sub-sub-a'   => 'AAA',
+        //            'sub-sub-b'   => 'BBB',
+        //          )
+        //      )
+        //  );
+        // top-level value
+        $this->assertEquals('A', $request->getMatch('input-?'));
+        $this->assertEquals('A', $request->getMatch('input-*'));
+        // with default
+        $this->assertEquals('default', $request->getMatch('not-an-input-?', 'default'));
+        // second level
+        $this->assertEquals('AA', $request->getMatch('sub[sub-?]'));
+        $this->assertEquals('AA', $request->getMatch('sub[sub-*]'));
+        // with default
+        $this->assertEquals('default', $request->getMatch('sub[not-an-input-?]', 'default'));
+        // third level
+        $this->assertEquals('AAA', $request->getMatch('sub[sub-sub][sub-sub-?]'));
+        $this->assertEquals('AAA', $request->getMatch('sub[sub-sub][sub-sub-*]'));
+        // with default
+        $this->assertEquals('default', $request->getMatch('sub[sub-sub][not-an-input-?]', 'default'));
+        // not set
+        $this->assertNull($request->getMatch('input-c-*'));
+        $this->assertNull($request->getMatch('sub[sub-c-*]'));
+        $this->assertNull($request->getMatch('sub[sub-sub-*][sub-sub-c]'));
+    }
+}
+// Location: tests/testcases/core/request_stack/RequestTest.php

--- a/tests/testcases/core/services/request/RequestTest.php
+++ b/tests/testcases/core/services/request/RequestTest.php
@@ -75,7 +75,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals(
             $this->getParams(),
-            $request->getParams()
+            $request->requestParams()
         );
     }
 
@@ -117,7 +117,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals(
             array_merge($this->getParams(), $this->postParams()),
-            $request->getParams()
+            $request->requestParams()
         );
     }
 
@@ -132,7 +132,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $key = 'new-key';
         $value = 'ima noob';
         $request->setRequestParam($key, $value);
-        $params = $request->getParams();
+        $params = $request->requestParams();
         $this->assertArrayHasKey($key, $params);
         $this->assertEquals($value, $params[$key]);
     }
@@ -146,7 +146,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             array()
         );
         $request->setRequestParam('ee', 'module-route');
-        $params = $request->getParams();
+        $params = $request->requestParams();
         $this->assertArrayHasKey('ee', $params);
         $this->assertEquals('module-route', $params['ee']);
     }
@@ -160,7 +160,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             array()
         );
         $request->setRequestParam('ee', 'module-route');
-        $params = $request->getParams();
+        $params = $request->requestParams();
         $this->assertArrayHasKey('ee', $params);
         $this->assertNotEquals('module-route', $params['ee']);
         $this->assertEquals('existing-route', $params['ee']);
@@ -175,7 +175,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             array()
         );
         $request->setRequestParam('ee', 'module-route', true);
-        $params = $request->getParams();
+        $params = $request->requestParams();
         $this->assertArrayHasKey('ee', $params);
         $this->assertEquals('module-route', $params['ee']);
     }


### PR DESCRIPTION
Doing a bunch of updates for some issues with the EE decaf version.

This PR:

- replaces ALL production uses of the legacy `EE_Request` class with `EventEspresso\core\services\request\Request`
- does some formatting and code cleanup on touched files