### PR TITLE
Bump `composer/installers` to v2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,14 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
+* text eol=lf
 
-# Explicitly declare text files we want to always be normalized and converted 
+# Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout. But on commit, they should be given unix-style line endings (LFs)
 *.c text
 *.h text
 *.php text
 *.js text
-*.html text 
+*.html text
 *.css text
 *.txt text
 *.md text

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
 		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"require": {
-		"composer/installers": "~1.0",
-		"php": ">=7.1",
+		"composer/installers": "~2.0",
+		"php": ">=7.2",
 		"ext-json": "*"
 	},
 	"scripts": {

--- a/tests/includes/CoreLoader.php
+++ b/tests/includes/CoreLoader.php
@@ -122,7 +122,7 @@ class CoreLoader
                 return $wp_root;
             }
         }
-        echo "The PHPUnit Polyfills could not be found.";
+        echo "\n\nThe PHPUnit Polyfills could not be found.";
         return null;
     }
 


### PR DESCRIPTION
trying to fix unit test setup for the waitlist add-on and need to bump the `composer/installers`  dependency to v2
and therefore need to do the same here