### PR TITLE
Fix upcoming events widget echo date range.

### DIFF
--- a/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
+++ b/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
@@ -700,7 +700,8 @@ class EEW_Upcoming_Events extends EspressoWidget
                 $time_format,
                 $single_date_format,
                 $single_time_format,
-                $event->ID()
+                $event->ID(),
+                false
             );
         }
         return espresso_list_of_event_dates(


### PR DESCRIPTION
This just sets the echo flag on espresso_event_date_range() used within the widget.

Before this change: 
![image](https://user-images.githubusercontent.com/4345417/142665967-f9548496-52b0-468f-95bd-e9c1db7eb634.png)

After (and how release shows the dates): 
![image](https://user-images.githubusercontent.com/4345417/142666221-da198f09-02bf-4564-90ab-08af440b9796.png)

Use the upcoming events widget and set the 'Show date range' option to be true.