### PR TITLE
Fix New Messages Template Parameter Name

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -434,14 +434,14 @@ class Messages_Admin_Page extends EE_Admin_Page
             'insert_message_template'          => [
                 'func'       => '_insert_or_update_message_template',
                 'capability' => 'ee_edit_messages',
-                'args'       => ['new_template' => true],
+                'args'       => ['new' => true],
                 'noheader'   => true,
             ],
             'update_message_template'          => [
                 'func'       => '_insert_or_update_message_template',
                 'capability' => 'ee_edit_message',
                 'obj_id'     => $grp_id,
-                'args'       => ['new_template' => false],
+                'args'       => ['new' => false],
                 'noheader'   => true,
             ],
             'trash_message_template'           => [


### PR DESCRIPTION
closes #3515

this PR simply corrects some parameter names passed by array to `Messages_Admin_Page::_insert_or_update_message_template()` when creating a new default template, because PHP 8 no likey.
