### PR TITLE
More Decaf Fixes

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1673,7 +1673,10 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         );
         $price = $ticket->ID() !== 0
             ? $ticket->get_first_related('Price', array('default_where_conditions' => 'none'))
-            : EE_Registry::instance()->load_model('Price')->create_default_object();
+            : null;
+        $price = $price instanceof EE_Price
+            ? $price
+            : EEM_Price::instance()->create_default_object();
         $price_args = array(
             'price_currency_symbol' => EE_Registry::instance()->CFG->currency->sign,
             'PRC_amount'            => $price->get('PRC_amount'),

--- a/core/services/request/RequestParams.php
+++ b/core/services/request/RequestParams.php
@@ -234,7 +234,7 @@ class RequestParams
      * @param        $key
      * @param null   $default
      * @param string $return
-     * @param array  $request_params
+     * @param mixed  $request_params
      * @return bool|mixed|null
      */
     private function parameterDrillDown(
@@ -242,7 +242,7 @@ class RequestParams
         $default = null,
         $callback = 'is_set',
         $return = 'value',
-        array $request_params = []
+        $request_params = []
     ) {
         $callback       = in_array($callback, ['is_set', 'get', 'match'], true)
             ? $callback


### PR DESCRIPTION
@Pebblo found the following issue by plugging some queries directly into the debug bar console:

```
[28-Sep-2021 19:30:19 UTC] PHP Fatal error:  
Uncaught TypeError: Argument 5 passed to EventEspresso\core\services\request\RequestParams::parameterDrillDown() 
must be of the type array, string given, 
called in \core\services\request\RequestParams.php on line 276 and defined in \core\services\request\RequestParams.php:240

Stack trace:
#0 \core\services\request\RequestParams.php(276): EventEspresso\core\services\request\RequestParams->parameterDrillDown('ee_front_ajax', false, 'get', 'value', '')
#1 \core\services\request\RequestParams.php(116): EventEspresso\core\services\request\RequestParams->parameterDrillDown('data', false, 'get')
#2 \core\services\request\Request.php(192): EventEspresso\core\services\request\RequestParams->getRequestParam('data[ee_fro in \core\services\request\RequestParams.php on line 240
```

and while trying to recreate the issue he found, I found an existing logic flaw in the tickets admin:

```
Fatal error: Uncaught Error: Call to a member function get() on null 
in /admin_pages/events/Events_Admin_Page.core.php:1679 

Stack trace: 
#0 /admin_pages/events/Events_Admin_Page.core.php(1609): Events_Admin_Page->_get_ticket_row() 
#1 /wp-admin/includes/template.php(1395): Events_Admin_Page->ticket_metabox() 
#2 /wp-admin/edit-form-advanced.php(688): do_meta_boxes() 
#3 /core/admin/EE_Admin_Page_CPT.core.php(1477): include_once('/var/www/dev.te...') 
#4 /core/admin/EE_Admin_Page_CPT.core.php(1533): EE_Admin_Page_CPT->loadEditorTemplate() 
#5 /core/admin/EE_Admin_Page.core.php(1048): EE_Admin_Page_CPT->_edit_cpt_item() 
#6 /core/admin/EE_Admin_Page_CPT.core.php(419): EE_Admin_Page->_route_admin_request() 
#7 /core/admin/EE_Admin_Page_CPT.core.php(323): EE_Admin_Page_CPT->_load_page_dependencies() 
#8 /wp-includes/class-wp-hook.php(303): EE_Admin_Page_CPT->load_page_dependencies() 
#9 /wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters() 
#10 /wp-includes/plugin.php(470): WP_Hook->do_action() 
#11 /wp-admin/admin.php(237): do_action() 
#12 {main} thrown in /admin_pages/events/Events_Admin_Page.core.php on line 1679
```

This PR fixes both of those issues