### PR TITLE
Replace Legacy Request Data in Registrations Admin

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -21,7 +21,6 @@ jobs:
               uses: eventespresso/actions/packages/checkout-and-LAMP@main
               with:
                   php-version: ${{ matrix.php-version }}
-                  composer-dependencies: locked
 
             - name: PHP Lint
               run: composer config-eventespressocs && composer run-script lint:skip-warnings

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -14,13 +14,14 @@ jobs:
         if: ${{ needs.what_has_changed.outputs.php == 'true' }}
         strategy:
             matrix:
-                php-version: ['7.3']
+                php-version: ['7.1']
         name: Lint with PHP ${{ matrix.php-version }}
         steps:
             - name: Checkout and set up LAMP
               uses: eventespresso/actions/packages/checkout-and-LAMP@main
               with:
                   php-version: ${{ matrix.php-version }}
+                  composer-dependencies: locked
 
             - name: PHP Lint
               run: composer config-eventespressocs && composer run-script lint:skip-warnings

--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -942,61 +942,56 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
         $actions  = [];
         $attendee = $item->attendee();
         $this->_set_related_details($item);
-        // Build row actions
-        $view_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-            [
-                'action'  => 'view_registration',
-                '_REG_ID' => $item->ID(),
-            ],
-            REG_ADMIN_URL
-        );
-        $edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-            [
-                'action' => 'edit_attendee',
-                'post'   => $item->attendee_ID(),
-            ],
-            REG_ADMIN_URL
-        );
-        // page=attendees&event_admin_reports=resend_email&registration_id=43653465634&event_id=2&form_action=resend_email
-        // $resend_reg_lnk_url_params = array( 'action'=>'resend_registration', '_REG_ID'=>$item->REG_ID );
-        $resend_reg_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-            [
-                'action'  => 'resend_registration',
-                '_REG_ID' => $item->ID(),
-            ],
-            REG_ADMIN_URL,
-            true
-        );
-        // Build row actions
-        $actions['view_lnk'] = EE_Registry::instance()->CAP->current_user_can(
-            'ee_read_registration',
-            'espresso_registrations_view_registration',
-            $item->ID()
-        )
-            ? '<li><a href="'
-              . $view_lnk_url
-              . '" title="'
-              . esc_attr__('View Registration Details', 'event_espresso')
-              . '" class="tiny-text">
-				<div class="dashicons dashicons-clipboard"></div>
-			</a>
-			</li>'
-            : '';
-        $actions['edit_lnk'] = EE_Registry::instance()->CAP->current_user_can(
-            'ee_edit_contacts',
-            'espresso_registrations_edit_attendee'
-        )
-                               && $attendee instanceof EE_Attendee
-            ? '
-			<li>
-			<a href="' . $edit_lnk_url . '" title="'
-              . esc_attr__('Edit Contact Details', 'event_espresso') . '" class="tiny-text">
-				<div class="ee-icon ee-icon-user-edit ee-icon-size-16"></div>
-			</a>
-			</li>'
-            : '';
 
-        $actions['resend_reg_lnk'] = '';
+        // Build row actions
+        if (
+            EE_Registry::instance()->CAP->current_user_can(
+                'ee_read_registration',
+                'espresso_registrations_view_registration',
+                $item->ID()
+            )
+        ) {
+            $view_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+                [
+                    'action'  => 'view_registration',
+                    '_REG_ID' => $item->ID(),
+                ],
+                REG_ADMIN_URL
+            );
+            $actions['view_lnk'] = '
+            <li>
+                <a href="' . $view_lnk_url . '" title="'
+                . esc_attr__('View Registration Details', 'event_espresso')
+                . '" class="tiny-text">
+				    <div class="dashicons dashicons-clipboard"></div>
+			    </a>
+			</li>';
+        }
+
+        if (
+            $attendee instanceof EE_Attendee
+            && EE_Registry::instance()->CAP->current_user_can(
+                'ee_edit_contacts',
+                'espresso_registrations_edit_attendee'
+            )
+        ) {
+            $edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+                [
+                    'action' => 'edit_attendee',
+                    'post'   => $item->attendee_ID(),
+                ],
+                REG_ADMIN_URL
+            );
+            $actions['edit_lnk'] = '
+			<li>
+                <a href="' . $edit_lnk_url . '" title="'
+                . esc_attr__('Edit Contact Details', 'event_espresso')
+                . '" class="tiny-text">
+                    <div class="ee-icon ee-icon-user-edit ee-icon-size-16"></div>
+                </a>
+			</li>';
+        }
+
         if (
             $attendee instanceof EE_Attendee
             && EE_Registry::instance()->CAP->current_user_can(
@@ -1005,24 +1000,24 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 $item->ID()
             )
         ) {
-            $actions['resend_reg_lnk'] = '<li>';
-            $actions['resend_reg_lnk'] .= '<a href="' . $resend_reg_lnk_url;
-            $actions['resend_reg_lnk'] .= '" title="';
-            $actions['resend_reg_lnk'] .= esc_attr__('Resend Registration Details', 'event_espresso');
-            $actions['resend_reg_lnk'] .= '" class="tiny-text">';
-            $actions['resend_reg_lnk'] .= '<div class="dashicons dashicons-email-alt"></div>';
-            $actions['resend_reg_lnk'] .= '</a>';
-            $actions['resend_reg_lnk'] .= '</li>';
+            $resend_reg_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
+                [
+                    'action'  => 'resend_registration',
+                    '_REG_ID' => $item->ID(),
+                ],
+                REG_ADMIN_URL,
+                true
+            );
+            $actions['resend_reg_lnk'] = '
+			<li>
+			    <a href="' . $resend_reg_lnk_url . '" title="'
+                . esc_attr__('Resend Registration Details', 'event_espresso')
+                . '" class="tiny-text">
+			        <div class="dashicons dashicons-email-alt"></div>
+			    </a>
+            </li>';
         }
-        // page=transactions&action=view_transaction&txn=256&_wpnonce=6414da4dbb
-        $view_txn_lnk_url        = EE_Admin_Page::add_query_args_and_nonce(
-            [
-                'action' => 'view_transaction',
-                'TXN_ID' => $this->_transaction_details['id'],
-            ],
-            TXN_ADMIN_URL
-        );
-        $actions['view_txn_lnk'] = '';
+
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_read_transaction',
@@ -1030,22 +1025,23 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 $this->_transaction_details['id']
             )
         ) {
+            $view_txn_lnk_url        = EE_Admin_Page::add_query_args_and_nonce(
+                [
+                    'action' => 'view_transaction',
+                    'TXN_ID' => $this->_transaction_details['id'],
+                ],
+                TXN_ADMIN_URL
+            );
             $actions['view_txn_lnk'] = '
 			<li>
-			<a class="ee-status-color-'
-                                       . $this->_transaction_details['status']
-                                       . ' tiny-text" href="'
-                                       . $view_txn_lnk_url
-                                       . '"  title="'
-                                       . $this->_transaction_details['title_attr']
-                                       . '">
-				<div class="dashicons dashicons-cart"></div>
-			</a>
+                <a class="ee-status-color-' . $this->_transaction_details['status']
+                . ' tiny-text" href="' . $view_txn_lnk_url
+                . '"  title="' . $this->_transaction_details['title_attr'] . '">
+                    <div class="dashicons dashicons-cart"></div>
+                </a>
 			</li>';
         }
-        // invoice link
-        $actions['dl_invoice_lnk'] = '';
-        $dl_invoice_lnk_url        = $item->invoice_url();
+
         // only show invoice link if message type is active.
         if (
             $attendee instanceof EE_Attendee
@@ -1053,26 +1049,28 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             && EEH_MSG_Template::is_mt_active('invoice')
         ) {
             $actions['dl_invoice_lnk'] = '
-		<li>
-			<a title="' . esc_attr__('View Transaction Invoice', 'event_espresso')
-                                         . '" target="_blank" href="'
-                                         . $dl_invoice_lnk_url
-                                         . '" class="tiny-text">
-				<span class="dashicons dashicons-media-spreadsheet ee-icon-size-18"></span>
-			</a>
-		</li>';
+            <li>
+                <a title="' . esc_attr__('View Transaction Invoice', 'event_espresso')
+                . '" target="_blank" href="' . $item->invoice_url() . '" class="tiny-text">
+                    <span class="dashicons dashicons-media-spreadsheet ee-icon-size-18"></span>
+                </a>
+            </li>';
         }
-        $actions['filtered_messages_link'] = '';
+
         // message list table link (filtered by REG_ID
-        if (EE_Registry::instance()->CAP->current_user_can('ee_read_global_messages', 'view_filtered_messages')) {
-            $actions['filtered_messages_link'] = '<li>';
-            $actions['filtered_messages_link'] .= EEH_MSG_Template::get_message_action_link(
-                'see_notifications_for',
-                null,
-                ['_REG_ID' => $item->ID()]
-            );
-            $actions['filtered_messages_link'] .= '</li>';
+        if (
+            EE_Registry::instance()->CAP->current_user_can('ee_read_global_messages', 'view_filtered_messages')
+        ) {
+            $actions['filtered_messages_link'] = '
+            <li>
+                ' . EEH_MSG_Template::get_message_action_link(
+                    'see_notifications_for',
+                    null,
+                    ['_REG_ID' => $item->ID()]
+                ) . '
+            </li>';
         }
+
         $actions = apply_filters('FHEE__EE_Registrations_List_Table__column_actions__actions', $actions, $item, $this);
         return $this->_action_string(implode('', $actions), $item, 'ul', 'reg-overview-actions-ul');
     }

--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -1064,10 +1064,10 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             $actions['filtered_messages_link'] = '
             <li>
                 ' . EEH_MSG_Template::get_message_action_link(
-                    'see_notifications_for',
-                    null,
-                    ['_REG_ID' => $item->ID()]
-                ) . '
+                'see_notifications_for',
+                null,
+                ['_REG_ID' => $item->ID()]
+            ) . '
             </li>';
         }
 

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -32,8 +32,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * @var EE_Session
      */
-    private        $_session;
+    private $_session;
 
+    /**
+     * @var array
+     */
     private static $_reg_status;
 
     /**
@@ -1193,11 +1196,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             )
         ) {
             $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-                    'new_registration',
-                    'add-registrant',
-                    ['event_id' => $EVT_ID],
-                    'add-new-h2'
-                );
+                'new_registration',
+                'add-registrant',
+                ['event_id' => $EVT_ID],
+                'add-new-h2'
+            );
         }
     }
 

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -12,9 +12,9 @@ use EventEspresso\core\services\request\CurrentPage;
 /**
  * Registrations_Admin_Page class
  *
- * @package               Event Espresso
- * @subpackage            includes/core/admin/transactions/Registrations_Admin_Page.core.php
- * @author                Brent Christensen
+ * @package     Event Espresso
+ * @subpackage  includes/core/admin/transactions/Registrations_Admin_Page.core.php
+ * @author      Brent Christensen
  */
 class Registrations_Admin_Page extends EE_Admin_Page_CPT
 {
@@ -32,7 +32,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * @var EE_Session
      */
-    private $_session;
+    private        $_session;
 
     private static $_reg_status;
 
@@ -76,8 +76,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     public function __construct($routing = true)
     {
         parent::__construct($routing);
-        add_action('wp_loaded', array($this, 'wp_loaded'));
+        add_action('wp_loaded', [$this, 'wp_loaded']);
     }
+
 
     /**
      * @return EEM_Registration
@@ -93,6 +94,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         }
         return $this->registration_model;
     }
+
 
     /**
      * @return EEM_Attendee
@@ -124,6 +126,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         }
         return $this->event_model;
     }
+
 
     /**
      * @return EEM_Status
@@ -160,35 +163,40 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
     protected function _init_page_props()
     {
-        $this->page_slug = REG_PG_SLUG;
-        $this->_admin_base_url = REG_ADMIN_URL;
+        $this->page_slug        = REG_PG_SLUG;
+        $this->_admin_base_url  = REG_ADMIN_URL;
         $this->_admin_base_path = REG_ADMIN;
-        $this->page_label = esc_html__('Registrations', 'event_espresso');
-        $this->_cpt_routes = array(
+        $this->page_label       = esc_html__('Registrations', 'event_espresso');
+        $this->_cpt_routes      = [
             'add_new_attendee' => 'espresso_attendees',
             'edit_attendee'    => 'espresso_attendees',
             'insert_attendee'  => 'espresso_attendees',
             'update_attendee'  => 'espresso_attendees',
-        );
-        $this->_cpt_model_names = array(
+        ];
+        $this->_cpt_model_names = [
             'add_new_attendee' => 'EEM_Attendee',
             'edit_attendee'    => 'EEM_Attendee',
-        );
-        $this->_cpt_edit_routes = array(
+        ];
+        $this->_cpt_edit_routes = [
             'espresso_attendees' => 'edit_attendee',
-        );
-        $this->_pagenow_map = array(
+        ];
+        $this->_pagenow_map     = [
             'add_new_attendee' => 'post-new.php',
             'edit_attendee'    => 'post.php',
             'trash'            => 'post.php',
-        );
-        add_action('edit_form_after_title', array($this, 'after_title_form_fields'), 10);
+        ];
+        add_action('edit_form_after_title', [$this, 'after_title_form_fields'], 10);
         // add filters so that the comment urls don't take users to a confusing 404 page
-        add_filter('get_comment_link', array($this, 'clear_comment_link'), 10, 3);
+        add_filter('get_comment_link', [$this, 'clear_comment_link'], 10, 2);
     }
 
 
-    public function clear_comment_link($link, $comment, $args)
+    /**
+     * @param string     $link    The comment permalink with '#comment-$id' appended.
+     * @param WP_Comment $comment The current comment object.
+     * @return string
+     */
+    public function clear_comment_link($link, WP_Comment $comment)
     {
         // gotta make sure this only happens on this route
         $post_type = get_post_type($comment->comment_post_ID);
@@ -202,15 +210,15 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _ajax_hooks()
     {
         // todo: all hooks for registrations ajax goes in here
-        add_action('wp_ajax_toggle_checkin_status', array($this, 'toggle_checkin_status'));
+        add_action('wp_ajax_toggle_checkin_status', [$this, 'toggle_checkin_status']);
     }
 
 
     protected function _define_page_props()
     {
         $this->_admin_page_title = $this->page_label;
-        $this->_labels = array(
-            'buttons'                      => array(
+        $this->_labels           = [
+            'buttons'                      => [
                 'add-registrant'      => esc_html__('Add New Registration', 'event_espresso'),
                 'add-attendee'        => esc_html__('Add Contact', 'event_espresso'),
                 'edit'                => esc_html__('Edit Contact', 'event_espresso'),
@@ -219,457 +227,456 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'report_filtered'     => esc_html__('Filtered CSV Report', 'event_espresso'),
                 'contact_list_report' => esc_html__('Contact List Report', 'event_espresso'),
                 'contact_list_export' => esc_html__('Export Data', 'event_espresso'),
-            ),
-            'publishbox'                   => array(
+            ],
+            'publishbox'                   => [
                 'add_new_attendee' => esc_html__('Add Contact Record', 'event_espresso'),
                 'edit_attendee'    => esc_html__('Update Contact Record', 'event_espresso'),
-            ),
-            'hide_add_button_on_cpt_route' => array(
+            ],
+            'hide_add_button_on_cpt_route' => [
                 'edit_attendee' => true,
-            ),
-        );
+            ],
+        ];
     }
 
 
     /**
-     *        grab url requests and route them
+     * grab url requests and route them
      *
-     * @access private
      * @return void
      * @throws EE_Error
      */
     public function _set_page_routes()
     {
         $this->_get_registration_status_array();
-        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
-        $REG_ID = $this->request->getRequestParam('reg_status_change_form[REG_ID]', $REG_ID, 'int');
-        $ATT_ID = $this->request->getRequestParam('ATT_ID', 0, 'int');
-        $ATT_ID = $this->request->getRequestParam('post', $ATT_ID, 'int');
-        $this->_page_routes = array(
-            'default'                             => array(
+        $REG_ID             = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $REG_ID             = $this->request->getRequestParam('reg_status_change_form[REG_ID]', $REG_ID, 'int');
+        $ATT_ID             = $this->request->getRequestParam('ATT_ID', 0, 'int');
+        $ATT_ID             = $this->request->getRequestParam('post', $ATT_ID, 'int');
+        $this->_page_routes = [
+            'default'                             => [
                 'func'       => '_registrations_overview_list_table',
                 'capability' => 'ee_read_registrations',
-            ),
-            'view_registration'                   => array(
+            ],
+            'view_registration'                   => [
                 'func'       => '_registration_details',
                 'capability' => 'ee_read_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'edit_registration'                   => array(
+            ],
+            'edit_registration'                   => [
                 'func'               => '_update_attendee_registration_form',
                 'noheader'           => true,
                 'headers_sent_route' => 'view_registration',
                 'capability'         => 'ee_edit_registration',
                 'obj_id'             => $REG_ID,
                 '_REG_ID'            => $REG_ID,
-            ),
-            'trash_registrations'                 => array(
+            ],
+            'trash_registrations'                 => [
                 'func'       => '_trash_or_restore_registrations',
-                'args'       => array('trash' => true),
+                'args'       => ['trash' => true],
                 'noheader'   => true,
                 'capability' => 'ee_delete_registrations',
-            ),
-            'restore_registrations'               => array(
+            ],
+            'restore_registrations'               => [
                 'func'       => '_trash_or_restore_registrations',
-                'args'       => array('trash' => false),
+                'args'       => ['trash' => false],
                 'noheader'   => true,
                 'capability' => 'ee_delete_registrations',
-            ),
-            'delete_registrations'                => array(
+            ],
+            'delete_registrations'                => [
                 'func'       => '_delete_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_delete_registrations',
-            ),
-            'new_registration'                    => array(
+            ],
+            'new_registration'                    => [
                 'func'       => 'new_registration',
                 'capability' => 'ee_edit_registrations',
-            ),
-            'process_reg_step'                    => array(
+            ],
+            'process_reg_step'                    => [
                 'func'       => 'process_reg_step',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-            ),
-            'redirect_to_txn'                     => array(
+            ],
+            'redirect_to_txn'                     => [
                 'func'       => 'redirect_to_txn',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-            ),
-            'change_reg_status'                   => array(
+            ],
+            'change_reg_status'                   => [
                 'func'       => '_change_reg_status',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'approve_registration'                => array(
+            ],
+            'approve_registration'                => [
                 'func'       => 'approve_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'approve_and_notify_registration'     => array(
+            ],
+            'approve_and_notify_registration'     => [
                 'func'       => 'approve_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'approve_registrations'               => array(
+            ],
+            'approve_registrations'               => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('approve'),
-            ),
-            'approve_and_notify_registrations'    => array(
+                'args'       => ['approve'],
+            ],
+            'approve_and_notify_registrations'    => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('approve', true),
-            ),
-            'decline_registration'                => array(
+                'args'       => ['approve', true],
+            ],
+            'decline_registration'                => [
                 'func'       => 'decline_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'decline_and_notify_registration'     => array(
+            ],
+            'decline_and_notify_registration'     => [
                 'func'       => 'decline_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'decline_registrations'               => array(
+            ],
+            'decline_registrations'               => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('decline'),
-            ),
-            'decline_and_notify_registrations'    => array(
+                'args'       => ['decline'],
+            ],
+            'decline_and_notify_registrations'    => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('decline', true),
-            ),
-            'pending_registration'                => array(
+                'args'       => ['decline', true],
+            ],
+            'pending_registration'                => [
                 'func'       => 'pending_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'pending_and_notify_registration'     => array(
+            ],
+            'pending_and_notify_registration'     => [
                 'func'       => 'pending_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'pending_registrations'               => array(
+            ],
+            'pending_registrations'               => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('pending'),
-            ),
-            'pending_and_notify_registrations'    => array(
+                'args'       => ['pending'],
+            ],
+            'pending_and_notify_registrations'    => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('pending', true),
-            ),
-            'no_approve_registration'             => array(
+                'args'       => ['pending', true],
+            ],
+            'no_approve_registration'             => [
                 'func'       => 'not_approve_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'no_approve_and_notify_registration'  => array(
+            ],
+            'no_approve_and_notify_registration'  => [
                 'func'       => 'not_approve_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'no_approve_registrations'            => array(
+            ],
+            'no_approve_registrations'            => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('not_approve'),
-            ),
-            'no_approve_and_notify_registrations' => array(
+                'args'       => ['not_approve'],
+            ],
+            'no_approve_and_notify_registrations' => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('not_approve', true),
-            ),
-            'cancel_registration'                 => array(
+                'args'       => ['not_approve', true],
+            ],
+            'cancel_registration'                 => [
                 'func'       => 'cancel_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'cancel_and_notify_registration'      => array(
+            ],
+            'cancel_and_notify_registration'      => [
                 'func'       => 'cancel_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'cancel_registrations'                => array(
+            ],
+            'cancel_registrations'                => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('cancel'),
-            ),
-            'cancel_and_notify_registrations'     => array(
+                'args'       => ['cancel'],
+            ],
+            'cancel_and_notify_registrations'     => [
                 'func'       => 'bulk_action_on_registrations',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registrations',
-                'args'       => array('cancel', true),
-            ),
-            'wait_list_registration'              => array(
+                'args'       => ['cancel', true],
+            ],
+            'wait_list_registration'              => [
                 'func'       => 'wait_list_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'wait_list_and_notify_registration'   => array(
+            ],
+            'wait_list_and_notify_registration'   => [
                 'func'       => 'wait_list_registration',
                 'noheader'   => true,
-                'args'       => array(true),
+                'args'       => [true],
                 'capability' => 'ee_edit_registration',
                 'obj_id'     => $REG_ID,
-            ),
-            'contact_list'                        => array(
+            ],
+            'contact_list'                        => [
                 'func'       => '_attendee_contact_list_table',
                 'capability' => 'ee_read_contacts',
-            ),
-            'add_new_attendee'                    => array(
+            ],
+            'add_new_attendee'                    => [
                 'func' => '_create_new_cpt_item',
-                'args' => array(
+                'args' => [
                     'new_attendee' => true,
                     'capability'   => 'ee_edit_contacts',
-                ),
-            ),
-            'edit_attendee'                       => array(
+                ],
+            ],
+            'edit_attendee'                       => [
                 'func'       => '_edit_cpt_item',
                 'capability' => 'ee_edit_contacts',
                 'obj_id'     => $ATT_ID,
-            ),
-            'duplicate_attendee'                  => array(
+            ],
+            'duplicate_attendee'                  => [
                 'func'       => '_duplicate_attendee',
                 'noheader'   => true,
                 'capability' => 'ee_edit_contacts',
                 'obj_id'     => $ATT_ID,
-            ),
-            'insert_attendee'                     => array(
+            ],
+            'insert_attendee'                     => [
                 'func'       => '_insert_or_update_attendee',
-                'args'       => array(
+                'args'       => [
                     'new_attendee' => true,
-                ),
+                ],
                 'noheader'   => true,
                 'capability' => 'ee_edit_contacts',
-            ),
-            'update_attendee'                     => array(
+            ],
+            'update_attendee'                     => [
                 'func'       => '_insert_or_update_attendee',
-                'args'       => array(
+                'args'       => [
                     'new_attendee' => false,
-                ),
+                ],
                 'noheader'   => true,
                 'capability' => 'ee_edit_contacts',
                 'obj_id'     => $ATT_ID,
-            ),
-            'trash_attendees'                     => array(
+            ],
+            'trash_attendees'                     => [
                 'func'       => '_trash_or_restore_attendees',
-                'args'       => array(
+                'args'       => [
                     'trash' => 'true',
-                ),
+                ],
                 'noheader'   => true,
                 'capability' => 'ee_delete_contacts',
-            ),
-            'trash_attendee'                      => array(
+            ],
+            'trash_attendee'                      => [
                 'func'       => '_trash_or_restore_attendees',
-                'args'       => array(
+                'args'       => [
                     'trash' => true,
-                ),
+                ],
                 'noheader'   => true,
                 'capability' => 'ee_delete_contacts',
                 'obj_id'     => $ATT_ID,
-            ),
-            'restore_attendees'                   => array(
+            ],
+            'restore_attendees'                   => [
                 'func'       => '_trash_or_restore_attendees',
-                'args'       => array(
+                'args'       => [
                     'trash' => false,
-                ),
+                ],
                 'noheader'   => true,
                 'capability' => 'ee_delete_contacts',
                 'obj_id'     => $ATT_ID,
-            ),
-            'resend_registration'                 => array(
+            ],
+            'resend_registration'                 => [
                 'func'       => '_resend_registration',
                 'noheader'   => true,
                 'capability' => 'ee_send_message',
-            ),
-            'registrations_report'                => array(
+            ],
+            'registrations_report'                => [
                 'func'       => '_registrations_report',
                 'noheader'   => true,
                 'capability' => 'ee_read_registrations',
-            ),
-            'contact_list_export'                 => array(
+            ],
+            'contact_list_export'                 => [
                 'func'       => '_contact_list_export',
                 'noheader'   => true,
                 'capability' => 'export',
-            ),
-            'contact_list_report'                 => array(
+            ],
+            'contact_list_report'                 => [
                 'func'       => '_contact_list_report',
                 'noheader'   => true,
                 'capability' => 'ee_read_contacts',
-            ),
-        );
+            ],
+        ];
     }
 
 
     protected function _set_page_config()
     {
-        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
-        $ATT_ID = $this->request->getRequestParam('ATT_ID', 0, 'int');
-        $this->_page_config = array(
-            'default'           => array(
-                'nav'           => array(
+        $REG_ID             = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $ATT_ID             = $this->request->getRequestParam('ATT_ID', 0, 'int');
+        $this->_page_config = [
+            'default'           => [
+                'nav'           => [
                     'label' => esc_html__('Overview', 'event_espresso'),
                     'order' => 5,
-                ),
-                'help_tabs'     => array(
-                    'registrations_overview_help_tab'                       => array(
+                ],
+                'help_tabs'     => [
+                    'registrations_overview_help_tab'                       => [
                         'title'    => esc_html__('Registrations Overview', 'event_espresso'),
                         'filename' => 'registrations_overview',
-                    ),
-                    'registrations_overview_table_column_headings_help_tab' => array(
+                    ],
+                    'registrations_overview_table_column_headings_help_tab' => [
                         'title'    => esc_html__('Registrations Table Column Headings', 'event_espresso'),
                         'filename' => 'registrations_overview_table_column_headings',
-                    ),
-                    'registrations_overview_filters_help_tab'               => array(
+                    ],
+                    'registrations_overview_filters_help_tab'               => [
                         'title'    => esc_html__('Registration Filters', 'event_espresso'),
                         'filename' => 'registrations_overview_filters',
-                    ),
-                    'registrations_overview_views_help_tab'                 => array(
+                    ],
+                    'registrations_overview_views_help_tab'                 => [
                         'title'    => esc_html__('Registration Views', 'event_espresso'),
                         'filename' => 'registrations_overview_views',
-                    ),
-                    'registrations_regoverview_other_help_tab'              => array(
+                    ],
+                    'registrations_regoverview_other_help_tab'              => [
                         'title'    => esc_html__('Registrations Other', 'event_espresso'),
                         'filename' => 'registrations_overview_other',
-                    ),
-                ),
+                    ],
+                ],
                 // disabled temporarily. see: https://github.com/eventespresso/eventsmart.com-website/issues/836
                 // 'help_tour'     => array('Registration_Overview_Help_Tour'),
-                'qtips'         => array('Registration_List_Table_Tips'),
+                'qtips'         => ['Registration_List_Table_Tips'],
                 'list_table'    => 'EE_Registrations_List_Table',
                 'require_nonce' => false,
-            ),
-            'view_registration' => array(
-                'nav'           => array(
+            ],
+            'view_registration' => [
+                'nav'           => [
                     'label'      => esc_html__('REG Details', 'event_espresso'),
                     'order'      => 15,
                     'url'        => $REG_ID
-                        ? add_query_arg(array('_REG_ID' => $REG_ID), $this->_current_page_view_url)
+                        ? add_query_arg(['_REG_ID' => $REG_ID], $this->_current_page_view_url)
                         : $this->_admin_base_url,
                     'persistent' => false,
-                ),
-                'help_tabs'     => array(
-                    'registrations_details_help_tab'                    => array(
+                ],
+                'help_tabs'     => [
+                    'registrations_details_help_tab'                    => [
                         'title'    => esc_html__('Registration Details', 'event_espresso'),
                         'filename' => 'registrations_details',
-                    ),
-                    'registrations_details_table_help_tab'              => array(
+                    ],
+                    'registrations_details_table_help_tab'              => [
                         'title'    => esc_html__('Registration Details Table', 'event_espresso'),
                         'filename' => 'registrations_details_table',
-                    ),
-                    'registrations_details_form_answers_help_tab'       => array(
+                    ],
+                    'registrations_details_form_answers_help_tab'       => [
                         'title'    => esc_html__('Registration Form Answers', 'event_espresso'),
                         'filename' => 'registrations_details_form_answers',
-                    ),
-                    'registrations_details_registrant_details_help_tab' => array(
+                    ],
+                    'registrations_details_registrant_details_help_tab' => [
                         'title'    => esc_html__('Contact Details', 'event_espresso'),
                         'filename' => 'registrations_details_registrant_details',
-                    ),
-                ),
+                    ],
+                ],
                 // disabled temporarily. see: https://github.com/eventespresso/eventsmart.com-website/issues/836
                 // 'help_tour'     => array('Registration_Details_Help_Tour'),
                 'metaboxes'     => array_merge(
                     $this->_default_espresso_metaboxes,
-                    array('_registration_details_metaboxes')
+                    ['_registration_details_metaboxes']
                 ),
                 'require_nonce' => false,
-            ),
-            'new_registration'  => array(
-                'nav'           => array(
+            ],
+            'new_registration'  => [
+                'nav'           => [
                     'label'      => esc_html__('Add New Registration', 'event_espresso'),
                     'url'        => '#',
                     'order'      => 15,
                     'persistent' => false,
-                ),
+                ],
                 'metaboxes'     => $this->_default_espresso_metaboxes,
-                'labels'        => array(
+                'labels'        => [
                     'publishbox' => esc_html__('Save Registration', 'event_espresso'),
-                ),
+                ],
                 'require_nonce' => false,
-            ),
-            'add_new_attendee'  => array(
-                'nav'           => array(
+            ],
+            'add_new_attendee'  => [
+                'nav'           => [
                     'label'      => esc_html__('Add Contact', 'event_espresso'),
                     'order'      => 15,
                     'persistent' => false,
-                ),
+                ],
                 'metaboxes'     => array_merge(
                     $this->_default_espresso_metaboxes,
-                    array('_publish_post_box', 'attendee_editor_metaboxes')
+                    ['_publish_post_box', 'attendee_editor_metaboxes']
                 ),
                 'require_nonce' => false,
-            ),
-            'edit_attendee'     => array(
-                'nav'           => array(
+            ],
+            'edit_attendee'     => [
+                'nav'           => [
                     'label'      => esc_html__('Edit Contact', 'event_espresso'),
                     'order'      => 15,
                     'persistent' => false,
                     'url'        => $ATT_ID
-                        ? add_query_arg(array('ATT_ID' => $ATT_ID), $this->_current_page_view_url)
+                        ? add_query_arg(['ATT_ID' => $ATT_ID], $this->_current_page_view_url)
                         : $this->_admin_base_url,
-                ),
-                'metaboxes'     => array('attendee_editor_metaboxes'),
+                ],
+                'metaboxes'     => ['attendee_editor_metaboxes'],
                 'require_nonce' => false,
-            ),
-            'contact_list'      => array(
-                'nav'           => array(
+            ],
+            'contact_list'      => [
+                'nav'           => [
                     'label' => esc_html__('Contact List', 'event_espresso'),
                     'order' => 20,
-                ),
+                ],
                 'list_table'    => 'EE_Attendee_Contact_List_Table',
-                'help_tabs'     => array(
-                    'registrations_contact_list_help_tab'                       => array(
+                'help_tabs'     => [
+                    'registrations_contact_list_help_tab'                       => [
                         'title'    => esc_html__('Registrations Contact List', 'event_espresso'),
                         'filename' => 'registrations_contact_list',
-                    ),
-                    'registrations_contact-list_table_column_headings_help_tab' => array(
+                    ],
+                    'registrations_contact-list_table_column_headings_help_tab' => [
                         'title'    => esc_html__('Contact List Table Column Headings', 'event_espresso'),
                         'filename' => 'registrations_contact_list_table_column_headings',
-                    ),
-                    'registrations_contact_list_views_help_tab'                 => array(
+                    ],
+                    'registrations_contact_list_views_help_tab'                 => [
                         'title'    => esc_html__('Contact List Views', 'event_espresso'),
                         'filename' => 'registrations_contact_list_views',
-                    ),
-                    'registrations_contact_list_other_help_tab'                 => array(
+                    ],
+                    'registrations_contact_list_other_help_tab'                 => [
                         'title'    => esc_html__('Contact List Other', 'event_espresso'),
                         'filename' => 'registrations_contact_list_other',
-                    ),
-                ),
+                    ],
+                ],
                 // disabled temporarily. see: https://github.com/eventespresso/eventsmart.com-website/issues/836
                 // 'help_tour'     => array('Contact_List_Help_Tour'),
-                'metaboxes'     => array(),
+                'metaboxes'     => [],
                 'require_nonce' => false,
-            ),
+            ],
             // override default cpt routes
             'create_new'        => '',
             'edit'              => '',
-        );
+        ];
     }
 
 
@@ -706,15 +713,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        get list of registration statuses
+     * get list of registration statuses
      *
-     * @access private
      * @return void
      * @throws EE_Error
      */
     private function _get_registration_status_array()
     {
-        self::$_reg_status = EEM_Registration::reg_status_array(array(), true);
+        self::$_reg_status = EEM_Registration::reg_status_array([], true);
     }
 
 
@@ -738,7 +744,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _add_screen_options_contact_list()
     {
-        $page_title = $this->_admin_page_title;
+        $page_title              = $this->_admin_page_title;
         $this->_admin_page_title = esc_html__('Contacts', 'event_espresso');
         $this->_per_page_screen_option();
         $this->_admin_page_title = $page_title;
@@ -751,7 +757,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         wp_register_style(
             'espresso_reg',
             REG_ASSETS_URL . 'espresso_registrations_admin.css',
-            array('ee-admin-css'),
+            ['ee-admin-css'],
             EVENT_ESPRESSO_VERSION
         );
         wp_enqueue_style('espresso_reg');
@@ -759,7 +765,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         wp_register_script(
             'espresso_reg',
             REG_ASSETS_URL . 'espresso_registrations_admin.js',
-            array('jquery-ui-datepicker', 'jquery-ui-draggable', 'ee_admin_js'),
+            ['jquery-ui-datepicker', 'jquery-ui-draggable', 'ee_admin_js'],
             EVENT_ESPRESSO_VERSION,
             true
         );
@@ -778,13 +784,13 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     public function load_scripts_styles_edit_attendee()
     {
         // stuff to only show up on our attendee edit details page.
-        $attendee_details_translations = array(
+        $attendee_details_translations = [
             'att_publish_text' => sprintf(
-                /* translators: The date and time */
+            /* translators: The date and time */
                 wp_strip_all_tags(__('Created on: %s', 'event_espresso')),
                 '<b>' . $this->_cpt_model_obj->get_datetime('ATT_created') . '</b>'
             ),
-        );
+        ];
         wp_localize_script('espresso_reg', 'ATTENDEE_DETAILS', $attendee_details_translations);
         wp_enqueue_script('jquery-validate');
     }
@@ -804,7 +810,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         wp_enqueue_style('espresso-ui-theme');
         // scripts
         $this->_get_reg_custom_questions_form($this->_registration->ID());
-        $this->_reg_custom_questions_form->wp_enqueue_scripts(true);
+        $this->_reg_custom_questions_form->wp_enqueue_scripts();
     }
 
 
@@ -814,7 +820,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         wp_register_style(
             'espresso_att',
             REG_ASSETS_URL . 'espresso_attendees_admin.css',
-            array('ee-admin-css'),
+            ['ee-admin-css'],
             EVENT_ESPRESSO_VERSION
         );
         wp_enqueue_style('espresso_att');
@@ -826,7 +832,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         wp_register_script(
             'ee-spco-for-admin',
             REG_ASSETS_URL . 'spco_for_admin.js',
-            array('underscore', 'jquery'),
+            ['underscore', 'jquery'],
             EVENT_ESPRESSO_VERSION,
             true
         );
@@ -864,16 +870,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         EED_Messages::set_autoloaders();
         /** @type EE_Message_Resource_Manager $message_resource_manager */
         $message_resource_manager = EE_Registry::instance()->load_lib('Message_Resource_Manager');
-        $active_mts = $message_resource_manager->list_of_active_message_types();
+        $active_mts               = $message_resource_manager->list_of_active_message_types();
         // key= bulk_action_slug, value= message type.
-        $match_array = array(
+        $match_array = [
             'approve_registrations'    => 'registration',
             'decline_registrations'    => 'declined_registration',
             'pending_registrations'    => 'pending_approval',
             'no_approve_registrations' => 'not_approved_registration',
             'cancel_registrations'     => 'cancelled_registration',
-        );
-        $can_send = EE_Registry::instance()->CAP->current_user_can(
+        ];
+        $can_send    = EE_Registry::instance()->CAP->current_user_can(
             'ee_send_message',
             'batch_send_messages'
         );
@@ -926,30 +932,30 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $can_send
         );
 
-        $this->_views = array(
-            'all'   => array(
+        $this->_views = [
+            'all'   => [
                 'slug'        => 'all',
                 'label'       => esc_html__('View All Registrations', 'event_espresso'),
                 'count'       => 0,
                 'bulk_action' => array_merge(
                     $def_reg_status_actions,
-                    array(
+                    [
                         'trash_registrations' => esc_html__('Trash Registrations', 'event_espresso'),
-                    )
+                    ]
                 ),
-            ),
-            'month' => array(
+            ],
+            'month' => [
                 'slug'        => 'month',
                 'label'       => esc_html__('This Month', 'event_espresso'),
                 'count'       => 0,
                 'bulk_action' => array_merge(
                     $def_reg_status_actions,
-                    array(
+                    [
                         'trash_registrations' => esc_html__('Trash Registrations', 'event_espresso'),
-                    )
+                    ]
                 ),
-            ),
-            'today' => array(
+            ],
+            'today' => [
                 'slug'        => 'today',
                 'label'       => sprintf(
                     esc_html__('Today - %s', 'event_espresso'),
@@ -958,105 +964,109 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'count'       => 0,
                 'bulk_action' => array_merge(
                     $def_reg_status_actions,
-                    array(
+                    [
                         'trash_registrations' => esc_html__('Trash Registrations', 'event_espresso'),
-                    )
+                    ]
                 ),
-            ),
-        );
+            ],
+        ];
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_delete_registrations',
                 'espresso_registrations_delete_registration'
             )
         ) {
-            $this->_views['incomplete'] = array(
+            $this->_views['incomplete'] = [
                 'slug'        => 'incomplete',
                 'label'       => esc_html__('Incomplete', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'trash_registrations' => esc_html__('Trash Registrations', 'event_espresso'),
-                ),
-            );
-            $this->_views['trash'] = array(
+                ],
+            ];
+            $this->_views['trash']      = [
                 'slug'        => 'trash',
                 'label'       => esc_html__('Trash', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'restore_registrations' => esc_html__('Restore Registrations', 'event_espresso'),
                     'delete_registrations'  => esc_html__('Delete Registrations Permanently', 'event_espresso'),
-                ),
-            );
+                ],
+            ];
         }
     }
 
 
     protected function _set_list_table_views_contact_list()
     {
-        $this->_views = array(
-            'in_use' => array(
+        $this->_views = [
+            'in_use' => [
                 'slug'        => 'in_use',
                 'label'       => esc_html__('In Use', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'trash_attendees' => esc_html__('Move to Trash', 'event_espresso'),
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_delete_contacts',
                 'espresso_registrations_trash_attendees'
             )
         ) {
-            $this->_views['trash'] = array(
+            $this->_views['trash'] = [
                 'slug'        => 'trash',
                 'label'       => esc_html__('Trash', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'restore_attendees' => esc_html__('Restore from Trash', 'event_espresso'),
-                ),
-            );
+                ],
+            ];
         }
     }
 
 
+    /**
+     * @return array
+     * @throws EE_Error
+     */
     protected function _registration_legend_items()
     {
-        $fc_items = array(
-            'star-icon'        => array(
+        $fc_items = [
+            'star-icon'        => [
                 'class' => 'dashicons dashicons-star-filled lt-blue-icon ee-icon-size-8',
                 'desc'  => esc_html__('This is the Primary Registrant', 'event_espresso'),
-            ),
-            'view_details'     => array(
+            ],
+            'view_details'     => [
                 'class' => 'dashicons dashicons-clipboard',
                 'desc'  => esc_html__('View Registration Details', 'event_espresso'),
-            ),
-            'edit_attendee'    => array(
+            ],
+            'edit_attendee'    => [
                 'class' => 'ee-icon ee-icon-user-edit ee-icon-size-16',
                 'desc'  => esc_html__('Edit Contact Details', 'event_espresso'),
-            ),
-            'view_transaction' => array(
+            ],
+            'view_transaction' => [
                 'class' => 'dashicons dashicons-cart',
                 'desc'  => esc_html__('View Transaction Details', 'event_espresso'),
-            ),
-            'view_invoice'     => array(
+            ],
+            'view_invoice'     => [
                 'class' => 'dashicons dashicons-media-spreadsheet',
                 'desc'  => esc_html__('View Transaction Invoice', 'event_espresso'),
-            ),
-        );
+            ],
+        ];
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_send_message',
                 'espresso_registrations_resend_registration'
             )
         ) {
-            $fc_items['resend_registration'] = array(
+            $fc_items['resend_registration'] = [
                 'class' => 'dashicons dashicons-email-alt',
                 'desc'  => esc_html__('Resend Registration Details', 'event_espresso'),
-            );
+            ];
         } else {
-            $fc_items['blank'] = array('class' => 'blank', 'desc' => '');
+            $fc_items['blank'] = ['class' => 'blank', 'desc' => ''];
         }
         if (
             EE_Registry::instance()->CAP->current_user_can(
@@ -1066,70 +1076,70 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         ) {
             $related_for_icon = EEH_MSG_Template::get_message_action_icon('see_notifications_for');
             if (is_array($related_for_icon) && isset($related_for_icon['css_class'], $related_for_icon['label'])) {
-                $fc_items['view_related_messages'] = array(
+                $fc_items['view_related_messages'] = [
                     'class' => $related_for_icon['css_class'],
                     'desc'  => $related_for_icon['label'],
-                );
+                ];
             }
         }
-        $sc_items = array(
-            'approved_status'   => array(
+        $sc_items = [
+            'approved_status'   => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_approved,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_approved,
                     false,
                     'sentence'
                 ),
-            ),
-            'pending_status'    => array(
+            ],
+            'pending_status'    => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_pending_payment,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_pending_payment,
                     false,
                     'sentence'
                 ),
-            ),
-            'wait_list'         => array(
+            ],
+            'wait_list'         => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_wait_list,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_wait_list,
                     false,
                     'sentence'
                 ),
-            ),
-            'incomplete_status' => array(
+            ],
+            'incomplete_status' => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_incomplete,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_incomplete,
                     false,
                     'sentence'
                 ),
-            ),
-            'not_approved'      => array(
+            ],
+            'not_approved'      => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_not_approved,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_not_approved,
                     false,
                     'sentence'
                 ),
-            ),
-            'declined_status'   => array(
+            ],
+            'declined_status'   => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_declined,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_declined,
                     false,
                     'sentence'
                 ),
-            ),
-            'cancelled_status'  => array(
+            ],
+            'cancelled_status'  => [
                 'class' => 'ee-status-legend ee-status-legend-' . EEM_Registration::status_id_cancelled,
                 'desc'  => EEH_Template::pretty_status(
                     EEM_Registration::status_id_cancelled,
                     false,
                     'sentence'
                 ),
-            ),
-        );
+            ],
+        ];
         return array_merge($fc_items, $sc_items);
     }
 
@@ -1138,19 +1148,17 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /***************************************        REGISTRATION OVERVIEW        **************************************/
 
 
-
     /**
      * @throws DomainException
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
-     * @throws ReflectionException
      */
     protected function _registrations_overview_list_table()
     {
         $this->appendAddNewRegistrationButtonToPageTitle();
-        $header_text = '';
+        $header_text                  = '';
         $admin_page_header_decorators = [
             'EventEspresso\core\domain\services\admin\registrations\list_table\page_header\AttendeeFilterHeader',
             'EventEspresso\core\domain\services\admin\registrations\list_table\page_header\EventFilterHeader',
@@ -1159,10 +1167,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         ];
         foreach ($admin_page_header_decorators as $admin_page_header_decorator) {
             $filter_header_decorator = $this->getLoader()->getNew($admin_page_header_decorator);
-            $header_text = $filter_header_decorator->getHeaderText($header_text);
+            $header_text             = $filter_header_decorator->getHeaderText($header_text);
         }
         $this->_template_args['admin_page_header'] = $header_text;
-        $this->_template_args['after_list_table'] = $this->_display_legend($this->_registration_legend_items());
+        $this->_template_args['after_list_table']  = $this->_display_legend($this->_registration_legend_items());
         $this->display_admin_list_table_page_with_no_sidebar();
     }
 
@@ -1185,11 +1193,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             )
         ) {
             $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-                'new_registration',
-                'add-registrant',
-                array('event_id' => $EVT_ID),
-                'add-new-h2'
-            );
+                    'new_registration',
+                    'add-registrant',
+                    ['event_id' => $EVT_ID],
+                    'add-new-h2'
+                );
         }
     }
 
@@ -1197,8 +1205,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * This sets the _registration property for the registration details screen
      *
-     * @access private
-     * @return bool
+     * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -1208,11 +1215,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         // get out if we've already set the object
         if ($this->_registration instanceof EE_Registration) {
-            return true;
+            return;
         }
         $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
         if ($this->_registration = $this->getRegistrationModel()->get_one_by_ID($REG_ID)) {
-            return true;
+            return;
         }
         $error_msg = sprintf(
             esc_html__(
@@ -1223,7 +1230,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         );
         EE_Error::add_error($error_msg, __FILE__, __FUNCTION__, __LINE__);
         $this->_registration = null;
-        return false;
     }
 
 
@@ -1257,9 +1263,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
          * Override the default groupby added by EEM_Base so that sorts with multiple order bys work as expected
          *
          * @link https://events.codebasehq.com/projects/event-espresso/tickets/10093
-         * @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-         *                             or if you have the development copy of EE you can view this at the path:
-         *                             /docs/G--Model-System/model-query-params.md
+         * @see  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+         *                      or if you have the development copy of EE you can view this at the path:
+         *                      /docs/G--Model-System/model-query-params.md
          */
         $query_params['group_by'] = '';
 
@@ -1284,14 +1290,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * @throws InvalidInterfaceException
      */
     protected function _get_registration_query_parameters(
-        $request = array(),
+        $request = [],
         $per_page = 10,
         $count = false
     ) {
         /** @var EventEspresso\core\domain\services\admin\registrations\list_table\QueryBuilder $list_table_query_builder */
         $list_table_query_builder = $this->getLoader()->getNew(
             'EventEspresso\core\domain\services\admin\registrations\list_table\QueryBuilder',
-            [ null, null, $request ]
+            [null, null, $request]
         );
         return $list_table_query_builder->getQueryParams($per_page, $count);
     }
@@ -1307,9 +1313,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
     /***************************************        REGISTRATION DETAILS        ***************************************/
     /**
-     *        generates HTML for the View Registration Details Admin page
+     * generates HTML for the View Registration Details Admin page
      *
-     * @access protected
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -1321,91 +1326,92 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _registration_details()
     {
-        $this->_template_args = array();
+        $this->_template_args = [];
         $this->_set_registration_object();
         if (is_object($this->_registration)) {
-            $transaction = $this->_registration->transaction()
+            $transaction                                   = $this->_registration->transaction()
                 ? $this->_registration->transaction()
                 : EE_Transaction::new_instance();
-            $this->_session = $transaction->session_data();
-            $event_id = $this->_registration->event_ID();
-            $this->_template_args['reg_nmbr']['value'] = $this->_registration->ID();
-            $this->_template_args['reg_nmbr']['label'] = esc_html__('Registration Number', 'event_espresso');
+            $this->_session                                = $transaction->session_data();
+            $event_id                                      = $this->_registration->event_ID();
+            $this->_template_args['reg_nmbr']['value']     = $this->_registration->ID();
+            $this->_template_args['reg_nmbr']['label']     = esc_html__('Registration Number', 'event_espresso');
             $this->_template_args['reg_datetime']['value'] = $this->_registration->get_i18n_datetime('REG_date');
             $this->_template_args['reg_datetime']['label'] = esc_html__('Date', 'event_espresso');
-            $this->_template_args['grand_total'] = $transaction->total();
-            $this->_template_args['currency_sign'] = EE_Registry::instance()->CFG->currency->sign;
+            $this->_template_args['grand_total']           = $transaction->total();
+            $this->_template_args['currency_sign']         = EE_Registry::instance()->CFG->currency->sign;
             // link back to overview
-            $this->_template_args['reg_overview_url'] = REG_ADMIN_URL;
-            $this->_template_args['registration'] = $this->_registration;
+            $this->_template_args['reg_overview_url']            = REG_ADMIN_URL;
+            $this->_template_args['registration']                = $this->_registration;
             $this->_template_args['filtered_registrations_link'] = EE_Admin_Page::add_query_args_and_nonce(
-                array(
+                [
                     'action'   => 'default',
                     'event_id' => $event_id,
-                ),
+                ],
                 REG_ADMIN_URL
             );
-            $this->_template_args['filtered_transactions_link'] = EE_Admin_Page::add_query_args_and_nonce(
-                array(
+            $this->_template_args['filtered_transactions_link']  = EE_Admin_Page::add_query_args_and_nonce(
+                [
                     'action' => 'default',
                     'EVT_ID' => $event_id,
                     'page'   => 'espresso_transactions',
-                ),
+                ],
                 admin_url('admin.php')
             );
-            $this->_template_args['event_link'] = EE_Admin_Page::add_query_args_and_nonce(
-                array(
+            $this->_template_args['event_link']                  = EE_Admin_Page::add_query_args_and_nonce(
+                [
                     'page'   => 'espresso_events',
                     'action' => 'edit',
                     'post'   => $event_id,
-                ),
+                ],
                 admin_url('admin.php')
             );
             // next and previous links
-            $next_reg = $this->_registration->next(
+            $next_reg                                      = $this->_registration->next(
                 null,
-                array(),
+                [],
                 'REG_ID'
             );
-            $this->_template_args['next_registration'] = $next_reg
+            $this->_template_args['next_registration']     = $next_reg
                 ? $this->_next_link(
                     EE_Admin_Page::add_query_args_and_nonce(
-                        array(
+                        [
                             'action'  => 'view_registration',
                             '_REG_ID' => $next_reg['REG_ID'],
-                        ),
+                        ],
                         REG_ADMIN_URL
                     ),
                     'dashicons dashicons-arrow-right ee-icon-size-22'
                 )
                 : '';
-            $previous_reg = $this->_registration->previous(
+            $previous_reg                                  = $this->_registration->previous(
                 null,
-                array(),
+                [],
                 'REG_ID'
             );
             $this->_template_args['previous_registration'] = $previous_reg
                 ? $this->_previous_link(
                     EE_Admin_Page::add_query_args_and_nonce(
-                        array(
+                        [
                             'action'  => 'view_registration',
                             '_REG_ID' => $previous_reg['REG_ID'],
-                        ),
+                        ],
                         REG_ADMIN_URL
                     ),
                     'dashicons dashicons-arrow-left ee-icon-size-22'
                 )
                 : '';
             // grab header
-            $template_path = REG_TEMPLATE_PATH . 'reg_admin_details_header.template.php';
-            $this->_template_args['REG_ID'] = $this->_registration->ID();
+            $template_path                             = REG_TEMPLATE_PATH . 'reg_admin_details_header.template.php';
+            $this->_template_args['REG_ID']            = $this->_registration->ID();
             $this->_template_args['admin_page_header'] = EEH_Template::display_template(
                 $template_path,
                 $this->_template_args,
                 true
             );
         } else {
-            $this->_template_args['admin_page_header'] = $this->display_espresso_notices();
+            $this->_template_args['admin_page_header'] = '';
+            $this->_display_espresso_notices();
         }
         // the details template wrapper
         $this->display_admin_page_with_sidebar();
@@ -1428,16 +1434,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         add_meta_box(
             'edit-reg-status-mbox',
             esc_html__('Registration Status', 'event_espresso'),
-            array($this, 'set_reg_status_buttons_metabox'),
-            $this->wp_page_slug,
+            [$this, 'set_reg_status_buttons_metabox'],
+            $this->_wp_page_slug,
             'normal',
             'high'
         );
         add_meta_box(
             'edit-reg-details-mbox',
             esc_html__('Registration Details', 'event_espresso'),
-            array($this, '_reg_details_meta_box'),
-            $this->wp_page_slug,
+            [$this, '_reg_details_meta_box'],
+            $this->_wp_page_slug,
             'normal',
             'high'
         );
@@ -1452,8 +1458,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             add_meta_box(
                 'edit-reg-questions-mbox',
                 esc_html__('Registration Form Answers', 'event_espresso'),
-                array($this, '_reg_questions_meta_box'),
-                $this->wp_page_slug,
+                [$this, '_reg_questions_meta_box'],
+                $this->_wp_page_slug,
                 'normal',
                 'high'
             );
@@ -1461,8 +1467,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         add_meta_box(
             'edit-reg-registrant-mbox',
             esc_html__('Contact Details', 'event_espresso'),
-            array($this, '_reg_registrant_side_meta_box'),
-            $this->wp_page_slug,
+            [$this, '_reg_registrant_side_meta_box'],
+            $this->_wp_page_slug,
             'side',
             'high'
         );
@@ -1470,8 +1476,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             add_meta_box(
                 'edit-reg-attendees-mbox',
                 esc_html__('Other Registrations in this Transaction', 'event_espresso'),
-                array($this, '_reg_attendees_meta_box'),
-                $this->wp_page_slug,
+                [$this, '_reg_attendees_meta_box'],
+                $this->_wp_page_slug,
                 'normal',
                 'high'
             );
@@ -1482,7 +1488,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * set_reg_status_buttons_metabox
      *
-     * @access protected
      * @return void
      * @throws EE_Error
      * @throws EntityNotFoundException
@@ -1495,16 +1500,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         $this->_set_registration_object();
         $change_reg_status_form = $this->_generate_reg_status_change_form();
-        $output = $change_reg_status_form->form_open(
+        $output                 = $change_reg_status_form->form_open(
             self::add_query_args_and_nonce(
-                array(
+                [
                     'action' => 'change_reg_status',
-                ),
+                ],
                 REG_ADMIN_URL
             )
         );
-        $output .= $change_reg_status_form->get_html();
-        $output .= $change_reg_status_form->form_close();
+        $output                 .= $change_reg_status_form->get_html();
+        $output                 .= $change_reg_status_form->form_close();
         echo $output; // already escaped
     }
 
@@ -1520,24 +1525,24 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _generate_reg_status_change_form()
     {
-        $reg_status_change_form_array = array(
+        $reg_status_change_form_array = [
             'name'            => 'reg_status_change_form',
             'html_id'         => 'reg-status-change-form',
             'layout_strategy' => new EE_Admin_Two_Column_Layout(),
-            'subsections'     => array(
-                'return'             => new EE_Hidden_Input(
-                    array(
+            'subsections'     => [
+                'return'         => new EE_Hidden_Input(
+                    [
                         'name'    => 'return',
                         'default' => 'view_registration',
-                    )
+                    ]
                 ),
-                'REG_ID'             => new EE_Hidden_Input(
-                    array(
+                'REG_ID'         => new EE_Hidden_Input(
+                    [
                         'name'    => 'REG_ID',
                         'default' => $this->_registration->ID(),
-                    )
+                    ]
                 ),
-                'current_status'     => new EE_Form_Section_HTML(
+                'current_status' => new EE_Form_Section_HTML(
                     EEH_HTML::table(
                         EEH_HTML::tr(
                             EEH_HTML::th(
@@ -1557,9 +1562,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                             )
                         )
                     )
-                )
-            )
-        );
+                ),
+            ],
+        ];
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_edit_registration',
@@ -1567,29 +1572,29 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 $this->_registration->ID()
             )
         ) {
-            $reg_status_change_form_array['subsections']['reg_status'] = new EE_Select_Input(
+            $reg_status_change_form_array['subsections']['reg_status']         = new EE_Select_Input(
                 $this->_get_reg_statuses(),
-                array(
+                [
                     'html_label_text' => esc_html__('Change Registration Status to', 'event_espresso'),
                     'default'         => $this->_registration->status_ID(),
-                )
+                ]
             );
             $reg_status_change_form_array['subsections']['send_notifications'] = new EE_Yes_No_Input(
-                array(
+                [
                     'html_label_text' => esc_html__('Send Related Messages', 'event_espresso'),
                     'default'         => false,
                     'html_help_text'  => esc_html__(
                         'If set to "Yes", then the related messages will be sent to the registrant.',
                         'event_espresso'
-                    )
-                )
+                    ),
+                ]
             );
-            $reg_status_change_form_array['subsections']['submit'] = new EE_Submit_Input(
-                array(
+            $reg_status_change_form_array['subsections']['submit']             = new EE_Submit_Input(
+                [
                     'html_class'      => 'button-primary',
                     'html_label_text' => '&nbsp;',
                     'default'         => esc_html__('Update Registration Status', 'event_espresso'),
-                )
+                ]
             );
         }
         return new EE_Form_Section_Proper($reg_status_change_form_array);
@@ -1691,8 +1696,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      *
      * @param array  $REG_IDs
      * @param string $status
-     * @param bool   $notify  Used to indicate whether notification was requested or not.  This determines the context
-     *                        slug sent with setting the registration status.
+     * @param bool   $notify Used to indicate whether notification was requested or not.  This determines the context
+     *                       slug sent with setting the registration status.
      * @return array (an array with 'success' key representing whether status change was successful, and 'REG_ID' as
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -1703,7 +1708,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * @throws EntityNotFoundException
      * @throws DomainException
      */
-    protected function _set_registration_status($REG_IDs = array(), $status = '', $notify = false)
+    protected function _set_registration_status($REG_IDs = [], $status = '', $notify = false)
     {
         $success = false;
         // typecast $REG_IDs
@@ -1711,7 +1716,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         if (! empty($REG_IDs)) {
             $success = true;
             // set default status if none is passed
-            $status = $status ? $status : EEM_Registration::status_id_pending_payment;
+            $status         = $status ?: EEM_Registration::status_id_pending_payment;
             $status_context = $notify
                 ? Domain::CONTEXT_REGISTRATION_STATUS_CHANGE_REGISTRATION_ADMIN_NOTIFY
                 : Domain::CONTEXT_REGISTRATION_STATUS_CHANGE_REGISTRATION_ADMIN;
@@ -1738,7 +1743,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         }
 
         // return $success and processed registrations
-        return array('REG_ID' => $REG_IDs, 'success' => $success);
+        return ['REG_ID' => $REG_IDs, 'success' => $success];
     }
 
 
@@ -1759,8 +1764,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _reg_status_change_return($STS_ID, $notify = false)
     {
-        $result = ! empty($STS_ID) ? $this->_set_registration_status_from_request($STS_ID, $notify)
-            : array('success' => false);
+        $result  = ! empty($STS_ID) ? $this->_set_registration_status_from_request($STS_ID, $notify)
+            : ['success' => false];
         $success = isset($result['success']) && $result['success'];
         // setup success message
         if ($success) {
@@ -1788,10 +1793,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             );
         }
         $return = $this->request->getRequestParam('return');
-        $route = $return === 'view_registration'
+        $route  = $return === 'view_registration'
             ? ['action' => 'view_registration', '_REG_ID' => reset($result['REG_ID'])]
             : ['action' => 'default'];
-        $route = $this->mergeExistingRequestParamsWithRedirectArgs($route);
+        $route  = $this->mergeExistingRequestParamsWithRedirectArgs($route);
         $this->_redirect_after_action($success, '', '', $route, true);
     }
 
@@ -1813,7 +1818,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         $this->request->setRequestParam('return', 'view_registration');
         // set notify based on whether the send notifications toggle is set or not
-        $notify = $this->request->getRequestParam('reg_status_change_form[send_notifications]', false, 'bool');
+        $notify     = $this->request->getRequestParam('reg_status_change_form[send_notifications]', false, 'bool');
         $reg_status = $this->request->getRequestParam('reg_status_change_form[reg_status]', '');
         $this->request->setRequestParam('reg_status_change_form[reg_status]', $reg_status);
         switch ($reg_status) {
@@ -1878,7 +1883,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * approve_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their approval.
      * @return void
      * @throws EE_Error
@@ -1897,9 +1901,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        decline_registration
+     * decline_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their status change.
      * @return void
      * @throws EE_Error
@@ -1918,9 +1921,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        cancel_registration
+     * cancel_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their status change.
      * @return void
      * @throws EE_Error
@@ -1939,9 +1941,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        not_approve_registration
+     * not_approve_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their status change.
      * @return void
      * @throws EE_Error
@@ -1960,9 +1961,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        decline_registration
+     * decline_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their status change.
      * @return void
      * @throws EE_Error
@@ -1983,7 +1983,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * waitlist_registration
      *
-     * @access protected
      * @param bool $notify whether or not to notify the registrant about their status change.
      * @return void
      * @throws EE_Error
@@ -2002,9 +2001,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        generates HTML for the Registration main meta box
+     * generates HTML for the Registration main meta box
      *
-     * @access public
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -2019,26 +2017,26 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         EEH_Autoloader::register_line_item_display_autoloaders();
         EEH_Autoloader::register_line_item_filter_autoloaders();
         EE_Registry::instance()->load_helper('Line_Item');
-        $transaction = $this->_registration->transaction() ? $this->_registration->transaction()
+        $transaction    = $this->_registration->transaction() ? $this->_registration->transaction()
             : EE_Transaction::new_instance();
         $this->_session = $transaction->session_data();
-        $filters = new EE_Line_Item_Filter_Collection();
+        $filters        = new EE_Line_Item_Filter_Collection();
         $filters->add(new EE_Single_Registration_Line_Item_Filter($this->_registration));
         $filters->add(new EE_Non_Zero_Line_Item_Filter());
-        $line_item_filter_processor = new EE_Line_Item_Filter_Processor(
+        $line_item_filter_processor              = new EE_Line_Item_Filter_Processor(
             $filters,
             $transaction->total_line_item()
         );
-        $filtered_line_item_tree = $line_item_filter_processor->process();
-        $line_item_display = new EE_Line_Item_Display(
+        $filtered_line_item_tree                 = $line_item_filter_processor->process();
+        $line_item_display                       = new EE_Line_Item_Display(
             'reg_admin_table',
             'EE_Admin_Table_Registration_Line_Item_Display_Strategy'
         );
         $this->_template_args['line_item_table'] = $line_item_display->display_line_item(
             $filtered_line_item_tree,
-            array('EE_Registration' => $this->_registration)
+            ['EE_Registration' => $this->_registration]
         );
-        $attendee = $this->_registration->attendee();
+        $attendee                                = $this->_registration->attendee();
         if (
             EE_Registry::instance()->CAP->current_user_can(
                 'ee_read_transaction',
@@ -2047,10 +2045,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         ) {
             $this->_template_args['view_transaction_button'] = EEH_Template::get_button_or_link(
                 EE_Admin_Page::add_query_args_and_nonce(
-                    array(
+                    [
                         'action' => 'view_transaction',
                         'TXN_ID' => $transaction->ID(),
-                    ),
+                    ],
                     TXN_ADMIN_URL
                 ),
                 esc_html__(' View Transaction', 'event_espresso'),
@@ -2069,11 +2067,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         ) {
             $this->_template_args['resend_registration_button'] = EEH_Template::get_button_or_link(
                 EE_Admin_Page::add_query_args_and_nonce(
-                    array(
+                    [
                         'action'      => 'resend_registration',
                         '_REG_ID'     => $this->_registration->ID(),
                         'redirect_to' => 'view_registration',
-                    ),
+                    ],
                     REG_ADMIN_URL
                 ),
                 esc_html__(' Resend Registration', 'event_espresso'),
@@ -2084,22 +2082,22 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $this->_template_args['resend_registration_button'] = '';
         }
         $this->_template_args['currency_sign'] = EE_Registry::instance()->CFG->currency->sign;
-        $payment = $transaction->get_first_related('Payment');
-        $payment = ! $payment instanceof EE_Payment
+        $payment                               = $transaction->get_first_related('Payment');
+        $payment                               = ! $payment instanceof EE_Payment
             ? EE_Payment::new_instance()
             : $payment;
-        $payment_method = $payment->get_first_related('Payment_Method');
-        $payment_method = ! $payment_method instanceof EE_Payment_Method
+        $payment_method                        = $payment->get_first_related('Payment_Method');
+        $payment_method                        = ! $payment_method instanceof EE_Payment_Method
             ? EE_Payment_Method::new_instance()
             : $payment_method;
-        $reg_details = array(
+        $reg_details                           = [
             'payment_method'       => $payment_method->name(),
             'response_msg'         => $payment->gateway_response(),
             'registration_id'      => $this->_registration->get('REG_code'),
             'registration_session' => $this->_registration->session_ID(),
             'ip_address'           => isset($this->_session['ip_address']) ? $this->_session['ip_address'] : '',
             'user_agent'           => isset($this->_session['user_agent']) ? $this->_session['user_agent'] : '',
-        );
+        ];
         if (isset($reg_details['registration_id'])) {
             $this->_template_args['reg_details']['registration_id']['value'] = $reg_details['registration_id'];
             $this->_template_args['reg_details']['registration_id']['label'] = esc_html__(
@@ -2115,12 +2113,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'event_espresso'
             );
             $this->_template_args['reg_details']['payment_method']['class'] = 'regular-text';
-            $this->_template_args['reg_details']['response_msg']['value'] = $reg_details['response_msg'];
-            $this->_template_args['reg_details']['response_msg']['label'] = esc_html__(
+            $this->_template_args['reg_details']['response_msg']['value']   = $reg_details['response_msg'];
+            $this->_template_args['reg_details']['response_msg']['label']   = esc_html__(
                 'Payment method response',
                 'event_espresso'
             );
-            $this->_template_args['reg_details']['response_msg']['class'] = 'regular-text';
+            $this->_template_args['reg_details']['response_msg']['class']   = 'regular-text';
         }
         $this->_template_args['reg_details']['registration_session']['value'] = $reg_details['registration_session'];
         $this->_template_args['reg_details']['registration_session']['label'] = esc_html__(
@@ -2128,28 +2126,29 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'event_espresso'
         );
         $this->_template_args['reg_details']['registration_session']['class'] = 'regular-text';
-        $this->_template_args['reg_details']['ip_address']['value'] = $reg_details['ip_address'];
-        $this->_template_args['reg_details']['ip_address']['label'] = esc_html__(
+        $this->_template_args['reg_details']['ip_address']['value']           = $reg_details['ip_address'];
+        $this->_template_args['reg_details']['ip_address']['label']           = esc_html__(
             'Registration placed from IP',
             'event_espresso'
         );
-        $this->_template_args['reg_details']['ip_address']['class'] = 'regular-text';
-        $this->_template_args['reg_details']['user_agent']['value'] = $reg_details['user_agent'];
-        $this->_template_args['reg_details']['user_agent']['label'] = esc_html__(
+        $this->_template_args['reg_details']['ip_address']['class']           = 'regular-text';
+        $this->_template_args['reg_details']['user_agent']['value']           = $reg_details['user_agent'];
+        $this->_template_args['reg_details']['user_agent']['label']           = esc_html__(
             'Registrant User Agent',
             'event_espresso'
         );
-        $this->_template_args['reg_details']['user_agent']['class'] = 'large-text';
-        $this->_template_args['event_link'] = EE_Admin_Page::add_query_args_and_nonce(
-            array(
+        $this->_template_args['reg_details']['user_agent']['class']           = 'large-text';
+        $this->_template_args['event_link']                                   = EE_Admin_Page::add_query_args_and_nonce(
+            [
                 'action'   => 'default',
                 'event_id' => $this->_registration->event_ID(),
-            ),
+            ],
             REG_ADMIN_URL
         );
-        $this->_template_args['REG_ID'] = $this->_registration->ID();
-        $this->_template_args['event_id'] = $this->_registration->event_ID();
-        $template_path = REG_TEMPLATE_PATH . 'reg_admin_details_main_meta_box_reg_details.template.php';
+        $this->_template_args['REG_ID']                                       = $this->_registration->ID();
+        $this->_template_args['event_id']                                     = $this->_registration->event_ID();
+        $template_path                                                        =
+            REG_TEMPLATE_PATH . 'reg_admin_details_main_meta_box_reg_details.template.php';
         EEH_Template::display_template($template_path, $this->_template_args); // already escaped
     }
 
@@ -2159,7 +2158,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * If pre-4.8.32.rc.000 hooks are used, uses old methods (with its filters),
      * otherwise uses new forms system
      *
-     * @access public
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -2179,15 +2177,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 $this->_registration
             )
         ) {
-            $form = $this->_get_reg_custom_questions_form(
+            $form                                              = $this->_get_reg_custom_questions_form(
                 $this->_registration->ID()
             );
-            $this->_template_args['att_questions'] = count($form->subforms()) > 0
+            $this->_template_args['att_questions']             = count($form->subforms()) > 0
                 ? $form->get_html_and_js()
                 : '';
             $this->_template_args['reg_questions_form_action'] = 'edit_registration';
-            $this->_template_args['REG_ID'] = $this->_registration->ID();
-            $template_path = REG_TEMPLATE_PATH . 'reg_admin_details_main_meta_box_reg_questions.template.php';
+            $this->_template_args['REG_ID']                    = $this->_registration->ID();
+            $template_path                                     =
+                REG_TEMPLATE_PATH . 'reg_admin_details_main_meta_box_reg_questions.template.php';
             EEH_Template::display_template($template_path, $this->_template_args);
         }
     }
@@ -2196,10 +2195,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * form_before_question_group
      *
-     * @deprecated    as of 4.8.32.rc.000
-     * @access        public
-     * @param        string $output
+     * @param string $output
      * @return        string
+     * @deprecated    as of 4.8.32.rc.000
      */
     public function form_before_question_group($output)
     {
@@ -2221,10 +2219,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * form_after_question_group
      *
-     * @deprecated    as of 4.8.32.rc.000
-     * @access        public
-     * @param        string $output
+     * @param string $output
      * @return        string
+     * @deprecated    as of 4.8.32.rc.000
      */
     public function form_after_question_group($output)
     {
@@ -2259,10 +2256,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * form_form_field_label_wrap
      *
-     * @deprecated    as of 4.8.32.rc.000
-     * @access        public
-     * @param        string $label
+     * @param string $label
      * @return        string
+     * @deprecated    as of 4.8.32.rc.000
      */
     public function form_form_field_label_wrap($label)
     {
@@ -2285,10 +2281,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * form_form_field_input__wrap
      *
-     * @deprecated    as of 4.8.32.rc.000
-     * @access        public
-     * @param        string $input
+     * @param string $input
      * @return        string
+     * @deprecated    as of 4.8.32.rc.000
      */
     public function form_form_field_input__wrap($input)
     {
@@ -2313,7 +2308,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * If it's not a post, the "view_registrations" route will be called next on the SAME request
      * to display the page
      *
-     * @access protected
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -2325,13 +2319,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         do_action('AHEE__Registrations_Admin_Page___update_attendee_registration_form__start', $this);
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+            $REG_ID  = $this->request->getRequestParam('_REG_ID', 0, 'int');
             $success = $this->_save_reg_custom_questions_form($REG_ID);
             if ($success) {
-                $what = esc_html__('Registration Form', 'event_espresso');
-                $route = $REG_ID ? array('action' => 'view_registration', '_REG_ID' => $REG_ID)
-                    : array('action' => 'default');
-                $this->_redirect_after_action($success, $what, esc_html__('updated', 'event_espresso'), $route);
+                $what  = esc_html__('Registration Form', 'event_espresso');
+                $route = $REG_ID
+                    ? ['action' => 'view_registration', '_REG_ID' => $REG_ID]
+                    : ['action' => 'default'];
+                $this->_redirect_after_action(true, $what, esc_html__('updated', 'event_espresso'), $route);
             }
         }
     }
@@ -2347,6 +2342,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     protected function _get_reg_custom_questions_form($REG_ID)
     {
@@ -2364,7 +2360,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * Saves
      *
-     * @access private
      * @param bool $REG_ID
      * @return bool
      * @throws EE_Error
@@ -2392,21 +2387,21 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         if ($form->is_valid()) {
             foreach ($form->subforms() as $question_group_form) {
                 foreach ($question_group_form->inputs() as $question_id => $input) {
-                    $where_conditions = array(
+                    $where_conditions    = [
                         'QST_ID' => $question_id,
                         'REG_ID' => $REG_ID,
-                    );
-                    $possibly_new_values = array(
+                    ];
+                    $possibly_new_values = [
                         'ANS_value' => $input->normalized_value(),
-                    );
-                    $answer = EEM_Answer::instance()->get_one(array($where_conditions));
+                    ];
+                    $answer              = EEM_Answer::instance()->get_one([$where_conditions]);
                     if ($answer instanceof EE_Answer) {
                         $success = $answer->save($possibly_new_values);
                     } else {
                         // insert it then
                         $cols_n_vals = array_merge($where_conditions, $possibly_new_values);
-                        $answer = EE_Answer::new_instance($cols_n_vals);
-                        $success = $answer->save();
+                        $answer      = EE_Answer::new_instance($cols_n_vals);
+                        $success     = $answer->save();
                     }
                 }
             }
@@ -2418,9 +2413,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        generates HTML for the Registration main meta box
+     * generates HTML for the Registration main meta box
      *
-     * @access public
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -2434,17 +2428,17 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $REG = $this->getRegistrationModel();
         // get all other registrations on this transaction, and cache
         // the attendees for them so we don't have to run another query using force_join
-        $registrations = $REG->get_all(
-            array(
-                array(
+        $registrations                           = $REG->get_all(
+            [
+                [
                     'TXN_ID' => $this->_registration->transaction_ID(),
-                    'REG_ID' => array('!=', $this->_registration->ID()),
-                ),
-                'force_join' => array('Attendee'),
+                    'REG_ID' => ['!=', $this->_registration->ID()],
+                ],
+                'force_join'               => ['Attendee'],
                 'default_where_conditions' => 'other_models_only',
-            )
+            ]
         );
-        $this->_template_args['attendees'] = array();
+        $this->_template_args['attendees']       = [];
         $this->_template_args['attendee_notice'] = '';
         if (
             empty($registrations)
@@ -2465,28 +2459,29 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $att_nmbr = 1;
             foreach ($registrations as $registration) {
                 /* @var $registration EE_Registration */
-                $attendee = $registration->attendee()
+                $attendee                                                      = $registration->attendee()
                     ? $registration->attendee()
                     : $this->getAttendeeModel()->create_default_object();
-                $this->_template_args['attendees'][ $att_nmbr ]['STS_ID'] = $registration->status_ID();
-                $this->_template_args['attendees'][ $att_nmbr ]['fname'] = $attendee->fname();
-                $this->_template_args['attendees'][ $att_nmbr ]['lname'] = $attendee->lname();
-                $this->_template_args['attendees'][ $att_nmbr ]['email'] = $attendee->email();
+                $this->_template_args['attendees'][ $att_nmbr ]['STS_ID']      = $registration->status_ID();
+                $this->_template_args['attendees'][ $att_nmbr ]['fname']       = $attendee->fname();
+                $this->_template_args['attendees'][ $att_nmbr ]['lname']       = $attendee->lname();
+                $this->_template_args['attendees'][ $att_nmbr ]['email']       = $attendee->email();
                 $this->_template_args['attendees'][ $att_nmbr ]['final_price'] = $registration->final_price();
-                $this->_template_args['attendees'][ $att_nmbr ]['address'] = implode(
+                $this->_template_args['attendees'][ $att_nmbr ]['address']     = implode(
                     ', ',
                     $attendee->full_address_as_array()
                 );
-                $this->_template_args['attendees'][ $att_nmbr ]['att_link'] = self::add_query_args_and_nonce(
-                    array(
+                $this->_template_args['attendees'][ $att_nmbr ]['att_link']    = self::add_query_args_and_nonce(
+                    [
                         'action' => 'edit_attendee',
                         'post'   => $attendee->ID(),
-                    ),
+                    ],
                     REG_ADMIN_URL
                 );
-                $this->_template_args['attendees'][ $att_nmbr ]['event_name'] = $registration->event_obj() instanceof EE_Event
-                    ? $registration->event_obj()->name()
-                    : '';
+                $this->_template_args['attendees'][ $att_nmbr ]['event_name']  =
+                    $registration->event_obj() instanceof EE_Event
+                        ? $registration->event_obj()->name()
+                        : '';
                 $att_nmbr++;
             }
             $this->_template_args['currency_sign'] = EE_Registry::instance()->CFG->currency->sign;
@@ -2497,9 +2492,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        generates HTML for the Edit Registration side meta box
+     * generates HTML for the Edit Registration side meta box
      *
-     * @access public
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -2512,7 +2506,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         /*@var $attendee EE_Attendee */
         $att_check = $this->_registration->attendee();
-        $attendee = $att_check instanceof EE_Attendee
+        $attendee  = $att_check instanceof EE_Attendee
             ? $att_check
             : $this->getAttendeeModel()->create_default_object();
         // now let's determine if this is not the primary registration.  If it isn't then we set the
@@ -2520,7 +2514,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         // primary registration object (that way we know if we need to show create button or not)
         if (! $this->_registration->is_primary_registrant()) {
             $primary_registration = $this->_registration->get_primary_registration();
-            $primary_attendee = $primary_registration instanceof EE_Registration ? $primary_registration->attendee()
+            $primary_attendee     = $primary_registration instanceof EE_Registration ? $primary_registration->attendee()
                 : null;
             if (! $primary_attendee instanceof EE_Attendee || $attendee->ID() !== $primary_attendee->ID()) {
                 // in here?  This means the displayed registration is not the primary registrant but ALREADY HAS its own
@@ -2530,33 +2524,34 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         } else {
             $primary_registration = null;
         }
-        $this->_template_args['ATT_ID'] = $attendee->ID();
-        $this->_template_args['fname'] = $attendee->fname();
-        $this->_template_args['lname'] = $attendee->lname();
-        $this->_template_args['email'] = $attendee->email();
-        $this->_template_args['phone'] = $attendee->phone();
+        $this->_template_args['ATT_ID']            = $attendee->ID();
+        $this->_template_args['fname']             = $attendee->fname();
+        $this->_template_args['lname']             = $attendee->lname();
+        $this->_template_args['email']             = $attendee->email();
+        $this->_template_args['phone']             = $attendee->phone();
         $this->_template_args['formatted_address'] = EEH_Address::format($attendee);
         // edit link
-        $this->_template_args['att_edit_link'] = EE_Admin_Page::add_query_args_and_nonce(
-            array(
+        $this->_template_args['att_edit_link']  = EE_Admin_Page::add_query_args_and_nonce(
+            [
                 'action' => 'edit_attendee',
                 'post'   => $attendee->ID(),
-            ),
+            ],
             REG_ADMIN_URL
         );
         $this->_template_args['att_edit_label'] = esc_html__('View/Edit Contact', 'event_espresso');
         // create link
-        $this->_template_args['create_link'] = $primary_registration instanceof EE_Registration
+        $this->_template_args['create_link']  = $primary_registration instanceof EE_Registration
             ? EE_Admin_Page::add_query_args_and_nonce(
-                array(
+                [
                     'action'  => 'duplicate_attendee',
                     '_REG_ID' => $this->_registration->ID(),
-                ),
+                ],
                 REG_ADMIN_URL
             ) : '';
         $this->_template_args['create_label'] = esc_html__('Create Contact', 'event_espresso');
-        $this->_template_args['att_check'] = $att_check;
-        $template_path = REG_TEMPLATE_PATH . 'reg_admin_details_side_meta_box_registrant.template.php';
+        $this->_template_args['att_check']    = $att_check;
+        $template_path                        =
+            REG_TEMPLATE_PATH . 'reg_admin_details_side_meta_box_registrant.template.php';
         EEH_Template::display_template($template_path, $this->_template_args);
     }
 
@@ -2564,14 +2559,13 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * trash or restore registrations
      *
-     * @param  boolean $trash whether to archive or restore
+     * @param boolean $trash whether to archive or restore
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws RuntimeException
-     * @access protected
      */
     protected function _trash_or_restore_registrations($trash = true)
     {
@@ -2590,19 +2584,19 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 __LINE__,
                 __FUNCTION__
             );
-            $this->_redirect_after_action(false, '', '', array(), true);
+            $this->_redirect_after_action(false, '', '', [], true);
         }
-        $success = 0;
+        $success        = 0;
         $overwrite_msgs = false;
         // Checkboxes
         $reg_count = count($REG_IDs);
         // cycle thru checkboxes
         foreach ($REG_IDs as $REG_ID) {
             /** @var EE_Registration $REG */
-            $REG = $this->getRegistrationModel()->get_one_by_ID($REG_ID);
+            $REG      = $this->getRegistrationModel()->get_one_by_ID($REG_ID);
             $payments = $REG->registration_payments();
             if (! empty($payments)) {
-                $name = $REG->attendee() instanceof EE_Attendee
+                $name           = $REG->attendee() instanceof EE_Attendee
                     ? $REG->attendee()->full_name()
                     : esc_html__('Unknown Attendee', 'event_espresso');
                 $overwrite_msgs = true;
@@ -2634,7 +2628,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $trash
                 ? esc_html__('moved to the trash', 'event_espresso')
                 : esc_html__('restored', 'event_espresso'),
-            $this->mergeExistingRequestParamsWithRedirectArgs(array('action' => 'default')),
+            $this->mergeExistingRequestParamsWithRedirectArgs(['action' => 'default']),
             $overwrite_msgs
         );
     }
@@ -2681,7 +2675,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             }
         }
 
-        $what = $success > 1
+        $what        = $success > 1
             ? esc_html__('Registrations', 'event_espresso')
             : esc_html__('Registration', 'event_espresso');
         $action_desc = esc_html__('permanently deleted.', 'event_espresso');
@@ -2727,7 +2721,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             );
             return false;
         }
-        $REGS = $TXN->get_many_related('Registration');
+        $REGS        = $TXN->get_many_related('Registration');
         $all_trashed = true;
         foreach ($REGS as $registration) {
             if (! $registration->get('REG_deleted')) {
@@ -2787,7 +2781,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      *    generates HTML for the Register New Attendee Admin page
      *
-     * @access private
      * @throws DomainException
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -2822,21 +2815,21 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         // event name
         if ($this->_reg_event) {
             $this->_template_args['event_name'] = $this->_reg_event->name();
-            $edit_event_url = self::add_query_args_and_nonce(
-                array(
+            $edit_event_url                     = self::add_query_args_and_nonce(
+                [
                     'action' => 'edit',
                     'post'   => $this->_reg_event->ID(),
-                ),
+                ],
                 EVENTS_ADMIN_URL
             );
-            $edit_event_lnk = '<a href="'
-                              . $edit_event_url
-                              . '" title="'
-                              . esc_attr__('Edit ', 'event_espresso')
-                              . $this->_reg_event->name()
-                              . '">'
-                              . esc_html__('Edit Event', 'event_espresso')
-                              . '</a>';
+            $edit_event_lnk                     = '<a href="'
+                                                  . $edit_event_url
+                                                  . '" title="'
+                                                  . esc_attr__('Edit ', 'event_espresso')
+                                                  . $this->_reg_event->name()
+                                                  . '">'
+                                                  . esc_html__('Edit Event', 'event_espresso')
+                                                  . '</a>';
             $this->_template_args['event_name'] .= ' <span class="admin-page-header-edit-lnk not-bold">'
                                                    . $edit_event_lnk
                                                    . '</span>';
@@ -2846,7 +2839,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $this->_return_json();
         }
         // grab header
-        $template_path = REG_TEMPLATE_PATH . 'reg_admin_register_new_attendee.template.php';
+        $template_path                              =
+            REG_TEMPLATE_PATH . 'reg_admin_register_new_attendee.template.php';
         $this->_template_args['admin_page_content'] = EEH_Template::display_template(
             $template_path,
             $this->_template_args,
@@ -2861,7 +2855,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * This returns the content for a registration step
      *
-     * @access protected
      * @return string html
      * @throws DomainException
      * @throws EE_Error
@@ -2901,51 +2894,53 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 	    }, 800 );
 	</script >';
         }
-        $template_args = array(
+        $template_args = [
             'title'                    => '',
             'content'                  => '',
             'step_button_text'         => '',
             'show_notification_toggle' => false,
-        );
+        ];
         // to indicate we're processing a new registration
-        $hidden_fields = array(
-            'processing_registration' => array(
+        $hidden_fields = [
+            'processing_registration' => [
                 'type'  => 'hidden',
                 'value' => 0,
-            ),
-            'event_id'                => array(
+            ],
+            'event_id'                => [
                 'type'  => 'hidden',
                 'value' => $this->_reg_event->ID(),
-            ),
-        );
+            ],
+        ];
         // if the cart is empty then we know we're at step one, so we'll display the ticket selector
         $cart = EE_Registry::instance()->SSN->cart();
         $step = ! $cart instanceof EE_Cart ? 'ticket' : 'questions';
         switch ($step) {
             case 'ticket':
                 $hidden_fields['processing_registration']['value'] = 1;
-                $template_args['title'] = esc_html__(
+                $template_args['title']                            = esc_html__(
                     'Step One: Select the Ticket for this registration',
                     'event_espresso'
                 );
-                $template_args['content'] = EED_Ticket_Selector::instance()->display_ticket_selector($this->_reg_event);
-                $template_args['content'] .= '</div>';
-                $template_args['step_button_text'] = esc_html__(
+                $template_args['content']                          =
+                    EED_Ticket_Selector::instance()->display_ticket_selector($this->_reg_event);
+                $template_args['content']                          .= '</div>';
+                $template_args['step_button_text']                 = esc_html__(
                     'Add Tickets and Continue to Registrant Details',
                     'event_espresso'
                 );
-                $template_args['show_notification_toggle'] = false;
+                $template_args['show_notification_toggle']         = false;
                 break;
             case 'questions':
                 $hidden_fields['processing_registration']['value'] = 2;
-                $template_args['title'] = esc_html__(
+                $template_args['title']                            = esc_html__(
                     'Step Two: Add Registrant Details for this Registration',
                     'event_espresso'
                 );
                 // in theory, we should be able to run EED_SPCO at this point
                 // because the cart should have been set up properly by the first process_reg_step run.
-                $template_args['content'] = EED_Single_Page_Checkout::registration_checkout_for_admin();
-                $template_args['step_button_text'] = esc_html__(
+                $template_args['content']                  =
+                    EED_Single_Page_Checkout::registration_checkout_for_admin();
+                $template_args['step_button_text']         = esc_html__(
                     'Save Registration and Continue to Details',
                     'event_espresso'
                 );
@@ -2963,9 +2958,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        set_reg_event
+     * set_reg_event
      *
-     * @access private
      * @return bool
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -3033,12 +3027,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 if ($this->request->isAjax()) {
                     $this->new_registration(); // display next step
                 } else {
-                    $query_args = array(
+                    $query_args = [
                         'action'                  => 'new_registration',
                         'processing_registration' => 1,
                         'event_id'                => $this->_reg_event->ID(),
                         'uts'                     => time(),
-                    );
+                    ];
                     $this->_redirect_after_action(
                         false,
                         '',
@@ -3055,18 +3049,18 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 // process registration
                 $transaction = EED_Single_Page_Checkout::instance()->process_registration_from_admin();
                 if ($cart instanceof EE_Cart) {
-                    $grand_total = $cart->get_cart_grand_total();
+                    $grand_total = $cart->get_grand_total();
                     if ($grand_total instanceof EE_Line_Item) {
                         $grand_total->save_this_and_descendants_to_txn();
                     }
                 }
                 if (! $transaction instanceof EE_Transaction) {
-                    $query_args = array(
+                    $query_args = [
                         'action'                  => 'new_registration',
                         'processing_registration' => 2,
                         'event_id'                => $this->_reg_event->ID(),
                         'uts'                     => time(),
-                    );
+                    ];
                     if ($this->request->isAjax()) {
                         // display registration form again because there are errors (maybe validation?)
                         $this->new_registration();
@@ -3086,13 +3080,13 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                     $transaction->save();
                 }
                 EE_Registry::instance()->SSN->clear_session(__CLASS__, __FUNCTION__);
-                $query_args = array(
+                $query_args = [
                     'action'        => 'redirect_to_txn',
                     'TXN_ID'        => $transaction->ID(),
                     'EVT_ID'        => $this->_reg_event->ID(),
                     'event_name'    => urlencode($this->_reg_event->name()),
                     'redirect_from' => 'new_registration',
-                );
+                ];
                 $this->_redirect_after_action(false, '', '', $query_args, true);
                 break;
         }
@@ -3103,7 +3097,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * redirect_to_txn
      *
-     * @access public
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -3115,14 +3108,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         EE_System::do_not_cache();
         EE_Registry::instance()->SSN->clear_session(__CLASS__, __FUNCTION__);
-        $query_args = array(
+        $query_args = [
             'action' => 'view_transaction',
             'TXN_ID' => $this->request->getRequestParam('TXN_ID', 0, 'int'),
             'page'   => 'espresso_transactions',
-        );
+        ];
         if ($this->request->requestParamIsSet('EVT_ID') && $this->request->requestParamIsSet('redirect_from')) {
-            $query_args['EVT_ID'] = $this->request->getRequestParam('EVT_ID', 0, 'int');
-            $query_args['event_name'] = urlencode($this->request->getRequestParam('event_name'));
+            $query_args['EVT_ID']        = $this->request->getRequestParam('EVT_ID', 0, 'int');
+            $query_args['event_name']    = urlencode($this->request->getRequestParam('event_name'));
             $query_args['redirect_from'] = $this->request->getRequestParam('redirect_from');
         }
         EE_Error::add_success(
@@ -3136,9 +3129,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        generates HTML for the Attendee Contact List
+     * generates HTML for the Attendee Contact List
      *
-     * @access protected
      * @return void
      * @throws DomainException
      * @throws EE_Error
@@ -3152,17 +3144,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        get_attendees
+     * get_attendees
      *
      * @param      $per_page
      * @param bool $count whether to return count or data.
      * @param bool $trash
-     * @return array
+     * @return array|int
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
-     * @access public
      */
     public function get_attendees($per_page, $count = false, $trash = false)
     {
@@ -3183,62 +3174,53 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             default:
                 $orderby = 'ATT_lname';
         }
-        $sort = $this->request->getRequestParam('order', 'ASC');
+        $sort         = $this->request->getRequestParam('order', 'ASC');
         $current_page = $this->request->getRequestParam('paged', 1, 'int');
-        $per_page = absint($per_page) ? $per_page : 10;
-        $per_page = $this->request->getRequestParam('perpage', $per_page, 'int');
-        $_where = array();
-        $search_term = $this->request->getRequestParam('s');
+        $per_page     = absint($per_page) ? $per_page : 10;
+        $per_page     = $this->request->getRequestParam('perpage', $per_page, 'int');
+        $_where       = [];
+        $search_term  = $this->request->getRequestParam('s');
         if ($search_term) {
-            $search_term = '%' . $search_term . '%';
-            $_where['OR'] = array(
-                'Registration.Event.EVT_name'       => array('LIKE', $search_term),
-                'Registration.Event.EVT_desc'       => array('LIKE', $search_term),
-                'Registration.Event.EVT_short_desc' => array('LIKE', $search_term),
-                'ATT_fname'                         => array('LIKE', $search_term),
-                'ATT_lname'                         => array('LIKE', $search_term),
-                'ATT_short_bio'                     => array('LIKE', $search_term),
-                'ATT_email'                         => array('LIKE', $search_term),
-                'ATT_address'                       => array('LIKE', $search_term),
-                'ATT_address2'                      => array('LIKE', $search_term),
-                'ATT_city'                          => array('LIKE', $search_term),
-                'Country.CNT_name'                  => array('LIKE', $search_term),
-                'State.STA_name'                    => array('LIKE', $search_term),
-                'ATT_phone'                         => array('LIKE', $search_term),
-                'Registration.REG_final_price'      => array('LIKE', $search_term),
-                'Registration.REG_code'             => array('LIKE', $search_term),
-                'Registration.REG_group_size'       => array('LIKE', $search_term),
-            );
+            $search_term  = '%' . $search_term . '%';
+            $_where['OR'] = [
+                'Registration.Event.EVT_name'       => ['LIKE', $search_term],
+                'Registration.Event.EVT_desc'       => ['LIKE', $search_term],
+                'Registration.Event.EVT_short_desc' => ['LIKE', $search_term],
+                'ATT_fname'                         => ['LIKE', $search_term],
+                'ATT_lname'                         => ['LIKE', $search_term],
+                'ATT_short_bio'                     => ['LIKE', $search_term],
+                'ATT_email'                         => ['LIKE', $search_term],
+                'ATT_address'                       => ['LIKE', $search_term],
+                'ATT_address2'                      => ['LIKE', $search_term],
+                'ATT_city'                          => ['LIKE', $search_term],
+                'Country.CNT_name'                  => ['LIKE', $search_term],
+                'State.STA_name'                    => ['LIKE', $search_term],
+                'ATT_phone'                         => ['LIKE', $search_term],
+                'Registration.REG_final_price'      => ['LIKE', $search_term],
+                'Registration.REG_code'             => ['LIKE', $search_term],
+                'Registration.REG_group_size'       => ['LIKE', $search_term],
+            ];
         }
-        $offset = ($current_page - 1) * $per_page;
-        $limit = $count ? null : array($offset, $per_page);
-        $query_args = array(
+        $offset     = ($current_page - 1) * $per_page;
+        $limit      = $count ? null : [$offset, $per_page];
+        $query_args = [
             $_where,
-            'extra_selects' => array('Registration_Count' => array('Registration.REG_ID', 'count', '%d')),
+            'extra_selects' => ['Registration_Count' => ['Registration.REG_ID', 'count', '%d']],
             'limit'         => $limit,
-        );
+        ];
         if (! $count) {
-            $query_args['order_by'] = array($orderby => $sort);
+            $query_args['order_by'] = [$orderby => $sort];
         }
-        if ($trash) {
-            $query_args[0]['status'] = array('!=', 'publish');
-            $all_attendees = $count
-                ? $this->getAttendeeModel()->count($query_args, 'ATT_ID', true)
-                : $this->getAttendeeModel()->get_all($query_args);
-        } else {
-            $query_args[0]['status'] = array('IN', array('publish'));
-            $all_attendees = $count
-                ? $this->getAttendeeModel()->count($query_args, 'ATT_ID', true)
-                : $this->getAttendeeModel()->get_all($query_args);
-        }
-        return $all_attendees;
+        $query_args[0]['status'] = $trash ? ['!=', 'publish'] : ['IN', ['publish']];
+        return $count
+            ? $this->getAttendeeModel()->count($query_args, 'ATT_ID', true)
+            : $this->getAttendeeModel()->get_all($query_args);
     }
 
 
     /**
      * This is just taking care of resending the registration confirmation
      *
-     * @access protected
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -3249,13 +3231,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _resend_registration()
     {
         $this->_process_resend_registration();
-        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $REG_ID      = $this->request->getRequestParam('_REG_ID', 0, 'int');
         $redirect_to = $this->request->getRequestParam('redirect_to');
-        $query_args = $redirect_to
-            ? array('action' => $redirect_to, '_REG_ID' => $REG_ID)
-            : array('action' => 'default');
+        $query_args  = $redirect_to
+            ? ['action' => $redirect_to, '_REG_ID' => $REG_ID]
+            : ['action' => 'default'];
         $this->_redirect_after_action(false, '', '', $query_args, true);
     }
+
 
     /**
      * Creates a registration report, but accepts the name of a method to use for preparing the query parameters
@@ -3274,7 +3257,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $request_params = $this->request->requestParams();
             wp_redirect(
                 EE_Admin_Page::add_query_args_and_nonce(
-                    array(
+                    [
                         'page'        => 'espresso_batch',
                         'batch'       => 'file',
                         'EVT_ID'      => $EVT_ID,
@@ -3288,15 +3271,15 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         'use_filters' => EEH_Array::is_set($request_params, 'use_filters', false),
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\RegistrationsReport'),
                         'return_url'  => urlencode($this->request->getRequestParam('return_url')),
-                    )
+                    ]
                 )
             );
         } else {
-            $new_request_args = array(
+            $new_request_args = [
                 'export' => 'report',
                 'action' => 'registrations_report_for_event',
                 'EVT_ID' => $EVT_ID,
-            );
+            ];
             $this->request->mergeRequestParams($new_request_args);
             if (is_readable(EE_CLASSES . 'EE_Export.class.php')) {
                 require_once(EE_CLASSES . 'EE_Export.class.php');
@@ -3333,12 +3316,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         if (! defined('EE_USE_OLD_CSV_REPORT_CLASS')) {
             wp_redirect(
                 EE_Admin_Page::add_query_args_and_nonce(
-                    array(
+                    [
                         'page'        => 'espresso_batch',
                         'batch'       => 'file',
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\AttendeesReport'),
                         'return_url'  => urlencode($this->request->getRequestParam('return_url')),
-                    )
+                    ]
                 )
             );
         } else {
@@ -3380,7 +3363,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 __LINE__,
                 __FUNCTION__
             );
-            $query_args = array('action' => $action);
+            $query_args = ['action' => $action];
             $this->_redirect_after_action('', '', '', $query_args, true);
         }
         // okay necessary deets present... let's dupe the incoming attendee and attach to incoming registration.
@@ -3412,7 +3395,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             )
         );
         // redirect to edit page for attendee
-        $query_args = array('post' => $new_attendee->ID(), 'action' => 'edit_attendee');
+        $query_args = ['post' => $new_attendee->ID(), 'action' => 'edit_attendee'];
         $this->_redirect_after_action('', '', '', $query_args, true);
     }
 
@@ -3433,16 +3416,16 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _insert_update_cpt_item($post_id, $post)
     {
-        $success = true;
+        $success  = true;
         $attendee = $post instanceof WP_Post && $post->post_type === 'espresso_attendees'
             ? $this->getAttendeeModel()->get_one_by_ID($post_id)
             : null;
         // for attendee updates
         if ($attendee instanceof EE_Attendee) {
             // note we should only be UPDATING attendees at this point.
-            $fname = $this->request->getRequestParam('ATT_fname', '');
-            $lname = $this->request->getRequestParam('ATT_lname', '');
-            $updated_fields = array(
+            $fname          = $this->request->getRequestParam('ATT_fname', '');
+            $lname          = $this->request->getRequestParam('ATT_lname', '');
+            $updated_fields = [
                 'ATT_fname'     => $fname,
                 'ATT_lname'     => $lname,
                 'ATT_full_name' => "{$fname} {$lname}",
@@ -3452,21 +3435,21 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'STA_ID'        => $this->request->getRequestParam('STA_ID', ''),
                 'CNT_ISO'       => $this->request->getRequestParam('CNT_ISO', ''),
                 'ATT_zip'       => $this->request->getRequestParam('ATT_zip', ''),
-            );
+            ];
             foreach ($updated_fields as $field => $value) {
                 $attendee->set($field, $value);
             }
 
             // process contact details metabox form handler (which will also save the attendee)
             $contact_details_form = $this->getAttendeeContactDetailsMetaboxFormHandler($attendee);
-            $success = $contact_details_form->process($this->request->requestParams());
+            $success              = $contact_details_form->process($this->request->requestParams());
 
             $attendee_update_callbacks = apply_filters(
                 'FHEE__Registrations_Admin_Page__insert_update_cpt_item__attendee_update',
-                array()
+                []
             );
             foreach ($attendee_update_callbacks as $a_callback) {
-                if (false === call_user_func_array($a_callback, array($attendee, $this->request->requestParams()))) {
+                if (false === call_user_func_array($a_callback, [$attendee, $this->request->requestParams()])) {
                     throw new EE_Error(
                         sprintf(
                             esc_html__(
@@ -3516,6 +3499,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
     /**
      * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.10.2.p
      */
     public function attendee_editor_metaboxes()
@@ -3526,7 +3510,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $this->_cpt_routes[ $this->_req_action ],
             'normal'
         );
-        remove_meta_box('commentstatusdiv', $this->_cpt_routes[ $this->_req_action ], 'normal', 'core');
+        remove_meta_box('commentstatusdiv', $this->_cpt_routes[ $this->_req_action ], 'normal');
         if (post_type_supports('espresso_attendees', 'excerpt')) {
             add_meta_box(
                 'postexcerpt',
@@ -3549,7 +3533,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         add_meta_box(
             'attendee_contact_info',
             esc_html__('Contact Info', 'event_espresso'),
-            array($this, 'attendee_contact_info'),
+            [$this, 'attendee_contact_info'],
             $this->_cpt_routes[ $this->_req_action ],
             'side',
             'core'
@@ -3557,7 +3541,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         add_meta_box(
             'attendee_details_address',
             esc_html__('Address Details', 'event_espresso'),
-            array($this, 'attendee_address_details'),
+            [$this, 'attendee_address_details'],
             $this->_cpt_routes[ $this->_req_action ],
             'normal',
             'core'
@@ -3565,7 +3549,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         add_meta_box(
             'attendee_registrations',
             esc_html__('Registrations for this Contact', 'event_espresso'),
-            array($this, 'attendee_registrations_meta_box'),
+            [$this, 'attendee_registrations_meta_box'],
             $this->_cpt_routes[ $this->_req_action ],
             'normal',
             'high'
@@ -3576,7 +3560,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * Metabox for attendee contact info
      *
-     * @param  WP_Post $post wp post object
+     * @param WP_Post $post wp post object
      * @return void attendee contact info ( and form )
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -3613,68 +3597,69 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * Metabox for attendee details
      *
-     * @param  WP_Post $post wp post object
-     * @throws DomainException
+     * @param WP_Post $post wp post object
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function attendee_address_details($post)
     {
         // get attendee object (should already have it)
-        $this->_template_args['attendee'] = $this->_cpt_model_obj;
-        $this->_template_args['state_html'] = EEH_Form_Fields::generate_form_input(
+        $this->_template_args['attendee']     = $this->_cpt_model_obj;
+        $this->_template_args['state_html']   = EEH_Form_Fields::generate_form_input(
             new EE_Question_Form_Input(
                 EE_Question::new_instance(
-                    array(
+                    [
                         'QST_ID'           => 0,
                         'QST_display_text' => esc_html__('State/Province', 'event_espresso'),
                         'QST_system'       => 'admin-state',
-                    )
+                    ]
                 ),
                 EE_Answer::new_instance(
-                    array(
+                    [
                         'ANS_ID'    => 0,
                         'ANS_value' => $this->_cpt_model_obj->state_ID(),
-                    )
+                    ]
                 ),
-                array(
+                [
                     'input_id'       => 'STA_ID',
                     'input_name'     => 'STA_ID',
                     'input_prefix'   => '',
                     'append_qstn_id' => false,
-                )
+                ]
             )
         );
         $this->_template_args['country_html'] = EEH_Form_Fields::generate_form_input(
             new EE_Question_Form_Input(
                 EE_Question::new_instance(
-                    array(
+                    [
                         'QST_ID'           => 0,
                         'QST_display_text' => esc_html__('Country', 'event_espresso'),
                         'QST_system'       => 'admin-country',
-                    )
+                    ]
                 ),
                 EE_Answer::new_instance(
-                    array(
+                    [
                         'ANS_ID'    => 0,
                         'ANS_value' => $this->_cpt_model_obj->country_ID(),
-                    )
+                    ]
                 ),
-                array(
+                [
                     'input_id'       => 'CNT_ISO',
                     'input_name'     => 'CNT_ISO',
                     'input_prefix'   => '',
                     'append_qstn_id' => false,
-                )
+                ]
             )
         );
-        $template = REG_TEMPLATE_PATH . 'attendee_address_details_metabox_content.template.php';
+        $template                             =
+            REG_TEMPLATE_PATH . 'attendee_address_details_metabox_content.template.php';
         EEH_Template::display_template($template, $this->_template_args);
     }
 
 
     /**
-     *        _attendee_details
+     * _attendee_details
      *
-     * @access protected
      * @param $post
      * @return void
      * @throws DomainException
@@ -3686,9 +3671,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     public function attendee_registrations_meta_box($post)
     {
-        $this->_template_args['attendee'] = $this->_cpt_model_obj;
+        $this->_template_args['attendee']      = $this->_cpt_model_obj;
         $this->_template_args['registrations'] = $this->_cpt_model_obj->get_many_related('Registration');
-        $template = REG_TEMPLATE_PATH . 'attendee_registrations_main_meta_box.template.php';
+        $template                              =
+            REG_TEMPLATE_PATH . 'attendee_registrations_main_meta_box.template.php';
         EEH_Template::display_template($template, $this->_template_args);
     }
 
@@ -3696,14 +3682,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * add in the form fields for the attendee edit
      *
-     * @param  WP_Post $post wp post object
+     * @param WP_Post $post wp post object
      * @return void echos html for new form.
      * @throws DomainException
      */
     public function after_title_form_fields($post)
     {
         if ($post->post_type === 'espresso_attendees') {
-            $template = REG_TEMPLATE_PATH . 'attendee_details_after_title_form_fields.template.php';
+            $template                  = REG_TEMPLATE_PATH . 'attendee_details_after_title_form_fields.template.php';
             $template_args['attendee'] = $this->_cpt_model_obj;
             EEH_Template::display_template($template, $template_args);
         }
@@ -3711,7 +3697,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
 
     /**
-     *        _trash_or_restore_attendee
+     * _trash_or_restore_attendee
      *
      * @param boolean $trash - whether to move item to trash (TRUE) or restore it (FALSE)
      * @return void
@@ -3719,8 +3705,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
-     * @throws ReflectionException
-     * @access protected
      */
     protected function _trash_or_restore_attendees($trash = true)
     {
@@ -3744,12 +3728,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             // update attendee
             $success = $this->getAttendeeModel()->update_by_ID(['status' => $status], $ATT_ID) ? 1 : 0;
         }
-        $what = $success > 1
+        $what        = $success > 1
             ? esc_html__('Contacts', 'event_espresso')
             : esc_html__('Contact', 'event_espresso');
         $action_desc = $trash
             ? esc_html__('moved to the trash', 'event_espresso')
             : esc_html__('restored', 'event_espresso');
-        $this->_redirect_after_action($success, $what, $action_desc, array('action' => 'contact_list'));
+        $this->_redirect_after_action($success, $what, $action_desc, ['action' => 'contact_list']);
     }
 }

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -3273,7 +3273,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         ),
                         'use_filters' => EEH_Array::is_set($request_params, 'use_filters', false),
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\RegistrationsReport'),
-                        'return_url'  => urlencode($this->request->getRequestParam('return_url')),
+                        'return_url'  => urlencode($this->request->getRequestParam('return_url', '', 'url')),
                     ]
                 )
             );
@@ -3323,7 +3323,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         'page'        => 'espresso_batch',
                         'batch'       => 'file',
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\AttendeesReport'),
-                        'return_url'  => urlencode($this->request->getRequestParam('return_url')),
+                        'return_url'  => urlencode($this->request->getRequestParam('return_url', '', 'url')),
                     ]
                 )
             );

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -144,12 +144,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     public function wp_loaded()
     {
         // when adding a new registration...
-        if (isset($this->_req_data['action']) && $this->_req_data['action'] === 'new_registration') {
+        $action = $this->request->getRequestParam('action');
+        if ($action === 'new_registration') {
             EE_System::do_not_cache();
-            if (
-                ! isset($this->_req_data['processing_registration'])
-                || absint($this->_req_data['processing_registration']) !== 1
-            ) {
+            if ($this->request->getRequestParam('processing_registration', 0, 'int') !== 1) {
                 // and it's NOT the attendee information reg step
                 // force cookie expiration by setting time to last week
                 setcookie('ee_registration_added', 0, time() - WEEK_IN_SECONDS, '/');
@@ -243,16 +241,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     public function _set_page_routes()
     {
         $this->_get_registration_status_array();
-        $reg_id = ! empty($this->_req_data['_REG_ID']) && ! is_array($this->_req_data['_REG_ID'])
-            ? $this->_req_data['_REG_ID'] : 0;
-        $reg_id = empty($reg_id) && ! empty($this->_req_data['reg_status_change_form']['REG_ID'])
-            ? $this->_req_data['reg_status_change_form']['REG_ID']
-            : $reg_id;
-        $att_id = ! empty($this->_req_data['ATT_ID']) && ! is_array($this->_req_data['ATT_ID'])
-            ? $this->_req_data['ATT_ID'] : 0;
-        $att_id = ! empty($this->_req_data['post']) && ! is_array($this->_req_data['post'])
-            ? $this->_req_data['post']
-            : $att_id;
+        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $REG_ID = $this->request->getRequestParam('reg_status_change_form[REG_ID]', $REG_ID, 'int');
+        $ATT_ID = $this->request->getRequestParam('ATT_ID', 0, 'int');
+        $ATT_ID = $this->request->getRequestParam('post', $ATT_ID, 'int');
         $this->_page_routes = array(
             'default'                             => array(
                 'func'       => '_registrations_overview_list_table',
@@ -261,15 +253,15 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'view_registration'                   => array(
                 'func'       => '_registration_details',
                 'capability' => 'ee_read_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'edit_registration'                   => array(
                 'func'               => '_update_attendee_registration_form',
                 'noheader'           => true,
                 'headers_sent_route' => 'view_registration',
                 'capability'         => 'ee_edit_registration',
-                'obj_id'             => $reg_id,
-                '_REG_ID'            => $reg_id,
+                'obj_id'             => $REG_ID,
+                '_REG_ID'            => $REG_ID,
             ),
             'trash_registrations'                 => array(
                 'func'       => '_trash_or_restore_registrations',
@@ -306,20 +298,20 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => '_change_reg_status',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'approve_registration'                => array(
                 'func'       => 'approve_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'approve_and_notify_registration'     => array(
                 'func'       => 'approve_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'approve_registrations'               => array(
                 'func'       => 'bulk_action_on_registrations',
@@ -337,14 +329,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => 'decline_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'decline_and_notify_registration'     => array(
                 'func'       => 'decline_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'decline_registrations'               => array(
                 'func'       => 'bulk_action_on_registrations',
@@ -362,14 +354,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => 'pending_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'pending_and_notify_registration'     => array(
                 'func'       => 'pending_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'pending_registrations'               => array(
                 'func'       => 'bulk_action_on_registrations',
@@ -387,14 +379,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => 'not_approve_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'no_approve_and_notify_registration'  => array(
                 'func'       => 'not_approve_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'no_approve_registrations'            => array(
                 'func'       => 'bulk_action_on_registrations',
@@ -412,14 +404,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => 'cancel_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'cancel_and_notify_registration'      => array(
                 'func'       => 'cancel_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'cancel_registrations'                => array(
                 'func'       => 'bulk_action_on_registrations',
@@ -437,14 +429,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'func'       => 'wait_list_registration',
                 'noheader'   => true,
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'wait_list_and_notify_registration'   => array(
                 'func'       => 'wait_list_registration',
                 'noheader'   => true,
                 'args'       => array(true),
                 'capability' => 'ee_edit_registration',
-                'obj_id'     => $reg_id,
+                'obj_id'     => $REG_ID,
             ),
             'contact_list'                        => array(
                 'func'       => '_attendee_contact_list_table',
@@ -460,13 +452,13 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'edit_attendee'                       => array(
                 'func'       => '_edit_cpt_item',
                 'capability' => 'ee_edit_contacts',
-                'obj_id'     => $att_id,
+                'obj_id'     => $ATT_ID,
             ),
             'duplicate_attendee'                  => array(
                 'func'       => '_duplicate_attendee',
                 'noheader'   => true,
                 'capability' => 'ee_edit_contacts',
-                'obj_id'     => $att_id,
+                'obj_id'     => $ATT_ID,
             ),
             'insert_attendee'                     => array(
                 'func'       => '_insert_or_update_attendee',
@@ -483,7 +475,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 ),
                 'noheader'   => true,
                 'capability' => 'ee_edit_contacts',
-                'obj_id'     => $att_id,
+                'obj_id'     => $ATT_ID,
             ),
             'trash_attendees'                     => array(
                 'func'       => '_trash_or_restore_attendees',
@@ -500,7 +492,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 ),
                 'noheader'   => true,
                 'capability' => 'ee_delete_contacts',
-                'obj_id'     => $att_id,
+                'obj_id'     => $ATT_ID,
             ),
             'restore_attendees'                   => array(
                 'func'       => '_trash_or_restore_attendees',
@@ -509,7 +501,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 ),
                 'noheader'   => true,
                 'capability' => 'ee_delete_contacts',
-                'obj_id'     => $att_id,
+                'obj_id'     => $ATT_ID,
             ),
             'resend_registration'                 => array(
                 'func'       => '_resend_registration',
@@ -537,6 +529,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
     protected function _set_page_config()
     {
+        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $ATT_ID = $this->request->getRequestParam('ATT_ID', 0, 'int');
         $this->_page_config = array(
             'default'           => array(
                 'nav'           => array(
@@ -575,8 +569,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'nav'           => array(
                     'label'      => esc_html__('REG Details', 'event_espresso'),
                     'order'      => 15,
-                    'url'        => isset($this->_req_data['_REG_ID'])
-                        ? add_query_arg(array('_REG_ID' => $this->_req_data['_REG_ID']), $this->_current_page_view_url)
+                    'url'        => $REG_ID
+                        ? add_query_arg(array('_REG_ID' => $REG_ID), $this->_current_page_view_url)
                         : $this->_admin_base_url,
                     'persistent' => false,
                 ),
@@ -636,8 +630,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                     'label'      => esc_html__('Edit Contact', 'event_espresso'),
                     'order'      => 15,
                     'persistent' => false,
-                    'url'        => isset($this->_req_data['ATT_ID'])
-                        ? add_query_arg(array('ATT_ID' => $this->_req_data['ATT_ID']), $this->_current_page_view_url)
+                    'url'        => $ATT_ID
+                        ? add_query_arg(array('ATT_ID' => $ATT_ID), $this->_current_page_view_url)
                         : $this->_admin_base_url,
                 ),
                 'metaboxes'     => array('attendee_editor_metaboxes'),
@@ -1181,9 +1175,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     private function appendAddNewRegistrationButtonToPageTitle()
     {
-        $EVT_ID = ! empty($this->_req_data['event_id'])
-            ? absint($this->_req_data['event_id'])
-            : 0;
+        $EVT_ID = $this->request->getRequestParam('event_id', 0, 'int');
         if (
             $EVT_ID
             && EE_Registry::instance()->CAP->current_user_can(
@@ -1218,7 +1210,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         if ($this->_registration instanceof EE_Registration) {
             return true;
         }
-        $REG_ID = (! empty($this->_req_data['_REG_ID'])) ? absint($this->_req_data['_REG_ID']) : false;
+        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
         if ($this->_registration = $this->getRegistrationModel()->get_one_by_ID($REG_ID)) {
             return true;
         }
@@ -1255,12 +1247,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $today = false
     ) {
         if ($this_month) {
-            $this->_req_data['status'] = 'month';
+            $this->request->setRequestParam('status', 'month');
         }
         if ($today) {
-            $this->_req_data['status'] = 'today';
+            $this->request->setRequestParam('status', 'today');
         }
-        $query_params = $this->_get_registration_query_parameters($this->_req_data, $per_page, $count);
+        $query_params = $this->_get_registration_query_parameters($this->request->requestParams(), $per_page, $count);
         /**
          * Override the default groupby added by EEM_Base so that sorts with multiple order bys work as expected
          *
@@ -1648,15 +1640,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _set_registration_status_from_request($status = false, $notify = false)
     {
-        if (isset($this->_req_data['reg_status_change_form'])) {
-            $REG_IDs = isset($this->_req_data['reg_status_change_form']['REG_ID'])
-                ? (array) $this->_req_data['reg_status_change_form']['REG_ID']
-                : array();
-        } else {
-            $REG_IDs = isset($this->_req_data['_REG_ID'])
-                ? (array) $this->_req_data['_REG_ID']
-                : array();
-        }
+        $REG_IDs = $this->request->requestParamIsSet('reg_status_change_form')
+            ? $this->request->getRequestParam('reg_status_change_form[REG_ID]', [], 'int', true)
+            : $this->request->getRequestParam('_REG_ID', [], 'int', true);
+
         // sanitize $REG_IDs
         $REG_IDs = array_map('absint', $REG_IDs);
         // and remove empty entries
@@ -1673,19 +1660,20 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
          * @param bool                     $success          If the status was changed successfully for all registrations.
          * @param Registrations_Admin_Page $admin_page_object
          */
-        $this->_req_data['_REG_ID'] = apply_filters(
+        $REG_ID = apply_filters(
             'FHEE__Registrations_Admin_Page___set_registration_status_from_request__REG_IDs',
             $result['REG_ID'],
             $status,
             $result['success'],
             $this
         );
+        $this->request->setRequestParam('_REG_ID', $REG_ID);
 
         // notify?
         if (
             $notify
             && $result['success']
-            && ! empty($this->_req_data['_REG_ID'])
+            && ! empty($REG_ID)
             && EE_Registry::instance()->CAP->current_user_can(
                 'ee_send_message',
                 'espresso_registrations_resend_registration'
@@ -1799,11 +1787,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 __FUNCTION__
             );
         }
-        if (isset($this->_req_data['return']) && $this->_req_data['return'] === 'view_registration') {
-            $route = array('action' => 'view_registration', '_REG_ID' => reset($result['REG_ID']));
-        } else {
-            $route = array('action' => 'default');
-        }
+        $return = $this->request->getRequestParam('return');
+        $route = $return === 'view_registration'
+            ? ['action' => 'view_registration', '_REG_ID' => reset($result['REG_ID'])]
+            : ['action' => 'default'];
         $route = $this->mergeExistingRequestParamsWithRedirectArgs($route);
         $this->_redirect_after_action($success, '', '', $route, true);
     }
@@ -1824,13 +1811,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _change_reg_status()
     {
-        $this->_req_data['return'] = 'view_registration';
+        $this->request->setRequestParam('return', 'view_registration');
         // set notify based on whether the send notifications toggle is set or not
-        $notify = ! empty($this->_req_data['reg_status_change_form']['send_notifications']);
-        // $notify = ! empty( $this->_req_data['txn_reg_status_change']['send_notifications'] );
-        $this->_req_data['reg_status_change_form']['reg_status'] = isset($this->_req_data['reg_status_change_form']['reg_status'])
-            ? $this->_req_data['reg_status_change_form']['reg_status'] : '';
-        switch ($this->_req_data['reg_status_change_form']['reg_status']) {
+        $notify = $this->request->getRequestParam('reg_status_change_form[send_notifications]', false, 'bool');
+        $reg_status = $this->request->getRequestParam('reg_status_change_form[reg_status]', '');
+        $this->request->setRequestParam('reg_status_change_form[reg_status]', $reg_status);
+        switch ($reg_status) {
             case EEM_Registration::status_id_approved:
             case EEH_Template::pretty_status(EEM_Registration::status_id_approved, false, 'sentence'):
                 $this->approve_registration($notify);
@@ -1857,9 +1843,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 break;
             case EEM_Registration::status_id_incomplete:
             default:
-                $result['success'] = false;
-                unset($this->_req_data['return']);
-                $this->_reg_status_change_return('', false);
+                $this->request->unSetRequestParam('return');
+                $this->_reg_status_change_return('');
                 break;
         }
     }
@@ -2340,7 +2325,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         do_action('AHEE__Registrations_Admin_Page___update_attendee_registration_form__start', $this);
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            $REG_ID = isset($this->_req_data['_REG_ID']) ? absint($this->_req_data['_REG_ID']) : false;
+            $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
             $success = $this->_save_reg_custom_questions_form($REG_ID);
             if ($success) {
                 $what = esc_html__('Registration Form', 'event_espresso');
@@ -2388,7 +2373,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    private function _save_reg_custom_questions_form($REG_ID = false)
+    private function _save_reg_custom_questions_form($REG_ID = 0)
     {
         if (! $REG_ID) {
             EE_Error::add_error(
@@ -2402,10 +2387,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             );
         }
         $form = $this->_get_reg_custom_questions_form($REG_ID);
-        $form->receive_form_submission($this->_req_data);
+        $form->receive_form_submission($this->request->requestParams());
         $success = false;
         if ($form->is_valid()) {
-            foreach ($form->subforms() as $question_group_id => $question_group_form) {
+            foreach ($form->subforms() as $question_group_form) {
                 foreach ($question_group_form->inputs() as $question_id => $input) {
                     $where_conditions = array(
                         'QST_ID' => $question_id,
@@ -2591,7 +2576,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _trash_or_restore_registrations($trash = true)
     {
         // if empty _REG_ID then get out because there's nothing to do
-        if (empty($this->_req_data['_REG_ID'])) {
+        $REG_IDs = $this->request->getRequestParam('_REG_ID', [], 'int', true);
+        if (empty($REG_IDs)) {
             EE_Error::add_error(
                 sprintf(
                     esc_html__(
@@ -2609,12 +2595,9 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $success = 0;
         $overwrite_msgs = false;
         // Checkboxes
-        if (! is_array($this->_req_data['_REG_ID'])) {
-            $this->_req_data['_REG_ID'] = array($this->_req_data['_REG_ID']);
-        }
-        $reg_count = count($this->_req_data['_REG_ID']);
+        $reg_count = count($REG_IDs);
         // cycle thru checkboxes
-        foreach ($this->_req_data['_REG_ID'] as $REG_ID) {
+        foreach ($REG_IDs as $REG_ID) {
             /** @var EE_Registration $REG */
             $REG = $this->getRegistrationModel()->get_one_by_ID($REG_ID);
             $payments = $REG->registration_payments();
@@ -2678,13 +2661,15 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _delete_registrations()
     {
         $REG_MDL = $this->getRegistrationModel();
-        $success = 1;
+        $success = 0;
         // Checkboxes
-        if (! empty($this->_req_data['_REG_ID']) && is_array($this->_req_data['_REG_ID'])) {
+        $REG_IDs = $this->request->getRequestParam('_REG_ID', [], 'int', true);
+
+        if (! empty($REG_IDs)) {
             // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['_REG_ID']) > 1 ? 2 : 1;
+            $success = count($REG_IDs) > 1 ? 2 : 1;
             // cycle thru checkboxes
-            foreach ($this->_req_data['_REG_ID'] as $REG_ID) {
+            foreach ($REG_IDs as $REG_ID) {
                 $REG = $REG_MDL->get_one_by_ID($REG_ID);
                 if (! $REG instanceof EE_Registration) {
                     continue;
@@ -2694,16 +2679,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                     $success = 0;
                 }
             }
-        } else {
-            // grab single id and delete
-            $REG_ID = $this->_req_data['_REG_ID'];
-            /** @var EE_Registration $REG */
-            $REG = $REG_MDL->get_one_by_ID($REG_ID);
-            $deleted = $this->_delete_registration($REG);
-            if (! $deleted) {
-                $success = 0;
-            }
         }
+
         $what = $success > 1
             ? esc_html__('Registrations', 'event_espresso')
             : esc_html__('Registration', 'event_espresso');
@@ -2833,8 +2810,11 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $current_page->setEspressoPage(true);
         // gotta start with a clean slate if we're not coming here via ajax
         if (
-            ! defined('DOING_AJAX')
-            && (! isset($this->_req_data['processing_registration']) || isset($this->_req_data['step_error']))
+            ! $this->request->isAjax()
+            && (
+                ! $this->request->requestParamIsSet('processing_registration')
+                || $this->request->requestParamIsSet('step_error')
+            )
         ) {
             EE_Registry::instance()->SSN->clear_session(__CLASS__, __FUNCTION__);
         }
@@ -2862,7 +2842,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                                                    . '</span>';
         }
         $this->_template_args['step_content'] = $this->_get_registration_step_content();
-        if (defined('DOING_AJAX')) {
+        if ($this->request->isAjax()) {
             $this->_return_json();
         }
         // grab header
@@ -2997,7 +2977,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         if (is_object($this->_reg_event)) {
             return true;
         }
-        $EVT_ID = (! empty($this->_req_data['event_id'])) ? absint($this->_req_data['event_id']) : false;
+
+        $EVT_ID = $this->request->getRequestParam('event_id[reg_status]', 0, 'int');
         if (! $EVT_ID) {
             return false;
         }
@@ -3009,8 +2990,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     /**
      * process_reg_step
      *
-     * @access        public
-     * @return string
+     * @return void
      * @throws DomainException
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -3031,9 +3011,8 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $cart = EE_Registry::instance()->SSN->cart();
         $step = ! $cart instanceof EE_Cart ? 'ticket' : 'questions';
         // if doing ajax then we need to verify the nonce
-        if (defined('DOING_AJAX')) {
-            $nonce = isset($this->_req_data[ $this->_req_nonce ])
-                ? sanitize_text_field($this->_req_data[ $this->_req_nonce ]) : '';
+        if ($this->request->isAjax()) {
+            $nonce = $this->request->getRequestParam($this->_req_nonce, '');
             $this->_verify_nonce($nonce, $this->_req_nonce);
         }
         switch ($step) {
@@ -3048,9 +3027,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         )
                     );
                 } else {
-                    $query_args['step_error'] = $this->_req_data['step_error'] = true;
+                    $this->request->setRequestParam('step_error', true);
+                    $query_args['step_error'] = $this->request->getRequestParam('step_error', true, 'bool');
                 }
-                if (defined('DOING_AJAX')) {
+                if ($this->request->isAjax()) {
                     $this->new_registration(); // display next step
                 } else {
                     $query_args = array(
@@ -3069,12 +3049,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 }
                 break;
             case 'questions':
-                if (
-                    ! isset(
-                        $this->_req_data['txn_reg_status_change'],
-                        $this->_req_data['txn_reg_status_change']['send_notifications']
-                    )
-                ) {
+                if (! $this->request->requestParamIsSet('txn_reg_status_change[send_notifications]')) {
                     add_filter('FHEE__EED_Messages___maybe_registration__deliver_notifications', '__return_false', 15);
                 }
                 // process registration
@@ -3092,7 +3067,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         'event_id'                => $this->_reg_event->ID(),
                         'uts'                     => time(),
                     );
-                    if (defined('DOING_AJAX')) {
+                    if ($this->request->isAjax()) {
                         // display registration form again because there are errors (maybe validation?)
                         $this->new_registration();
                         return;
@@ -3111,7 +3086,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                     $transaction->save();
                 }
                 EE_Registry::instance()->SSN->clear_session(__CLASS__, __FUNCTION__);
-                $this->_req_data = array();
                 $query_args = array(
                     'action'        => 'redirect_to_txn',
                     'TXN_ID'        => $transaction->ID(),
@@ -3143,13 +3117,13 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         EE_Registry::instance()->SSN->clear_session(__CLASS__, __FUNCTION__);
         $query_args = array(
             'action' => 'view_transaction',
-            'TXN_ID' => isset($this->_req_data['TXN_ID']) ? absint($this->_req_data['TXN_ID']) : 0,
+            'TXN_ID' => $this->request->getRequestParam('TXN_ID', 0, 'int'),
             'page'   => 'espresso_transactions',
         );
-        if (isset($this->_req_data['EVT_ID'], $this->_req_data['redirect_from'])) {
-            $query_args['EVT_ID'] = $this->_req_data['EVT_ID'];
-            $query_args['event_name'] = urlencode($this->_req_data['event_name']);
-            $query_args['redirect_from'] = $this->_req_data['redirect_from'];
+        if ($this->request->requestParamIsSet('EVT_ID') && $this->request->requestParamIsSet('redirect_from')) {
+            $query_args['EVT_ID'] = $this->request->getRequestParam('EVT_ID', 0, 'int');
+            $query_args['event_name'] = urlencode($this->request->getRequestParam('event_name'));
+            $query_args['redirect_from'] = $this->request->getRequestParam('redirect_from');
         }
         EE_Error::add_success(
             esc_html__(
@@ -3194,25 +3168,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         require_once(REG_ADMIN . 'EE_Attendee_Contact_List_Table.class.php');
-        $this->_req_data['orderby'] = ! empty($this->_req_data['orderby']) ? $this->_req_data['orderby'] : '';
-        switch ($this->_req_data['orderby']) {
+        $orderby = $this->request->getRequestParam('orderby');
+        switch ($orderby) {
             case 'ATT_ID':
-                $orderby = 'ATT_ID';
-                break;
             case 'ATT_fname':
-                $orderby = 'ATT_fname';
-                break;
             case 'ATT_email':
-                $orderby = 'ATT_email';
-                break;
             case 'ATT_city':
-                $orderby = 'ATT_city';
-                break;
             case 'STA_ID':
-                $orderby = 'STA_ID';
-                break;
             case 'CNT_ID':
-                $orderby = 'CNT_ID';
                 break;
             case 'Registration_Count':
                 $orderby = 'Registration_Count';
@@ -3220,36 +3183,31 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             default:
                 $orderby = 'ATT_lname';
         }
-        $sort = (isset($this->_req_data['order']) && ! empty($this->_req_data['order']))
-            ? $this->_req_data['order']
-            : 'ASC';
-        $current_page = isset($this->_req_data['paged']) && ! empty($this->_req_data['paged'])
-            ? $this->_req_data['paged']
-            : 1;
-        $per_page = isset($per_page) && ! empty($per_page) ? $per_page : 10;
-        $per_page = isset($this->_req_data['perpage']) && ! empty($this->_req_data['perpage'])
-            ? $this->_req_data['perpage']
-            : $per_page;
+        $sort = $this->request->getRequestParam('order', 'ASC');
+        $current_page = $this->request->getRequestParam('paged', 1, 'int');
+        $per_page = absint($per_page) ? $per_page : 10;
+        $per_page = $this->request->getRequestParam('perpage', $per_page, 'int');
         $_where = array();
-        if (! empty($this->_req_data['s'])) {
-            $sstr = '%' . $this->_req_data['s'] . '%';
+        $search_term = $this->request->getRequestParam('s');
+        if ($search_term) {
+            $search_term = '%' . $search_term . '%';
             $_where['OR'] = array(
-                'Registration.Event.EVT_name'       => array('LIKE', $sstr),
-                'Registration.Event.EVT_desc'       => array('LIKE', $sstr),
-                'Registration.Event.EVT_short_desc' => array('LIKE', $sstr),
-                'ATT_fname'                         => array('LIKE', $sstr),
-                'ATT_lname'                         => array('LIKE', $sstr),
-                'ATT_short_bio'                     => array('LIKE', $sstr),
-                'ATT_email'                         => array('LIKE', $sstr),
-                'ATT_address'                       => array('LIKE', $sstr),
-                'ATT_address2'                      => array('LIKE', $sstr),
-                'ATT_city'                          => array('LIKE', $sstr),
-                'Country.CNT_name'                  => array('LIKE', $sstr),
-                'State.STA_name'                    => array('LIKE', $sstr),
-                'ATT_phone'                         => array('LIKE', $sstr),
-                'Registration.REG_final_price'      => array('LIKE', $sstr),
-                'Registration.REG_code'             => array('LIKE', $sstr),
-                'Registration.REG_group_size'       => array('LIKE', $sstr),
+                'Registration.Event.EVT_name'       => array('LIKE', $search_term),
+                'Registration.Event.EVT_desc'       => array('LIKE', $search_term),
+                'Registration.Event.EVT_short_desc' => array('LIKE', $search_term),
+                'ATT_fname'                         => array('LIKE', $search_term),
+                'ATT_lname'                         => array('LIKE', $search_term),
+                'ATT_short_bio'                     => array('LIKE', $search_term),
+                'ATT_email'                         => array('LIKE', $search_term),
+                'ATT_address'                       => array('LIKE', $search_term),
+                'ATT_address2'                      => array('LIKE', $search_term),
+                'ATT_city'                          => array('LIKE', $search_term),
+                'Country.CNT_name'                  => array('LIKE', $search_term),
+                'State.STA_name'                    => array('LIKE', $search_term),
+                'ATT_phone'                         => array('LIKE', $search_term),
+                'Registration.REG_final_price'      => array('LIKE', $search_term),
+                'Registration.REG_code'             => array('LIKE', $search_term),
+                'Registration.REG_group_size'       => array('LIKE', $search_term),
             );
         }
         $offset = ($current_page - 1) * $per_page;
@@ -3291,8 +3249,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _resend_registration()
     {
         $this->_process_resend_registration();
-        $query_args = isset($this->_req_data['redirect_to'])
-            ? array('action' => $this->_req_data['redirect_to'], '_REG_ID' => $this->_req_data['_REG_ID'])
+        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $redirect_to = $this->request->getRequestParam('redirect_to');
+        $query_args = $redirect_to
+            ? array('action' => $redirect_to, '_REG_ID' => $REG_ID)
             : array('action' => 'default');
         $this->_redirect_after_action(false, '', '', $query_args, true);
     }
@@ -3307,27 +3267,27 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     public function _registrations_report_base($method_name_for_getting_query_params)
     {
+        $EVT_ID = $this->request->requestParamIsSet('EVT_ID')
+            ? $this->request->getRequestParam('EVT_ID', 0, 'int')
+            : null;
         if (! defined('EE_USE_OLD_CSV_REPORT_CLASS')) {
+            $request_params = $this->request->requestParams();
             wp_redirect(
                 EE_Admin_Page::add_query_args_and_nonce(
                     array(
                         'page'        => 'espresso_batch',
                         'batch'       => 'file',
-                        'EVT_ID'      => isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : null,
+                        'EVT_ID'      => $EVT_ID,
                         'filters'     => urlencode(
                             serialize(
                                 $this->$method_name_for_getting_query_params(
-                                    EEH_Array::is_set(
-                                        $this->_req_data,
-                                        'filters',
-                                        array()
-                                    )
+                                    EEH_Array::is_set($request_params, 'filters', [])
                                 )
                             )
                         ),
-                        'use_filters' => EEH_Array::is_set($this->_req_data, 'use_filters', false),
+                        'use_filters' => EEH_Array::is_set($request_params, 'use_filters', false),
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\RegistrationsReport'),
-                        'return_url'  => urlencode($this->_req_data['return_url']),
+                        'return_url'  => urlencode($this->request->getRequestParam('return_url')),
                     )
                 )
             );
@@ -3335,12 +3295,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $new_request_args = array(
                 'export' => 'report',
                 'action' => 'registrations_report_for_event',
-                'EVT_ID' => isset($this->_req_data['EVT_ID']) ? $this->_req_data['EVT_ID'] : null,
+                'EVT_ID' => $EVT_ID,
             );
-            $this->_req_data = array_merge($this->_req_data, $new_request_args);
+            $this->request->mergeRequestParams($new_request_args);
             if (is_readable(EE_CLASSES . 'EE_Export.class.php')) {
                 require_once(EE_CLASSES . 'EE_Export.class.php');
-                $EE_Export = EE_Export::instance($this->_req_data);
+                $EE_Export = EE_Export::instance($this->request->requestParams());
                 $EE_Export->export();
             }
         }
@@ -3362,7 +3322,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     {
         if (is_readable(EE_CLASSES . 'EE_Export.class.php')) {
             require_once(EE_CLASSES . 'EE_Export.class.php');
-            $EE_Export = EE_Export::instance($this->_req_data);
+            $EE_Export = EE_Export::instance($this->request->requestParams());
             $EE_Export->export_attendees();
         }
     }
@@ -3377,14 +3337,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                         'page'        => 'espresso_batch',
                         'batch'       => 'file',
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\AttendeesReport'),
-                        'return_url'  => urlencode($this->_req_data['return_url']),
+                        'return_url'  => urlencode($this->request->getRequestParam('return_url')),
                     )
                 )
             );
         } else {
             if (is_readable(EE_CLASSES . 'EE_Export.class.php')) {
                 require_once(EE_CLASSES . 'EE_Export.class.php');
-                $EE_Export = EE_Export::instance($this->_req_data);
+                $EE_Export = EE_Export::instance($this->request->requestParams());
                 $EE_Export->report_attendees();
             }
         }
@@ -3407,9 +3367,10 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
      */
     protected function _duplicate_attendee()
     {
-        $action = ! empty($this->_req_data['return']) ? $this->_req_data['return'] : 'default';
+        $REG_ID = $this->request->getRequestParam('_REG_ID', 0, 'int');
+        $action = $this->request->getRequestParam('return', 'default');
         // verify we have necessary info
-        if (empty($this->_req_data['_REG_ID'])) {
+        if (! $REG_ID) {
             EE_Error::add_error(
                 esc_html__(
                     'Unable to create the contact for the registration because the required parameters are not present (_REG_ID )',
@@ -3423,7 +3384,18 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $this->_redirect_after_action('', '', '', $query_args, true);
         }
         // okay necessary deets present... let's dupe the incoming attendee and attach to incoming registration.
-        $registration = $this->getRegistrationModel()->get_one_by_ID($this->_req_data['_REG_ID']);
+        $registration = $this->getRegistrationModel()->get_one_by_ID($REG_ID);
+        if (! $registration instanceof EE_Registration) {
+            throw new RuntimeException(
+                sprintf(
+                    esc_html__(
+                        'Unable to create the contact because a valid registration could not be retrieved for REG ID: %1$d',
+                        'event_espresso'
+                    ),
+                    $REG_ID
+                )
+            );
+        }
         $attendee = $registration->attendee();
         // remove relation of existing attendee on registration
         $registration->_remove_relation_to($attendee, 'Attendee');
@@ -3468,16 +3440,18 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         // for attendee updates
         if ($attendee instanceof EE_Attendee) {
             // note we should only be UPDATING attendees at this point.
+            $fname = $this->request->getRequestParam('ATT_fname', '');
+            $lname = $this->request->getRequestParam('ATT_lname', '');
             $updated_fields = array(
-                'ATT_fname'     => $this->_req_data['ATT_fname'],
-                'ATT_lname'     => $this->_req_data['ATT_lname'],
-                'ATT_full_name' => $this->_req_data['ATT_fname'] . ' ' . $this->_req_data['ATT_lname'],
-                'ATT_address'   => isset($this->_req_data['ATT_address']) ? $this->_req_data['ATT_address'] : '',
-                'ATT_address2'  => isset($this->_req_data['ATT_address2']) ? $this->_req_data['ATT_address2'] : '',
-                'ATT_city'      => isset($this->_req_data['ATT_city']) ? $this->_req_data['ATT_city'] : '',
-                'STA_ID'        => isset($this->_req_data['STA_ID']) ? $this->_req_data['STA_ID'] : '',
-                'CNT_ISO'       => isset($this->_req_data['CNT_ISO']) ? $this->_req_data['CNT_ISO'] : '',
-                'ATT_zip'       => isset($this->_req_data['ATT_zip']) ? $this->_req_data['ATT_zip'] : '',
+                'ATT_fname'     => $fname,
+                'ATT_lname'     => $lname,
+                'ATT_full_name' => "{$fname} {$lname}",
+                'ATT_address'   => $this->request->getRequestParam('ATT_address', ''),
+                'ATT_address2'  => $this->request->getRequestParam('ATT_address2', ''),
+                'ATT_city'      => $this->request->getRequestParam('ATT_city', ''),
+                'STA_ID'        => $this->request->getRequestParam('STA_ID', ''),
+                'CNT_ISO'       => $this->request->getRequestParam('CNT_ISO', ''),
+                'ATT_zip'       => $this->request->getRequestParam('ATT_zip', ''),
             );
             foreach ($updated_fields as $field => $value) {
                 $attendee->set($field, $value);
@@ -3485,14 +3459,14 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 
             // process contact details metabox form handler (which will also save the attendee)
             $contact_details_form = $this->getAttendeeContactDetailsMetaboxFormHandler($attendee);
-            $success = $contact_details_form->process($this->_req_data);
+            $success = $contact_details_form->process($this->request->requestParams());
 
             $attendee_update_callbacks = apply_filters(
                 'FHEE__Registrations_Admin_Page__insert_update_cpt_item__attendee_update',
                 array()
             );
             foreach ($attendee_update_callbacks as $a_callback) {
-                if (false === call_user_func_array($a_callback, array($attendee, $this->_req_data))) {
+                if (false === call_user_func_array($a_callback, array($attendee, $this->request->requestParams()))) {
                     throw new EE_Error(
                         sprintf(
                             esc_html__(
@@ -3751,29 +3725,24 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
     protected function _trash_or_restore_attendees($trash = true)
     {
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-        $success = 1;
+        $status = $trash ? 'trash' : 'publish';
         // Checkboxes
-        if (! empty($this->_req_data['checkbox']) && is_array($this->_req_data['checkbox'])) {
+        if ($this->request->requestParamIsSet('checkbox')) {
+            $ATT_IDs = $this->request->getRequestParam('checkbox', [], 'int', true);
             // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['checkbox']) > 1 ? 2 : 1;
+            $success = count($ATT_IDs) > 1 ? 2 : 1;
             // cycle thru checkboxes
-            foreach ($this->_req_data['checkbox'] as $ATT_ID) {
-                $updated = $trash ? $this->getAttendeeModel()->update_by_ID(array('status' => 'trash'), $ATT_ID)
-                    : $this->getAttendeeModel()->update_by_ID(array('status' => 'publish'), $ATT_ID);
+            foreach ($ATT_IDs as $ATT_ID) {
+                $updated = $this->getAttendeeModel()->update_by_ID(['status' => $status], $ATT_ID);
                 if (! $updated) {
                     $success = 0;
                 }
             }
         } else {
             // grab single id and delete
-            $ATT_ID = absint($this->_req_data['ATT_ID']);
-            // get attendee
-            $att = $this->getAttendeeModel()->get_one_by_ID($ATT_ID);
-            $updated = $trash ? $att->set_status('trash') : $att->set_status('publish');
-            $updated = $att->save() && $updated;
-            if (! $updated) {
-                $success = 0;
-            }
+            $ATT_ID = $this->request->getRequestParam('ATT_ID', 0, 'int');
+            // update attendee
+            $success = $this->getAttendeeModel()->update_by_ID(['status' => $status], $ATT_ID) ? 1 : 0;
         }
         $what = $success > 1
             ? esc_html__('Contacts', 'event_espresso')

--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -887,6 +887,6 @@ abstract class EE_Admin_List_Table extends WP_List_Table
     {
         $host = $this->_admin_page->get_request()->getServerParam('HTTP_HOST');
         $uri  = $this->_admin_page->get_request()->getServerParam('REQUEST_URI');
-        return urlencode("//{$host}{$uri}");
+        return urlencode(esc_url_raw("//{$host}{$uri}"));
     }
 }

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -2728,7 +2728,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
      *
      * @return void
      */
-    private function _display_espresso_notices()
+    protected function _display_espresso_notices()
     {
         $notices = $this->_get_transient(true);
         echo stripslashes($notices);

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1161,7 +1161,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
                 if (strpos($key, 'nonce') !== false) {
                     continue;
                 }
-                $args[ 'wp_referer[' . $key . ']' ] = $value;
+                $args[ 'wp_referer[' . $key . ']' ] = htmlspecialchars($value);
             }
         }
         return EEH_URL::add_query_args_and_nonce($args, $url, $exclude_nonce);

--- a/core/exceptions/ExceptionStackTraceDisplay.php
+++ b/core/exceptions/ExceptionStackTraceDisplay.php
@@ -100,14 +100,14 @@ class ExceptionStackTraceDisplay
 	<div class="ee-error-dev-msg-dv">
 		<p class="ee-error-dev-msg-pg">
 		    '
-               . sprintf(
-                   esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
-                   '<strong class="ee-error-dev-msg-str">',
-                   get_class($exception),
-                   '</strong>  &nbsp; <span>',
-                   $code . '</span>'
-                )
-               . '<br />
+            . sprintf(
+               esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
+               '<strong class="ee-error-dev-msg-str">',
+               get_class($exception),
+               '</strong>  &nbsp; <span>',
+               $code . '</span>'
+            )
+            . '<br />
             <span class="big-text">"' . trim($msg) . '"</span><br/>
             <a id="display-ee-error-trace-1'
                . $time
@@ -117,14 +117,14 @@ class ExceptionStackTraceDisplay
                 ' . esc_html__('click to view backtrace and class/method details', 'event_espresso') . '
             </a><br />
             '
-               . $exception->getFile()
-               . sprintf(
-                   esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
-                   ' &nbsp; <span class="small-text lt-grey-text">',
-                   $exception->getLine(),
-                   '</span>'
-                )
-               . '
+            . $exception->getFile()
+            . sprintf(
+               esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
+               ' &nbsp; <span class="small-text lt-grey-text">',
+               $exception->getLine(),
+               '</span>'
+            )
+            . '
         </p>
         <div id="ee-error-trace-1'
                . $time

--- a/core/exceptions/ExceptionStackTraceDisplay.php
+++ b/core/exceptions/ExceptionStackTraceDisplay.php
@@ -86,7 +86,7 @@ class ExceptionStackTraceDisplay
         return '
     <p>
         <span class="ee-error-user-msg-spn">' . trim($msg) . '</span> &nbsp; <sup>' . $code . '</sup>
-	</p>';
+    </p>';
     }
 
 

--- a/core/exceptions/ExceptionStackTraceDisplay.php
+++ b/core/exceptions/ExceptionStackTraceDisplay.php
@@ -101,12 +101,12 @@ class ExceptionStackTraceDisplay
 		<p class="ee-error-dev-msg-pg">
 		    '
                . sprintf(
-               esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
-               '<strong class="ee-error-dev-msg-str">',
-               get_class($exception),
-               '</strong>  &nbsp; <span>',
-               $code . '</span>'
-            )
+                   esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
+                   '<strong class="ee-error-dev-msg-str">',
+                   get_class($exception),
+                   '</strong>  &nbsp; <span>',
+                   $code . '</span>'
+                )
                . '<br />
             <span class="big-text">"' . trim($msg) . '"</span><br/>
             <a id="display-ee-error-trace-1'
@@ -119,11 +119,11 @@ class ExceptionStackTraceDisplay
             '
                . $exception->getFile()
                . sprintf(
-               esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
-               ' &nbsp; <span class="small-text lt-grey-text">',
-               $exception->getLine(),
-               '</span>'
-            )
+                   esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
+                   ' &nbsp; <span class="small-text lt-grey-text">',
+                   $exception->getLine(),
+                   '</span>'
+                )
                . '
         </p>
         <div id="ee-error-trace-1'

--- a/core/exceptions/ExceptionStackTraceDisplay.php
+++ b/core/exceptions/ExceptionStackTraceDisplay.php
@@ -101,11 +101,11 @@ class ExceptionStackTraceDisplay
 		<p class="ee-error-dev-msg-pg">
 		    '
             . sprintf(
-               esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
-               '<strong class="ee-error-dev-msg-str">',
-               get_class($exception),
-               '</strong>  &nbsp; <span>',
-               $code . '</span>'
+                esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
+                '<strong class="ee-error-dev-msg-str">',
+                get_class($exception),
+                '</strong>  &nbsp; <span>',
+                $code . '</span>'
             )
             . '<br />
             <span class="big-text">"' . trim($msg) . '"</span><br/>
@@ -119,10 +119,10 @@ class ExceptionStackTraceDisplay
             '
             . $exception->getFile()
             . sprintf(
-               esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
-               ' &nbsp; <span class="small-text lt-grey-text">',
-               $exception->getLine(),
-               '</span>'
+                esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
+                ' &nbsp; <span class="small-text lt-grey-text">',
+                $exception->getLine(),
+                '</span>'
             )
             . '
         </p>

--- a/core/exceptions/ExceptionStackTraceDisplay.php
+++ b/core/exceptions/ExceptionStackTraceDisplay.php
@@ -19,6 +19,18 @@ use ReflectionMethod;
 class ExceptionStackTraceDisplay
 {
 
+    /**
+     * @var   string
+     * @since $VID:$
+     */
+    private $class_name = '';
+
+    /**
+     * @var   string
+     * @since $VID:$
+     */
+    private $error_code = '';
+
 
     /**
      * @param Exception $exception
@@ -41,191 +53,185 @@ class ExceptionStackTraceDisplay
      */
     protected function displayException(Exception $exception)
     {
-        $error_code = '';
-        $trace_details = '';
-        $time = time();
-        $trace = $exception->getTrace();
         // get separate user and developer messages if they exist
         $msg = explode('||', $exception->getMessage());
         $user_msg = $msg[0];
         $dev_msg = isset($msg[1]) ? $msg[1] : $msg[0];
         $msg = WP_DEBUG ? $dev_msg : $user_msg;
-        // start gathering output
-        $output = $this->exceptionStyles();
-        $output .= '
-<div id="ee-error-message" class="error">';
-        if (! WP_DEBUG) {
-            $output .= '
-	<p>';
-        }
         // process trace info
+        $trace_details = $this->traceDetails($exception);
+        $code          = $exception->getCode() ?: $this->error_code;
+        // add helpful developer messages if debugging is on
+        // or generic non-identifying messages for non-privileged users
+        $error_message = WP_DEBUG
+            ? $this->developerError($exception, $msg, $code, $trace_details)
+            : $this->genericError($msg, $code);
+        // start gathering output
+        $output = '
+<div id="ee-error-message" class="error">
+    ' . $error_message . '
+</div>';
+        $styles = $this->exceptionStyles();
+        $scripts = $this->printScripts(true);
+        if (defined('DOING_AJAX')) {
+            echo wp_json_encode(array('error' => $styles . $output . $scripts));
+            exit();
+        }
+        echo $styles, $output, $scripts; // already escaped
+    }
+
+
+    private function genericError($msg, $code)
+    {
+        return '
+    <p>
+        <span class="ee-error-user-msg-spn">' . trim($msg) . '</span> &nbsp; <sup>' . $code . '</sup>
+	</p>';
+    }
+
+
+    /**
+     * @throws ReflectionException
+     */
+    private function developerError(Exception $exception, $msg, $code, $trace_details)
+    {
+        $time = time();
+        return '
+	<div class="ee-error-dev-msg-dv">
+		<p class="ee-error-dev-msg-pg">
+		    '
+               . sprintf(
+               esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
+               '<strong class="ee-error-dev-msg-str">',
+               get_class($exception),
+               '</strong>  &nbsp; <span>',
+               $code . '</span>'
+            )
+               . '<br />
+            <span class="big-text">"' . trim($msg) . '"</span><br/>
+            <a id="display-ee-error-trace-1'
+               . $time
+               . '" class="display-ee-error-trace-lnk small-text" rel="ee-error-trace-1'
+               . $time
+               . '">
+                ' . esc_html__('click to view backtrace and class/method details', 'event_espresso') . '
+            </a><br />
+            '
+               . $exception->getFile()
+               . sprintf(
+               esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
+               ' &nbsp; <span class="small-text lt-grey-text">',
+               $exception->getLine(),
+               '</span>'
+            )
+               . '
+        </p>
+        <div id="ee-error-trace-1'
+               . $time
+               . '-dv" class="ee-error-trace-dv" style="display: none;">
+            '
+               . $trace_details
+               . $this->classDetails() . '
+        </div>
+    </div>';
+    }
+
+
+    /**
+     * @throws ReflectionException
+     */
+    private function classDetails()
+    {
+        if (empty($this->class_name)) {
+            return '';
+        }
+        $a = new ReflectionClass($this->class_name);
+        return '
+            <div style="padding:3px; margin:0 0 1em; border:1px solid #999; background:#fff; border-radius:3px;">
+                <div style="padding:1em 2em; border:1px solid #999; background:#fcfcfc;">
+                    <h3>' . esc_html__('Class Details', 'event_espresso') . '</h3>
+                    <pre>' . $a . '</pre>
+                </div>
+            </div>';
+    }
+
+    /**
+     * @param Exception $exception
+     * @return string
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    private function traceDetails(Exception $exception)
+    {
+        $trace = $exception->getTrace();
         if (empty($trace)) {
-            $trace_details .= esc_html__(
+            return esc_html__(
                 'Sorry, but no trace information was available for this exception.',
                 'event_espresso'
             );
-        } else {
-            $trace_details .= '
-			<div id="ee-trace-details">
-			<table width="100%" border="0" cellpadding="5" cellspacing="0">
-				<tr>
-					<th scope="col" align="right" style="width:2.5%;">#</th>
-					<th scope="col" align="right" style="width:3.5%;">Line</th>
-					<th scope="col" align="left" style="width:40%;">File</th>
-					<th scope="col" align="left">
-					' . esc_html__('Class', 'event_espresso')
-                      . '->'
-                      . esc_html__('Method( arguments )', 'event_espresso') . '
-					</th>
-				</tr>';
-            $last_on_stack = count($trace) - 1;
-            // reverse array so that stack is in proper chronological order
-            $sorted_trace = array_reverse($trace);
-            foreach ($sorted_trace as $nmbr => $trace) {
-                $file = isset($trace['file']) ? $trace['file'] : '';
-                $class = isset($trace['class']) ? $trace['class'] : '';
-                $type = isset($trace['type']) ? $trace['type'] : '';
-                $function = isset($trace['function']) ? $trace['function'] : '';
-                $args = isset($trace['args']) ? $this->_convert_args_to_string($trace['args']) : '';
-                $args = isset($trace['args']) && count($trace['args']) > 4 ? ' <br />' . $args . '<br />' : $args;
-                $line = isset($trace['line']) ? $trace['line'] : '';
-                $zebra = $nmbr % 2 !== 0 ? ' odd' : '';
-                if (empty($file) && ! empty($class)) {
-                    $a = new ReflectionClass($class);
-                    $file = $a->getFileName();
-                    if (empty($line) && ! empty($function)) {
-                        try {
-                            // if $function is a closure, this throws an exception
-                            $b = new ReflectionMethod($class, $function);
-                            $line = $b->getStartLine();
-                        } catch (Exception $closure_exception) {
-                            $line = 'unknown';
-                        }
+        }
+
+        $trace_details = '
+        <div id="ee-trace-details">
+            <table>
+                <tr>
+                    <th scope="col" class="ee-align-right" style="width:2.5%;">#</th>
+                    <th scope="col" class="ee-align-right" style="width:3.5%;">Line</th>
+                    <th scope="col" class="ee-align-left" style="width:40%;">File</th>
+                    <th scope="col" class="ee-align-left">
+                    ' . esc_html__('Class', 'event_espresso')
+                              . '->'
+                              . esc_html__('Method( arguments )', 'event_espresso') . '
+                    </th>
+                </tr>';
+        $last_on_stack = count($trace) - 1;
+        // reverse array so that stack is in proper chronological order
+        $sorted_trace = array_reverse($trace);
+        foreach ($sorted_trace as $nmbr => $trace) {
+            $this->class_name = isset($trace['class']) ? $trace['class'] : '';
+            $file     = isset($trace['file']) ? $trace['file'] : '';
+            $type     = isset($trace['type']) ? $trace['type'] : '';
+            $function = isset($trace['function']) ? $trace['function'] : '';
+            $args     = isset($trace['args']) ? $this->_convert_args_to_string($trace['args']) : '';
+            $args     = isset($trace['args']) && count($trace['args']) > 4 ? ' <br />' . $args . '<br />' : $args;
+            $line     = isset($trace['line']) ? $trace['line'] : '';
+            if (empty($file) && ! empty($this->class_name)) {
+                $a    = new ReflectionClass($this->class_name);
+                $file = $a->getFileName();
+                if (empty($line) && ! empty($function)) {
+                    try {
+                        // if $function is a closure, this throws an exception
+                        $b    = new ReflectionMethod($this->class_name, $function);
+                        $line = $b->getStartLine();
+                    } catch (Exception $closure_exception) {
+                        $line = 'unknown';
                     }
                 }
-                if ($nmbr === $last_on_stack) {
-                    $file = $exception->getFile() !== '' ? $exception->getFile() : $file;
-                    $line = $exception->getLine() !== '' ? $exception->getLine() : $line;
-                    $error_code = $this->generate_error_code($file, $trace['function'], $line);
-                }
-                $file = EEH_File::standardise_directory_separators($file);
-                $nmbr = ! empty($nmbr) ? $nmbr : '&nbsp;';
-                $line = ! empty($line) ? $line : '&nbsp;';
-                $file = ! empty($file) ? $file : '&nbsp;';
-                $class_display = ! empty($class) ? $class : '';
-                $type = ! empty($type) ? $type : '';
-                $function = ! empty($function) ? $function : '';
-                $args = ! empty($args) ? '( ' . $args . ' )' : '()';
-                $trace_details .= '
-					<tr>
-						<td align="right" valign="top" class="'
-                                  . $zebra
-                                  . '">'
-                                  . $nmbr
-                                  . '</td>
-						<td align="right" valign="top" class="'
-                                  . $zebra
-                                  . '">'
-                                  . $line
-                                  . '</td>
-						<td align="left" valign="top" class="'
-                                  . $zebra
-                                  . '">'
-                                  . $file
-                                  . '</td>
-						<td align="left" valign="top" class="'
-                                  . $zebra
-                                  . '">'
-                                  . $class_display
-                                  . $type
-                                  . $function
-                                  . $args
-                                  . '</td>
-					</tr>';
             }
+            if ($nmbr === $last_on_stack) {
+                $file       = $exception->getFile() ?: $file;
+                $line       = $exception->getLine() ?: $line;
+                $this->error_code = $this->generate_error_code($file, $trace['function'], $line);
+            }
+            $file          = EEH_File::standardise_directory_separators($file);
+            $nmbr          = ! empty($nmbr) ? $nmbr : '&nbsp;';
+            $line          = ! empty($line) ? $line : '&nbsp;';
+            $file          = ! empty($file) ? $file : '&nbsp;';
+            $type          = ! empty($type) ? $type : '';
+            $function      = ! empty($function) ? $function : '';
+            $args          = ! empty($args) ? '( ' . $args . ' )' : '()';
             $trace_details .= '
-			 </table>
-			</div>';
+                <tr>
+                    <td class="ee-align-right">' . $nmbr . '</td>
+                    <td class="ee-align-right">' . $line . '</td>
+                    <td class="ee-align-left">' . $file . '</td>
+                    <td class="ee-align-left">' . $this->class_name . $type . $function . $args . '</td>
+                </tr>';
         }
-        $code = $exception->getCode() ? $exception->getCode() : $error_code;
-        // add generic non-identifying messages for non-privileged users
-        if (! WP_DEBUG) {
-            $output .= '<span class="ee-error-user-msg-spn">'
-                       . trim($msg)
-                       . '</span> &nbsp; <sup>'
-                       . $code
-                       . '</sup><br />';
-        } else {
-            // or helpful developer messages if debugging is on
-            $output .= '
-		<div class="ee-error-dev-msg-dv">
-			<p class="ee-error-dev-msg-pg">
-				'
-                       . sprintf(
-                           esc_html__('%1$sAn %2$s was thrown!%3$s code: %4$s', 'event_espresso'),
-                           '<strong class="ee-error-dev-msg-str">',
-                           get_class($exception),
-                           '</strong>  &nbsp; <span>',
-                           $code . '</span>'
-                       )
-                       . '<br />
-				<span class="big-text">"'
-                       . trim($msg)
-                       . '"</span><br/>
-				<a id="display-ee-error-trace-1'
-                       . $time
-                       . '" class="display-ee-error-trace-lnk small-text" rel="ee-error-trace-1'
-                       . $time
-                       . '">
-					'
-                       . esc_html__('click to view backtrace and class/method details', 'event_espresso')
-                       . '
-				</a><br />
-				'
-                       . $exception->getFile()
-                       . sprintf(
-                           esc_html__('%1$s( line no: %2$s )%3$s', 'event_espresso'),
-                           ' &nbsp; <span class="small-text lt-grey-text">',
-                           $exception->getLine(),
-                           '</span>'
-                       )
-                       . '
-			</p>
-			<div id="ee-error-trace-1'
-                       . $time
-                       . '-dv" class="ee-error-trace-dv" style="display: none;">
-				'
-                       . $trace_details;
-            if (! empty($class)) {
-                $output .= '
-				<div style="padding:3px; margin:0 0 1em; border:1px solid #999; background:#fff; border-radius:3px;">
-					<div style="padding:1em 2em; border:1px solid #999; background:#fcfcfc;">
-						<h3>' . esc_html__('Class Details', 'event_espresso') . '</h3>';
-                $a = new ReflectionClass($class);
-                $output .= '
-						<pre>' . $a . '</pre>
-					</div>
-				</div>';
-            }
-            $output .= '
-			</div>
-		</div>
-		<br />';
-        }
-        // remove last linebreak
-        $output = substr($output, 0, -6);
-        if (! WP_DEBUG) {
-            $output .= '
-	</p>';
-        }
-        $output .= '
-</div>';
-        $output .= $this->printScripts(true);
-        if (defined('DOING_AJAX')) {
-            echo wp_json_encode(array('error' => $output));
-            exit();
-        }
-        echo $output; // already escaped
+        $trace_details .= '
+            </table>
+        </div>';
+        return $trace_details;
     }
 
 
@@ -323,53 +329,52 @@ class ExceptionStackTraceDisplay
 
 
     /**
-     * _exception_styles
-     *
      * @return string
      */
     private function exceptionStyles()
     {
         return '
-<style type="text/css">
+<style media="screen">
 	#ee-error-message {
 		max-width:90% !important;
-		margin: 0 5%;
+		margin: 2em 5%;
 	}
 	.ee-error-dev-msg-pg,
 	.error .ee-error-dev-msg-pg {
 		padding:1em;
 		margin:0 0 1em;
-		border:2px solid #E44064;
+		border:2px solid #e65983;
 		background:#fff;
 		border-radius:3px;
 		line-height: 1.5em;;
 	}
 	#ee-trace-details {
-		padding:3px;
 		margin:0 0 1em;
-		border:1px solid #999;
-		background:#f9f9f9;
-		border-radius:3px;
 	}
 	#ee-trace-details table {
-		border:1px solid #999;
-		border-bottom:none;
 		background:#fff;
+		width: 100%;
 	}
 	#ee-trace-details table th {
-		background:#eee;
-		border-bottom:1px solid #ccc;
+		background:#e6e6e6;
+		padding: .75rem 1.5rem;
 	}
 	#ee-trace-details table td {
-		border-bottom:1px solid #e8e8e8;
-		padding: 10px 5px;
+		padding: .75rem 1.5rem;
 	}
-	#ee-trace-details table td.odd {
-		background:#fdfdfd;
+	#ee-trace-details table .ee-align-left {
+		text-align: start;
+	}
+	#ee-trace-details table .ee-align-right {
+		text-align: end;
+	}
+	#ee-trace-details tr:nth-child(odd) {
+		background:#f6f6f6;
 	}
 	.display-ee-error-trace-lnk {
-		color:blue;
+		color: #008dcb;
 		cursor:pointer;
+		font-weight: bold;
 	}
 	.display-ee-error-trace-lnk:hover {
 		text-decoration:underline;
@@ -398,7 +403,8 @@ class ExceptionStackTraceDisplay
     private function printScripts($force_print = false)
     {
         if (! $force_print && (did_action('admin_enqueue_scripts') || did_action('wp_enqueue_scripts'))) {
-            if (wp_script_is('ee_error_js', 'enqueued')) {
+            //  if script is already enqueued then we can just get out
+            if (wp_script_is('ee_error_js')) {
                 return '';
             }
             if (wp_script_is('ee_error_js', 'registered')) {
@@ -406,19 +412,21 @@ class ExceptionStackTraceDisplay
                 wp_enqueue_style('espresso_custom_css');
                 wp_enqueue_script('ee_error_js');
                 wp_localize_script('ee_error_js', 'ee_settings', array('wp_debug' => WP_DEBUG));
+                return '';
             }
-        } else {
-            return '
+        }
+        $jquery = esc_url_raw(includes_url() . 'js/jquery/jquery.js');
+        $core = esc_url_raw(EE_GLOBAL_ASSETS_URL . 'scripts/espresso_core.js?ver=' . espresso_version());
+        $ee_error = esc_url_raw(EE_GLOBAL_ASSETS_URL . 'scripts/EE_Error.js?ver=' . espresso_version());
+        return '
 <script>
 /* <![CDATA[ */
-var ee_settings = {"wp_debug":"' . WP_DEBUG . '"};
+const ee_settings = {"wp_debug":"' . WP_DEBUG . '"};
 /* ]]> */
 </script>
-<script src="' . esc_url_raw(includes_url() . 'js/jquery/jquery.js') . '" type="text/javascript"></script>
-<script src="' . esc_url_raw(EE_GLOBAL_ASSETS_URL . 'scripts/espresso_core.js' . '?ver=' . espresso_version()) . '" type="text/javascript"></script>
-<script src="' . esc_url_raw(EE_GLOBAL_ASSETS_URL . 'scripts/EE_Error.js' . '?ver=' . espresso_version()) . '" type="text/javascript"></script>
+<script src="' . $jquery . '" type="text/javascript" ></script>
+<script src="' . $core . '" type="text/javascript" ></script>
+<script src="' . $ee_error . '" type="text/javascript" ></script>
 ';
-        }
-        return '';
     }
 }

--- a/core/services/request/Request.php
+++ b/core/services/request/Request.php
@@ -179,6 +179,19 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
 
 
     /**
+     * merges the incoming array of parameters into the existing request parameters
+     *
+     * @param array $request_params
+     * @return void
+     * @since   $VID:$
+     */
+    public function mergeRequestParams(array $request_params)
+    {
+        $this->request_params->mergeRequestParams($request_params);
+    }
+
+
+    /**
      * returns sanitized value for a request param if the given key exists
      *
      * @param string     $key

--- a/core/services/request/RequestInterface.php
+++ b/core/services/request/RequestInterface.php
@@ -197,4 +197,14 @@ interface RequestInterface extends RequestTypeContextCheckerInterface
      * @param bool $is_bot
      */
     public function setIsBot($is_bot);
+
+
+    /**
+     * merges the incoming array of parameters into the existing request parameters
+     *
+     * @param array $request_params
+     * @return mixed
+     * @since   $VID:$
+     */
+    public function mergeRequestParams(array $request_params);
 }

--- a/core/services/request/RequestParams.php
+++ b/core/services/request/RequestParams.php
@@ -102,6 +102,19 @@ class RequestParams
 
 
     /**
+     * merges the incoming array of parameters into the existing request parameters
+     *
+     * @param array $request_params
+     * @return void
+     * @since   $VID:$
+     */
+    public function mergeRequestParams(array $request_params)
+    {
+        $this->request = array_merge_recursive($this->request, $request_params);
+    }
+
+
+    /**
      * returns   the value for a request param if the given key exists
      *
      * @param string     $key

--- a/core/templates/global_assets/scripts/EE_Error.js
+++ b/core/templates/global_assets/scripts/EE_Error.js
@@ -1,31 +1,32 @@
 jQuery(document).ready(function($) {
 
-	var $message = $('#ee-error-message');
-	var $notices = $('#espresso-notices');
-    var $body = $('body');
+	const $message = $('#ee-error-message');
+	const $notices = $('#espresso-notices');
+	const $body = $('body');
 
-    var target;
+	let target;
 
-	if ($message.length ) {
-        $message.remove();
-		if ($notices.size() ) {
+	if ($message.length) {
+		if ($notices.length) {
 			target = $notices;
-		} else if ( $('#screen-meta-links').size() ) {
+		} else if ( $('#screen-meta-links').length ) {
 			target = $('#screen-meta-links');
-		} else if ( $('#wpbody-content').size() ) {
+		} else if ( $('#wpbody-content').length ) {
 			target = $('#wpbody-content');
 		} else {
-			target = $body;
+			target = {};
 		}
 
-		$( target ).html($message).css(
-            {
-                'position': 'relative',
-                'top': 0, 'left': 0,
-                'margin': '3em 1em 0 0',
-                'z-index': 5
-            }
-		);
+		if (target.length) {
+			$(target).html($message).css(
+				{
+					'position': 'relative',
+					'top': 0, 'left': 0,
+					'margin': '3em 1em 0 0',
+					'z-index': 5
+				}
+			);
+		}
 		//set from wp_localize_script in php
 		if( ee_settings.wp_debug !== '1' ) {
 			$( '.ee-error-trace-dv').hide();
@@ -34,7 +35,7 @@ jQuery(document).ready(function($) {
         $body.on( 'click', '.display-ee-error-trace-lnk', function(e) {
 			e.preventDefault();
 			e.stopPropagation();
-			var traceTable = '#' + $(this).attr('rel') +'-dv';
+			const traceTable = '#' + $(this).attr('rel') +'-dv';
 			$( traceTable ).slideToggle();
 		});
 
@@ -42,8 +43,8 @@ jQuery(document).ready(function($) {
 
 
 	$('.dismiss-ee-nag-notice').click(function(event) {
-		var nag_notice = $(this).data('target');
-		if ( $('#'+nag_notice).size() ) {
+		const nag_notice = $(this).data('target');
+		if ( $('#'+nag_notice).length ) {
 			event.preventDefault();
 			$.ajax({
 				type: "POST",
@@ -70,7 +71,7 @@ jQuery(document).ready(function($) {
 				},
 				error: function() {
 					$('#'+nag_notice).fadeOut('fast');
-					var msg = {};
+					const msg = {};
 					msg.errors = ee_dismiss.unknown_error;
 					console.log( msg );
 					window.show_admin_page_ajax_msg( msg );
@@ -78,7 +79,5 @@ jQuery(document).ready(function($) {
 				});
 		}
 	});
-
-
 
 });

--- a/tests/mocks/core/services/request/RequestMockBlank.php
+++ b/tests/mocks/core/services/request/RequestMockBlank.php
@@ -220,4 +220,9 @@ class RequestMockBlank implements RequestInterface
     public function slug()
     {
     }
+
+
+    public function mergeRequestParams(array $request_params)
+    {
+    }
 }


### PR DESCRIPTION
This PR simply updates the Registrations Admin by replacing all uses of the legacy `_req_data` array with functionality on the new Request class