### PR TITLE
Fix  'something went wrong because we're missing the registration ID'

### DIFF
--- a/core/libraries/messages/EE_Messages_Processor.lib.php
+++ b/core/libraries/messages/EE_Messages_Processor.lib.php
@@ -569,7 +569,7 @@ class EE_Messages_Processor
         /** @var RequestInterface $request */
         $request = LoaderFactory::getLoader()->getShared(RequestInterface::class);
         $regs_to_send = array();
-        $regIDs = $request->getRequestParam($registration_ids_key, [], 'int', true);
+        $regIDs = $request->getRequestParam($registration_ids_key, [], 'int');
         if (empty($regIDs)) {
             EE_Error::add_error(esc_html__('Something went wrong because we\'re missing the registration ID', 'event_espresso'), __FILE__, __FUNCTION__, __LINE__);
             return false;


### PR DESCRIPTION
_REG_ID will either be an array of IDs or a string with a single ID depending on how the message was triggered so need to remove the is_array flag as it's not always an array.

Testing this is a little tricky right now due to another bug, see #3596 

When the above is fixed, you can test in:

Event Espresso -> Registrations.

Click the 'Resend Registration Details' icon in actions.

A notice should show on the page to show it triggered the message correctly.

---

Next, use the checkboxes next to the registration and select 1 registration. 

In bulk actions, select 'Set {status} and Notify' (status being the same status the registration currently is)

That should trigger another message for that registration.

Finally, select 2 or more registrations with the checkboxes, do the same test about, it should trigger messages for both.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
