### PR TITLE
Initialize Routes Earlier

### DIFF
--- a/core/EE_System.core.php
+++ b/core/EE_System.core.php
@@ -1130,13 +1130,13 @@ final class EE_System implements ResettableInterface
      */
     public function initialize_last()
     {
+        $this->router->initializeLast();
         do_action('AHEE__EE_System__initialize_last');
         /** @var EventEspresso\core\domain\services\custom_post_types\RewriteRules $rewrite_rules */
         $rewrite_rules = $this->loader->getShared(
             'EventEspresso\core\domain\services\custom_post_types\RewriteRules'
         );
         $rewrite_rules->flushRewriteRules();
-        $this->router->initializeLast();
         add_action('admin_bar_init', [$this, 'addEspressoToolbar']);
     }
 


### PR DESCRIPTION
plz see: https://github.com/eventespresso/eventsmart.com-website/issues/922

This PR: 

- moves some route initialization a little earlier because some admin routes are hooked into 'AHEE__EE_System__initialize_last'