### PR TITLE
Revert AddonLoader Namespace

### DIFF
--- a/tests/includes/AddonLoader.php
+++ b/tests/includes/AddonLoader.php
@@ -1,5 +1,7 @@
 <?php
-namespace EventEspresso\tests\includes;
+namespace EETests\bootstrap;
+
+use EventEspresso\tests\includes\CoreLoader;
 
 class AddonLoader extends CoreLoader
 {


### PR DESCRIPTION
see: https://github.com/eventespresso/eea-wpuser-integration/pull/36#issuecomment-943477806

this PR reverts the AddonLoader namespace to its previous "incorrect" version because that's what multiple add-ons are using 😖 