### PR TITLE
Don't escape EE3 migration table output

### DIFF
--- a/admin_pages/maintenance/templates/ee_migration_page.template.php
+++ b/admin_pages/maintenance/templates/ee_migration_page.template.php
@@ -93,7 +93,7 @@ if ($show_backup_db_text) { ?>
 
         <?php
         if ($show_backup_db_text) {
-            echo esc_html($migration_options_html);
+            echo $migration_options_html;
         } ?>
 
         <?php

--- a/admin_pages/maintenance/templates/migration_options_from_ee3.template.php
+++ b/admin_pages/maintenance/templates/migration_options_from_ee3.template.php
@@ -35,26 +35,24 @@
                 <tr>
                     <td><h3><?php esc_html_e('1', 'event_espresso'); ?></h3></td>
                     <td>
-                        <?php echo esc_html(
-                            apply_filters(
-                                'FHEE__ee_migration_page__option_1_main',
-                                sprintf(
-                                    __(
-                                        '%1$sYes. I have backed up my database%2$s, %3$sunderstand the risks involved%4$s, and am ready to migrate my existing %5$s data to %6$s.',
-                                        "event_espresso"
-                                    ),
-                                    '<strong>',
-                                    '</strong>',
-                                    '<a id="migration-risks" class="" title="'
-                                    . esc_attr__('click for more details', "event_espresso")
-                                    . '">',
-                                    '</a>',
-                                    $current_db_state,
-                                    $next_db_state
+                        <?php echo apply_filters(
+                            'FHEE__ee_migration_page__option_1_main',
+                            sprintf(
+                                __(
+                                    '%1$sYes. I have backed up my database%2$s, %3$sunderstand the risks involved%4$s, and am ready to migrate my existing %5$s data to %6$s.',
+                                    "event_espresso"
                                 ),
+                                '<strong>',
+                                '</strong>',
+                                '<a id="migration-risks" class="" title="'
+                                . esc_attr__('click for more details', "event_espresso")
+                                . '">',
+                                '</a>',
                                 $current_db_state,
                                 $next_db_state
-                            )
+                            ),
+                            $current_db_state,
+                            $next_db_state
                         );
                             ?>
                         <a id="display-migration-details"


### PR DESCRIPTION
Migrations showed up as escaped html, so looked like this:

https://monosnap.com/file/SKfRMhn0gaJBnigbKAY577PReaLowY

This change fixes the table and one of the table's contents as that was also escaped but contains HTML:

https://monosnap.com/file/WFOF9NugQexx3ANonBjQAfIVnkVt6O
(The option 1 section uses HTML tags)

Side note... I'm aware 'escapation' isn't a word, but migration escapation kinda rolls off the tongue right?

I'll leave you with this: 

![escape](https://i.pinimg.com/originals/5f/45/ea/5f45ea5d358bd52fa1d8f0bb0a423b45.jpg)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
