### PR TITLE
Enhance venue GQL schema

### DIFF
--- a/core/domain/entities/admin/GraphQLData/Event.php
+++ b/core/domain/entities/admin/GraphQLData/Event.php
@@ -44,6 +44,7 @@ class Event extends GraphQLData
                 shortDescription
                 status
                 timezoneString
+                venue
                 visibleOn
                 __typename
             }

--- a/core/domain/entities/admin/GraphQLData/Venues.php
+++ b/core/domain/entities/admin/GraphQLData/Venues.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EventEspresso\core\domain\entities\admin\GraphQLData;
+
+/**
+ * Class Venues
+ * Description
+ *
+ * @package EventEspresso\core\domain\entities\admin\GraphQLData
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class Venues extends GraphQLData
+{
+
+    /**
+     * @param array $where_params
+     * @return array|null
+     * @since $VID:$
+     */
+    public function getData(array $where_params = [])
+    {
+        $field_key = lcfirst($this->namespace) . 'Venues';
+        $query = <<<QUERY
+        query GET_VENUES(\$where: RootQueryTo{$this->namespace}VenueConnectionWhereArgs, \$first: Int, \$last: Int ) {
+            {$field_key}(where: \$where, first: \$first, last: \$last) {
+                nodes {
+                    id
+                    address
+                    address2
+                    cacheId
+                    city
+                    countryName
+                    dbId
+                    name
+                    stateName
+                    zip
+                    __typename
+                }
+                __typename
+            }
+        }
+QUERY;
+        $this->setParams([
+            'operation_name' => 'GET_VENUES',
+            'variables'      => [
+                'first' => 100,
+            ],
+            'query'          => $query,
+        ]);
+
+        return $this->getQueryResponse($field_key, $where_params);
+    }
+}

--- a/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
+++ b/core/domain/entities/routing/handlers/admin/EspressoEventEditor.php
@@ -52,6 +52,7 @@ class EspressoEventEditor extends EspressoEventsAdmin
                 'EventEspresso\core\domain\services\admin\events\editor\EventEntityRelations'    => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\domain\services\admin\events\editor\TicketMeta'              => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\domain\services\admin\events\editor\FormBuilder'             => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\entities\admin\GraphQLData\Venues'                   => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\core\domain\services\admin\events\editor\EventEntityRelations' => [
                 'EEM_Datetime'                                         => EE_Dependency_Map::load_from_cache,

--- a/core/domain/services/admin/events/editor/EventEditorGraphQLData.php
+++ b/core/domain/services/admin/events/editor/EventEditorGraphQLData.php
@@ -8,6 +8,7 @@ use EventEspresso\core\domain\entities\admin\GraphQLData\Event;
 use EventEspresso\core\domain\entities\admin\GraphQLData\Prices;
 use EventEspresso\core\domain\entities\admin\GraphQLData\PriceTypes;
 use EventEspresso\core\domain\entities\admin\GraphQLData\Tickets;
+use EventEspresso\core\domain\entities\admin\GraphQLData\Venues;
 use ReflectionException;
 
 /**
@@ -71,6 +72,11 @@ class EventEditorGraphQLData
      */
     protected $form_builder;
 
+    /**
+     * @var Venues
+     */
+    protected $venues;
+
 
     /**
      * EventEditorGraphQLData constructor.
@@ -85,6 +91,7 @@ class EventEditorGraphQLData
      * @param NewEventDefaultEntities $default_entities
      * @param TicketMeta              $ticket_meta
      * @param FormBuilder             $form_builder
+     * @param Venues                  $venues
      */
     public function __construct(
         Datetimes $datetimes,
@@ -96,7 +103,8 @@ class EventEditorGraphQLData
         EventManagerData $managers,
         NewEventDefaultEntities $default_entities,
         TicketMeta $ticket_meta,
-        FormBuilder $form_builder
+        FormBuilder $form_builder,
+        Venues $venues
     ) {
         $this->datetimes        = $datetimes;
         $this->event            = $event;
@@ -108,6 +116,7 @@ class EventEditorGraphQLData
         $this->tickets          = $tickets;
         $this->ticket_meta      = $ticket_meta;
         $this->form_builder     = $form_builder;
+        $this->venues           = $venues;
     }
 
 
@@ -144,6 +153,8 @@ class EventEditorGraphQLData
 
         $formBuilder = $this->form_builder->getData($eventId);
 
+        $venues = $this->venues->getData();
+
         return compact(
             'datetimes',
             'event',
@@ -153,7 +164,8 @@ class EventEditorGraphQLData
             'priceTypes',
             'relations',
             'tickets',
-            'ticketMeta'
+            'ticketMeta',
+            'venues'
         );
     }
 }

--- a/core/domain/services/graphql/mutators/EventUpdate.php
+++ b/core/domain/services/graphql/mutators/EventUpdate.php
@@ -58,15 +58,24 @@ class EventUpdate extends EntityMutator
                 $entity = EntityMutator::getEntityFromID($model, $id);
                 $args = EventMutation::prepareFields($input);
 
+                if (isset($args['venue'])) {
+                    $venue = $args['venue'];
+                    unset($args['venue']);
+                }
+
                 // Update the entity
                 $entity->save($args);
+
+                if (isset($venue)) {
+                    EventMutation::setEventVenue($entity, $venue);
+                }
 
                 do_action('AHEE__EventEspresso_core_domain_services_graphql_mutators_event_update', $entity, $input);
             } catch (Exception $exception) {
                 EntityMutator::handleExceptions(
                     $exception,
                     esc_html__(
-                        'The datetime could not be updated because of the following error(s)',
+                        'The event could not be updated because of the following error(s)',
                         'event_espresso'
                     )
                 );

--- a/core/domain/services/graphql/mutators/VenueUpdate.php
+++ b/core/domain/services/graphql/mutators/VenueUpdate.php
@@ -66,7 +66,7 @@ class VenueUpdate extends EntityMutator
                 EntityMutator::handleExceptions(
                     $exception,
                     esc_html__(
-                        'The datetime could not be updated because of the following error(s)',
+                        'The venue could not be updated because of the following error(s)',
                         'event_espresso'
                     )
                 );

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -219,7 +219,7 @@ class Event extends TypeBase
                     $venues = $source->venues();
                     /** @var EE_Venue $venue */
                     $venue = reset($venues);
-                    
+
                     return $venue instanceof EE_Venue
                     // Since venue is a CPT, $type will be 'post'
                     ? Relay::toGlobalId('post', $venue->ID())

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -2,6 +2,8 @@
 
 namespace EventEspresso\core\domain\services\graphql\types;
 
+use EE_Event;
+use EE_Venue;
 use EEM_Event;
 use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
 use EventEspresso\core\services\graphql\types\TypeBase;
@@ -9,6 +11,7 @@ use EventEspresso\core\services\graphql\fields\GraphQLField;
 use EventEspresso\core\services\graphql\fields\GraphQLInputField;
 use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
 use EventEspresso\core\domain\services\graphql\mutators\EventUpdate;
+use GraphQLRelay\Relay;
 
 /**
  * Class Event
@@ -205,6 +208,23 @@ class Event extends TypeBase
                 'String',
                 'visible_on',
                 esc_html__('Event Visible Date', 'event_espresso')
+            ),
+            new GraphQLField(
+                'venue',
+                'String',
+                null,
+                esc_html__('Event venue ID', 'event_espresso'),
+                null,
+                function (EE_Event $source) {
+                    $venues = $source->venues();
+                    /** @var EE_Venue $venue */
+                    $venue = reset($venues);
+                    
+                    return $venue instanceof EE_Venue
+                    // Since venue is a CPT, $type will be 'post'
+                    ? Relay::toGlobalId('post', $venue->ID())
+                    : null;
+                }
             ),
         ];
 

--- a/core/domain/services/graphql/types/Venue.php
+++ b/core/domain/services/graphql/types/Venue.php
@@ -125,6 +125,12 @@ class Venue extends TypeBase
                 null,
                 esc_html__('Venue state', 'event_espresso')
             ),
+            new GraphQLOutputField(
+                'stateName',
+                'String',
+                'state_name',
+                esc_html__('Venue state name', 'event_espresso')
+            ),
             new GraphQLInputField(
                 'state',
                 'Int',
@@ -136,6 +142,12 @@ class Venue extends TypeBase
                 $this->namespace . 'Country',
                 null,
                 esc_html__('Venue country', 'event_espresso')
+            ),
+            new GraphQLOutputField(
+                'countryName',
+                'String',
+                'country_name',
+                esc_html__('Venue country name', 'event_espresso')
             ),
             new GraphQLInputField(
                 'country',


### PR DESCRIPTION
This PR prepares venue GQL schema for Venue EDTR:
- Adds `countryName` and `stateName` to Venue object to simplify the venue query
- Adds `venue` field to `Event` object and wires up event mutation to set the venue
- Adds venues list to EDTR DOM Data