### PR TITLE
Fix registration messages not triggered when applying/deleting a payment

### DIFF
--- a/modules/messages/EED_Messages.module.php
+++ b/modules/messages/EED_Messages.module.php
@@ -630,7 +630,10 @@ class EED_Messages extends EED_Module
         }
         $request = self::getRequest();
         // first we check if we're in admin and not doing front ajax
-        if ($request->isAdmin() && ! $request->isFrontAjax()) {
+        if (
+            ($request->isAdmin() || $request->isAdminAjax())
+            && ! $request->isFrontAjax()
+        ) {
             $status_change = $request->getRequestParam('txn_reg_status_change', [], 'int', true);
             // make sure appropriate admin params are set for sending messages
             if (! $status_change['send_notifications']) {


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/transaction-screen-send-related-messages-registration-messages-not-working/

## Problem this Pull Request solves
Registration related messages are not being triggered when a payment is applied/deleted from a transaction.

In 4.10.13 just an is_admin() check was enough to confirm if we are working within the admin (including ajax requests sent via the admin) however, in the new Request class we have both isAdmin() and isAdminAjax().

isAdmin() on its own returns false for admin-ajax requests so added this additional check.

## How has this been tested
Use an incomplete transaction (set it up however you prefer, create a new one and use an offline payment method or delete a payment from an existing transaction).

Manually apply a payment to the transaction (full amount is fine).

Make sure under 'Send Related Messages?' the 'Registration Messages' option is checked 
(Payment related messages are still working in master anyway, they trigger differently)

If applying a full payment then a 'Payment Received' and a 'Registration Approved' message should be triggered, in master only the payment received messages triggers.

Now delete the payment from the transaction, if you select 'Leave the same' for the reg status then even if you select to send related messages, nothing should send. If you change the registration status option to anything else, then the messages should trigger (if send related messages is checked).

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
