### PR TITLE
Fix creating custom messages

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -1242,8 +1242,8 @@ class Messages_Admin_Page extends EE_Admin_Page
     protected function _add_message_template($message_type = '', $messenger = '', $GRP_ID = '')
     {
         // set values override any request data
-        $message_type = ! empty($message_type) ? $message_type : $this->request->getRequestParam('MTP_message_type');
-        $messenger    = ! empty($messenger) ? $messenger : $this->request->getRequestParam('MTP_messenger');
+        $message_type = ! empty($message_type) ? $message_type : $this->request->getRequestParam('message_type');
+        $messenger    = ! empty($messenger) ? $messenger : $this->request->getRequestParam('messenger');
         $GRP_ID       = ! empty($GRP_ID) ? $GRP_ID : $this->request->getRequestParam('GRP_ID', 0, 'int');
 
         // we need messenger and message type.  They should be coming from the event editor. If not here then return error


### PR DESCRIPTION
In #3606 I missed that the parameter prefixes had also been added to the _add_message_template() method, that change has broke the 'Create custom' button within message, it now throws a fatal with:

```
2021-11-29 23:42:33]  Exception Details
Message: Sorry, but we can&#039;t create new templates because we&#039;re missing the messenger or message type
Code: Messages_Admin_Page - _add_message_template - 1251
File: C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\admin_pages\messages\Messages_Admin_Page.core.php
Line No: 1251
```

This change just removes the prefix again.

---

To test, go to Event Espresso -> Messages -> Default message templates.

Click 'create custom' on any message type.