### PR TITLE
Use correct request param for the event_id

### DIFF
--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -2975,7 +2975,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             return true;
         }
 
-        $EVT_ID = $this->request->getRequestParam('event_id[reg_status]', 0, 'int');
+        $EVT_ID = $this->request->getRequestParam('event_id', 0, 'int');
         if (! $EVT_ID) {
             return false;
         }


### PR DESCRIPTION
To reproduce use master and go to Event Espresso -> Events -> {hover over event} -> Registrations.

Click the add new registration button at the top, you'll see an error like this:

```
An EE_Error exception was thrown!   code: Registrations_Admin_Page - new_registration - 2797
"Unable to continue with registering because there is no Event ID in the request"
click to view backtrace and class/method details
/event-espresso-core-reg/admin_pages/registrations/Registrations_Admin_Page.core.php   ( line no: 2797 )
```

With this branch that's fixed.