### PR TITLE
Fix Event CPT Status Dropdown

### DIFF
--- a/core/admin/templates/status_dropdown.template.php
+++ b/core/admin/templates/status_dropdown.template.php
@@ -8,9 +8,7 @@
  * @var string[] $statuses
  */
 ?>
-
-<?php /* ?>
-<div id="ee-status-container">
+<div id="ee-status-container" style="display: none;">
     <span id="cur_status"><?php echo esc_html($cur_status_label); ?></span>
     <span id="localized_status_save"><?php echo esc_html($localized_status_save); ?></span>
     <span id="cur_stat_id"><?php echo esc_html($cur_status); ?></span>
@@ -22,4 +20,3 @@
         <?php endforeach; ?>
     </select>
 </div>
-<?php */


### PR DESCRIPTION
This PR:

- closes #3614 
- uncomments html in `status_dropdown.template.php` and re-adds `display: none;` as a style, because the best way to make things appear is to set their display property to "none" 😕 

I'm guessing that the dropdown selector in `status_dropdown.template.php`  was hidden, not because it was not being used (as I had assumed) but because it was being used to replace the existing WordPress post status dropdown via javascript.