### PR TITLE
Fix question editor stripping values

### DIFF
--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -322,7 +322,7 @@ if ($QST_system === 'country') {
                                                 <?php if ($has_answers) : ?>
                                                     <input type="hidden"
                                                            name="question_options[<?php echo $count; ?>][QSO_value]"
-                                                           value="<?php echo esc_attr($option->f('QSO_value')); ?>"
+                                                           value="<?php esc_attr($option->f('QSO_value')); ?>"
                                                     />
                                                 <?php endif; ?>
                                             </td>

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -220,7 +220,7 @@ if ($QST_system === 'country') {
                                min="1"
                                name="QST_max"
                                type="number"
-                               value="<?php esc_attr_e($question->get_f('QST_max')); ?>"
+                               value="<?php echo esc_attr($question->get_f('QST_max')); ?>"
                         />
                         <p>
                             <span class="description">

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -62,7 +62,7 @@ if ($QST_system === 'country') {
                                id="QST_display_text"
                                name="QST_display_text"
                                type="text"
-                               value="<?php ($question->get_pretty('QST_display_text')) ?>"
+                               value="<?php $question->f('QST_display_text') ?>"
                         />
                     </td>
                 </tr>
@@ -83,7 +83,7 @@ if ($QST_system === 'country') {
                                id="QST_admin_label<?php echo $id; // escape not needed ?>"
                                name="QST_admin_label<?php echo $id; // escape not needed ?>"
                                type="text"
-                               value="<?php ($question->get_pretty('QST_admin_label')) ?>"
+                               value="<?php $question->f('QST_admin_label') ?>"
                                <?php echo $disabled_attr ?>
                         />
                         <input class="QST_order"
@@ -220,7 +220,7 @@ if ($QST_system === 'country') {
                                min="1"
                                name="QST_max"
                                type="number"
-                               value="<?php esc_attr($question->get_pretty('QST_max')); ?>"
+                               value="<?php esc_attr($question->f('QST_max')); ?>"
                         />
                         <p>
                             <span class="description">
@@ -316,13 +316,13 @@ if ($QST_system === 'country') {
                                                 <input type="text"
                                                        class="option-value regular-text"
                                                        name="question_options[<?php echo $count ?>][QSO_value]"
-                                                       value="<?php echo esc_attr($option->get_pretty('QSO_value')) ?>"
+                                                       value="<?php echo esc_attr($option->f('QSO_value')) ?>"
                                                     <?php echo $disabled_attr; // escape not needed ?>
                                                 />
                                                 <?php if ($has_answers) : ?>
                                                     <input type="hidden"
                                                            name="question_options[<?php echo $count; ?>][QSO_value]"
-                                                           value="<?php echo esc_attr($option->get_pretty('QSO_value')); ?>"
+                                                           value="<?php echo esc_attr($option->f('QSO_value')); ?>"
                                                     />
                                                 <?php endif; ?>
                                             </td>
@@ -330,7 +330,7 @@ if ($QST_system === 'country') {
                                                 <input type="text"
                                                        class="option-desc regular-text"
                                                        name="question_options[<?php echo $count ?>][QSO_desc]"
-                                                       value="<?php esc_attr($option->get_pretty('QSO_desc')) ?>"
+                                                       value="<?php esc_attr($option->f('QSO_desc')) ?>"
                                                 />
                                             </td>
                                             <td>
@@ -485,7 +485,7 @@ if ($QST_system === 'country') {
                                class="regular-text"
                                id="QST_required_text"
                                name="QST_required_text"
-                               value="<?php echo esc_html($question->get_pretty('QST_required_text')); ?>"
+                               value="<?php echo esc_html($question->f('QST_required_text')); ?>"
                         />
 
                     </td>

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -90,13 +90,13 @@ if ($QST_system === 'country') {
                                id="QST_order<?php echo $id; // escape not needed ?>"
                                name="QST_order<?php echo $id; // escape not needed ?>"
                                type="hidden"
-                               value="<?php echo esc_attr($question->get('QST_order')); ?>"
+                               value="<?php echo $question->get('QST_order'); ?>"
                         />
                         <?php if (! empty($QST_system)) { ?>
                             <input id='QST_admin_label'
                                    name="QST_admin_label"
                                    type="hidden"
-                                   value="<?php echo esc_attr($question->admin_label()); ?>"
+                                   value="<?php echo $question->admin_label(); ?>"
                             />
                         <?php } ?>
                         <br />
@@ -183,7 +183,7 @@ if ($QST_system === 'country') {
                             <input id='QST_type'
                                    name="QST_type"
                                    type="hidden"
-                                   value="<?php echo esc_attr($question->type()); ?>"
+                                   value="<?php echo $question->type(); ?>"
                             />
                             <?php
                             $explanatory_text = esc_html__(
@@ -220,7 +220,7 @@ if ($QST_system === 'country') {
                                min="1"
                                name="QST_max"
                                type="number"
-                               value="<?php esc_attr($question->f('QST_max')); ?>"
+                               value="<?php esc_attr_e($question->get_f('QST_max')); ?>"
                         />
                         <p>
                             <span class="description">
@@ -316,13 +316,13 @@ if ($QST_system === 'country') {
                                                 <input type="text"
                                                        class="option-value regular-text"
                                                        name="question_options[<?php echo $count ?>][QSO_value]"
-                                                       value="<?php echo esc_attr($option->f('QSO_value')) ?>"
+                                                       value="<?php $option->f('QSO_value') ?>"
                                                     <?php echo $disabled_attr; // escape not needed ?>
                                                 />
                                                 <?php if ($has_answers) : ?>
                                                     <input type="hidden"
                                                            name="question_options[<?php echo $count; ?>][QSO_value]"
-                                                           value="<?php esc_attr($option->f('QSO_value')); ?>"
+                                                           value="<?php $option->f('QSO_value'); ?>"
                                                     />
                                                 <?php endif; ?>
                                             </td>
@@ -330,7 +330,7 @@ if ($QST_system === 'country') {
                                                 <input type="text"
                                                        class="option-desc regular-text"
                                                        name="question_options[<?php echo $count ?>][QSO_desc]"
-                                                       value="<?php esc_attr($option->f('QSO_desc')) ?>"
+                                                       value="<?php $option->f('QSO_desc') ?>"
                                                 />
                                             </td>
                                             <td>
@@ -485,7 +485,7 @@ if ($QST_system === 'country') {
                                class="regular-text"
                                id="QST_required_text"
                                name="QST_required_text"
-                               value="<?php echo esc_html($question->f('QST_required_text')); ?>"
+                               value="<?php $question->f('QST_required_text'); ?>"
                         />
 
                     </td>


### PR DESCRIPTION
Currently, if you create a question, the values will save as expected when saved.

If you then edit the question, none of the values show on the form and if you save, the empty values are saved to the DB.

I switched these fields back to using `f()` as these are form inputs and that appears to be what that function is intended for.

## How has this been tested
Create or edit a question, I used both text and checkbox question types to test.

Add some values for each of the question types and also add some HTML (where applicable).

On master when you edit the question now of the values will show, on this branch they will.

Make a change to the values and save, make sure that change shows when saved and that everything within th question shows as expected.

A couple of examples, first question text HTML:
https://monosnap.com/file/UVLsBJgSLcmbfwUZ03thq64wNCs142

Checkbox HTML:
https://monosnap.com/file/PXZhtB57NHEyePvdpSBxuhwuoJlGAt


## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
