### PR TITLE
Decaf fix - Don't escape HTML output on the event editor publish metabox

### DIFF
--- a/admin_pages/events/templates/event_publish_box_extras.template.php
+++ b/admin_pages/events/templates/event_publish_box_extras.template.php
@@ -43,5 +43,5 @@
     <?php echo absint($not_approved_regs); ?>
 </div>
 
-<?php echo esc_html($event_editor_overview_add); ?>
+<?php echo $event_editor_overview_add; ?>
 <br />


### PR DESCRIPTION
The waitlist add-on uses the `AHEE__Events_Admin_Page___generate_publish_box_extra_content__event_editor_overview_add` hook to add a 'Wait list Registrations' count to the publish metabox:

https://monosnap.com/file/CVd8GxihBa2UlorVfKXF6zn2jsfJB8

With the latest decaf fixes the HTML was escaped so it ended up like this:

https://monosnap.com/file/7DmeuDYU9UE72J9YP7qHxODaJ2x7Ro

This change removes the esc_html() call from that hooks output to fix it.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
