### PR TITLE
Typecast Array Values Passed to RequestSanitizer

### DIFF
--- a/core/services/request/sanitizers/RequestSanitizer.php
+++ b/core/services/request/sanitizers/RequestSanitizer.php
@@ -24,7 +24,7 @@ class RequestSanitizer
         $is_array = $is_array || is_array($param);
         if ($is_array) {
             $values = [];
-            foreach ($param as $key => $value) {
+            foreach ((array) $param as $key => $value) {
                 $values[ $key ] = $this->clean($value, $type, is_array($value), $delimiter);
             }
             return $values;


### PR DESCRIPTION
This PR:

- closes #3597
- ensures that parameters supplied to `RequestSanitizer` are always an array if they are expected to be