### PR TITLE
Enhance Country and State GraphQL schema

### DIFF
--- a/core/db_classes/EE_Country.class.php
+++ b/core/db_classes/EE_Country.class.php
@@ -43,6 +43,28 @@ class EE_Country extends EE_Base_Class
 
 
     /**
+     * Whether the country is active/enabled
+     *
+     * @return bool
+     */
+    public function is_active(): bool
+    {
+        return $this->get('CNT_active');
+    }
+
+
+    /**
+     * Gets the country ISO3
+     *
+     * @return string
+     */
+    public function ISO3(): string
+    {
+        return $this->get('CNT_ISO3');
+    }
+
+
+    /**
      * gets the country's currency code
      *
      * @return string

--- a/core/domain/entities/routing/handlers/shared/GQLRequests.php
+++ b/core/domain/entities/routing/handlers/shared/GQLRequests.php
@@ -180,12 +180,20 @@ class GQLRequests extends Route
             ['EEM_Attendee' => EE_Dependency_Map::load_from_cache]
         );
         $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryCountriesConnection',
+            ['EEM_Country' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\connections\RootQueryFormElementsConnection',
             ['EEM_Form_Element' => EE_Dependency_Map::load_from_cache]
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\connections\RootQueryFormSectionsConnection',
             ['EEM_Form_Section' => EE_Dependency_Map::load_from_cache]
+        );
+        $this->dependency_map->registerDependencies(
+            'EventEspresso\core\domain\services\graphql\connections\RootQueryStatesConnection',
+            ['EEM_State' => EE_Dependency_Map::load_from_cache]
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\graphql\connections\DatetimeTicketsConnection',

--- a/core/domain/services/graphql/connection_resolvers/CountryConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/CountryConnectionResolver.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connection_resolvers;
+
+use EE_Error;
+use EEM_Country;
+use EEM_Ticket;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
+use Throwable;
+
+/**
+ * Class DatetimeConnectionResolver
+ */
+class CountryConnectionResolver extends AbstractConnectionResolver
+{
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_loader_name(): string
+    {
+        return 'espresso_country';
+    }
+
+    /**
+     * @return EEM_Country
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query(): EEM_Country
+    {
+        return EEM_Country::instance();
+    }
+
+
+    /**
+     * Return an array of item IDs from the query
+     *
+     * @return array
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_ids(): array
+    {
+        $results = $this->query->get_col($this->query_args);
+
+        return ! empty($results) ? $results : [];
+    }
+
+    /**
+     * Get_query_amount
+     *
+     * Returns the max between what was requested and what is defined as the $max_query_amount to
+     * ensure that queries don't exceed unwanted limits when querying data.
+     *
+     * @return int
+     * @throws Exception
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query_amount()
+    {
+        // Override the default limit (100) for countries
+        return 300;
+    }
+
+
+    /**
+     * Here, we map the args from the input, then we make sure that we're only querying
+     * for IDs. The IDs are then passed down the resolve tree, and deferred resolvers
+     * handle batch resolution of the posts.
+     *
+     * @return array
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query_args(): array
+    {
+        $where_params = [];
+        $query_args   = [];
+
+        $query_args['limit'] = $this->getLimit();
+
+        // Avoid multiple entries by join.
+        $query_args['group_by'] = 'CNT_ISO';
+
+        $query_args['default_where_conditions'] = 'minimum';
+
+        /**
+         * Collect the input_fields and sanitize them to prepare them for sending to the Query
+         */
+        $input_fields = [];
+        if (! empty($this->args['where'])) {
+            $input_fields = $this->sanitizeInputFields($this->args['where']);
+
+            // Since we do not have any falsy values in query params
+            // Lets get rid of empty values
+            $input_fields = array_filter($input_fields);
+
+            // Use the proper operator.
+            if (! empty($input_fields['CNT_ISO']) && is_array($input_fields['CNT_ISO'])) {
+                $input_fields['CNT_ISO'] = ['IN', $input_fields['CNT_ISO']];
+            }
+            if (! empty($input_fields['CNT_ISO3']) && is_array($input_fields['CNT_ISO3'])) {
+                $input_fields['CNT_ISO3'] = ['IN', $input_fields['CNT_ISO3']];
+            }
+        }
+
+        /**
+         * Merge the input_fields with the default query_args
+         */
+        if (! empty($input_fields)) {
+            $where_params = array_merge($where_params, $input_fields);
+        }
+
+        // limit to active countries by default.
+        if (!isset($this->args['where']['activeOnly']) || $this->args['where']['activeOnly']) {
+            $where_params['CNT_active'] = true;
+        }
+
+        [$query_args, $where_params] = $this->mapOrderbyInputArgs($query_args, $where_params, 'CNT_ISO');
+
+        if (empty($query_args['order_by'])) {
+            // set order_by to 'name' by default
+            $query_args['order_by'] = [
+                'CNT_name' => 'ASC',
+            ];
+        }
+
+        $search = $this->getSearchKeywords($this->args['where']);
+
+        if (! empty($search)) {
+            // use OR operator to search in any of the fields
+            $where_params['OR'] = array(
+                'CNT_name' => array('LIKE', '%' . $search . '%'),
+                'CNT_ISO'  => array('LIKE', '%' . $search . '%'),
+            );
+        }
+
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__country_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
+        $query_args[] = $where_params;
+
+        /**
+         * Return the $query_args
+         */
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__country_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
+    }
+
+
+    /**
+     * This sets up the "allowed" args, and translates the GraphQL-friendly keys to model
+     * friendly keys.
+     *
+     * @param array $where_args
+     * @return array
+     */
+    public function sanitizeInputFields(array $where_args): array
+    {
+        $arg_mapping = [
+            'isoIn'  => 'CNT_ISO',
+            'in'     => 'CNT_ISO',
+            'iso3In' => 'CNT_ISO3',
+        ];
+        return $this->sanitizeWhereArgsForInputFields(
+            $where_args,
+            $arg_mapping,
+            ['in']
+        );
+    }
+}

--- a/core/domain/services/graphql/connection_resolvers/StateConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/StateConnectionResolver.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connection_resolvers;
+
+use EE_Error;
+use EEM_State;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class DatetimeConnectionResolver
+ */
+class StateConnectionResolver extends AbstractConnectionResolver
+{
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_loader_name(): string
+    {
+        return 'espresso_state';
+    }
+
+    /**
+     * @return EEM_State
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query(): EEM_State
+    {
+        return EEM_State::instance();
+    }
+
+
+    /**
+     * Return an array of item IDs from the query
+     *
+     * @return array
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_ids(): array
+    {
+        $results = $this->query->get_col($this->query_args);
+
+        return ! empty($results) ? $results : [];
+    }
+
+
+    /**
+     * Here, we map the args from the input, then we make sure that we're only querying
+     * for IDs. The IDs are then passed down the resolve tree, and deferred resolvers
+     * handle batch resolution of the posts.
+     *
+     * @return array
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function get_query_args(): array
+    {
+        $where_params = [];
+        $query_args   = [];
+
+        $query_args['limit'] = $this->getLimit();
+
+        // Avoid multiple entries by join.
+        $query_args['group_by'] = 'STA_ID';
+
+        $query_args['default_where_conditions'] = 'minimum';
+
+        /**
+         * Collect the input_fields and sanitize them to prepare them for sending to the Query
+         */
+        $input_fields = [];
+        if (! empty($this->args['where'])) {
+            $input_fields = $this->sanitizeInputFields($this->args['where']);
+
+            // Since we do not have any falsy values in query params
+            // Lets get rid of empty values
+            $input_fields = array_filter($input_fields);
+
+            // Use the proper operator.
+            if (! empty($input_fields['STA_ID']) && is_array($input_fields['STA_ID'])) {
+                $input_fields['STA_ID'] = ['IN', $input_fields['STA_ID']];
+            }
+            if (! empty($input_fields['CNT_ISO']) && is_array($input_fields['CNT_ISO'])) {
+                $input_fields['CNT_ISO'] = ['IN', $input_fields['CNT_ISO']];
+            }
+        }
+
+        /**
+         * Merge the input_fields with the default query_args
+         */
+        if (! empty($input_fields)) {
+            $where_params = array_merge($where_params, $input_fields);
+        }
+
+        // limit to active countries by default.
+        if (!isset($this->args['where']['activeOnly']) || $this->args['where']['activeOnly']) {
+            $where_params['STA_active'] = true;
+        }
+
+        [$query_args, $where_params] = $this->mapOrderbyInputArgs($query_args, $where_params, 'STA_ID');
+
+        if (empty($query_args['order_by'])) {
+            // set order_by to 'name' by default
+            $query_args['order_by'] = [
+                'STA_name' => 'ASC',
+            ];
+        }
+
+        $search = $this->getSearchKeywords($this->args['where']);
+
+        if (! empty($search)) {
+            // use OR operator to search in any of the fields
+            $where_params['OR'] = array(
+                'STA_name' => array('LIKE', '%' . $search . '%'),
+            );
+        }
+
+        $where_params = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__state_where_params',
+            $where_params,
+            $this->source,
+            $this->args
+        );
+
+        $query_args[] = $where_params;
+
+        /**
+         * Return the $query_args
+         */
+        return apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connection_resolvers__state_query_args',
+            $query_args,
+            $this->source,
+            $this->args
+        );
+    }
+
+
+    /**
+     * This sets up the "allowed" args, and translates the GraphQL-friendly keys to model
+     * friendly keys.
+     *
+     * @param array $where_args
+     * @return array
+     */
+    public function sanitizeInputFields(array $where_args): array
+    {
+        $arg_mapping = [
+            'in'           => 'STA_ID',
+            'countryIsoIn' => 'CNT_ISO',
+        ];
+        return $this->sanitizeWhereArgsForInputFields(
+            $where_args,
+            $arg_mapping,
+            ['in']
+        );
+    }
+}

--- a/core/domain/services/graphql/connections/RootQueryCountriesConnection.php
+++ b/core/domain/services/graphql/connections/RootQueryCountriesConnection.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connections;
+
+use EEM_Country;
+use EventEspresso\core\domain\services\graphql\connection_resolvers\AbstractConnectionResolver;
+use EventEspresso\core\domain\services\graphql\connection_resolvers\CountryConnectionResolver;
+use EventEspresso\core\domain\services\graphql\abstracts\AbstractRootQueryConnection;
+use Exception;
+
+/**
+ * Class RootQueryCountriesConnection
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\connections
+ * @author  Manzoor Ahmad Wani
+ * @since   $VID:$
+ */
+class RootQueryCountriesConnection extends AbstractRootQueryConnection
+{
+
+
+    /**
+     * CountryConnection constructor.
+     *
+     * @param EEM_Country               $model
+     */
+    public function __construct(EEM_Country $model)
+    {
+        parent::__construct($model);
+    }
+
+
+    /**
+     * @return array
+     */
+    public function config(): array
+    {
+        return [
+            'fromType'           => 'RootQuery',
+            'toType'             => $this->namespace . 'Country',
+            'fromFieldName'      => lcfirst($this->namespace . 'Countries'),
+            'connectionTypeName' => "{$this->namespace}RootQueryCountriesConnection",
+            'connectionArgs'     => RootQueryCountriesConnection::get_connection_args(),
+            'resolve'            => [$this, 'resolveConnection'],
+        ];
+    }
+
+
+    /**
+     * @param $entity
+     * @param $args
+     * @param $context
+     * @param $info
+     * @return CountryConnectionResolver
+     * @throws Exception
+     */
+    public function getConnectionResolver($entity, $args, $context, $info): AbstractConnectionResolver
+    {
+        return new CountryConnectionResolver($entity, $args, $context, $info);
+    }
+
+    /**
+     * Given an optional array of args, this returns the args to be used in the connection
+     *
+     * @param array $args The args to modify the defaults
+     * @return array
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public static function get_connection_args(array $args = []): array
+    {
+        $newArgs = [
+            'orderby'      => [
+                'type'        => ['list_of' => 'EspressoCountriesConnectionOrderbyInput'],
+                'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
+            ],
+            'in' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__(
+                    'Limit the result to the set of given country IDs.',
+                    'event_espresso'
+                ),
+            ],
+            'isoIn' => [
+                'type'        => ['list_of' => 'String'],
+                'description' => esc_html__(
+                    'Limit the result to the set of given country ISOs.',
+                    'event_espresso'
+                ),
+            ],
+            'iso3In' => [
+                'type'        => ['list_of' => 'String'],
+                'description' => esc_html__(
+                    'Limit the result to the set of given country ISO3s.',
+                    'event_espresso'
+                ),
+            ],
+            'search' => [
+                'type'        => 'String',
+                'description' => esc_html__(
+                    'Limit the result to the given search query.',
+                    'event_espresso'
+                ),
+            ],
+            'activeOnly' => [
+                'type'        => 'Boolean',
+                'description' => esc_html__(
+                    'Limit the result to the active countries.',
+                    'event_espresso'
+                ),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__country_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
+            $args
+        );
+    }
+}

--- a/core/domain/services/graphql/connections/RootQueryStatesConnection.php
+++ b/core/domain/services/graphql/connections/RootQueryStatesConnection.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\connections;
+
+use EEM_State;
+use EventEspresso\core\domain\services\graphql\connection_resolvers\AbstractConnectionResolver;
+use EventEspresso\core\domain\services\graphql\connection_resolvers\StateConnectionResolver;
+use EventEspresso\core\domain\services\graphql\abstracts\AbstractRootQueryConnection;
+use Exception;
+
+/**
+ * Class RootQueryStatesConnection
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\connections
+ * @author  Manzoor Ahmad Wani
+ * @since   $VID:$
+ */
+class RootQueryStatesConnection extends AbstractRootQueryConnection
+{
+
+
+    /**
+     * StateConnection constructor.
+     *
+     * @param EEM_State               $model
+     */
+    public function __construct(EEM_State $model)
+    {
+        parent::__construct($model);
+    }
+
+
+    /**
+     * @return array
+     */
+    public function config(): array
+    {
+        return [
+            'fromType'           => 'RootQuery',
+            'toType'             => $this->namespace . 'State',
+            'fromFieldName'      => lcfirst($this->namespace) . 'States',
+            'connectionTypeName' => "{$this->namespace}RootQueryStatesConnection",
+            'connectionArgs'     => self::get_connection_args(),
+            'resolve'            => [$this, 'resolveConnection'],
+        ];
+    }
+
+
+    /**
+     * @param $entity
+     * @param $args
+     * @param $context
+     * @param $info
+     * @return StateConnectionResolver
+     * @throws Exception
+     */
+    public function getConnectionResolver($entity, $args, $context, $info): AbstractConnectionResolver
+    {
+        return new StateConnectionResolver($entity, $args, $context, $info);
+    }
+
+    /**
+     * Given an optional array of args, this returns the args to be used in the connection
+     *
+     * @param array $args The args to modify the defaults
+     * @return array
+     */
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public static function get_connection_args(array $args = []): array
+    {
+        $newArgs = [
+            'orderby'      => [
+                'type'        => ['list_of' => 'EspressoCountriesConnectionOrderbyInput'],
+                'description' => esc_html__('What parameter to use to order the objects by.', 'event_espresso'),
+            ],
+            'in' => [
+                'type'        => ['list_of' => 'ID'],
+                'description' => esc_html__(
+                    'Limit the result to the set of given state IDs.',
+                    'event_espresso'
+                ),
+            ],
+            'countryIsoIn' => [
+                'type'        => ['list_of' => 'String'],
+                'description' => esc_html__(
+                    'Limit the result to the set of given country ISOs.',
+                    'event_espresso'
+                ),
+            ],
+            'search' => [
+                'type'        => 'String',
+                'description' => esc_html__('The search keywords', 'event_espresso'),
+            ],
+            'activeOnly' => [
+                'type'        => 'Boolean',
+                'description' => esc_html__(
+                    'Limit the result to the active states.',
+                    'event_espresso'
+                ),
+            ],
+        ];
+
+        $newArgs = apply_filters(
+            'FHEE__EventEspresso_core_domain_services_graphql_connections__state_args',
+            $newArgs,
+            $args
+        );
+        return array_merge(
+            $newArgs,
+            $args
+        );
+    }
+}

--- a/core/domain/services/graphql/data/domains/EspressoEditor.php
+++ b/core/domain/services/graphql/data/domains/EspressoEditor.php
@@ -27,11 +27,13 @@ class EspressoEditor implements GQLDataDomainInterface
     {
         $newLoaders = [
             'espresso_attendee'    => new Loaders\AttendeeLoader($context),
+            'espresso_country'     => new Loaders\CountryLoader($context),
             'espresso_datetime'    => new Loaders\DatetimeLoader($context),
             'espresso_price'       => new Loaders\PriceLoader($context),
             'espresso_priceType'   => new Loaders\PriceTypeLoader($context),
             'espresso_formSection' => new Loaders\FormSectionLoader($context),
             'espresso_formElement' => new Loaders\FormElementLoader($context),
+            'espresso_state'       => new Loaders\StateLoader($context),
             'espresso_ticket'      => new Loaders\TicketLoader($context),
             'espresso_venue'       => new Loaders\VenueLoader($context),
         ];

--- a/core/domain/services/graphql/data/loaders/CountryLoader.php
+++ b/core/domain/services/graphql/data/loaders/CountryLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\data\loaders;
+
+use EE_Error;
+use EEM_Country;
+use EEM_Base;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class CountryLoader
+ */
+class CountryLoader extends AbstractLoader
+{
+    /**
+     * @return EEM_Base|EEM_Country
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    protected function getQuery(): EEM_Base
+    {
+        return EEM_Country::instance();
+    }
+
+
+    /**
+     * @param array $keys
+     * @return array
+     */
+    protected function getWhereParams(array $keys): array
+    {
+        return [
+            'CNT_ISO' => ['IN', $keys],
+        ];
+    }
+}

--- a/core/domain/services/graphql/data/loaders/StateLoader.php
+++ b/core/domain/services/graphql/data/loaders/StateLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\data\loaders;
+
+use EE_Error;
+use EEM_State;
+use EEM_Base;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+use InvalidArgumentException;
+use ReflectionException;
+
+/**
+ * Class StateLoader
+ */
+class StateLoader extends AbstractLoader
+{
+    /**
+     * @return EEM_Base|EEM_State
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws ReflectionException
+     */
+    protected function getQuery(): EEM_Base
+    {
+        return EEM_State::instance();
+    }
+
+
+    /**
+     * @param array $keys
+     * @return array
+     */
+    protected function getWhereParams(array $keys): array
+    {
+        return [
+            'STA_ID' => ['IN', $keys],
+        ];
+    }
+}

--- a/core/domain/services/graphql/enums/CountriesConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/CountriesConnectionOrderbyEnum.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\enums;
+
+use EventEspresso\core\services\graphql\enums\EnumBase;
+
+/**
+ * Class CountriesConnectionOrderbyEnum
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\enums
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class CountriesConnectionOrderbyEnum extends EnumBase
+{
+
+    /**
+     * CountriesConnectionOrderbyEnum constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'CountriesConnectionOrderbyEnum');
+        $this->setDescription(esc_html__('Field to order the connection by', 'event_espresso'));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return array
+     */
+    protected function getValues(): array
+    {
+        return [
+            'NAME'     => [
+                'value'       => 'CNT_name',
+                'description' => esc_html__('Order by country name', 'event_espresso'),
+            ],
+            'ISO'     => [
+                'value'       => 'CNT_ISO',
+                'description' => esc_html__('Order by country ISO', 'event_espresso'),
+            ],
+            'CNT_ISO3'     => [
+                'value'       => 'CNT_ISO3',
+                'description' => esc_html__('Order by country ISO3', 'event_espresso'),
+            ],
+        ];
+    }
+}

--- a/core/domain/services/graphql/enums/StatesConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/StatesConnectionOrderbyEnum.php
@@ -36,7 +36,7 @@ class StatesConnectionOrderbyEnum extends EnumBase
                 'value'       => 'CNT_name',
                 'description' => esc_html__('Order by state name', 'event_espresso'),
             ],
-            'COUNRY_ISO'     => [
+            'COUNTRY_ISO'     => [
                 'value'       => 'CNT_ISO',
                 'description' => esc_html__('Order by country ISO', 'event_espresso'),
             ],

--- a/core/domain/services/graphql/enums/StatesConnectionOrderbyEnum.php
+++ b/core/domain/services/graphql/enums/StatesConnectionOrderbyEnum.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\enums;
+
+use EventEspresso\core\services\graphql\enums\EnumBase;
+
+/**
+ * Class StatesConnectionOrderbyEnum
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\enums
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class StatesConnectionOrderbyEnum extends EnumBase
+{
+
+    /**
+     * StatesConnectionOrderbyEnum constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'StatesConnectionOrderbyEnum');
+        $this->setDescription(esc_html__('Field to order the connection by', 'event_espresso'));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return array
+     */
+    protected function getValues(): array
+    {
+        return [
+            'NAME'     => [
+                'value'       => 'CNT_name',
+                'description' => esc_html__('Order by state name', 'event_espresso'),
+            ],
+            'COUNRY_ISO'     => [
+                'value'       => 'CNT_ISO',
+                'description' => esc_html__('Order by country ISO', 'event_espresso'),
+            ],
+        ];
+    }
+}

--- a/core/domain/services/graphql/inputs/CountriesConnectionOrderbyInput.php
+++ b/core/domain/services/graphql/inputs/CountriesConnectionOrderbyInput.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\inputs;
+
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\inputs\InputBase;
+use EventEspresso\core\services\graphql\fields\GraphQLField;
+
+/**
+ * Class CountriesConnectionOrderbyInput
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\inputs
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class CountriesConnectionOrderbyInput extends InputBase
+{
+
+    /**
+     * CountriesConnectionOrderbyInput constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'CountriesConnectionOrderbyInput');
+        $this->setDescription(esc_html__('Options for ordering the connection', 'event_espresso'));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     */
+    protected function getFields(): array
+    {
+        return [
+            new GraphQLField(
+                'field',
+                ['non_null' => $this->namespace . 'CountriesConnectionOrderbyEnum']
+            ),
+            new GraphQLField(
+                'order',
+                'OrderEnum'
+            ),
+        ];
+    }
+}

--- a/core/domain/services/graphql/inputs/StatesConnectionOrderbyInput.php
+++ b/core/domain/services/graphql/inputs/StatesConnectionOrderbyInput.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace EventEspresso\core\domain\services\graphql\inputs;
+
+use EventEspresso\core\services\graphql\fields\GraphQLFieldInterface;
+use EventEspresso\core\services\graphql\inputs\InputBase;
+use EventEspresso\core\services\graphql\fields\GraphQLField;
+
+/**
+ * Class StatesConnectionOrderbyInput
+ * Description
+ *
+ * @package EventEspresso\core\domain\services\graphql\inputs
+ * @author  Manzoor Wani
+ * @since   $VID:$
+ */
+class StatesConnectionOrderbyInput extends InputBase
+{
+
+    /**
+     * StatesConnectionOrderbyInput constructor.
+     */
+    public function __construct()
+    {
+        $this->setName($this->namespace . 'StatesConnectionOrderbyInput');
+        $this->setDescription(esc_html__('Options for ordering the connection', 'event_espresso'));
+        parent::__construct();
+    }
+
+
+    /**
+     * @return GraphQLFieldInterface[]
+     */
+    protected function getFields(): array
+    {
+        return [
+            new GraphQLField(
+                'field',
+                ['non_null' => $this->namespace . 'StatesConnectionOrderbyEnum']
+            ),
+            new GraphQLField(
+                'order',
+                'OrderEnum'
+            ),
+        ];
+    }
+}

--- a/core/domain/services/graphql/types/Country.php
+++ b/core/domain/services/graphql/types/Country.php
@@ -55,7 +55,7 @@ class Country extends TypeBase
             new GraphQLField(
                 'isActive',
                 'Boolean',
-                null, // 'active',
+                'is_active',
                 esc_html__(
                     'Flag that indicates if the country should appear in dropdown select lists',
                     'event_espresso'
@@ -64,13 +64,13 @@ class Country extends TypeBase
             new GraphQLField(
                 'ISO',
                 'String',
-                null, // 'ISO',
+                'ID',
                 esc_html__('Country ISO Code', 'event_espresso')
             ),
             new GraphQLField(
                 'ISO3',
                 'String',
-                null, // 'ISO3',
+                'ISO3',
                 esc_html__('Country ISO3 Code', 'event_espresso')
             ),
             new GraphQLField(

--- a/docs/GraphQL-API/query/country.md
+++ b/docs/GraphQL-API/query/country.md
@@ -1,0 +1,31 @@
+# Country query examples
+
+Country object has connections with `RootQuery`.
+
+## Example with `RootQuery`
+
+```gql
+query GET_COUNTRIES($where: EspressoRootQueryCountriesConnectionWhereArgs) {
+	espressoCountries(where: $where, first: 300) {
+		nodes {
+			id
+			name
+			ISO
+			isActive
+			currencyCode
+			currencySign
+		}
+	}
+}
+```
+
+### Query variables
+
+```json
+{
+	"where": {
+		"activeOnly": false,
+		"isoIn": ["US", "GB"]
+	}
+}
+```

--- a/docs/GraphQL-API/query/state.md
+++ b/docs/GraphQL-API/query/state.md
@@ -1,0 +1,34 @@
+# State query examples
+
+State object has connections with `RootQuery`.
+
+## Example with `RootQuery`
+
+```gql
+query GET_STATES($where: EspressoRootQueryStatesConnectionWhereArgs) {
+	espressoStates(where: $where) {
+		nodes {
+			id
+			name
+			abbreviation
+			isActive
+			country {
+				id
+				ISO
+				name
+			}
+		}
+	}
+}
+```
+
+### Query variables
+
+```json
+{
+	"where": {
+		"activeOnly": false,
+		"countryIsoIn": ["US", "GB"]
+	}
+}
+```


### PR DESCRIPTION
This PR adds support for querying the country and state lists in GQL schema in order to facilitate better querying needed for venue data.