### PR TITLE
Calculate Ticket Selector Rows Dynamically

### DIFF
--- a/modules/ticket_selector/TicketSelector.php
+++ b/modules/ticket_selector/TicketSelector.php
@@ -2,6 +2,14 @@
 
 namespace EventEspresso\modules\ticket_selector;
 
+use EE_Error;
+use EE_Event;
+use EE_Ticket;
+use EEH_Template;
+use EEH_URL;
+use Exception;
+use ReflectionException;
+
 /**
  * Class TicketSelector
  * Description
@@ -13,42 +21,45 @@ abstract class TicketSelector
 {
 
     /**
-     * @var \EE_Event $event
+     * @var EE_Event
      */
     protected $event;
 
     /**
-     * @var \EE_Ticket[] $tickets
+     * @var EE_Ticket[]
      */
     protected $tickets;
 
     /**
-     * @var int max_attendees
+     * @var int
      */
     protected $max_attendees;
 
     /**
-     * @var array $template_args
+     * @var array
      */
     protected $template_args;
+
+    /**
+     * @var int
+     */
+    protected $ticket_rows = 0;
 
 
     /**
      * TicketSelectorSimple constructor.
      *
-     * @param \EE_Event    $event
-     * @param \EE_Ticket[] $tickets
+     * @param EE_Event    $event
+     * @param EE_Ticket[] $tickets
      * @param int          $max_attendees
      * @param array        $template_args
-     * @throws \EE_Error
      */
-    public function __construct(\EE_Event $event, array $tickets, $max_attendees, array $template_args)
+    public function __construct(EE_Event $event, array $tickets, $max_attendees, array $template_args)
     {
         $this->event = $event;
         $this->tickets = $tickets;
         $this->max_attendees = $max_attendees;
         $this->template_args = $template_args;
-        $this->template_args['hidden_inputs'] = $this->getHiddenInputs();
         $this->addTemplateArgs();
     }
 
@@ -69,7 +80,8 @@ abstract class TicketSelector
     protected function loadTicketSelectorTemplate()
     {
         try {
-            return \EEH_Template::locate_template(
+            $this->template_args['hidden_inputs'] = $this->getHiddenInputs();
+            return EEH_Template::locate_template(
                 apply_filters(
                     'FHEE__EE_Ticket_Selector__display_ticket_selector__template_path',
                     $this->template_args['template_path'],
@@ -77,8 +89,8 @@ abstract class TicketSelector
                 ),
                 $this->template_args
             );
-        } catch (\Exception $e) {
-            \EE_Error::add_error($e->getMessage(), __FILE__, __FUNCTION__, __LINE__);
+        } catch (Exception $e) {
+            EE_Error::add_error($e->getMessage(), __FILE__, __FUNCTION__, __LINE__);
         }
         return '';
     }
@@ -100,16 +112,16 @@ abstract class TicketSelector
      * getHiddenInputs
      *
      * @return string
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function getHiddenInputs()
     {
-        // $rows = count($this->tickets);
         $html = '<input type="hidden" name="noheader" value="true"/>';
         $html .= '<input type="hidden" name="tkt-slctr-return-url-' . $this->event->ID() . '"';
-        $html .= ' value="' . \EEH_URL::current_url() . $this->template_args['anchor_id'] . '"/>';
+        $html .= ' value="' . EEH_URL::current_url() . $this->template_args['anchor_id'] . '"/>';
         $html .= '<input type="hidden" name="tkt-slctr-rows-' . $this->event->ID();
-        $html .= '" value="' . count($this->tickets) . '"/>';
+        $html .= '" value="' . $this->ticket_rows . '"/>';
         $html .= '<input type="hidden" name="tkt-slctr-max-atndz-' . $this->event->ID();
         $html .= '" value="' . $this->template_args['max_atndz'] . '"/>';
         $html .= '<input type="hidden" name="tkt-slctr-event-id" value="' . $this->event->ID() . '"/>';

--- a/modules/ticket_selector/TicketSelectorSimple.php
+++ b/modules/ticket_selector/TicketSelectorSimple.php
@@ -56,6 +56,7 @@ class TicketSelectorSimple extends TicketSelector
      */
     protected function addTemplateArgs()
     {
+        $this->ticket_rows = 1;
         unset($this->template_args['tickets']);
         $this->template_args['ticket'] = $this->ticket;
         $ticket_selector_row           = new TicketSelectorRowSimple(

--- a/modules/ticket_selector/TicketSelectorStandard.php
+++ b/modules/ticket_selector/TicketSelectorStandard.php
@@ -80,8 +80,8 @@ class TicketSelectorStandard extends TicketSelector
      */
     protected function addTemplateArgs()
     {
-        $row                      = 1;
-        $ticket_row_html          = '';
+        $this->ticket_rows        = 0;
+        $all_ticket_rows_html     = '';
         $required_ticket_sold_out = false;
         // flag to indicate that at least one taxable ticket has been encountered
         $taxable_tickets                          = false;
@@ -104,6 +104,7 @@ class TicketSelectorStandard extends TicketSelector
         // loop through tickets
         foreach ($this->tickets as $ticket) {
             if ($ticket instanceof EE_Ticket) {
+                $this->ticket_rows++;
                 $cols                     = 2;
                 $taxable_tickets          = $ticket->taxable() ? true : $taxable_tickets;
                 $ticket_selector_row      = new TicketSelectorRowStandard(
@@ -111,7 +112,7 @@ class TicketSelectorStandard extends TicketSelector
                     $this->tax_config,
                     $total_tickets,
                     $this->max_attendees,
-                    $row,
+                    $this->ticket_rows,
                     $cols,
                     $required_ticket_sold_out,
                     $this->template_args['event_status'],
@@ -119,13 +120,21 @@ class TicketSelectorStandard extends TicketSelector
                         ? $datetime_selector->getTicketDatetimeClasses($ticket)
                         : ''
                 );
-                $ticket_row_html          .= $ticket_selector_row->getHtml();
+                $ticket_row_html = $ticket_selector_row->getHtml();
+                // check if something was actually returned
+                if (! empty($ticket_row_html)) {
+                    // add any output to the cumulative HTML
+                    $all_ticket_rows_html .= $ticket_row_html;
+                } else {
+                    // or decrement the ticket row count since it looks like one has been removed
+                    $this->ticket_rows--;
+                }
+
                 $required_ticket_sold_out = $ticket_selector_row->getRequiredTicketSoldOut();
-                $row++;
             }
         }
-        $this->template_args['row']                              = $row;
-        $this->template_args['ticket_row_html']                  = $ticket_row_html;
+        $this->template_args['row']                              = $this->ticket_rows;
+        $this->template_args['ticket_row_html']                  = $all_ticket_rows_html;
         $this->template_args['taxable_tickets']                  = $taxable_tickets;
         $this->template_args['prices_displayed_including_taxes'] = $this->tax_config->prices_displayed_including_taxes;
         $this->template_args['template_path']                    =


### PR DESCRIPTION
Had a customer that was using a filter to remove tickets from the ticket selector. This unfortunately throws off the value set in a hidden input that is used for tracking the number of ticket rows in the TS. This was because that value was being set simply by counting the number of elements in the initial tickets array. That doesn't work however if tickets are being removed afterwards via a filter. This ultimately results in an error being thrown because the ticket selections can not be processed properly.

This PR:

- uses a separate counter for tracking the number of ticket rows 
- increments / decrements the above counter based on whether HTML is actually returned from the ticket row filters
- fixes some formatting and phpdoc issues