### PR TITLE
Fix "Invalid arguments supplied for the SessionStartHandler" error

### DIFF
--- a/core/domain/entities/routing/handlers/shared/SessionRequests.php
+++ b/core/domain/entities/routing/handlers/shared/SessionRequests.php
@@ -24,7 +24,10 @@ class SessionRequests extends Route
      */
     public function matchesCurrentRequest(): bool
     {
-        return $this->request->isAdmin() || $this->request->isEeAjax() || $this->request->isFrontend();
+        return $this->request->isAdmin()
+               || $this->request->isEeAjax()
+               || $this->request->isFrontend()
+               || $this->request->isIframe();
     }
 
 


### PR DESCRIPTION
plz see: https://github.com/eventespresso/eventsmart.com-website/issues/923

This PR, ensures session handler is loaded on iFrame requests.
Oddly, this error does not appear to happen on single sites, and only seems to affect multisite.