### PR TITLE
Fix Invoice Payment Deactivation Issue After Disabling Receipt and Ticket Message Types.

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -4325,7 +4325,13 @@ class Messages_Admin_Page extends EE_Admin_Page
         }
 
         // if messenger was html or message type was invoice then let's make sure we deactivate invoice payment method.
-        if ($messenger->name === 'html' || $message_type_name === 'invoice') {
+        if (
+            $messenger->name === 'html'
+            && (
+                is_null($message_type)
+                || $message_type_name === 'invoice'
+            )
+        ) {
             EE_Registry::instance()->load_lib('Payment_Method_Manager');
             $count_updated = EE_Payment_Method_Manager::instance()->deactivate_payment_method('invoice');
             if ($count_updated > 0) {


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/2572

The issue happened due to a wrong logic for an if condition. I fixed it by correcting the condition.
I tested many possible configuration and everything looks good from my side.

Also I tested booking and payment process when receipt and ticket message types are disabled and Invoice Payment is enabled and everything went well.