### PR TITLE
EDTR | Remove isTaxable from tickets DOM data

### DIFF
--- a/core/domain/entities/admin/GraphQLData/Tickets.php
+++ b/core/domain/entities/admin/GraphQLData/Tickets.php
@@ -37,7 +37,6 @@ class Tickets extends GraphQLData
                     isPending
                     isRequired
                     isSoldOut
-                    isTaxable
                     isTrashed
                     max
                     min


### PR DESCRIPTION
This **_huge_** PR removes `isTaxable` flag from tickets DOM data in continuation of https://github.com/eventespresso/barista/pull/1062