### PR TITLE
Fix thank you page resend email link

### DIFF
--- a/modules/thank_you_page/templates/thank-you-page-registration-details.template.php
+++ b/modules/thank_you_page/templates/thank-you-page-registration-details.template.php
@@ -87,7 +87,7 @@
                                'Click here to resend the Registration Confirmation email',
                                'event_espresso'
                            ); ?>"
-                           rel="<?php echo esc_url_raw($registration->reg_url_link()); ?>"
+                           rel="<?php echo esc_attr($registration->reg_url_link()); ?>"
                         >
                             <span class="dashicons dashicons-email-alt"></span>
                             <?php esc_html_e('resend email', 'event_espresso'); ?>


### PR DESCRIPTION
reg_url_link isn't a URL here, it's used as a 'token' to know which registration to resend the email for.

If you complete a registration andget to the thank you page, then click on the resen email link it'll show an error:

> The Registration Confirmation email could not be sent because a valid Registration could not be retrieved from the database.

That's happening because the reg_url_link value is being passed but has `http://` at the beginning:

https://monosnap.com/file/4br6OywykafrrH0dAX3seFO8ocv3kr

This change fixes that value:

https://monosnap.com/file/SJ03voenecnMsh0pInTQzdy694KCzA

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
