### PR TITLE
Fix Missing RegIDs After Reg Status Update

### DIFF
--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -4174,7 +4174,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
      */
     protected function _process_resend_registration()
     {
-        $this->_template_args['success'] = EED_Messages::process_resend($this->request->requestParams());
+        $this->_template_args['success'] = EED_Messages::process_resend($this->_req_data);
         do_action(
             'AHEE__EE_Admin_Page___process_resend_registration',
             $this->_template_args['success'],

--- a/modules/messages/EED_Messages.module.php
+++ b/modules/messages/EED_Messages.module.php
@@ -720,7 +720,7 @@ class EED_Messages extends EED_Module
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function process_resend($req_data)
+    public static function process_resend(array $req_data = [])
     {
         self::_load_controller();
         $request = self::getRequest();
@@ -730,14 +730,14 @@ class EED_Messages extends EED_Module
         }
 
         // make sure any incoming request data is set on the request so that it gets picked up later.
-        $req_data = (array) $req_data;
-        foreach ($req_data as $request_key => $request_value) {
-            $request->setRequestParam($request_key, $request_value);
+        foreach ((array) $req_data as $request_key => $request_value) {
+            if (! $request->requestParamIsSet($request_key)) {
+                $request->setRequestParam($request_key, $request_value);
+            }
         }
 
         if (
-            ! $messages_to_send = self::$_MSG_PROCESSOR->setup_messages_to_generate_from_registration_ids_in_request(
-            )
+            ! $messages_to_send = self::$_MSG_PROCESSOR->setup_messages_to_generate_from_registration_ids_in_request()
         ) {
             return false;
         }


### PR DESCRIPTION
So this is what was really happening here:

- while replacing our usage of the legacy `EE_Request_Handler` I swapped out a local copy of the request data on `EE_Admin_Page` with the request data from the new `Request` class
- `Registrations_Admin_Page::_set_registration_status_from_request()` was mutating the request data (BIG no-no) and copying the REG IDs from one location within the request data to another location
- the message trigger was looking in this new location but the REG IDs were no longer there


this PR:

- closes #3646 
- returns to passing the mutated `EE_Admin_Page->_req_data` array to `EED_Messages::process_resend()`
- also adds a conditional so that request data is not overwritten if it already exists in ANOTHER spot in the code that mutates request data >:(


