### PR TITLE
Single date ticket query

### DIFF
--- a/core/domain/services/graphql/types/RootQuery.php
+++ b/core/domain/services/graphql/types/RootQuery.php
@@ -2,6 +2,10 @@
 
 namespace EventEspresso\core\domain\services\graphql\types;
 
+use EE_Datetime;
+use EE_Ticket;
+use EEM_Datetime;
+use EEM_Ticket;
 use EventEspresso\core\domain\services\admin\events\editor\EventEntityRelations;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use Exception;
@@ -15,6 +19,7 @@ use EventEspresso\core\services\graphql\fields\GraphQLOutputField;
 use GraphQL\Error\UserError;
 use WPGraphQL\AppContext;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQLRelay\Relay;
 
 /**
  * Class RootQuery
@@ -51,10 +56,45 @@ class RootQuery extends TypeBase
                 esc_html__('JSON encoded relational data of the models', 'event_espresso'),
                 null,
                 [$this, 'getEventRelationalData'],
+                [],
                 [
                     'eventId' => [
                         'type'        => ['non_null' => 'Int'],
                         'description' => esc_html__('The event ID to get the relational data for.', 'event_espresso'),
+                    ],
+                ]
+            ),
+            new GraphQLOutputField(
+                lcfirst($this->namespace) . 'Datetime',
+                $this->namespace . 'Datetime',
+                null,
+                esc_html__('A datetime', 'event_espresso'),
+                null,
+                [$this, 'getDatetime'],
+                [],
+                [
+                    'id' => [
+                        'type'        => [
+                            'non_null' => 'ID',
+                        ],
+                        'description' => esc_html__('The globally unique identifier of the datetime.', 'event_espresso'),
+                    ],
+                ]
+            ),
+            new GraphQLOutputField(
+                lcfirst($this->namespace) . 'Ticket',
+                $this->namespace . 'Ticket',
+                null,
+                esc_html__('A ticket', 'event_espresso'),
+                null,
+                [$this, 'getTicket'],
+                [],
+                [
+                    'id' => [
+                        'type'        => [
+                            'non_null' => 'ID',
+                        ],
+                        'description' => esc_html__('The globally unique identifier of the ticket.', 'event_espresso'),
                     ],
                 ]
             ),
@@ -94,5 +134,69 @@ class RootQuery extends TypeBase
             'EventEspresso\core\domain\services\admin\events\editor\EventEntityRelations'
         );
         return json_encode($event_entity_relations->getData($eventId));
+    }
+
+
+    /**
+     * @param mixed       $source  The source that's passed down the GraphQL queries
+     * @param array       $args    The inputArgs on the field
+     * @param AppContext  $context The AppContext passed down the GraphQL tree
+     * @param ResolveInfo $info    The ResolveInfo passed down the GraphQL tree
+     * @return string
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UserError
+     * @throws UnexpectedEntityException
+     * @since $VID:$
+     */
+    public function getDatetime($source, array $args, AppContext $context, ResolveInfo $info): EE_Datetime
+    {
+        $parts = Relay::fromGlobalId(sanitize_text_field($args['id']));
+
+        /**
+         * Throw an exception if there's no ID
+         */
+        if (empty($parts['id'])) {
+            throw new UserError(esc_html__(
+                'A missing or invalid ID was received.',
+                'event_espresso'
+            ));
+        }
+
+        return EEM_Datetime::instance()->get_one_by_ID(absint($parts['id']));
+    }
+
+
+    /**
+     * @param mixed       $source  The source that's passed down the GraphQL queries
+     * @param array       $args    The inputArgs on the field
+     * @param AppContext  $context The AppContext passed down the GraphQL tree
+     * @param ResolveInfo $info    The ResolveInfo passed down the GraphQL tree
+     * @return string
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
+     * @throws UserError
+     * @throws UnexpectedEntityException
+     * @since $VID:$
+     */
+    public function getTicket($source, array $args, AppContext $context, ResolveInfo $info): EE_Ticket
+    {
+        $parts = Relay::fromGlobalId(sanitize_text_field($args['id']));
+
+        /**
+         * Throw an exception if there's no ID
+         */
+        if (empty($parts['id'])) {
+            throw new UserError(esc_html__(
+                'A missing or invalid ID was received.',
+                'event_espresso'
+            ));
+        }
+
+        return EEM_Ticket::instance()->get_one_by_ID(absint($parts['id']));
     }
 }

--- a/core/services/graphql/fields/GraphQLField.php
+++ b/core/services/graphql/fields/GraphQLField.php
@@ -56,6 +56,11 @@ class GraphQLField implements GraphQLFieldInterface
     protected $caps;
 
     /**
+     * @var array $args
+     */
+    protected $args;
+
+    /**
      * @var bool $use_for_input
      */
     protected $use_for_input = true;
@@ -75,6 +80,7 @@ class GraphQLField implements GraphQLFieldInterface
      * @param callable|null   $resolver
      * @param array           $args
      * @param array           $caps
+     * @param array           $args
      */
     public function __construct(
         $name,
@@ -83,7 +89,8 @@ class GraphQLField implements GraphQLFieldInterface
         $description = '',
         callable $formatter = null,
         callable $resolver = null,
-        array $caps = []
+        array $caps = [],
+        array $args = []
     ) {
         $this->name = $name;
         $this->type = $type;
@@ -92,6 +99,7 @@ class GraphQLField implements GraphQLFieldInterface
         $this->formatter = $formatter;
         $this->resolver = $resolver;
         $this->caps = $caps;
+        $this->args = $args;
     }
 
 

--- a/core/services/graphql/fields/GraphQLOutputField.php
+++ b/core/services/graphql/fields/GraphQLOutputField.php
@@ -19,6 +19,7 @@ class GraphQLOutputField extends GraphQLField
      * @param callable|null   $formatter
      * @param callable|null   $resolver
      * @param array           $caps
+     * @param array           $args
      */
     public function __construct(
         $name,
@@ -27,7 +28,8 @@ class GraphQLOutputField extends GraphQLField
         $description = '',
         callable $formatter = null,
         callable $resolver = null,
-        array $caps = []
+        array $caps = [],
+        array $args = []
     ) {
         parent::__construct(
             $name,
@@ -36,7 +38,8 @@ class GraphQLOutputField extends GraphQLField
             $description,
             $formatter,
             $resolver,
-            $caps
+            $caps,
+            $args
         );
 
         $this->setUseForInput(false);

--- a/docs/GraphQL-API/query/datetime.md
+++ b/docs/GraphQL-API/query/datetime.md
@@ -4,6 +4,8 @@ Datetime object has connections with `RootQuery`, `EspressoEvent`, `EspressoTick
 
 ## Example with `RootQuery`
 
+### Get a list of datetimes
+
 ```gql
 query GET_DATETIMES(
 	$first: Int
@@ -28,7 +30,7 @@ query GET_DATETIMES(
 }
 ```
 
-### Query variables
+#### Query variables
 
 ```json
 {
@@ -48,6 +50,26 @@ or
 	"where": {
 		"eventId": 22
 	}
+}
+```
+
+### Get a single datetime
+
+```gql
+query GET_DATETIME($id: ID!) {
+	espressoDatetime(id: $id) {
+		id
+		name
+		description
+	}
+}
+```
+
+#### Query variables
+
+```json
+{
+	"id": "RGF0ZXRpbWU6MTQ="
 }
 ```
 

--- a/docs/GraphQL-API/query/ticket.md
+++ b/docs/GraphQL-API/query/ticket.md
@@ -4,6 +4,8 @@ Ticket object has connections with `RootQuery`, `Datetime` etc. and thus can be 
 
 ## Example with `RootQuery`
 
+### Get a list of tickets
+
 ```gql
 query GET_TICKETS($where: EspressoRootQueryTicketsConnectionWhereArgs) {
 	espressoTickets(where: $where) {
@@ -20,7 +22,7 @@ query GET_TICKETS($where: EspressoRootQueryTicketsConnectionWhereArgs) {
 }
 ```
 
-### Query variables
+#### Query variables
 
 ```json
 {
@@ -44,6 +46,26 @@ or
 	"where": {
 		"datetimeIn": ["RGF0ZXRpbWU6MTQ=", "RGF0ZXRpbWU6MTU="]
 	}
+}
+```
+
+### Get a single ticket
+
+```gql
+query GET_TICKET($id: ID!) {
+	espressoTicket(id: $id) {
+		id
+		name
+		description
+	}
+}
+```
+
+#### Query variables
+
+```json
+{
+	"id": "VGlja2V0OjQ1"
 }
 ```
 


### PR DESCRIPTION
In preparation for a client-side fix for https://github.com/eventespresso/barista/issues/1091, this PR enhances GQL schema to add support for querying single datetime and ticket by ID.