### PR TITLE
Fix filtered registration report filters - stripslashes() is no longer needed

### DIFF
--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -54,7 +54,7 @@ class RegistrationsReport extends JobHandlerFile
         );
         $job_parameters->add_extra_data('filepath', $filepath);
         if ($job_parameters->request_datum('use_filters', false)) {
-            $query_params = maybe_unserialize(stripslashes($job_parameters->request_datum('filters', array())));
+            $query_params = maybe_unserialize($job_parameters->request_datum('filters', array()));
         } else {
             $query_params = apply_filters('FHEE__EE_Export__report_registration_for_event', array(
                 array(


### PR DESCRIPTION
Fixes #3641

I checked into this and on 4.10.13.p the string returned by `$job_parameters->request_datum('filters', array())` was serialized but had extra dashes:

`
a:5:{i:0;a:2:{s:6:\"STS_ID\";s:3:\"RAP\";s:8:\"REG_date\";a:2:{i:0;s:7:\"BETWEEN\";i:1;a:2:{i:0;O:49:\"EventEspresso\\core\\domain\\entities\\DbSafeDateTime\":1:{s:19:\"\0*\0_datetime_string\";s:29:\"2021-12-01 00:00:00 +0000 UTC\";}i:1;O:49:\"EventEspresso\\core\\domain\\entities\\DbSafeDateTime\":1:{s:19:\"\0*\0_datetime_string\";s:29:\"2021-12-31 23:59:59 +0000 UTC\";}}}}s:4:\"caps\";s:10:\"read_admin\";s:24:\"default_where_conditions\";s:15:\"this_model_only\";s:8:\"order_by\";a:2:{s:8:\"REG_date\";s:4:\"DESC\";s:6:\"REG_ID\";s:4:\"DESC\";}s:5:\"limit\";a:2:{i:0;i:0;i:1;i:20;}}
`

Running stripdahses on that returned:

`
a:5:{i:0;a:2:{s:6:"STS_ID";s:3:"RAP";s:8:"REG_date";a:2:{i:0;s:7:"BETWEEN";i:1;a:2:{i:0;O:49:"EventEspresso\core\domain\entities\DbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-01 00:00:00 +0000 UTC";}i:1;O:49:"EventEspresso\core\domain\entities\DbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-31 23:59:59 +0000 UTC";}}}}s:4:"caps";s:10:"read_admin";s:24:"default_where_conditions";s:15:"this_model_only";s:8:"order_by";a:2:{s:8:"REG_date";s:4:"DESC";s:6:"REG_ID";s:4:"DESC";}s:5:"limit";a:2:{i:0;i:0;i:1;i:20;}}
`

That all works fine and maybe_unserialize() worked as expected.

On master, the string returned by `$job_parameters->request_datum('filters', array())` looks like it has already had the slashes removed:

`
a:5:{i:0;a:2:{s:6:"STS_ID";s:3:"RAP";s:8:"REG_date";a:2:{i:0;s:7:"BETWEEN";i:1;a:2:{i:0;O:49:"EventEspresso\core\domain\entities\DbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-01 00:00:00 +0000 UTC";}i:1;O:49:"EventEspresso\core\domain\entities\DbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-31 23:59:59 +0000 UTC";}}}}s:4:"caps";s:10:"read_admin";s:24:"default_where_conditions";s:15:"this_model_only";s:8:"order_by";a:2:{s:8:"REG_date";s:4:"DESC";s:6:"REG_ID";s:4:"DESC";}s:5:"limit";a:2:{i:0;i:0;i:1;i:20;}}
`

So then running stripslashes on that remove slashes from the serialized values and broke maybe_unserialize() (which then just returned false):

`
a:5:{i:0;a:2:{s:6:"STS_ID";s:3:"RAP";s:8:"REG_date";a:2:{i:0;s:7:"BETWEEN";i:1;a:2:{i:0;O:49:"EventEspressocoredomainentitiesDbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-01 00:00:00 +0000 UTC";}i:1;O:49:"EventEspressocoredomainentitiesDbSafeDateTime":1:{s:19:"*_datetime_string";s:29:"2021-12-31 23:59:59 +0000 UTC";}}}}s:4:"caps";s:10:"read_admin";s:24:"default_where_conditions";s:15:"this_model_only";s:8:"order_by";a:2:{s:8:"REG_date";s:4:"DESC";s:6:"REG_ID";s:4:"DESC";}s:5:"limit";a:2:{i:0;i:0;i:1;i:20;}}
`

So... I removed the stripslashes and jobs a good'n.


## Checklist
* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
