### PR TITLE
Fix deprecated filter hook

### DIFF
--- a/core/services/editor/BlockRegistrationManager.php
+++ b/core/services/editor/BlockRegistrationManager.php
@@ -92,7 +92,7 @@ class BlockRegistrationManager extends BlockManager
         $this->initializeBlocks();
         add_action('AHEE__EE_System__initialize_last', array($this, 'registerBlocks'));
         add_action('wp_loaded', array($this, 'unloadAssets'));
-        add_filter('block_categories', array($this, 'addEspressoBlockCategories'));
+        add_filter('block_categories_all', array($this, 'addEspressoBlockCategories'));
     }
 
 


### PR DESCRIPTION
Used new hook of WordPress to add block category instead of deprecated one.