### PR TITLE
Set 'Send test email to' field to not be required as it prevents message template changes when empty

### DIFF
--- a/core/libraries/messages/messenger/EE_Email_messenger.class.php
+++ b/core/libraries/messages/messenger/EE_Email_messenger.class.php
@@ -224,7 +224,7 @@ class EE_Email_messenger extends EE_messenger
                 'input'      => 'text',
                 'label'      => esc_html__('Send a test email to', 'event_espresso'),
                 'type'       => 'email',
-                'required'   => true,
+                'required'   => false,
                 'validation' => true,
                 'css_class'  => 'large-text',
                 'format'     => '%s',


### PR DESCRIPTION
If you edit a message template and don't have a value set for the 'Send test message to' field, when you hit save you get a 'required field' error, like this:

https://share.getcloudapp.com/GGuErw0d

Setting this to not be required means if someone doesn't set the email field and clicks the test send button they see:

https://monosnap.com/file/jz68ys5UJUH3PNnEAPMrsh0pmgfcin

----

2 issues with this:

1. It prevents message template changes if you don't set a value, people get confused by this when they don't want to send a test email.

2. Because you have to set a value, you can't then set an empty value to remove your email. I remember this coming up a while back where a developer tested emails and their email saved within the templates. They couldn't figure out how to remove it again as they needed a value (the solution was to save the admins email there but this removes that issue).
