### PR TITLE
Don't escape billing info details

### DIFF
--- a/admin_pages/transactions/templates/txn_admin_details_side_meta_box_billing_info.template.php
+++ b/admin_pages/transactions/templates/txn_admin_details_side_meta_box_billing_info.template.php
@@ -22,9 +22,9 @@ function ee_show_billing_info_cleaned(EE_Form_Section_Proper $form_section, $fou
             ?>
             <div class="clearfix">
             <span class="admin-side-mbox-label-spn lt-grey-txt float-left">
-                    <?php echo esc_html($subsection->get_html_for_label()); ?>
+                    <?php echo $subsection->get_html_for_label(); ?>
                 </span>
-            <?php echo esc_html($subsection->pretty_value()); ?>
+            <?php echo $subsection->pretty_value(); ?>
             </div><?php
         } elseif ($subsection instanceof EE_Form_Section_Proper) {
             $found_cc_data = ee_show_billing_info_cleaned($subsection, $found_cc_data);


### PR DESCRIPTION
@tn3rb if this checks out please just merge, I've tested it to confirm it fixes my issue.

## Problem this Pull Request solves
The billing info within the transaction page has been escaped:
https://monosnap.com/file/mAAPX61w1zQQ6gTSN95luKW3Q3NNfW

This change removes the escaping to fix the table:
https://monosnap.com/file/7BjWxWI7c1AhCugY5dPhTjBJYbh5oF


## How has this been tested
Open up a transaction that has a payment assigned to it. Some payment methods don't save any data, others do.

Onsite payment methods store billing info so test with one of those if needed.

Event Espresso -> Transactions.

View the Billing info section in the sidebar.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
