### PR TITLE
Fix events admin filters/search

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1885,9 +1885,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             default:
                 $where['status'] = $status;
         }
-        // categories?
-        $category = $this->request->getRequestParam('EVT_CAT', 0, 'int');
-        if ($category) {
+        // categories? The default for all categories is -1
+        $category = $this->request->getRequestParam('EVT_CAT', -1, 'int');
+        if ($category !== -1) {
             $where['Term_Taxonomy.taxonomy'] = EEM_CPT_Base::EVENT_CATEGORY_TAXONOMY;
             $where['Term_Taxonomy.term_id']  = $category;
         }


### PR DESCRIPTION
### Threads to update:
https://eventespresso.com/topic/event-filter-by-month-broken/
https://eventespresso.com/topic/event-espresso-search-feature-not-working-after-update/
https://eventespresso.com/topic/not-able-to-filter-by-date-alone/
https://eventespresso.com/topic/issue-with-version-4-10-25-p/
https://eventespresso.com/topic/dashboard-event-search-not-working/

This fixes #3684 

The default value used for 'All Categories' is -1, so I swapped that to be the default value and added that to the conditional used to add categories to the where clause.

## Problem this Pull Request solves
Go to Event Espresso -> Events.

The table files and search don't work in master as EE not always looks for a EE category of -1

This branch fixes those.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
