### PR TITLE
Decaf Fixes - Fix msg toggle switch

### DIFF
--- a/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
+++ b/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
@@ -47,14 +47,13 @@ $context = esc_attr($context);
         </div>
         <div class="switch">
             <?php $checked = $is_active ? ' checked="checked"' : ''; ?>
-            <label for="ee-on-off-toggle-<?php echo $context; // already escaped ?>">
-                <input class='ee-on-off-toggle ee-toggle-round-flat'<?php echo esc_attr($checked); ?>
-                       data-grpid="<?php echo esc_attr($message_template_group_id); ?>"
-                       id="ee-on-off-toggle-<?php echo $context; // already escaped ?>"
-                       type="checkbox"
-                       value="<?php echo esc_attr($on_off_action); ?>"
-                />
-            </label>
+            <input class='ee-on-off-toggle ee-toggle-round-flat'<?php echo esc_attr($checked); ?>
+                   data-grpid="<?php echo esc_attr($message_template_group_id); ?>"
+                   id="ee-on-off-toggle-<?php echo $context; // already escaped ?>"
+                   type="checkbox"
+                   value="<?php echo esc_attr($on_off_action); ?>"
+            />
+            <label for="ee-on-off-toggle-<?php echo $context; // already escaped ?>"></label>
         </div>
     </div>
 </div>

--- a/admin_pages/messages/templates/ee_msg_m_settings_content.template.php
+++ b/admin_pages/messages/templates/ee_msg_m_settings_content.template.php
@@ -24,12 +24,11 @@
         </span>
         <div class="switch">
             <?php $checked = $on_off_status ? ' checked="checked"' : ''; ?>
-            <label for="ee-on-off-toggle-<?php echo esc_attr($messenger); ?>">
-                <input id="ee-on-off-toggle-<?php echo esc_attr($messenger); ?>" type="checkbox"
-                       class="ee-on-off-toggle ee-toggle-round-flat"<?php echo esc_attr($checked); ?>
-                       value="<?php echo esc_attr($on_off_action); ?>"
-                />
-            </label>
+            <input id="ee-on-off-toggle-<?php echo esc_attr($messenger); ?>" type="checkbox"
+                   class="ee-on-off-toggle ee-toggle-round-flat"<?php echo esc_attr($checked); ?>
+                   value="<?php echo esc_attr($on_off_action); ?>"
+            />
+            <label for="ee-on-off-toggle-<?php echo esc_attr($messenger); ?>"></label>
         </div>
     </div> <!-- end .activate_messages_on_off_toggle_container -->
     <div class="messenger-description">


### PR DESCRIPTION
Fix msg toggle switch, the CSS explicitly selects the label after the input using the + selector.

Go to Event Espresso -> Messages -> Settings.

With master there's no green toggle switch to enable/disable messages. ([THIS](https://monosnap.com/file/Rvu0b4eo2fyWz23LJT4cEVrm8YDTwO) is what should be there)

Turns out the CSS explicitly selects the label after the input using `+`, like so `.ee-on-off-toggle+ label`

I went with the fix that required minimal additional testing and moved the label to be after the input again (it changed [HERE](https://github.com/eventespresso/event-espresso-core/commit/2a9afdd71f88ebeff07ea230eed40f26ceb205c5#diff-405b8f81936e4f2fce412beeae0f90d2cc10c2741f0671be60bf44b7f322c820R26-R32))

## Checklist

* [x ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
