### PR TITLE
GitHub Actions | Use composite action for LAMP set up

### DIFF
--- a/.github/workflows/pr-checks-dev.yml
+++ b/.github/workflows/pr-checks-dev.yml
@@ -35,7 +35,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.1', '7.2', '7.3', '7.4']
-        name: PHP ${{ matrix.php-version }}
+        name: PHP ${{ matrix.php-version }} Unit tests
         steps:
             - name: Checkout and set up LAMP
               uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action

--- a/.github/workflows/pr-checks-dev.yml
+++ b/.github/workflows/pr-checks-dev.yml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ needs.what_has_changed.outputs.php == 'true' }}
         strategy:
             matrix:
-                php-version: ['7.1', '7.2', '7.3', '7.4']
+                php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         name: PHP ${{ matrix.php-version }} Unit tests
         steps:
             - name: Checkout and set up LAMP
@@ -53,6 +53,8 @@ jobs:
 
             - name: Run PHP Unit Tests
               run: phpunit --configuration tests/phpunit.xml
+              # Allow failure for PHP 8.x
+              continue-on-error: ${{ startsWith( matrix.php-version, '8.' ) }}
 
               # run multisite test only with 1 PHP version
             - if: ${{ matrix.php-version == '7.4' }}

--- a/.github/workflows/pr-checks-dev.yml
+++ b/.github/workflows/pr-checks-dev.yml
@@ -19,28 +19,10 @@ jobs:
                 php-versions: ['7.3'] #, '7.4', '8.0', '8.1']
         name: Lint with PHP ${{ matrix.php-versions }}
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+            - name: Checkout and set up LAMP
+              uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
               with:
                   php-version: ${{ matrix.php-versions }}
-
-            - name: Get composer cache directory
-              id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Cache composer dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composercache.outputs.dir }}
-                  # Use composer-lock.json for key
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
-
-            - name: Install dependencies
-              run: composer install
 
             - name: PHP Lint
               run: composer config-eventespressocs && composer run-script lint:skip-warnings
@@ -58,46 +40,19 @@ jobs:
                 php-versions: ['7.1', '7.2', '7.3', '7.4']
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+            - name: Checkout and set up LAMP
+              uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
               with:
                   php-version: ${{ matrix.php-versions }}
-                  tools: phpunit:v7
-
-            - name: Start mysql service
-              run: sudo systemctl start mysql.service
-
-            - name: Get composer cache directory
-              id: composercache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Cache composer dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composercache.outputs.dir }}
-                  # Use composer.lock for key.
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
-
-            - name: Check PHP Version
-              run: php -v
-
-            - name: Composer install
-              run: composer install --optimize-autoloader --prefer-dist
+                  php-tools: phpunit:v7
 
             - name: Install WP Tests
-              uses: eventespresso/actions/packages/install-wp-tests@main
+              uses: eventespresso/actions/packages/install-wp-tests@checkout-and-lamp-action
               with:
                   database: wordpress_test
                   username: root
                   password: root
                   host: localhost
-
-            - name: Fix MySQL authentication for PHP < 7.4
-              run: mysql --user="root" --password="root" --database="wordpress_test" --execute="ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
             - name: Run PHP Unit Tests
               run: phpunit --configuration tests/phpunit.xml

--- a/.github/workflows/pr-checks-dev.yml
+++ b/.github/workflows/pr-checks-dev.yml
@@ -16,34 +16,31 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['7.3'] #, '7.4', '8.0', '8.1']
-        name: Lint with PHP ${{ matrix.php-versions }}
+                php-version: ['7.3']
+        name: Lint with PHP ${{ matrix.php-version }}
         steps:
             - name: Checkout and set up LAMP
               uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
               with:
-                  php-version: ${{ matrix.php-versions }}
+                  php-version: ${{ matrix.php-version }}
 
             - name: PHP Lint
               run: composer config-eventespressocs && composer run-script lint:skip-warnings
-              # Allow failure for PHP > 7.3
-              # continue-on-error: ${{ matrix.php-versions != '7.3' }}
 
     php-unit-tests:
-        runs-on: ${{ matrix.operating-system }}
+        runs-on: ubuntu-latest
         needs: what_has_changed
         # Run only if PHP files have changed
         if: ${{ needs.what_has_changed.outputs.php == 'true' }}
         strategy:
             matrix:
-                operating-system: [ubuntu-latest]
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
-        name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+                php-version: ['7.1', '7.2', '7.3', '7.4']
+        name: PHP ${{ matrix.php-version }}
         steps:
             - name: Checkout and set up LAMP
               uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
               with:
-                  php-version: ${{ matrix.php-versions }}
+                  php-version: ${{ matrix.php-version }}
                   php-tools: phpunit:v7
 
             - name: Install WP Tests
@@ -58,7 +55,7 @@ jobs:
               run: phpunit --configuration tests/phpunit.xml
 
               # run multisite test only with 1 PHP version
-            - if: ${{ matrix.php-versions == '7.4' }}
+            - if: ${{ matrix.php-version == '7.4' }}
               name: Run PHP Unit Tests - WP Multisite
               env:
                   WP_MULTISITE: 1

--- a/.github/workflows/pr-checks-dev.yml
+++ b/.github/workflows/pr-checks-dev.yml
@@ -20,7 +20,7 @@ jobs:
         name: Lint with PHP ${{ matrix.php-version }}
         steps:
             - name: Checkout and set up LAMP
-              uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
+              uses: eventespresso/actions/packages/checkout-and-LAMP@main
               with:
                   php-version: ${{ matrix.php-version }}
 
@@ -38,13 +38,13 @@ jobs:
         name: PHP ${{ matrix.php-version }} Unit tests
         steps:
             - name: Checkout and set up LAMP
-              uses: eventespresso/actions/packages/checkout-and-LAMP@checkout-and-lamp-action
+              uses: eventespresso/actions/packages/checkout-and-LAMP@main
               with:
                   php-version: ${{ matrix.php-version }}
                   php-tools: phpunit:v7
 
             - name: Install WP Tests
-              uses: eventespresso/actions/packages/install-wp-tests@checkout-and-lamp-action
+              uses: eventespresso/actions/packages/install-wp-tests@main
               with:
                   database: wordpress_test
                   username: root

--- a/espresso.php
+++ b/espresso.php
@@ -40,7 +40,7 @@ if (function_exists('espresso_version')) {
     if (! function_exists('espresso_duplicate_plugin_error')) {
         /**
          *    espresso_duplicate_plugin_error
-         *    displays if more than one version of EE is activated at the same time
+         *    displays if more than one version of EE is activated at the same time.
          */
         function espresso_duplicate_plugin_error()
         {


### PR DESCRIPTION
This PR uses the extracted composite action to checkout the commit and set up LAMP stack to avoid unnecessary repetition.