### PR TITLE
Fix schema eventStatus escaping.

### DIFF
--- a/core/helpers/EEH_Schema.helper.php
+++ b/core/helpers/EEH_Schema.helper.php
@@ -61,7 +61,7 @@ class EEH_Schema
                 $event_status = 'EventScheduled';
         }
         $template_args['event_attendance_mode'] = 'OfflineEventAttendanceMode';
-        $template_args['event_status'] = '"https://schema.org/' . $event_status . '"';
+        $template_args['event_status'] = 'https://schema.org/' . $event_status;
         $template_args['currency'] = EE_Registry::instance()->CFG->currency->code;
         foreach ($event->tickets() as $original_ticket) {
             // clone tickets so that date formats don't override those for the original ticket

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -26,7 +26,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
   "description": <?php echo wp_json_encode($event_description); ?>,
   "url": "<?php echo esc_url_raw($event_permalink); ?>",
   "eventAttendanceMode": "<?php echo esc_url_raw('https://schema.org/' . $event_attendance_mode); ?>",
-  "eventStatus": [ <?php echo esc_html($event_status); ?> ],
+  "eventStatus": [ "<?php echo esc_html($event_status); ?>" ],
   "offers": [
     <?php
     $i = 0;

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -26,7 +26,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
   "description": <?php echo wp_json_encode($event_description); ?>,
   "url": "<?php echo esc_url_raw($event_permalink); ?>",
   "eventAttendanceMode": "<?php echo esc_url_raw('https://schema.org/' . $event_attendance_mode); ?>",
-  "eventStatus": [ "<?php echo esc_html($event_status); ?>" ],
+  "eventStatus": [ "<?php echo esc_url_raw($event_status); ?>" ],
   "offers": [
     <?php
     $i = 0;


### PR DESCRIPTION
Create an event and check the schema output, the 'eventStatus' parameter has escaped double quotes `"`

`"eventStatus": [ &quot;https://schema.org/EventScheduled&quot; ]`

This change swaps out how that value is output to match the others used in that file, the quotes are hardcoded and no longer escaped.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
