### PR TITLE
Fix data node order

### DIFF
--- a/core/helpers/EEH_Array.helper.php
+++ b/core/helpers/EEH_Array.helper.php
@@ -34,9 +34,9 @@ class EEH_Array extends EEH_Base
      * @param array $array
      * @return boolean
      */
-    public static function is_associative_array(array $array)
+    public static function is_associative_array(array $array): bool
     {
-        return array_keys($array) !== range(0, count($array) - 1);
+        return ! empty($array) && array_keys($array) !== range(0, count($array) - 1);
     }
 
     /**

--- a/core/services/json/JsonDataNodeHandler.php
+++ b/core/services/json/JsonDataNodeHandler.php
@@ -65,27 +65,24 @@ class JsonDataNodeHandler
      * @param int                $depth
      * @return array
      */
-    private function initializeDataNodes(JsonDataNode $data_node, $depth = 0): array
+    private function initializeDataNodes(JsonDataNode $data_node, int $depth = 0): array
     {
         $depth++;
         $data = [];
         // initialize the data node if not done already
         if ($data_node->isNotInitialized()) {
             $data_node->initialize();
-            // grab the data node's data array
-            $data_node_data = $data_node->data();
-            foreach ($data_node_data as $child_node_name => $child_node) {
+            // loop thru the data node's data array
+            foreach ($data_node->data(true) as $child_node_name => $child_node) {
                 // don't parse node if it's the primary, OR if depth has exceeded wp_json_encode() limit
                 if ($child_node instanceof PrimaryJsonDataNode || $depth > 512) {
                     continue;
                 }
-                if ($child_node instanceof JsonDataNode) {
+                $data[ $child_node_name ] = $child_node instanceof JsonDataNode
                     // feed data node back into this function
-                    $data[ $child_node_name ] = $this->initializeDataNodes($child_node, $depth);
-                } else {
+                    ? $this->initializeDataNodes($child_node, $depth)
                     // or assign data directly
-                    $data[ $child_node_name ] = $child_node;
-                }
+                    : $child_node;
             }
         }
         return $data;


### PR DESCRIPTION
see https://github.com/eventespresso/barista/issues/980 && https://github.com/eventespresso/eea-wpuser-integration/issues/40

It appeared that the WP User ticket meta was not getting loaded because of an issue with filters, but it was the order of the data nodes that was causing the filters to be triggered out of order.

This PR adds some logic for ensuring that data nodes:

- are given a predictable and repeatable default ordering 
- have a mechanism in place for changing that order if need be

This was achieved by:

- adding an order property plus a getter and setter to the `JsonDataNode` class
- sorting the data node data array when needed using a custom sorting algorithm