### PR TITLE
Fix 'old' (no batch processing) CSV export

### DIFF
--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -3278,15 +3278,19 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 )
             );
         } else {
-            $new_request_args = [
+            // Pull the current request params
+            $request_args = $this->request->requestParams();
+            // Set the required request_args to be passed to the export
+            $required_request_args = [
                 'export' => 'report',
                 'action' => 'registrations_report_for_event',
                 'EVT_ID' => $EVT_ID,
             ];
-            $this->request->mergeRequestParams($new_request_args);
+            // Merge required request args, overriding any currently set
+            $request_args = array_merge($request_args, $required_request_args);
             if (is_readable(EE_CLASSES . 'EE_Export.class.php')) {
                 require_once(EE_CLASSES . 'EE_Export.class.php');
-                $EE_Export = EE_Export::instance($this->request->requestParams());
+                $EE_Export = EE_Export::instance($request_args);
                 $EE_Export->export();
             }
         }


### PR DESCRIPTION
Quick explanation on why I've switched this back to something very similar to what it was before.

The `EE_Export` class uses `$this->_req_data` throughout but that is actually the `$request_args` passed to constructor.

With the change to use:

`$this->request->mergeRequestParams($new_request_args);`

To merge in the request params it does so recursively which means things like:

`'action' => 'registrations_report_for_event',`

Become an array:

`'action' => array( 'registrations_report', 'registrations_report_for_event');`

Due to action already being set on the current requestParams.

Using `setRequestParam()` on the request also works, or updating the EE_Export class I suppose.

I went with this for the least impact but happy to do another method if preferred.


---

To test, use Master and add `define( 'EE_USE_OLD_CSV_REPORT_CLASS', true );` to your `wp-config.php` file.

Go to Event Espresso -> Events -> {hover over event} -> Registrations. 
Hit the Registration Export button (not the filtered one).

You'll get an error like:

> An error has occurred. The requested export report could not be found.
> EE_Export – export – 113

Switch to this branch and the export should work again.