### PR TITLE
Load FrontendRequests Route for iFrames

### DIFF
--- a/core/domain/entities/routing/handlers/frontend/FrontendRequests.php
+++ b/core/domain/entities/routing/handlers/frontend/FrontendRequests.php
@@ -26,7 +26,8 @@ class FrontendRequests extends PublicRoute
      */
     public function matchesCurrentRequest(): bool
     {
-        return ($this->request->isFrontend() || $this->request->isFrontAjax()) && ! $this->maintenance_mode->level();
+        return ($this->request->isFrontend() || $this->request->isFrontAjax() || $this->request->isIframe())
+               && ! $this->maintenance_mode->level();
     }
 
 


### PR DESCRIPTION
Fixes #3549

The dependencies for `EE_Front_Controller` were not getting registered because the `FrontendRequests` Route was not set to load for iFrames. 

This PR simply adds iFrames to the routes matched by the `FrontendRequests` Route.