### PR TITLE
Ensure Template Helper is Loaded for Espresso Shortcodes

### DIFF
--- a/core/EE_Front_Controller.core.php
+++ b/core/EE_Front_Controller.core.php
@@ -425,16 +425,20 @@ final class EE_Front_Controller
 
 
     /***********************************************        UTILITIES         ***********************************************/
+
+
     /**
-     *    template_include
-     *
-     * @access    public
-     * @param   string $template_include_path
-     * @return    string
+     * @param string $template_include_path
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function template_include($template_include_path = null)
     {
         if ($this->current_page->isEspressoPage()) {
+            // despite all helpers having autoloaders set, we need to manually load the template loader
+            // because there are some side effects in that class for triggering template tag functions
+            $this->Registry->load_helper('EEH_Template');
             $this->_template_path = ! empty($this->_template_path)
                 ? basename($this->_template_path)
                 : basename(

--- a/core/services/request/CurrentPage.php
+++ b/core/services/request/CurrentPage.php
@@ -36,7 +36,7 @@ class CurrentPage
     /**
      * @var bool
      */
-    private $is_espresso_page = false;
+    private $is_espresso_page;
 
     /**
      * @var int
@@ -187,7 +187,7 @@ class CurrentPage
             }
             // this stinks but let's run a query to try and get the post name from the URL
             // (assuming pretty permalinks are on)
-            if (! $post_name && $WP->request !== null && ! empty($WP->request)) {
+            if (! $post_name && ! empty($WP->request)) {
                 $possible_post_name = basename($WP->request);
                 if (! is_numeric($possible_post_name)) {
                     $SQL                = "SELECT ID from {$wpdb->posts}";
@@ -247,6 +247,9 @@ class CurrentPage
      */
     public function isEspressoPage()
     {
+        if ($this->is_espresso_page === null) {
+            $this->setEspressoPage();
+        }
         return $this->is_espresso_page;
     }
 

--- a/core/services/shortcodes/LegacyShortcodesManager.php
+++ b/core/services/shortcodes/LegacyShortcodesManager.php
@@ -257,7 +257,7 @@ class LegacyShortcodesManager
         // in case $current_post is hierarchical like: /parent-page/current-page
         $current_post = basename($current_post);
         if (
-// is current page/post the "blog" page ?
+            // is current page/post the "blog" page ?
             $current_post === EE_Config::get_page_for_posts()
             // or are we on a category page?
             || (


### PR DESCRIPTION
This PR:

- closes #3643 
- improves logic pertaining to retrieval of post content by first checking for global post object
- adds wildcard check for any shortcode starting with `[espresso_`
- ensures that `CurrentPage::testForEspressoPage()` is called when checking `isEspressoPage()`
- manually loads `EEH_Template` if `isEspressoPage()` is `true`