### PR TITLE
Fix an invalid instance check.

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1211,7 +1211,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             //  Otherwise we instantiate a new object for save.
             if (! empty($datetime_data['DTT_ID'])) {
                 $datetime = EEM_Datetime::instance($event_timezone)->get_one_by_ID($datetime_data['DTT_ID']);
-                if (! $datetime instanceof EE_Ticket) {
+                if (! $datetime instanceof EE_Datetime) {
                     throw new RuntimeException(
                         sprintf(
                             esc_html__(


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/3715

The error was related to a wrong `instanceof` condition. The buggy code was checking if `$datetime` is an instance of `EE_Ticket` class.