### PR TITLE
Fix upcoming events widget sort setting.

### DIFF
--- a/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
+++ b/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
@@ -474,7 +474,7 @@ class EEW_Upcoming_Events extends EspressoWidget
             ? $instance['date_range']
             : false;
         $this->limit        = isset($instance['limit']) ? absint($instance['limit']) : 10;
-        $this->order        = isset($instance['order']) && $instance['order'] === 'DESC'
+        $this->order        = isset($instance['sort']) && $instance['sort'] === 'DESC'
             ? 'DESC'
             : 'ASC';
     }


### PR DESCRIPTION
Reported: https://eventespresso.com/topic/upcoming-events-widget-6/

This was changed [HERE](https://github.com/eventespresso/event-espresso-core/commit/ec3dd64b#diff-6cb609930340084f3cd9de4cde41e7e2abef6fd541334bf9defe1d36eee8df9bR478) and managed to slip through unnoticed.

This change just switches the instance settings back to use the value set for 'sort' as the order property.

---

To test with master, load the Upcoming Events widget on a site.

Se the order to DESC so that the widget orders by Event Start desc.

Load on the front end and you'll see its still loading ASC.

In this branch that's fixed.

Switch back to ASC and confirm the order of the widget changes again.