### PR TITLE
Allow Legacy Request

### DIFF
--- a/core/libraries/form_sections/form_handlers/SequentialStepFormManager.php
+++ b/core/libraries/form_sections/form_handlers/SequentialStepFormManager.php
@@ -116,7 +116,8 @@ abstract class SequentialStepFormManager
         $this->setFormConfig($form_config);
         $this->setProgressStepStyle($progress_step_style);
         $this->request = $request instanceof RequestInterface
-            ?: LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface');
+            ? $request
+            : LoaderFactory::getLoader()->getShared('EventEspresso\core\services\request\RequestInterface');
     }
 
 


### PR DESCRIPTION
see: https://github.com/eventespresso/eea-attendee-mover/issues/16

this PR:

- eases request type hinting in SequentialStepFormManager so that old versions of the Attendee Mover addon don't throw errors