### PR TITLE
Decaf Fixes - Comment out debug code

### DIFF
--- a/modules/ticket_selector/ProcessTicketSelector.php
+++ b/modules/ticket_selector/ProcessTicketSelector.php
@@ -405,7 +405,7 @@ class ProcessTicketSelector
             // if the user is an admin that can edit registrations,
             // then we'll also allow them to add any tickets, even if they are expired
             $current_user_is_admin = current_user_can('ee_edit_registrations');
-            \EEH_Debug_Tools::printr($current_user_is_admin, '$current_user_is_admin', __FILE__, __LINE__);
+            // \EEH_Debug_Tools::printr($current_user_is_admin, '$current_user_is_admin', __FILE__, __LINE__);
             // cycle thru the number of data rows sent from the event listing
             for ($x = 0; $x < $valid['rows']; $x++) {
                 // does this row actually contain a ticket quantity?
@@ -416,7 +416,7 @@ class ProcessTicketSelector
                     if (isset($valid['ticket_id'][ $x ])) {
                         // get ticket via the ticket id we put in the form
                         $ticket = $this->ticket_model->get_one_by_ID($valid['ticket_id'][ $x ]);
-                        \EEH_Debug_Tools::printr($ticket->is_on_sale(), '$ticket->is_on_sale()', __FILE__, __LINE__);
+                        // \EEH_Debug_Tools::printr($ticket->is_on_sale(), '$ticket->is_on_sale()', __FILE__, __LINE__);
                         if ($ticket instanceof EE_Ticket && ($ticket->is_on_sale() || $current_user_is_admin)) {
                             $valid_ticket = true;
                             $tickets_added += $this->addTicketToCart(


### PR DESCRIPTION
There's no debug flag in this class so commented out some debug code from changes made during decaf fixes.

Wasn't sure if you wanted to keep it for future use etc so just commented out for now.

## How has this been tested
Use MER and add tickets to the cart, the 'notices' popup would show blank but the ticket were added to the cart.

Captured the ajax request and could see debug code output there.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
