### PR TITLE
Fix CPT Model Name Retrieval 

### DIFF
--- a/core/domain/entities/custom_post_types/CustomPostTypeDefinitions.php
+++ b/core/domain/entities/custom_post_types/CustomPostTypeDefinitions.php
@@ -241,7 +241,7 @@ class CustomPostTypeDefinitions
         // if we made it here then we're returning an array of cpt model names indexed by post_type_slug.
         $cpt_models = array();
         foreach ($cpts as $slug => $args) {
-            $model = $this->getCustomPostTypeModelName($post_type_slug, $cpts[ $post_type_slug ]);
+            $model = $this->getCustomPostTypeModelName($slug, $args);
             if (! empty($model)) {
                 $cpt_models[ $slug ] = $model;
             }


### PR DESCRIPTION
for backstory see: https://eventespresso.com/topic/fatal-errors/

so in `EventEspresso\core\domain\entities\custom_post_types\CustomPostTypeDefinitions::getCustomPostTypeModelNames()`

we have the following logic:

```php
    public function getCustomPostTypeModelNames($post_type_slug = '')
    {
        $cpts = $this->getDefinitions();
        // first if slug passed in...
        if (! empty($post_type_slug)) {
            //  handle model name retrieval for incoming CPT slug
        }
        // if we made it here then we're returning an array of cpt model names indexed by post_type_slug.
        $cpt_models = array();
        foreach ($cpts as $slug => $args) {
            $model = $this->getCustomPostTypeModelName($post_type_slug, $cpts[ $post_type_slug ]);
            if (! empty($model)) {
                $cpt_models[ $slug ] = $model;
            }
        }
        return $cpt_models;
    }
```

this is the line that was throwing the error for the customer:

```php
$model = $this->getCustomPostTypeModelName($post_type_slug, $cpts[ $post_type_slug ]);
```

which is flat out wrong because we have already verified, via the first conditional in the method, that `$post_type_slug` is empty at this point in the code, so we can NOT use it as an array index 🙄 

This PR fixes this copy pasta oversight by using the `$slug` & `$args` provided in the loop