### PR TITLE
Fixed Event Status Banner Not Showing in Block Themes.

### DIFF
--- a/modules/event_single/EED_Event_Single.module.php
+++ b/modules/event_single/EED_Event_Single.module.php
@@ -224,7 +224,7 @@ class EED_Event_Single extends EED_Module
     public static function the_title($title = '', $id = 0)
     {
         global $post;
-        return in_the_loop() && $post->ID === (int) $id
+        return ((function_exists('wp_is_block_theme') && wp_is_block_theme()) || in_the_loop()) && $post->ID === (int) $id
             ? espresso_event_status_banner($post->ID) . $title
             : $title;
     }

--- a/modules/events_archive/EED_Events_Archive.module.php
+++ b/modules/events_archive/EED_Events_Archive.module.php
@@ -395,7 +395,9 @@ class EED_Events_Archive extends EED_Module
     {
         global $post;
         if ($post instanceof WP_Post) {
-            return in_the_loop() && $post->ID == $id ? espresso_event_status_banner($post->ID) . $title : $title;
+            return ((function_exists('wp_is_block_theme') && wp_is_block_theme()) || in_the_loop()) && $post->ID == $id
+            ? espresso_event_status_banner($post->ID) . $title
+            : $title;
         }
         return $title;
     }

--- a/modules/events_archive/EED_Events_Archive.module.php
+++ b/modules/events_archive/EED_Events_Archive.module.php
@@ -396,8 +396,8 @@ class EED_Events_Archive extends EED_Module
         global $post;
         if ($post instanceof WP_Post) {
             return ((function_exists('wp_is_block_theme') && wp_is_block_theme()) || in_the_loop()) && $post->ID == $id
-            ? espresso_event_status_banner($post->ID) . $title
-            : $title;
+                ? espresso_event_status_banner($post->ID) . $title
+                : $title;
         }
         return $title;
     }


### PR DESCRIPTION
Fixes #3676 issue.

To test please do the followings:

1- Activate Twenty Twenty-Two theme on your local website.
2- Make sure that Display Status Banner is set to Yes for both of single and archive pages.
3- Check both of pages to see the Status Banner.