### PR TITLE
Fix Event Active Status Tag

### DIFF
--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -1133,7 +1133,7 @@ label.error {
     border-radius: 3px;
     color: white;
     font-size: 10px;
-    width: 52px;
+    width: fit-content;
     text-decoration: none;
     font-weight: 500;
     text-align: center;
@@ -1500,7 +1500,7 @@ input.ee-register-button {
 .ee-footnote-text {
     font-style: italic;
     font-size: .8em;
-    font-color: #dcc;
+    color: #dcc;
     font-weight: normal;
 }
 


### PR DESCRIPTION
Fixes #3553 

This PR sets the css width for the event active status tag in the reg options meta box to `fit-content`.
It was previously set to `52px` ?!?!?

The only other place this class is used is for a sold out status tag in SPCO and `fit-content` should work fine for that.