### PR TITLE
Changed G-Maps Zoom Level fields to number instead of text

### DIFF
--- a/admin_pages/venues/templates/google_map.template.php
+++ b/admin_pages/venues/templates/google_map.template.php
@@ -106,10 +106,13 @@
                 </th>
                 <td>
                     <input id="event_details_map_zoom"
-                           type="text"
+                           type="number"
                            size=""
                            name="event_details_map_zoom"
                            value="<?php echo esc_attr($map_settings->event_details_map_zoom); ?>"
+                           min="1"
+                           max="19"
+                           step="1"
                     />
                 </td>
             </tr>
@@ -296,10 +299,13 @@
                 </th>
                 <td>
                     <input id="event_list_map_zoom"
-                           type="text"
+                           type="number"
                            size=""
                            name="event_list_map_zoom"
                            value="<?php echo esc_attr($map_settings->event_list_map_zoom); ?>"
+                           min="1"
+                           max="19"
+                           step="1"
                     />
                 </td>
             </tr>


### PR DESCRIPTION
I was checking the https://github.com/eventespresso/event-espresso-core/pull/3680/ and I found that Google Maps Zoom Level fields on Venues -> Google Maps had some issues. Therefore I fixed the issues by changing the field type to number instead of text and also by adding some HTML validation options.