### PR TITLE
Switch back to using list() in EE_Admin_Page

### DIFF
--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1028,9 +1028,9 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         );
         if (! empty($func)) {
             if (is_array($func)) {
-                [$class, $method] = $func;
+                list($class, $method) = $func;
             } elseif (strpos($func, '::') !== false) {
-                [$class, $method] = explode('::', $func);
+                list($class, $method) = explode('::', $func);
             } else {
                 $class  = $this;
                 $method = $func;


### PR DESCRIPTION
This was swapped out [HERE](https://github.com/eventespresso/event-espresso-core/pull/3603/commits/1eadb922ce861e13f4c0847fe10d30295aa963af)

But apparently, any version of PHP below 7.1 simply throws a fit with it, so swapping back.

## Problem this Pull Request solves
See #3608 

## How has this been tested
Load EE on PHP 5.6 or 7.0, you get a fatal error instantly (error relates to CurrentPage.php, but its from this code)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
