### PR TITLE
Fix EE_Request_Handler Loading

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -972,9 +972,7 @@ class EE_Dependency_Map
             'EE_Maintenance_Mode'                          => 'load_core',
             'EE_Register_CPTs'                             => 'load_core',
             'EE_Admin'                                     => 'load_core',
-            'EE_CPT_Strategy'                              => function () {
-                return EE_CPT_Strategy::instance();
-            },
+            'EE_CPT_Strategy'                              => 'load_core',
             // load_class
             'EE_Registration_Processor'                    => 'load_class',
             // load_lib

--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -972,7 +972,9 @@ class EE_Dependency_Map
             'EE_Maintenance_Mode'                          => 'load_core',
             'EE_Register_CPTs'                             => 'load_core',
             'EE_Admin'                                     => 'load_core',
-            'EE_CPT_Strategy'                              => 'load_core',
+            'EE_CPT_Strategy'                              => function () {
+                return EE_CPT_Strategy::instance();
+            },
             // load_class
             'EE_Registration_Processor'                    => 'load_class',
             // load_lib

--- a/core/EE_Registry.core.php
+++ b/core/EE_Registry.core.php
@@ -382,8 +382,8 @@ class EE_Registry implements ResettableInterface
                 EE_CORE,
                 EE_ADMIN,
                 EE_CPTS,
+                EE_CORE . 'CPTs/',
                 EE_CORE . 'data_migration_scripts/',
-                EE_CORE . 'capabilities/',
                 EE_CORE . 'request_stack/',
                 EE_CORE . 'middleware/',
             )

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -305,8 +305,6 @@ final class EE_System implements ResettableInterface
         // set autoloaders for all of the classes implementing EEI_Plugin_API
         // which provide helpers for EE plugin authors to more easily register certain components with EE.
         EEH_Autoloader::instance()->register_autoloaders_for_each_file_in_folder(EE_LIBRARIES . 'plugin_api');
-        // load legacy EE_Request_Handler in case add-ons still need it
-        $this->loader->getShared('EE_Request_Handler');
     }
 
 
@@ -1194,6 +1192,8 @@ final class EE_System implements ResettableInterface
         }
         // integrate WP_Query with the EE models
         $this->loader->getShared('EE_CPT_Strategy');
+        // load legacy EE_Request_Handler in case add-ons still need it
+        $this->loader->getShared('EE_Request_Handler');
         do_action('AHEE__EE_System__core_loaded_and_ready');
         // always load template tags, because it's faster than checking if it's a front-end request, and many page
         // builders require these even on the front-end

--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -125,6 +125,20 @@ final class EE_System implements ResettableInterface
      */
     private $request_type;
 
+    /**
+     * @param EventEspresso\core\domain\services\custom_post_types\RegisterCustomPostTypes
+     */
+    private $register_custom_post_types;
+
+    /**
+     * @param EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomies
+     */
+    private $register_custom_taxonomies;
+
+    /**
+     * @param EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomyTerms
+     */
+    private $register_custom_taxonomy_terms;
 
     /**
      * @singleton method used to instantiate class object
@@ -226,6 +240,11 @@ final class EE_System implements ResettableInterface
         add_action(
             'AHEE__EE_Bootstrap__load_core_configuration',
             array($this, 'loadRouteMatchSpecifications')
+        );
+        // load specifications for custom post types
+        add_action(
+            'AHEE__EE_Bootstrap__load_core_configuration',
+            array($this, 'loadCustomPostTypes')
         );
         // load EE_Config, EE_Textdomain, etc
         add_action(
@@ -956,6 +975,30 @@ final class EE_System implements ResettableInterface
 
 
     /**
+     * loading CPT related classes earlier so that their definitions are available
+     * but not performing any actual registration with WP core until load_CPTs_and_session() is called
+     *
+     * @since   $VID:$
+     */
+    public function loadCustomPostTypes()
+    {
+        $this->register_custom_taxonomies = $this->loader->getShared(
+            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomies'
+        );
+        $this->register_custom_post_types = $this->loader->getShared(
+            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomPostTypes'
+        );
+        $this->register_custom_taxonomy_terms = $this->loader->getShared(
+            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomyTerms'
+        );
+        // integrate WP_Query with the EE models
+        $this->loader->getShared('EE_CPT_Strategy');
+        // load legacy EE_Request_Handler in case add-ons still need it
+        $this->loader->getShared('EE_Request_Handler');
+    }
+
+
+    /**
      * register_shortcodes_modules_and_widgets
      * generate lists of shortcodes and modules, then verify paths and classes
      * This is hooked into 'AHEE__EE_Bootstrap__register_shortcodes_modules_and_widgets'
@@ -1105,21 +1148,9 @@ final class EE_System implements ResettableInterface
     public function load_CPTs_and_session()
     {
         do_action('AHEE__EE_System__load_CPTs_and_session__start');
-        /** @var EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomies $register_custom_taxonomies */
-        $register_custom_taxonomies = $this->loader->getShared(
-            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomies'
-        );
-        $register_custom_taxonomies->registerCustomTaxonomies();
-        /** @var EventEspresso\core\domain\services\custom_post_types\RegisterCustomPostTypes $register_custom_post_types */
-        $register_custom_post_types = $this->loader->getShared(
-            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomPostTypes'
-        );
-        $register_custom_post_types->registerCustomPostTypes();
-        /** @var EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomyTerms $register_custom_taxonomy_terms */
-        $register_custom_taxonomy_terms = $this->loader->getShared(
-            'EventEspresso\core\domain\services\custom_post_types\RegisterCustomTaxonomyTerms'
-        );
-        $register_custom_taxonomy_terms->registerCustomTaxonomyTerms();
+        $this->register_custom_taxonomies->registerCustomTaxonomies();
+        $this->register_custom_post_types->registerCustomPostTypes();
+        $this->register_custom_taxonomy_terms->registerCustomTaxonomyTerms();
         // load legacy Custom Post Types and Taxonomies
         $this->loader->getShared('EE_Register_CPTs');
         do_action('AHEE__EE_System__load_CPTs_and_session__complete');
@@ -1190,10 +1221,6 @@ final class EE_System implements ResettableInterface
         ) {
             $this->loader->getShared('EE_Session');
         }
-        // integrate WP_Query with the EE models
-        $this->loader->getShared('EE_CPT_Strategy');
-        // load legacy EE_Request_Handler in case add-ons still need it
-        $this->loader->getShared('EE_Request_Handler');
         do_action('AHEE__EE_System__core_loaded_and_ready');
         // always load template tags, because it's faster than checking if it's a front-end request, and many page
         // builders require these even on the front-end

--- a/modules/events_archive/EED_Events_Archive.module.php
+++ b/modules/events_archive/EED_Events_Archive.module.php
@@ -828,7 +828,7 @@ class EED_Events_Archive extends EED_Module
      *
      * @access    public
      * @param    EE_Template_Config $CFG
-     * @param    EE_Request_Handler $REQ
+     * @param    array $REQ
      * @return    EE_Template_Config
      */
     public static function update_template_settings($CFG, $REQ)


### PR DESCRIPTION
$this PR:

- closes #3608
- moves loading of `EE_Request_Handler` until after `EE_CPT_Strategy` is loaded
- adds CPTs folder to core paths array in `EE_Registry::load_core()`

I'm not sure if this will fix things because there is no good reason why the previous code shouldn't have worked.
Kinda grasping at straws here.