### PR TITLE
Register Dependencies for DisplayTicketSelector

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -713,6 +713,10 @@ class EE_Dependency_Map
             'EventEspresso\caffeinated\modules\recaptcha_invisible\RecaptchaAdminSettings'                                => [
                 'EE_Registration_Config' => EE_Dependency_Map::load_from_cache,
             ],
+            'EventEspresso\modules\ticket_selector\DisplayTicketSelector' => [
+                'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
+                'EE_Ticket_Selector_Config'                   => EE_Dependency_Map::load_from_cache,
+            ],
             'EventEspresso\modules\ticket_selector\ProcessTicketSelector'                                                 => [
                 'EE_Core_Config'                                                          => EE_Dependency_Map::load_from_cache,
                 'EventEspresso\core\services\request\Request'                             => EE_Dependency_Map::load_from_cache,

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -1056,6 +1056,9 @@ class EE_Dependency_Map
             'EE_Environment_Config'                        => function () {
                 return EE_Config::instance()->environment;
             },
+            'EE_Ticket_Selector_Config'                    => function () {
+                return EE_Config::instance()->template_settings->EED_Ticket_Selector;
+            },
         ];
     }
 


### PR DESCRIPTION
this PR:

- closes #3598 
- registers dependencies for the `DisplayTicketSelector` so that they can be auto injected by the iframe code