### PR TITLE
fix placeholder case

### DIFF
--- a/admin_pages/transactions/help_tabs/transactions_overview_table_column_headings.help_tab.php
+++ b/admin_pages/transactions/help_tabs/transactions_overview_table_column_headings.help_tab.php
@@ -102,7 +102,7 @@
             <li style="list-style-type: none;">
                 <strong>
                     <?php printf(
-                        esc_html__('View Transaction Details %1$S', 'event_espresso'),
+                        esc_html__('View Transaction Details %1$s', 'event_espresso'),
                         '<span class="dashicons dashicons-cart"></span>'
                     ); ?>
                 </strong>
@@ -115,7 +115,7 @@
             <li style="list-style-type: none;">
                 <strong>
                     <?php printf(
-                        esc_html__('View Invoice for Transaction %1$S', 'event_espresso'),
+                        esc_html__('View Invoice for Transaction %1$s', 'event_espresso'),
                         '<span class="dashicons dashicons-media-spreadsheet"></span>'
                     ); ?>
                 </strong>
@@ -135,7 +135,7 @@
             <li style="list-style-type: none;">
                 <strong>
                     <?php printf(
-                        esc_html__('View Registration Details %1$S', 'event_espresso'),
+                        esc_html__('View Registration Details %1$s', 'event_espresso'),
                         '<span class="dashicons dashicons-clipboard"></span>'
                     ); ?>
                 </strong>

--- a/core/services/encryption/openssl/OpenSSL.php
+++ b/core/services/encryption/openssl/OpenSSL.php
@@ -136,7 +136,7 @@ abstract class OpenSSL implements EncryptionMethodInterface
             );
         }
         return sprintf(
-            esc_html__('OpenSSL v1 encryption using %1$S is available for use.', 'event_espresso'),
+            esc_html__('OpenSSL v1 encryption using %1$s is available for use.', 'event_espresso'),
             OpenSSLv1::CIPHER_METHOD
         );
     }
@@ -247,7 +247,7 @@ abstract class OpenSSL implements EncryptionMethodInterface
         if ($encrypted_text === false) {
             throw new RuntimeException(
                 sprintf(
-                    esc_html__('The following error occurred during OpenSSL encryption: %1$S', 'event_espresso'),
+                    esc_html__('The following error occurred during OpenSSL encryption: %1$s', 'event_espresso'),
                     $this->getOpenSslError()
                 )
             );
@@ -274,7 +274,7 @@ abstract class OpenSSL implements EncryptionMethodInterface
         if ($encrypted_text === false) {
             throw new RuntimeException(
                 sprintf(
-                    esc_html__('OpenSSL decryption failed for the following reason: %1$S', 'event_espresso'),
+                    esc_html__('OpenSSL decryption failed for the following reason: %1$s', 'event_espresso'),
                     $this->getOpenSslError()
                 )
             );


### PR DESCRIPTION
see: https://eventespresso.com/topic/transactions-tab-gives-error/

this PR fixes a weird format/typo error where some placeholders in some templates got pasted as `%1$S` instead of `%1$s` 