### PR TITLE
Fix Ticket Selector Caps Restrictions Issue

### DIFF
--- a/modules/ticket_selector/ProcessTicketSelectorPostData.php
+++ b/modules/ticket_selector/ProcessTicketSelectorPostData.php
@@ -180,10 +180,18 @@ class ProcessTicketSelectorPostData
         // will only have one element and the value will be the ticket ID
         // ex: row qty = [ 0 => TKT_ID ]
         if ($max_atndz === 1 && count($row_qty) === 1) {
-            // so we'll grab that ticket ID, use it as the key, and set the value to 1
+            // if the TS used radio buttons, then the ticket ID is stored differently in the request data
+            $raw_qty = $this->request->getRequestParam($input_key);
+            // explode integers by the dash if qty is a string
+            $delimiter = is_string($raw_qty) && strpos($raw_qty, '-') ? '-' : '';
+            if ($delimiter !== '') {
+                $row_qty = explode($delimiter, $raw_qty);
+            }
+            // grab that ticket ID regardless of where it is
+            $ticket_id = isset($row_qty[0]) ? $row_qty[0] : key($row_qty);
+            // use it as the key, and set the value to 1
             // ex: row qty = [ TKT_ID => 1 ]
-            $ticket_id = array_pop($row_qty);
-            $row_qty = [ $ticket_id => 1 ];
+            $row_qty = [$ticket_id => 1];
         }
         foreach ($this->valid_data[ self::DATA_KEY_TICKET_ID ] as $ticket_id) {
             $qty = isset($row_qty[ $ticket_id ]) ? $row_qty[ $ticket_id ] : 0;

--- a/modules/ticket_selector/ProcessTicketSelectorPostData.php
+++ b/modules/ticket_selector/ProcessTicketSelectorPostData.php
@@ -20,7 +20,7 @@ class ProcessTicketSelectorPostData
 
     const DATA_KEY_MAX_ATNDZ     = 'max_atndz';
 
-    const DATA_KEY_QUANTITY      = 'qty';
+    const DATA_KEY_QUANTITY      = 'ticket-selections';
 
     const DATA_KEY_RETURN_URL    = 'return_url';
 
@@ -175,10 +175,19 @@ class ProcessTicketSelectorPostData
                 )
             );
         }
+        $max_atndz = $this->valid_data[ self::DATA_KEY_MAX_ATNDZ ];
+        // if max attendees is 1 then the incoming row qty array
+        // will only have one element and the value will be the ticket ID
+        // ex: row qty = [ 0 => TKT_ID ]
+        if ($max_atndz === 1 && count($row_qty) === 1) {
+            // so we'll grab that ticket ID, use it as the key, and set the value to 1
+            // ex: row qty = [ TKT_ID => 1 ]
+            $ticket_id = array_pop($row_qty);
+            $row_qty = [ $ticket_id => 1 ];
+        }
         foreach ($this->valid_data[ self::DATA_KEY_TICKET_ID ] as $ticket_id) {
             $qty = isset($row_qty[ $ticket_id ]) ? $row_qty[ $ticket_id ] : 0;
-            // sanitize as integers
-            $this->valid_data[ self::DATA_KEY_QUANTITY ][]     = $qty;
+            $this->valid_data[ self::DATA_KEY_QUANTITY ][ $ticket_id ]     = $qty;
             $this->valid_data[ self:: DATA_KEY_TOTAL_TICKETS ] += $qty;
         }
     }

--- a/modules/ticket_selector/TicketSelectorRowSimple.php
+++ b/modules/ticket_selector/TicketSelectorRowSimple.php
@@ -28,6 +28,10 @@ class TicketSelectorRowSimple extends TicketSelectorRow
     }
 
 
+    /**
+     * @return bool|string
+     * @throws EE_Error
+     */
     public function getTicketDescription()
     {
         $filtered_row_content = $this->getFilteredRowContents();

--- a/modules/ticket_selector/TicketSelectorRowStandard.php
+++ b/modules/ticket_selector/TicketSelectorRowStandard.php
@@ -53,7 +53,7 @@ class TicketSelectorRowStandard extends TicketSelectorRow
     /**
      * @var boolean
      */
-    protected $hidden_input_qty;
+    protected $hidden_input_qty = false;
 
     /**
      * @var string
@@ -156,7 +156,6 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         );
         $filtered_row_content = $this->getFilteredRowContents();
         if ($filtered_row_content !== false) {
-            $this->hidden_input_qty = true;
             if ($this->max_attendees === 1) {
                 return $ticket_selector_row_html
                        . $filtered_row_content
@@ -314,17 +313,19 @@ class TicketSelectorRowStandard extends TicketSelectorRow
      */
     protected function onlyOneAttendeeCanRegister()
     {
+        $this->hidden_input_qty = false;
         // display submit button since we have tickets available
         add_filter('FHEE__EE_Ticket_Selector__display_ticket_selector_submit', '__return_true');
-        $this->hidden_input_qty = false;
-        $id = 'ticket-selector-tbl-qty-slct-' . $this->EVT_ID . '-' . $this->row;
-        $html = '<label class="ee-a11y-screen-reader-text" for="' . $id . '">';
-        $html .= esc_html__('Select this ticket', 'event_espresso') . '</label>';
-        $html .= '<input type="radio" name="tkt-slctr-qty-' . $this->EVT_ID . '[' . $this->ticket->ID() . ']"';
-        $html .= ' id="' . $id . '"';
-        $html .= ' class="ticket-selector-tbl-qty-slct" value="1"';
-        $html .= $this->total_tickets === 1 ? ' checked="checked"' : '';
-        $html .= ' title=""/>';
+
+        $TKT   = $this->ticket->ID();
+        $label = esc_html__('Select this ticket', 'event_espresso');
+        $name  = "tkt-slctr-qty-{$this->EVT_ID}[]";
+        $class = "ticket-selector-tbl-qty-slct";
+        $id    = "{$class}-{$this->EVT_ID}-{$this->row}";
+        $checked = $this->total_tickets === 1 ? ' checked="checked"' : '';
+
+        $html = "<label class='ee-a11y-screen-reader-text' for='{$id}' >{$label}</label>";
+        $html .= "<input type='radio'{$checked} name='{$name}' id='{$id}' class='{$class}' value='{$TKT}' title='' />";
         return $html;
     }
 
@@ -337,24 +338,26 @@ class TicketSelectorRowStandard extends TicketSelectorRow
      */
     protected function ticketQuantitySelector()
     {
+        $this->hidden_input_qty = false;
         // display submit button since we have tickets available
         add_filter('FHEE__EE_Ticket_Selector__display_ticket_selector_submit', '__return_true');
-        $this->hidden_input_qty = false;
-        $id = 'ticket-selector-tbl-qty-slct-' . $this->EVT_ID . '-' . $this->row;
-        $html = '<label class="ee-a11y-screen-reader-text" for="' . $id . '">';
-        $html .= esc_html__('Quantity', 'event_espresso') . '</label>';
-        $html .= '<select name="tkt-slctr-qty-' . $this->EVT_ID . '[' . $this->ticket->ID() . ']"';
-        $html .= ' id="' . $id . '"';
-        $html .= ' class="ticket-selector-tbl-qty-slct">';
+
+        $TKT = $this->ticket->ID();
+        $label = esc_html__('Quantity', 'event_espresso');
+        $class = 'ticket-selector-tbl-qty-slct';
+        $id = "{$class}-{$this->EVT_ID}-{$this->row}";
+
+        $html = "<label class='ee-a11y-screen-reader-text' for='{$id}' >{$label}</label>";
+        $html .= "<select name='tkt-slctr-qty-{$this->EVT_ID}[{$TKT}]' id='{$id}' class='{$class}'>";
         // this ensures that non-required tickets with non-zero MIN QTYs don't HAVE to be purchased
         if ($this->min !== 0 && ! $this->ticket->required()) {
-            $html .= '<option value="0">&nbsp;0&nbsp;</option>';
+            $html .= "<option value='0'>&nbsp;0&nbsp;</option>";
         }
         // offer ticket quantities from the min to the max
         for ($i = $this->min; $i <= $this->max; $i++) {
-            $html .= '<option value="' . $i . '">&nbsp;' . $i . '&nbsp;</option>';
+            $html .= "<option value='{$i}'>&nbsp;{$i}&nbsp;</option>";
         }
-        $html .= '</select>';
+        $html .= "</select>";
         return $html;
     }
 
@@ -368,14 +371,13 @@ class TicketSelectorRowStandard extends TicketSelectorRow
     protected function ticketQtyAndIdHiddenInputs()
     {
         $html = '';
+        $EVT = $this->EVT_ID;
+        $TKT = $this->ticket->ID();
         // depending on group reg we need to change the format for qty
         if ($this->hidden_input_qty) {
-            $html .= '<input type="hidden" name="tkt-slctr-qty-' . $this->EVT_ID . '['
-                     . $this->ticket->ID()
-                     . ']" value="0"/>';
+            $html .= "<input type='hidden' name='tkt-slctr-qty-{$EVT}[]' value='0' />";
         }
-        $html .= '<input type="hidden" name="tkt-slctr-ticket-id-' . $this->EVT_ID . '[]"';
-        $html .= ' value="' . $this->ticket->ID() . '"/>';
+        $html .= "<input type='hidden' name='tkt-slctr-ticket-id-{$EVT}[]' value='{$TKT}' />";
         return $html;
     }
 }

--- a/modules/ticket_selector/TicketSelectorRowStandard.php
+++ b/modules/ticket_selector/TicketSelectorRowStandard.php
@@ -155,13 +155,14 @@ class TicketSelectorRowStandard extends TicketSelectorRow
             . espresso_get_object_css_class($this->ticket)
         );
         $filtered_row_content = $this->getFilteredRowContents();
-        if ($filtered_row_content !== false && $this->max_attendees === 1) {
-            return $ticket_selector_row_html
-                   . $filtered_row_content
-                   . $this->ticketQtyAndIdHiddenInputs()
-                   . EEH_HTML::trx();
-        }
         if ($filtered_row_content !== false) {
+            $this->hidden_input_qty = true;
+            if ($this->max_attendees === 1) {
+                return $ticket_selector_row_html
+                       . $filtered_row_content
+                       . $this->ticketQtyAndIdHiddenInputs()
+                       . EEH_HTML::trx();
+            }
             return $ticket_selector_row_html
                    . $filtered_row_content
                    . EEH_HTML::trx();
@@ -309,6 +310,7 @@ class TicketSelectorRowStandard extends TicketSelectorRow
      * onlyOneAttendeeCanRegister
      *
      * @return string
+     * @throws EE_Error
      */
     protected function onlyOneAttendeeCanRegister()
     {
@@ -318,9 +320,9 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         $id = 'ticket-selector-tbl-qty-slct-' . $this->EVT_ID . '-' . $this->row;
         $html = '<label class="ee-a11y-screen-reader-text" for="' . $id . '">';
         $html .= esc_html__('Select this ticket', 'event_espresso') . '</label>';
-        $html .= '<input type="radio" name="tkt-slctr-qty-' . $this->EVT_ID . '"';
+        $html .= '<input type="radio" name="tkt-slctr-qty-' . $this->EVT_ID . '[' . $this->ticket->ID() . ']"';
         $html .= ' id="' . $id . '"';
-        $html .= ' class="ticket-selector-tbl-qty-slct" value="' . $this->row . '-1"';
+        $html .= ' class="ticket-selector-tbl-qty-slct" value="1"';
         $html .= $this->total_tickets === 1 ? ' checked="checked"' : '';
         $html .= ' title=""/>';
         return $html;
@@ -341,7 +343,7 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         $id = 'ticket-selector-tbl-qty-slct-' . $this->EVT_ID . '-' . $this->row;
         $html = '<label class="ee-a11y-screen-reader-text" for="' . $id . '">';
         $html .= esc_html__('Quantity', 'event_espresso') . '</label>';
-        $html .= '<select name="tkt-slctr-qty-' . $this->EVT_ID . '[]"';
+        $html .= '<select name="tkt-slctr-qty-' . $this->EVT_ID . '[' . $this->ticket->ID() . ']"';
         $html .= ' id="' . $id . '"';
         $html .= ' class="ticket-selector-tbl-qty-slct">';
         // this ensures that non-required tickets with non-zero MIN QTYs don't HAVE to be purchased
@@ -368,7 +370,9 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         $html = '';
         // depending on group reg we need to change the format for qty
         if ($this->hidden_input_qty) {
-            $html .= '<input type="hidden" name="tkt-slctr-qty-' . $this->EVT_ID . '[]" value="0"/>';
+            $html .= '<input type="hidden" name="tkt-slctr-qty-' . $this->EVT_ID . '['
+                     . $this->ticket->ID()
+                     . ']" value="0"/>';
         }
         $html .= '<input type="hidden" name="tkt-slctr-ticket-id-' . $this->EVT_ID . '[]"';
         $html .= ' value="' . $this->ticket->ID() . '"/>';

--- a/modules/ticket_selector/TicketSelectorRowStandard.php
+++ b/modules/ticket_selector/TicketSelectorRowStandard.php
@@ -319,13 +319,13 @@ class TicketSelectorRowStandard extends TicketSelectorRow
 
         $TKT   = $this->ticket->ID();
         $label = esc_html__('Select this ticket', 'event_espresso');
-        $name  = "tkt-slctr-qty-{$this->EVT_ID}[]";
+        $name  = "tkt-slctr-qty-{$this->EVT_ID}";
         $class = "ticket-selector-tbl-qty-slct";
         $id    = "{$class}-{$this->EVT_ID}-{$this->row}";
         $checked = $this->total_tickets === 1 ? ' checked="checked"' : '';
 
         $html = "<label class='ee-a11y-screen-reader-text' for='{$id}' >{$label}</label>";
-        $html .= "<input type='radio'{$checked} name='{$name}' id='{$id}' class='{$class}' value='{$TKT}' title='' />";
+        $html .= "<input type='radio'{$checked} name='{$name}' id='{$id}' class='{$class}' value='{$TKT}-1' title='' />";
         return $html;
     }
 

--- a/modules/ticket_selector/templates/simple_ticket_selector.template.php
+++ b/modules/ticket_selector/templates/simple_ticket_selector.template.php
@@ -11,7 +11,10 @@
 ?>
 
 <?php echo $hidden_inputs; // already escaped ?>
-    <input type="hidden" name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[]" value="1" />
+    <input type="hidden"
+           name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[<?php echo esc_attr($TKT_ID); ?>]"
+           value="1"
+    />
     <input type="hidden"
            name="tkt-slctr-ticket-id-<?php echo esc_attr($EVT_ID); ?>[]"
            value="<?php echo esc_attr($TKT_ID); ?>"

--- a/modules/ticket_selector/templates/simple_ticket_selector.template.php
+++ b/modules/ticket_selector/templates/simple_ticket_selector.template.php
@@ -12,8 +12,8 @@
 
 <?php echo $hidden_inputs; // already escaped ?>
     <input type="hidden"
-           name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[<?php echo esc_attr($TKT_ID); ?>]"
-           value="1"
+           name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[]"
+           value="<?php echo esc_attr($TKT_ID); ?>"
     />
     <input type="hidden"
            name="tkt-slctr-ticket-id-<?php echo esc_attr($EVT_ID); ?>[]"

--- a/modules/ticket_selector/templates/simple_ticket_selector.template.php
+++ b/modules/ticket_selector/templates/simple_ticket_selector.template.php
@@ -12,8 +12,8 @@
 
 <?php echo $hidden_inputs; // already escaped ?>
     <input type="hidden"
-           name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[]"
-           value="<?php echo esc_attr($TKT_ID); ?>"
+           name="tkt-slctr-qty-<?php echo esc_attr($EVT_ID); ?>[<?php echo esc_attr($TKT_ID); ?>]"
+           value="1"
     />
     <input type="hidden"
            name="tkt-slctr-ticket-id-<?php echo esc_attr($EVT_ID); ?>[]"

--- a/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
+++ b/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
@@ -96,6 +96,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}{$this->anchor}1",
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [2 => 1],
                 ],
             ],
             [
@@ -108,6 +109,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}{$this->anchor}3", // <-- last number needs to match the EVT ID
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [4 => 1],
                 ],
             ],
             [
@@ -120,6 +122,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}?hack_attack=Robert');%20DROP%20TABLE%20students;--{$this->anchor}5",
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [6 => 1],
                 ],
                 false,
                 ["hack_attack=Robert'); DROP TABLE students;--"],
@@ -134,6 +137,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [0],
                     'return_url' => "{$this->mock_url}{$this->anchor}0",
                     'tickets'    => 0,
+                    'selected_ticket_ids' => [0],
                 ],
                 true, // <-- throws exception due to bad data
             ],
@@ -148,6 +152,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [0, 1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}7",
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [8 => 0, 9 => 1, 10 => 0],
                 ],
             ],
             [
@@ -160,6 +165,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [12 => 1, 13 => 0],
                 ],
             ],
             [
@@ -172,6 +178,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
                     'tickets'    => 1,
+                    'selected_ticket_ids' => [14 => 0],
                 ],
                 true, // <-- throws exception due to bad data
             ],
@@ -186,6 +193,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [0, 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}15",
                     'tickets'    => 2,
+                    'selected_ticket_ids' => [16 => 0, 17 => 2],
                 ],
             ],
             [
@@ -198,6 +206,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 1, 1, 1, 1],
                     'return_url' => "{$this->mock_url}{$this->anchor}18",
                     'tickets'    => 5,
+                    'selected_ticket_ids' => [19 => 1, 20 => 1, 21 => 1, 22 => 1, 23 => 1],
                 ],
             ],
             [
@@ -210,6 +219,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 2, 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
                     'tickets'    => 6,
+                    'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
             [
@@ -223,6 +233,7 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 2, 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
                     'tickets'    => 6,
+                    'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
             [
@@ -235,8 +246,24 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [1, 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}28",
                     'tickets'    => 3,
+                    'selected_ticket_ids' => [29 => 1, 30 => 2],
                 ],
                 true, // <-- throws exception due to bad data
+            ],
+            // max attendees = 1 & ticket options > 1 & first two tickets cap restricted
+            12 => [
+                '31',
+                ['32', '33', '34', '35', '36'],
+                '1',
+                '3',
+                '1-1',
+                // ['32' => 0, '33' => 0, '34' => 1],
+                [
+                    'qty'        => [0, 0, 1, 0, 0],
+                    'return_url' => "{$this->mock_url}{$this->anchor}31",
+                    'tickets'    => 1,
+                    'selected_ticket_ids' => [32 => 0, 33 => 0, 34 => 1, 35 => 0, 36 => 0],
+                ],
             ],
         ];
     }
@@ -268,7 +295,7 @@ class ProcessTicketSelectorTest extends TestCase
         if ($throws) {
             $this->expectException('DomainException');
         }
-        $this->initializeValidator((int) $event_id);
+        $this->initializeValidator();
         $this->post_data_validator->validatePostData();
 
         // event ID
@@ -295,6 +322,8 @@ class ProcessTicketSelectorTest extends TestCase
         $this->assertIsArray($quantities);
         foreach ($quantities as $key => $quantity) {
             $this->assertEquals($expected['qty'][ $key ], $quantity);
+            // also make sure that quantities for ticket IDs match up with expected
+            $this->assertEquals($expected['selected_ticket_ids'][ $tickets[ $key ] ], $quantity);
         }
 
         // total ticket count
@@ -307,7 +336,6 @@ class ProcessTicketSelectorTest extends TestCase
         // return_url
         $return_url = $this->post_data_validator->getValidData(PTSPD::DATA_KEY_RETURN_URL);
         $this->assertEquals($expected['return_url'], $return_url);
-
     }
 }
 // /tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php

--- a/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
+++ b/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
@@ -143,7 +143,7 @@ class ProcessTicketSelectorTest extends TestCase
                 ['8', '9', '10'],
                 '1',
                 '3',
-                [9],
+                '9-1',
                 [
                     'qty'        => [8 => 0, 9 => 1, 10 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}7",
@@ -155,7 +155,7 @@ class ProcessTicketSelectorTest extends TestCase
                 ['12', '13'],
                 '1',
                 '2',
-                [12],
+                '12-1',
                 [
                     'qty' => [12 => 1, 13 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
@@ -167,7 +167,7 @@ class ProcessTicketSelectorTest extends TestCase
                 ['not', 'valid', 'data'],
                 '1',
                 '0',
-                ['not'],
+                'not-1',
                 [
                     'qty'        => [0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
@@ -243,7 +243,7 @@ class ProcessTicketSelectorTest extends TestCase
                 ['32', '33', '34', '35', '36'],
                 '1',
                 '3',
-                [34],
+                '34-1',
                 [
                     'qty'        => [32 => 0, 33 => 0, 34 => 1, 35 => 0, 36 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}31",

--- a/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
+++ b/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
@@ -91,12 +91,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['2'],
                 '1',
                 '1',
-                ['2' => '1'],
+                ['2'],
                 [
-                    'qty'        => [1],
+                    'qty'        => [2 => 1],
                     'return_url' => "{$this->mock_url}{$this->anchor}1",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [2 => 1],
                 ],
             ],
             1 => [
@@ -104,12 +103,11 @@ class ProcessTicketSelectorTest extends TestCase
                 [4],
                 1,
                 1,
-                [4 => 1],
+                [4],
                 [
-                    'qty'        => [1],
+                    'qty'        => [4 => 1],
                     'return_url' => "{$this->mock_url}{$this->anchor}3", // <-- last number needs to match the EVT ID
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [4 => 1],
                 ],
             ],
             2 => [
@@ -117,12 +115,11 @@ class ProcessTicketSelectorTest extends TestCase
                 [6],
                 1,
                 1,
-                [6 => 1],
+                [6],
                 [
-                    'qty'        => [1],
+                    'qty'        => [6 => 1],
                     'return_url' => "{$this->mock_url}?hack_attack=Robert');%20DROP%20TABLE%20students;--{$this->anchor}5",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [6 => 1],
                 ],
                 false,
                 ["hack_attack=Robert'); DROP TABLE students;--"],
@@ -137,7 +134,6 @@ class ProcessTicketSelectorTest extends TestCase
                     'qty'        => [0],
                     'return_url' => "{$this->mock_url}{$this->anchor}0",
                     'tickets'    => 0,
-                    'selected_ticket_ids' => [0],
                 ],
                 true, // <-- throws exception due to bad data
             ],
@@ -147,12 +143,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['8', '9', '10'],
                 '1',
                 '3',
-                ['9' => '1'],
+                [9],
                 [
-                    'qty'        => [0, 1, 0],
+                    'qty'        => [8 => 0, 9 => 1, 10 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}7",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [8 => 0, 9 => 1, 10 => 0],
                 ],
             ],
             5 => [
@@ -160,12 +155,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['12', '13'],
                 '1',
                 '2',
-                ['12' => '1'],
+                [12],
                 [
-                    'qty'        => [1, 0],
+                    'qty' => [12 => 1, 13 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [12 => 1, 13 => 0],
                 ],
             ],
             6 => [
@@ -173,12 +167,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['not', 'valid', 'data'],
                 '1',
                 '0',
-                ['not' => '1'],
+                ['not'],
                 [
-                    'qty'        => [1, 0],
+                    'qty'        => [0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [14 => 0],
                 ],
                 true, // <-- throws exception due to bad data
             ],
@@ -188,12 +181,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['16', '17'],
                 '10', // <-- default max attendees value
                 '2',
-                ['16' => '0', '17' => '2'], // <-- selected 2 of ticket 17
+                [17 => 2], // <-- selected 2 of ticket 17
                 [
-                    'qty'        => [0, 2],
+                    'qty'        => [16 => 0, 17 => 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}15",
                     'tickets'    => 2,
-                    'selected_ticket_ids' => [16 => 0, 17 => 2],
                 ],
             ],
             8 => [
@@ -201,12 +193,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['19', '20', '21', '22', '23'],
                 '10', // <-- default max attendees value
                 '5',
-                ['19' => '1', '20' => '1', '21' => '1', '22' => '1', '23' => '1'], // <-- selected 1 of each ticket
+                [19 => 1, 20 => 1, 21 => 1, 22 => 1, 23 => 1], // <-- selected 1 of each ticket
                 [
-                    'qty'        => [1, 1, 1, 1, 1],
+                    'qty'        => [19 => 1, 20 => 1, 21 => 1, 22 => 1, 23 => 1],
                     'return_url' => "{$this->mock_url}{$this->anchor}18",
                     'tickets'    => 5,
-                    'selected_ticket_ids' => [19 => 1, 20 => 1, 21 => 1, 22 => 1, 23 => 1],
                 ],
             ],
             9 => [
@@ -214,12 +205,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['25', '26', '27'],
                 '10', // <-- default max attendees value
                 '3',
-                ['25' => '1', '26' => '2', '27' => '3'],
+                [25 => 1, 26 => 2, 27 => 3],
                 [
-                    'qty'        => [1, 2, 3],
+                    'qty'        => [25 => 1, 26 => 2, 27 => 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
                     'tickets'    => 6,
-                    'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
             10 => [
@@ -228,12 +218,11 @@ class ProcessTicketSelectorTest extends TestCase
                 '5', // <-- reduced max attendees value that is less than quantity of tickets selected,
                 // test will still pass because max attendees is NOT enforced within ProcessTicketSelectorPostData
                 '3',
-                ['25' => '1', '26' => '2', '27' => '3'],
+                [25 => 1, 26 => 2, 27 => 3],
                 [
-                    'qty'        => [1, 2, 3],
+                    'qty'        => [25 => 1, 26 => 2, 27 => 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
                     'tickets'    => 6,
-                    'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
             11 => [
@@ -241,12 +230,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['29', '30'],
                 '5', // <-- reduced max attendees value
                 '2',
-                ['29' => '1', '30' => '2', '3'], // mismatch with available ticket options
+                [29 => 1, 30 => 2, 3], // mismatch with available ticket options
                 [
-                    'qty'        => [1, 2],
+                    'qty'        => [29 => 1, 30 => 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}28",
                     'tickets'    => 3,
-                    'selected_ticket_ids' => [29 => 1, 30 => 2],
                 ],
             ],
             // max attendees = 1 & ticket options > 1 & first two tickets cap restricted
@@ -255,12 +243,11 @@ class ProcessTicketSelectorTest extends TestCase
                 ['32', '33', '34', '35', '36'],
                 '1',
                 '3',
-                ['32' => 0, '33' => 0, '34' => 1],
+                [34],
                 [
-                    'qty'        => [0, 0, 1, 0, 0],
+                    'qty'        => [32 => 0, 33 => 0, 34 => 1, 35 => 0, 36 => 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}31",
                     'tickets'    => 1,
-                    'selected_ticket_ids' => [32 => 0, 33 => 0, 34 => 1, 35 => 0, 36 => 0],
                 ],
             ],
         ];
@@ -318,10 +305,8 @@ class ProcessTicketSelectorTest extends TestCase
         // ticket quantities selected
         $quantities = $this->post_data_validator->getValidData(PTSPD::DATA_KEY_QUANTITY);
         $this->assertIsArray($quantities);
-        foreach ($quantities as $key => $quantity) {
-            $this->assertEquals($expected['qty'][ $key ], $quantity);
-            // also make sure that quantities for ticket IDs match up with expected
-            $this->assertEquals($expected['selected_ticket_ids'][ $tickets[ $key ] ], $quantity);
+        foreach ($quantities as $ticket_id => $quantity) {
+            $this->assertEquals($expected['qty'][ $ticket_id ], $quantity);
         }
 
         // total ticket count

--- a/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
+++ b/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
@@ -82,16 +82,16 @@ class ProcessTicketSelectorTest extends TestCase
      *
      * @return array[]
      */
-    public function postDataProvider(): array
+    public function postDataProvider()
     {
         return [
             // Dude Where's My Ticket Selector? ( max attendees = 1 & ticket options = 1  )
-            [
+            0 => [
                 '1',
                 ['2'],
                 '1',
                 '1',
-                ['1'],
+                ['2' => '1'],
                 [
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}{$this->anchor}1",
@@ -99,12 +99,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [2 => 1],
                 ],
             ],
-            [
+            1 => [
                 3,
                 [4],
                 1,
                 1,
-                [1],
+                [4 => 1],
                 [
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}{$this->anchor}3", // <-- last number needs to match the EVT ID
@@ -112,12 +112,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [4 => 1],
                 ],
             ],
-            [
+            2 => [
                 5,
                 [6],
                 1,
                 1,
-                [1],
+                [6 => 1],
                 [
                     'qty'        => [1],
                     'return_url' => "{$this->mock_url}?hack_attack=Robert');%20DROP%20TABLE%20students;--{$this->anchor}5",
@@ -127,12 +127,12 @@ class ProcessTicketSelectorTest extends TestCase
                 false,
                 ["hack_attack=Robert'); DROP TABLE students;--"],
             ],
-            [
+            3 => [
                 'bad',
                 ['garbage'],
                 'useless',
                 'junk',
-                ['Kid Rock'],
+                ['garbage' => 'Kid Rock'],
                 [
                     'qty'        => [0],
                     'return_url' => "{$this->mock_url}{$this->anchor}0",
@@ -142,12 +142,12 @@ class ProcessTicketSelectorTest extends TestCase
                 true, // <-- throws exception due to bad data
             ],
             // max attendees = 1 & ticket options > 1
-            [
+            4 => [
                 '7',
                 ['8', '9', '10'],
                 '1',
                 '3',
-                '2-1', // if max atndz = 1 but not DWMTS, then qty is a dash (-) separated value string
+                ['9' => '1'],
                 [
                     'qty'        => [0, 1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}7",
@@ -155,12 +155,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [8 => 0, 9 => 1, 10 => 0],
                 ],
             ],
-            [
+            5 => [
                 '11',
                 ['12', '13'],
                 '1',
                 '2',
-                '1-1',
+                ['12' => '1'],
                 [
                     'qty'        => [1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
@@ -168,12 +168,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [12 => 1, 13 => 0],
                 ],
             ],
-            [
+            6 => [
                 '14',
                 ['not', 'valid', 'data'],
                 '1',
                 '0',
-                '1-1',
+                ['not' => '1'],
                 [
                     'qty'        => [1, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}11",
@@ -183,12 +183,12 @@ class ProcessTicketSelectorTest extends TestCase
                 true, // <-- throws exception due to bad data
             ],
             // max attendees > 1 & ticket options > 1
-            [
+            7 => [
                 '15',
                 ['16', '17'],
                 '10', // <-- default max attendees value
                 '2',
-                ['0', '2'], // <-- selected 2 of ticket 17
+                ['16' => '0', '17' => '2'], // <-- selected 2 of ticket 17
                 [
                     'qty'        => [0, 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}15",
@@ -196,12 +196,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [16 => 0, 17 => 2],
                 ],
             ],
-            [
+            8 => [
                 '18',
                 ['19', '20', '21', '22', '23'],
                 '10', // <-- default max attendees value
                 '5',
-                ['1', '1', '1', '1', '1'], // <-- selected 1 of each ticket
+                ['19' => '1', '20' => '1', '21' => '1', '22' => '1', '23' => '1'], // <-- selected 1 of each ticket
                 [
                     'qty'        => [1, 1, 1, 1, 1],
                     'return_url' => "{$this->mock_url}{$this->anchor}18",
@@ -209,12 +209,12 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [19 => 1, 20 => 1, 21 => 1, 22 => 1, 23 => 1],
                 ],
             ],
-            [
+            9 => [
                 '24',
                 ['25', '26', '27'],
                 '10', // <-- default max attendees value
                 '3',
-                ['1', '2', '3'],
+                ['25' => '1', '26' => '2', '27' => '3'],
                 [
                     'qty'        => [1, 2, 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
@@ -222,13 +222,13 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
-            [
+            10 => [
                 '24',
                 ['25', '26', '27'],
                 '5', // <-- reduced max attendees value that is less than quantity of tickets selected,
                 // test will still pass because max attendees is NOT enforced within ProcessTicketSelectorPostData
                 '3',
-                ['1', '2', '3'],
+                ['25' => '1', '26' => '2', '27' => '3'],
                 [
                     'qty'        => [1, 2, 3],
                     'return_url' => "{$this->mock_url}{$this->anchor}24",
@@ -236,19 +236,18 @@ class ProcessTicketSelectorTest extends TestCase
                     'selected_ticket_ids' => [25 => 1, 26 => 2, 27 => 3],
                 ],
             ],
-            [
+            11 => [
                 '28',
                 ['29', '30'],
                 '5', // <-- reduced max attendees value
                 '2',
-                ['1', '2', '3'], // mismatch with available ticket options
+                ['29' => '1', '30' => '2', '3'], // mismatch with available ticket options
                 [
                     'qty'        => [1, 2],
                     'return_url' => "{$this->mock_url}{$this->anchor}28",
                     'tickets'    => 3,
                     'selected_ticket_ids' => [29 => 1, 30 => 2],
                 ],
-                true, // <-- throws exception due to bad data
             ],
             // max attendees = 1 & ticket options > 1 & first two tickets cap restricted
             12 => [
@@ -256,8 +255,7 @@ class ProcessTicketSelectorTest extends TestCase
                 ['32', '33', '34', '35', '36'],
                 '1',
                 '3',
-                '1-1',
-                // ['32' => 0, '33' => 0, '34' => 1],
+                ['32' => 0, '33' => 0, '34' => 1],
                 [
                     'qty'        => [0, 0, 1, 0, 0],
                     'return_url' => "{$this->mock_url}{$this->anchor}31",
@@ -287,7 +285,7 @@ class ProcessTicketSelectorTest extends TestCase
         $rows,
         $qty,
         array $expected,
-        bool $throws = false,
+        $throws = false,
         array $extra_url_params = []
     ) {
         // put test data into request


### PR DESCRIPTION
This PR:

- closes #3670
- adds a unit test to demonstrate the bug and confirm the subsequent fix
- changes how the ticket selector ticket quantity inputs are named by using the ticket ID for the keys (i'm not entirely sure why this wasn't done earlier but I'm guessing there was something about the original TS that prevented it)
- changes the POST processing to directly obtain selected ticket quantities using the ticket IDs instead of the row key
