### PR TITLE
Replace Legacy Request Data in Pricing Admin

### DIFF
--- a/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
+++ b/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
@@ -1,318 +1,311 @@
 <?php
 
+use EventEspresso\core\services\request\DataType;
+
 /**
  * Pricing_Admin_Page class
  *
- * @package               Event Espresso
- * @subpackage            includes/core/admin/pricing/Pricing_Admin_Page.core.php
- * @author                Brent Christensen
- *
- * ------------------------------------------------------------------------
+ * @package     Event Espresso
+ * @subpackage  includes/core/admin/pricing/Pricing_Admin_Page.core.php
+ * @author      Brent Christensen
  */
 class Pricing_Admin_Page extends EE_Admin_Page
 {
 
-    /**
-     *    constructor
-     *
-     * @Constructor
-     * @access public
-     * @param bool $routing
-     * @return Pricing_Admin_Page
-     */
-    public function __construct($routing = true)
-    {
-        parent::__construct($routing);
-    }
-
-
     protected function _init_page_props()
     {
-        $this->page_slug = PRICING_PG_SLUG;
-        $this->page_label = PRICING_LABEL;
-        $this->_admin_base_url = PRICING_ADMIN_URL;
+        $this->page_slug        = PRICING_PG_SLUG;
+        $this->page_label       = PRICING_LABEL;
+        $this->_admin_base_url  = PRICING_ADMIN_URL;
         $this->_admin_base_path = PRICING_ADMIN;
     }
 
 
     protected function _ajax_hooks()
     {
-        add_action('wp_ajax_espresso_update_prices_order', array($this, 'update_price_order'));
+        add_action('wp_ajax_espresso_update_prices_order', [$this, 'update_price_order']);
     }
 
 
     protected function _define_page_props()
     {
         $this->_admin_page_title = PRICING_LABEL;
-        $this->_labels = array(
-            'buttons' => array(
+        $this->_labels           = [
+            'buttons' => [
                 'add'         => esc_html__('Add New Default Price', 'event_espresso'),
                 'edit'        => esc_html__('Edit Default Price', 'event_espresso'),
                 'delete'      => esc_html__('Delete Default Price', 'event_espresso'),
                 'add_type'    => esc_html__('Add New Default Price Type', 'event_espresso'),
                 'edit_type'   => esc_html__('Edit Price Type', 'event_espresso'),
                 'delete_type' => esc_html__('Delete Price Type', 'event_espresso'),
-            ),
-        );
+            ],
+        ];
     }
 
 
     /**
-     *        an array for storing request actions and their corresponding methods
+     * an array for storing request actions and their corresponding methods
      *
-     * @access private
      * @return void
      */
     protected function _set_page_routes()
     {
-        $prc_id = ! empty($this->_req_data['PRC_ID']) && ! is_array($this->_req_data['PRC_ID'])
-            ? $this->_req_data['PRC_ID'] : 0;
-        $prt_id = ! empty($this->_req_data['PRT_ID']) && ! is_array($this->_req_data['PRT_ID'])
-            ? $this->_req_data['PRT_ID'] : 0;
-        $this->_page_routes = array(
-            'default'                     => array(
+        $PRC_ID             = $this->request->getRequestParam('PRC_ID', 0, DataType::INTEGER);
+        $PRT_ID             = $this->request->getRequestParam('PRT_ID', 0, DataType::INTEGER);
+        $this->_page_routes = [
+            'default'                     => [
                 'func'       => '_price_overview_list_table',
                 'capability' => 'ee_read_default_prices',
-            ),
-            'add_new_price'               => array(
+            ],
+            'add_new_price'               => [
                 'func'       => '_edit_price_details',
-                'args'       => array('new_price' => true),
+                'args'       => ['new_price' => true],
                 'capability' => 'ee_edit_default_prices',
-            ),
-            'edit_price'                  => array(
+            ],
+            'edit_price'                  => [
                 'func'       => '_edit_price_details',
-                'args'       => array('new_price' => false),
+                'args'       => ['new_price' => false],
                 'capability' => 'ee_edit_default_price',
-                'obj_id'     => $prc_id,
-            ),
-            'insert_price'                => array(
+                'obj_id'     => $PRC_ID,
+            ],
+            'insert_price'                => [
                 'func'       => '_insert_or_update_price',
-                'args'       => array('new_price' => true),
+                'args'       => ['new_price' => true],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_prices',
-            ),
-            'update_price'                => array(
+            ],
+            'update_price'                => [
                 'func'       => '_insert_or_update_price',
-                'args'       => array('new_price' => false),
+                'args'       => ['new_price' => false],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_price',
-                'obj_id'     => $prc_id,
-            ),
-            'trash_price'                 => array(
+                'obj_id'     => $PRC_ID,
+            ],
+            'trash_price'                 => [
                 'func'       => '_trash_or_restore_price',
-                'args'       => array('trash' => true),
+                'args'       => ['trash' => true],
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price',
-                'obj_id'     => $prc_id,
-            ),
-            'restore_price'               => array(
+                'obj_id'     => $PRC_ID,
+            ],
+            'restore_price'               => [
                 'func'       => '_trash_or_restore_price',
-                'args'       => array('trash' => false),
+                'args'       => ['trash' => false],
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price',
-                'obj_id'     => $prc_id,
-            ),
-            'delete_price'                => array(
+                'obj_id'     => $PRC_ID,
+            ],
+            'delete_price'                => [
                 'func'       => '_delete_price',
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price',
-                'obj_id'     => $prc_id,
-            ),
-            'espresso_update_price_order' => array(
+                'obj_id'     => $PRC_ID,
+            ],
+            'espresso_update_price_order' => [
                 'func'       => 'update_price_order',
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_prices',
-            ),
+            ],
             // price types
-            'price_types'                 => array(
+            'price_types'                 => [
                 'func'       => '_price_types_overview_list_table',
                 'capability' => 'ee_read_default_price_types',
-            ),
-            'add_new_price_type'          => array(
+            ],
+            'add_new_price_type'          => [
                 'func'       => '_edit_price_type_details',
                 'capability' => 'ee_edit_default_price_types',
-            ),
-            'edit_price_type'             => array(
+            ],
+            'edit_price_type'             => [
                 'func'       => '_edit_price_type_details',
                 'capability' => 'ee_edit_default_price_type',
-                'obj_id'     => $prt_id,
-            ),
-            'insert_price_type'           => array(
+                'obj_id'     => $PRT_ID,
+            ],
+            'insert_price_type'           => [
                 'func'       => '_insert_or_update_price_type',
-                'args'       => array('new_price_type' => true),
+                'args'       => ['new_price_type' => true],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_price_types',
-            ),
-            'update_price_type'           => array(
+            ],
+            'update_price_type'           => [
                 'func'       => '_insert_or_update_price_type',
-                'args'       => array('new_price_type' => false),
+                'args'       => ['new_price_type' => false],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_price_type',
-                'obj_id'     => $prt_id,
-            ),
-            'trash_price_type'            => array(
+                'obj_id'     => $PRT_ID,
+            ],
+            'trash_price_type'            => [
                 'func'       => '_trash_or_restore_price_type',
-                'args'       => array('trash' => true),
+                'args'       => ['trash' => true],
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price_type',
-                'obj_id'     => $prt_id,
-            ),
-            'restore_price_type'          => array(
+                'obj_id'     => $PRT_ID,
+            ],
+            'restore_price_type'          => [
                 'func'       => '_trash_or_restore_price_type',
-                'args'       => array('trash' => false),
+                'args'       => ['trash' => false],
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price_type',
-                'obj_id'     => $prt_id,
-            ),
-            'delete_price_type'           => array(
+                'obj_id'     => $PRT_ID,
+            ],
+            'delete_price_type'           => [
                 'func'       => '_delete_price_type',
                 'noheader'   => true,
                 'capability' => 'ee_delete_default_price_type',
-                'obj_id'     => $prt_id,
-            ),
-            'tax_settings'                => array(
+                'obj_id'     => $PRT_ID,
+            ],
+            'tax_settings'                => [
                 'func'       => '_tax_settings',
                 'capability' => 'manage_options',
-            ),
-            'update_tax_settings'         => array(
+            ],
+            'update_tax_settings'         => [
                 'func'       => '_update_tax_settings',
                 'capability' => 'manage_options',
                 'noheader'   => true,
-            ),
-        );
+            ],
+        ];
     }
 
 
     protected function _set_page_config()
     {
-
-        $this->_page_config = array(
-            'default'            => array(
-                'nav'           => array(
+        $PRC_ID             = $this->request->getRequestParam('id', 0, DataType::INTEGER);
+        $this->_page_config = [
+            'default'            => [
+                'nav'           => [
                     'label' => esc_html__('Default Pricing', 'event_espresso'),
                     'order' => 10,
-                ),
+                ],
                 'list_table'    => 'Prices_List_Table',
-                'help_tabs'     => array(
-                    'pricing_default_pricing_help_tab'                           => array(
+                'metaboxes'     => $this->_default_espresso_metaboxes,
+                'help_tabs'     => [
+                    'pricing_default_pricing_help_tab'                           => [
                         'title'    => esc_html__('Default Pricing', 'event_espresso'),
                         'filename' => 'pricing_default_pricing',
-                    ),
-                    'pricing_default_pricing_table_column_headings_help_tab'     => array(
+                    ],
+                    'pricing_default_pricing_table_column_headings_help_tab'     => [
                         'title'    => esc_html__('Default Pricing Table Column Headings', 'event_espresso'),
                         'filename' => 'pricing_default_pricing_table_column_headings',
-                    ),
-                    'pricing_default_pricing_views_bulk_actions_search_help_tab' => array(
+                    ],
+                    'pricing_default_pricing_views_bulk_actions_search_help_tab' => [
                         'title'    => esc_html__('Default Pricing Views & Bulk Actions & Search', 'event_espresso'),
                         'filename' => 'pricing_default_pricing_views_bulk_actions_search',
-                    ),
-                ),
+                    ],
+                ],
                 'require_nonce' => false,
-            ),
-            'add_new_price'      => array(
-                'nav'           => array(
+            ],
+            'add_new_price'      => [
+                'nav'           => [
                     'label'      => esc_html__('Add New Default Price', 'event_espresso'),
                     'order'      => 20,
                     'persistent' => false,
-                ),
-                'help_tabs'     => array(
-                    'add_new_default_price_help_tab' => array(
+                ],
+                'help_tabs'     => [
+                    'add_new_default_price_help_tab' => [
                         'title'    => esc_html__('Add New Default Price', 'event_espresso'),
                         'filename' => 'pricing_add_new_default_price',
-                    ),
+                    ],
+                ],
+                'metaboxes'     => array_merge(
+                    ['_publish_post_box'],
+                    $this->_default_espresso_metaboxes
                 ),
-                'metaboxes'     => array('_publish_post_box', '_espresso_news_post_box', '_price_details_meta_boxes'),
                 'require_nonce' => false,
-            ),
-            'edit_price'         => array(
-                'nav'           => array(
+            ],
+            'edit_price'         => [
+                'nav'           => [
                     'label'      => esc_html__('Edit Default Price', 'event_espresso'),
                     'order'      => 20,
-                    'url'        => isset($this->_req_data['id']) ? add_query_arg(
-                        array('id' => $this->_req_data['id']),
-                        $this->_current_page_view_url
-                    ) : $this->_admin_base_url,
+                    'url'        => $PRC_ID
+                        ? add_query_arg(['id' => $PRC_ID], $this->_current_page_view_url)
+                        : $this->_admin_base_url,
                     'persistent' => false,
+                ],
+                'metaboxes'     => array_merge(
+                    ['_publish_post_box'],
+                    $this->_default_espresso_metaboxes
                 ),
-                'metaboxes'     => array('_publish_post_box', '_espresso_news_post_box', '_price_details_meta_boxes'),
-                'help_tabs'     => array(
-                    'edit_default_price_help_tab' => array(
+                'help_tabs'     => [
+                    'edit_default_price_help_tab' => [
                         'title'    => esc_html__('Edit Default Price', 'event_espresso'),
                         'filename' => 'pricing_edit_default_price',
-                    ),
-                ),
+                    ],
+                ],
                 'require_nonce' => false,
-            ),
-            'price_types'        => array(
-                'nav'           => array(
+            ],
+            'price_types'        => [
+                'nav'           => [
                     'label' => esc_html__('Price Types', 'event_espresso'),
                     'order' => 30,
-                ),
+                ],
                 'list_table'    => 'Price_Types_List_Table',
-                'help_tabs'     => array(
-                    'pricing_price_types_help_tab'                           => array(
+                'help_tabs'     => [
+                    'pricing_price_types_help_tab'                           => [
                         'title'    => esc_html__('Price Types', 'event_espresso'),
                         'filename' => 'pricing_price_types',
-                    ),
-                    'pricing_price_types_table_column_headings_help_tab'     => array(
+                    ],
+                    'pricing_price_types_table_column_headings_help_tab'     => [
                         'title'    => esc_html__('Price Types Table Column Headings', 'event_espresso'),
                         'filename' => 'pricing_price_types_table_column_headings',
-                    ),
-                    'pricing_price_types_views_bulk_actions_search_help_tab' => array(
+                    ],
+                    'pricing_price_types_views_bulk_actions_search_help_tab' => [
                         'title'    => esc_html__('Price Types Views & Bulk Actions & Search', 'event_espresso'),
                         'filename' => 'pricing_price_types_views_bulk_actions_search',
-                    ),
-                ),
-                'metaboxes'     => array('_espresso_news_post_box', '_espresso_links_post_box'),
+                    ],
+                ],
+                'metaboxes'     => $this->_default_espresso_metaboxes,
                 'require_nonce' => false,
-            ),
-            'add_new_price_type' => array(
-                'nav'           => array(
+            ],
+            'add_new_price_type' => [
+                'nav'           => [
                     'label'      => esc_html__('Add New Price Type', 'event_espresso'),
                     'order'      => 40,
                     'persistent' => false,
-                ),
-                'help_tabs'     => array(
-                    'add_new_price_type_help_tab' => array(
+                ],
+                'help_tabs'     => [
+                    'add_new_price_type_help_tab' => [
                         'title'    => esc_html__('Add New Price Type', 'event_espresso'),
                         'filename' => 'pricing_add_new_price_type',
-                    ),
-                ),
-                'metaboxes'     => array(
-                    '_publish_post_box',
-                    '_espresso_news_post_box',
-                    '_price_type_details_meta_boxes',
+                    ],
+                ],
+                'metaboxes'     => array_merge(
+                    ['_publish_post_box'],
+                    $this->_default_espresso_metaboxes
                 ),
                 'require_nonce' => false,
-            ),
-            'edit_price_type'    => array(
-                'nav'       => array(
+            ],
+            'edit_price_type'    => [
+                'nav'           => [
                     'label'      => esc_html__('Edit Price Type', 'event_espresso'),
                     'order'      => 40,
                     'persistent' => false,
-                ),
-                'help_tabs' => array(
-                    'edit_price_type_help_tab' => array(
+                ],
+                'help_tabs'     => [
+                    'edit_price_type_help_tab' => [
                         'title'    => esc_html__('Edit Price Type', 'event_espresso'),
                         'filename' => 'pricing_edit_price_type',
-                    ),
+                    ],
+                ],
+                'metaboxes'     => array_merge(
+                    ['_publish_post_box'],
+                    $this->_default_espresso_metaboxes
                 ),
-                'metaboxes' => array('_publish_post_box', '_espresso_news_post_box', '_price_type_details_meta_boxes'),
-
                 'require_nonce' => false,
-            ),
-            'tax_settings'       => array(
-                'nav'           => array(
+            ],
+            'tax_settings'       => [
+                'nav'           => [
                     'label' => esc_html__('Tax Settings', 'event_espresso'),
                     'order' => 40,
-                ),
-                'labels'        => array(
+                ],
+                'labels'        => [
                     'publishbox' => esc_html__('Update Tax Settings', 'event_espresso'),
+                ],
+                'metaboxes'     => array_merge(
+                    ['_publish_post_box'],
+                    $this->_default_espresso_metaboxes
                 ),
-                'metaboxes'     => array_merge($this->_default_espresso_metaboxes, array('_publish_post_box')),
                 'require_nonce' => true,
-            ),
-        );
+            ],
+        ];
     }
 
 
@@ -330,7 +323,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
     protected function _add_screen_options_price_types()
     {
-        $page_title = $this->_admin_page_title;
+        $page_title              = $this->_admin_page_title;
         $this->_admin_page_title = esc_html__('Price Types', 'event_espresso');
         $this->_per_page_screen_option();
         $this->_admin_page_title = $page_title;
@@ -349,7 +342,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
         wp_register_style(
             'espresso_PRICING',
             PRICING_ASSETS_URL . 'espresso_pricing_admin.css',
-            array(),
+            [],
             EVENT_ESPRESSO_VERSION
         );
         wp_enqueue_style('espresso_PRICING');
@@ -358,13 +351,10 @@ class Pricing_Admin_Page extends EE_Admin_Page
         wp_enqueue_script('ee_admin_js');
         wp_enqueue_script('jquery-ui-position');
         wp_enqueue_script('jquery-ui-widget');
-        // wp_enqueue_script('jquery-ui-dialog');
-        // wp_enqueue_script('jquery-ui-draggable');
-        // wp_enqueue_script('jquery-ui-datepicker');
         wp_register_script(
             'espresso_PRICING',
             PRICING_ASSETS_URL . 'espresso_pricing_admin.js',
-            array('jquery'),
+            ['jquery'],
             EVENT_ESPRESSO_VERSION,
             true
         );
@@ -382,9 +372,11 @@ class Pricing_Admin_Page extends EE_Admin_Page
     {
     }
 
+
     public function admin_init()
     {
     }
+
 
     public function admin_notices()
     {
@@ -393,43 +385,43 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
     protected function _set_list_table_views_default()
     {
-        $this->_views = array(
-            'all' => array(
+        $this->_views = [
+            'all' => [
                 'slug'        => 'all',
                 'label'       => esc_html__('View All Default Pricing', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'trash_price' => esc_html__('Move to Trash', 'event_espresso'),
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         if (EE_Registry::instance()->CAP->current_user_can('ee_delete_default_prices', 'pricing_trash_price')) {
-            $this->_views['trashed'] = array(
+            $this->_views['trashed'] = [
                 'slug'        => 'trashed',
                 'label'       => esc_html__('Trash', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'restore_price' => esc_html__('Restore from Trash', 'event_espresso'),
                     'delete_price'  => esc_html__('Delete Permanently', 'event_espresso'),
-                ),
-            );
+                ],
+            ];
         }
     }
 
 
     protected function _set_list_table_views_price_types()
     {
-        $this->_views = array(
-            'all' => array(
+        $this->_views = [
+            'all' => [
                 'slug'        => 'all',
                 'label'       => esc_html__('All', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'trash_price_type' => esc_html__('Move to Trash', 'event_espresso'),
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         if (
             EE_Registry::instance()->CAP->current_user_can(
@@ -437,128 +429,120 @@ class Pricing_Admin_Page extends EE_Admin_Page
                 'pricing_trash_price_type'
             )
         ) {
-            $this->_views['trashed'] = array(
+            $this->_views['trashed'] = [
                 'slug'        => 'trashed',
                 'label'       => esc_html__('Trash', 'event_espresso'),
                 'count'       => 0,
-                'bulk_action' => array(
+                'bulk_action' => [
                     'restore_price_type' => esc_html__('Restore from Trash', 'event_espresso'),
                     'delete_price_type'  => esc_html__('Delete Permanently', 'event_espresso'),
-                ),
-            );
+                ],
+            ];
         }
     }
 
 
     /**
-     *        generates HTML for main Prices Admin page
+     * generates HTML for main Prices Admin page
      *
-     * @access protected
      * @return void
+     * @throws EE_Error
      */
     protected function _price_overview_list_table()
     {
         $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-            'add_new_price',
-            'add',
-            array(),
-            'add-new-h2'
-        );
-        $this->admin_page_title .= $this->_learn_more_about_pricing_link();
+                'add_new_price',
+                'add',
+                [],
+                'add-new-h2'
+            );
+        $this->_admin_page_title .= $this->_learn_more_about_pricing_link();
         $this->_search_btn_label = esc_html__('Default Prices', 'event_espresso');
-        $this->display_admin_list_table_page_with_no_sidebar();
+        $this->display_admin_list_table_page_with_sidebar();
     }
 
 
     /**
-     *    retrieve data for Prices List table
+     * retrieve data for Prices List table
      *
-     * @access public
-     * @param  int     $per_page how many prices displayed per page
-     * @param  boolean $count    return the count or objects
-     * @param  boolean $trashed  whether the current view is of the trash can - eww yuck!
-     * @return mixed (int|array)  int = count || array of price objects
+     * @param int  $per_page how many prices displayed per page
+     * @param bool $count    return the count or objects
+     * @param bool $trashed  whether the current view is of the trash can - eww yuck!
+     * @return EE_Soft_Delete_Base_Class[]|int int = count || array of price objects
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function get_prices_overview_data($per_page = 10, $count = false, $trashed = false)
+    public function get_prices_overview_data(int $per_page = 10, bool $count = false, bool $trashed = false)
     {
-
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         // start with an empty array
-        $event_pricing = array();
+        $event_pricing = [];
 
         require_once(PRICING_ADMIN . 'Prices_List_Table.class.php');
-        require_once(EE_MODELS . 'EEM_Price.model.php');
-        // $PRC = EEM_Price::instance();
 
-        $this->_req_data['orderby'] = empty($this->_req_data['orderby']) ? '' : $this->_req_data['orderby'];
-        $order = (isset($this->_req_data['order']) && ! empty($this->_req_data['order'])) ? $this->_req_data['order']
-            : 'ASC';
+        $orderby = $this->request->getRequestParam('orderby', '');
+        $order   = $this->request->getRequestParam('order', 'ASC');
 
-        switch ($this->_req_data['orderby']) {
+        switch ($orderby) {
             case 'name':
-                $orderby = array('PRC_name' => $order);
+                $orderby = ['PRC_name' => $order];
                 break;
             case 'type':
-                $orderby = array('Price_Type.PRT_name' => $order);
+                $orderby = ['Price_Type.PRT_name' => $order];
                 break;
             case 'amount':
-                $orderby = array('PRC_amount' => $order);
+                $orderby = ['PRC_amount' => $order];
                 break;
             default:
-                $orderby = array('PRC_order' => $order, 'Price_Type.PRT_order' => $order, 'PRC_ID' => $order);
+                $orderby = ['PRC_order' => $order, 'Price_Type.PRT_order' => $order, 'PRC_ID' => $order];
         }
 
-        $current_page = isset($this->_req_data['paged']) && ! empty($this->_req_data['paged'])
-            ? $this->_req_data['paged'] : 1;
-        $per_page = isset($this->_req_data['perpage']) && ! empty($this->_req_data['perpage'])
-            ? $this->_req_data['perpage'] : $per_page;
+        $current_page = $this->request->getRequestParam('paged', 1, DataType::INTEGER);
+        $per_page     = $this->request->getRequestParam('perpage', $per_page, DataType::INTEGER);
 
-        $_where = array(
+        $where = [
             'PRC_is_default' => 1,
             'PRC_deleted'    => $trashed,
-        );
+        ];
 
         $offset = ($current_page - 1) * $per_page;
-        $limit = array($offset, $per_page);
+        $limit  = [$offset, $per_page];
 
-        if (isset($this->_req_data['s'])) {
-            $sstr = '%' . $this->_req_data['s'] . '%';
-            $_where['OR'] = array(
-                'PRC_name'            => array('LIKE', $sstr),
-                'PRC_desc'            => array('LIKE', $sstr),
-                'PRC_amount'          => array('LIKE', $sstr),
-                'Price_Type.PRT_name' => array('LIKE', $sstr),
-            );
+        $search_term = $this->request->getRequestParam('s');
+        if ($search_term) {
+            $search_term = "%{$search_term}%";
+            $where['OR'] = [
+                'PRC_name'            => ['LIKE', $search_term],
+                'PRC_desc'            => ['LIKE', $search_term],
+                'PRC_amount'          => ['LIKE', $search_term],
+                'Price_Type.PRT_name' => ['LIKE', $search_term],
+            ];
         }
 
-        $query_params = array(
-            $_where,
+        $query_params = [
+            $where,
             'order_by' => $orderby,
             'limit'    => $limit,
             'group_by' => 'PRC_ID',
-        );
+        ];
 
         if ($count) {
-            return $trashed ? EEM_Price::instance()->count(array($_where))
-                : EEM_Price::instance()->count_deleted_and_undeleted(array($_where));
-        } else {
-            return EEM_Price::instance()->get_all_deleted_and_undeleted($query_params);
+            return $trashed
+                ? EEM_Price::instance()->count([$where])
+                : EEM_Price::instance()->count_deleted_and_undeleted([$where]);
         }
+        return EEM_Price::instance()->get_all_deleted_and_undeleted($query_params);
     }
 
 
     /**
-     *        _price_details
-     *
-     * @access protected
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _edit_price_details()
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         // grab price ID
-        $PRC_ID = isset($this->_req_data['id']) && ! empty($this->_req_data['id']) ? absint($this->_req_data['id'])
-            : false;
+        $PRC_ID = $this->request->getRequestParam('id', 0, DataType::INTEGER);
         // change page title based on request action
         switch ($this->_req_action) {
             case 'add_new_price':
@@ -573,46 +557,61 @@ class Pricing_Admin_Page extends EE_Admin_Page
         // add PRC_ID to title if editing
         $this->_admin_page_title = $PRC_ID ? $this->_admin_page_title . ' # ' . $PRC_ID : $this->_admin_page_title;
 
-        // get prices
-        require_once(EE_MODELS . 'EEM_Price.model.php');
-        $PRC = EEM_Price::instance();
-
         if ($PRC_ID) {
-            $price = $PRC->get_one_by_ID($PRC_ID);
-            $additional_hidden_fields = array(
-                'PRC_ID' => array('type' => 'hidden', 'value' => $PRC_ID),
-            );
+            $price                    = EEM_Price::instance()->get_one_by_ID($PRC_ID);
+            $additional_hidden_fields = [
+                'PRC_ID' => ['type' => 'hidden', 'value' => $PRC_ID],
+            ];
             $this->_set_add_edit_form_tags('update_price', $additional_hidden_fields);
         } else {
-            $price = $PRC->get_new_price();
+            $price = EEM_Price::instance()->get_new_price();
             $this->_set_add_edit_form_tags('insert_price');
         }
 
+        if (! $price instanceof EE_Price) {
+            throw new RuntimeException(
+                sprintf(
+                    esc_html__(
+                        'A valid Price could not be retrieved from the database with ID: %1$s',
+                        'event_espresso'
+                    ),
+                    $PRC_ID
+                )
+            );
+        }
+
         $this->_template_args['PRC_ID'] = $PRC_ID;
-        $this->_template_args['price'] = $price;
+        $this->_template_args['price']  = $price;
+
+        $default_base_price = $price->type_obj() && $price->type_obj()->base_type() === 1;
+
+        $this->_template_args['default_base_price'] = $default_base_price;
 
         // get price types
-        require_once(EE_MODELS . 'EEM_Price_Type.model.php');
-        $PRT = EEM_Price_Type::instance();
-        $price_types = $PRT->get_all(array(array('PBT_ID' => array('!=', 1))));
-        $price_type_names = array();
+        $price_types = EEM_Price_Type::instance()->get_all([['PBT_ID' => ['!=', 1]]]);
         if (empty($price_types)) {
             $msg = esc_html__(
                 'You have no price types defined. Please add a price type before adding a price.',
                 'event_espresso'
             );
             EE_Error::add_error($msg, __FILE__, __FUNCTION__, __LINE__);
-            exit();
-        } else {
-            foreach ($price_types as $type) {
-                // if ($type->is_global()) {
-                $price_type_names[] = array('id' => $type->ID(), 'text' => $type->name());
-            // }
-            }
+            $this->display_admin_page_with_sidebar();
         }
-
+        $attributes       = [];
+        $price_type_names = [];
+        $attributes[]     = 'id="PRT_ID"';
+        if ($default_base_price) {
+            $attributes[]       = 'disabled="disabled"';
+            $price_type_names[] = ['id' => 1, 'text' => esc_html__('Base Price', 'event_espresso')];
+        }
+        foreach ($price_types as $type) {
+            $price_type_names[] = ['id' => $type->ID(), 'text' => $type->name()];
+        }
+        $this->_template_args['attributes']  = implode(' ', $attributes);
         $this->_template_args['price_types'] = $price_type_names;
+
         $this->_template_args['learn_more_about_pricing_link'] = $this->_learn_more_about_pricing_link();
+        $this->_template_args['admin_page_content']            = $this->_edit_price_details_meta_box();
 
         $this->_set_publish_post_box_vars('id', $PRC_ID);
         // the details template wrapper
@@ -621,33 +620,12 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        declare price details page metaboxes
      *
-     * @access protected
-     * @return void
+     * @return string
      */
-    protected function _price_details_meta_boxes()
+    public function _edit_price_details_meta_box(): string
     {
-        add_meta_box(
-            'edit-price-details-mbox',
-            esc_html__('Default Price Details', 'event_espresso'),
-            array($this, '_edit_price_details_meta_box'),
-            $this->wp_page_slug,
-            'normal',
-            'high'
-        );
-    }
-
-
-    /**
-     *        _edit_price_details_meta_box
-     *
-     * @access public
-     * @return void
-     */
-    public function _edit_price_details_meta_box()
-    {
-        echo EEH_Template::display_template(
+        return EEH_Template::display_template(
             PRICING_TEMPLATE_PATH . 'pricing_details_main_meta_box.template.php',
             $this->_template_args,
             true
@@ -656,85 +634,82 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        set_price_column_values
-     *
-     * @access protected
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function set_price_column_values()
+    protected function set_price_column_values(): array
     {
-
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        $set_column_values = array(
-            'PRT_ID'         => absint($this->_req_data['PRT_ID']),
-            'PRC_amount'     => $this->_req_data['PRC_amount'],
-            'PRC_name'       => $this->_req_data['PRC_name'],
-            'PRC_desc'       => $this->_req_data['PRC_desc'],
+        $PRC_order = 0;
+        $PRT_ID    = $this->request->getRequestParam('PRT_ID', 0, DataType::INTEGER);
+        if ($PRT_ID) {
+            /** @var EE_Price_Type $price_type */
+            $price_type = EEM_Price_Type::instance()->get_one_by_ID($PRT_ID);
+            if ($price_type instanceof EE_Price_Type) {
+                $PRC_order = $price_type->order();
+            }
+        }
+        return [
+            'PRT_ID'         => $PRT_ID,
+            'PRC_amount'     => $this->request->getRequestParam('PRC_amount', 0, DataType::FLOAT),
+            'PRC_name'       => $this->request->getRequestParam('PRC_name'),
+            'PRC_desc'       => $this->request->getRequestParam('PRC_desc'),
             'PRC_is_default' => 1,
             'PRC_overrides'  => null,
-            'PRC_order'      => 0,
+            'PRC_order'      => $PRC_order,
             'PRC_deleted'    => 0,
             'PRC_parent'     => 0,
-        );
-        return $set_column_values;
+        ];
     }
 
 
     /**
-     *        insert_or_update_price
-     *
-     * @param boolean $insert - whether to insert or update
-     * @access protected
+     * @param bool $insert - whether to insert or update
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _insert_or_update_price($insert = false)
+    protected function _insert_or_update_price(bool $insert = false)
     {
-
-        // echo '<h3>'. __CLASS__ . '->' . __FUNCTION__ . ' <br /><span style="font-size:10px;font-weight:normal;">' . __FILE__ . '<br />line no: ' . __LINE__ . '</span></h3>';
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        require_once(EE_MODELS . 'EEM_Price.model.php');
-        $PRC = EEM_Price::instance();
-
         // why be so pessimistic ???  : (
-        $success = 0;
+        $updated = 0;
 
         $set_column_values = $this->set_price_column_values();
         // is this a new Price ?
         if ($insert) {
             // run the insert
-            if ($PRC_ID = $PRC->insert($set_column_values)) {
+            $PRC_ID = EEM_Price::instance()->insert($set_column_values);
+            if ($PRC_ID) {
                 // make sure this new price modifier is attached to the ticket but ONLY if it is not a tax type
-                $PR = EEM_price::instance()->get_one_by_ID($PRC_ID);
-                if ($PR->type_obj()->base_type() !== EEM_Price_Type::base_type_tax) {
+                $price = EEM_price::instance()->get_one_by_ID($PRC_ID);
+                if (
+                    $price instanceof EE_Price
+                    && $price->type_obj() instanceof EE_Price_type
+                    && $price->type_obj()->base_type() !== EEM_Price_Type::base_type_tax
+                ) {
                     $ticket = EEM_Ticket::instance()->get_one_by_ID(1);
-                    $ticket->_add_relation_to($PR, 'Price');
+                    $ticket->_add_relation_to($price, 'Price');
                     $ticket->save();
                 }
-                $success = 1;
-            } else {
-                $PRC_ID = false;
-                $success = 0;
+                $updated = 1;
             }
             $action_desc = 'created';
         } else {
-            $PRC_ID = absint($this->_req_data['PRC_ID']);
+            $PRC_ID = $this->request->getRequestParam('PRC_ID', 0, DataType::INTEGER);
             // run the update
-            $where_cols_n_values = array('PRC_ID' => $PRC_ID);
-            if ($PRC->update($set_column_values, array($where_cols_n_values))) {
-                $success = 1;
-            }
+            $where_cols_n_values = ['PRC_ID' => $PRC_ID];
+            $updated             = EEM_Price::instance()->update($set_column_values, [$where_cols_n_values]);
 
-            $PR = EEM_Price::instance()->get_one_by_ID($PRC_ID);
-            if ($PR->type_obj()->base_type() !== EEM_Price_Type::base_type_tax) {
-                // if this is $PRC_ID == 1, then we need to update the default ticket attached to this price so the TKT_price value is updated.
+            $price = EEM_Price::instance()->get_one_by_ID($PRC_ID);
+            if ($price instanceof EE_Price && $price->type_obj()->base_type() !== EEM_Price_Type::base_type_tax) {
+                // if this is $PRC_ID == 1,
+                // then we need to update the default ticket attached to this price so the TKT_price value is updated.
                 if ($PRC_ID === 1) {
-                    $ticket = $PR->get_first_related('Ticket');
+                    $ticket = $price->get_first_related('Ticket');
                     if ($ticket) {
-                        $ticket->set('TKT_price', $PR->get('PRC_amount'));
-                        $ticket->set('TKT_name', $PR->get('PRC_name'));
-                        $ticket->set('TKT_description', $PR->get('PRC_desc'));
+                        $ticket->set('TKT_price', $price->get('PRC_amount'));
+                        $ticket->set('TKT_name', $price->get('PRC_name'));
+                        $ticket->set('TKT_description', $price->get('PRC_desc'));
                         $ticket->save();
                     }
                 } else {
@@ -748,280 +723,237 @@ class Pricing_Admin_Page extends EE_Admin_Page
             $action_desc = 'updated';
         }
 
-        $query_args = array('action' => 'edit_price', 'id' => $PRC_ID);
+        $query_args = ['action' => 'edit_price', 'id' => $PRC_ID];
 
-        $this->_redirect_after_action($success, 'Prices', $action_desc, $query_args);
+        $this->_redirect_after_action($updated, 'Prices', $action_desc, $query_args);
     }
 
 
     /**
-     *        _trash_or_restore_price
-     *
-     * @param boolean $trash - whether to move item to trash (TRUE) or restore it (FALSE)
-     * @access protected
+     * @param bool $trash - whether to move item to trash (TRUE) or restore it (FALSE)
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _trash_or_restore_price($trash = true)
+    protected function _trash_or_restore_price(bool $trash = true)
     {
-
-        // echo '<h3>'. __CLASS__ . '->' . __FUNCTION__ . ' <br /><span style="font-size:10px;font-weight:normal;">' . __FILE__ . '<br />line no: ' . __LINE__ . '</span></h3>';
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        require_once(EE_MODELS . 'EEM_Price.model.php');
-        $PRC = EEM_Price::instance();
-
-        $success = 1;
-        $PRC_deleted = $trash ? true : false;
-
-        // get base ticket for updating
-        $ticket = EEM_Ticket::instance()->get_one_by_ID(1);
-        // Checkboxes
-        if (! empty($this->_req_data['checkbox']) && is_array($this->_req_data['checkbox'])) {
-            // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['checkbox']) > 1 ? 2 : 1;
-            // cycle thru checkboxes
-            while (list($PRC_ID, $value) = each($this->_req_data['checkbox'])) {
-                if (! $PRC->update_by_ID(array('PRC_deleted' => $PRC_deleted), absint($PRC_ID))) {
-                    $success = 0;
-                } else {
-                    $PR = EEM_Price::instance()->get_one_by_ID($PRC_ID);
-                    if ($PR->type_obj()->base_type() !== EEM_Price_Type::base_type_tax) {
-                        // if trashing then remove relations to base default ticket.  If restoring then add back to base default ticket
-                        if ($PRC_deleted) {
-                            $ticket->_remove_relation_to($PRC_ID, 'Price');
-                        } else {
-                            $ticket->_add_relation_to($PRC_ID, 'Price');
-                        }
-                        $ticket->save();
-                    }
-                }
-            }
-        } else {
-            // grab single id and delete
-            $PRC_ID = isset($this->_req_data['id']) ? absint($this->_req_data['id']) : 0;
-            if (empty($PRC_ID) || ! $PRC->update_by_ID(array('PRC_deleted' => $PRC_deleted), $PRC_ID)) {
-                $success = 0;
-            } else {
-                $PR = EEM_Price::instance()->get_one_by_ID($PRC_ID);
-                if ($PR->type_obj()->base_type() !== EEM_Price_Type::base_type_tax) {
-                    // if trashing then remove relations to base default ticket.  If restoring then add back to base default ticket
-                    if ($PRC_deleted) {
-                        $ticket->_remove_relation_to($PRC_ID, 'Price');
-                    } else {
-                        $ticket->_add_relation_to($PRC_ID, 'Price');
-                    }
-                    $ticket->save();
-                }
-            }
-        }
-        $query_args = array(
-            'action' => 'default',
+        $entity_model = EEM_Price::instance();
+        $action       = $trash ? EE_Admin_List_Table::ACTION_TRASH : EE_Admin_List_Table::ACTION_RESTORE;
+        $result       = $this->trashRestoreDeleteEntities(
+            $entity_model,
+            'id',
+            $action,
+            'PRC_deleted',
+            [$this, 'adjustTicketRelations']
         );
 
-        if ($success) {
-            if ($trash) {
-                $msg = $success == 2
-                    ? esc_html__('The Prices have been trashed.', 'event_espresso')
-                    : esc_html__(
-                        'The Price has been trashed.',
+        if ($result) {
+            $msg = $trash
+                ? esc_html(
+                    _n(
+                        'The Price has been trashed',
+                        'The Prices have been trashed',
+                        $result,
                         'event_espresso'
-                    );
-            } else {
-                $msg = $success == 2
-                    ? esc_html__('The Prices have been restored.', 'event_espresso')
-                    : esc_html__(
-                        'The Price has been restored.',
+                    )
+                )
+                : esc_html(
+                    _n(
+                        'The Price has been restored',
+                        'The Prices have been restored',
+                        $result,
                         'event_espresso'
-                    );
-            }
-
+                    )
+                );
             EE_Error::add_success($msg);
         }
 
-        $this->_redirect_after_action(false, '', '', $query_args, true);
+        $this->_redirect_after_action(
+            $result,
+            _n('Price', 'Prices', $result, 'event_espresso'),
+            $trash ? 'trashed' : 'restored',
+            ['action' => 'default'],
+            true
+        );
     }
 
 
     /**
-     *        _delete_price
-     *
-     * @access protected
-     * @return void
+     * @param EEM_Base   $entity_model
+     * @param int|string $entity_ID
+     * @param string     $action
+     * @param int        $result
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since $VID:$
      */
-    protected function _delete_price()
-    {
-
-        // echo '<h3>'. __CLASS__ . '->' . __FUNCTION__ . ' <br /><span style="font-size:10px;font-weight:normal;">' . __FILE__ . '<br />line no: ' . __LINE__ . '</span></h3>';
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        require_once(EE_MODELS . 'EEM_Price.model.php');
-        $PRC = EEM_Price::instance();
-
-        $success = 1;
-        // Checkboxes
-        if (! empty($this->_req_data['checkbox']) && is_array($this->_req_data['checkbox'])) {
-            // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['checkbox']) > 1 ? 2 : 1;
-            // cycle thru bulk action checkboxes
-            while (list($PRC_ID, $value) = each($this->_req_data['checkbox'])) {
-                if (! $PRC->delete_permanently_by_ID(absint($PRC_ID))) {
-                    $success = 0;
-                }
-            }
-        } else {
-            // grab single id and delete
-            $PRC_ID = absint($this->_req_data['id']);
-            if (! $PRC->delete_permanently_by_ID($PRC_ID)) {
-                $success = 0;
-            }
+    public function adjustTicketRelations(
+        EEM_Base $entity_model,
+                 $entity_ID,
+        string   $action,
+        int      $result
+    ) {
+        if (! $entity_ID || (float)$result < 1) {
+            return;
         }
 
-        $this->_redirect_after_action($success, 'Prices', 'deleted', array());
+        $entity = $entity_model->get_one_by_ID($entity_ID);
+        if (! $entity instanceof EE_Price || $entity->type_obj()->base_type() === EEM_Price_Type::base_type_tax) {
+            return;
+        }
+
+        // get default tickets for updating
+        $default_tickets = EEM_Ticket::instance()->get_all_default_tickets();
+        foreach ($default_tickets as $default_ticket) {
+            if (! $default_ticket instanceof EE_Ticket) {
+                continue;
+            }
+            switch ($action) {
+                case EE_Admin_List_Table::ACTION_DELETE:
+                case EE_Admin_List_Table::ACTION_TRASH:
+                    // if trashing then remove relations to base default ticket.
+                    $default_ticket->_remove_relation_to($entity_ID, 'Price');
+                    break;
+                case EE_Admin_List_Table::ACTION_RESTORE:
+                    // if restoring then add back to base default ticket
+                    $default_ticket->_add_relation_to($entity_ID, 'Price');
+                    break;
+            }
+            $default_ticket->save();
+        }
     }
 
 
+    /**
+     * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    protected function _delete_price()
+    {
+        $entity_model = EEM_Price::instance();
+        $deleted      = $this->trashRestoreDeleteEntities($entity_model, 'id');
+        $entity       = $entity_model->item_name($deleted);
+        $this->_redirect_after_action($deleted, $entity, 'deleted', ['action' => 'default']);
+    }
+
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function update_price_order()
     {
-        $success = esc_html__('Price order was updated successfully.', 'event_espresso');
-
         // grab our row IDs
-        $row_ids = isset($this->_req_data['row_ids']) && ! empty($this->_req_data['row_ids']) ? explode(
-            ',',
-            rtrim(
-                $this->_req_data['row_ids'],
-                ','
-            )
-        ) : false;
+        $row_ids = $this->request->getRequestParam('row_ids', '');
+        $row_ids = explode(',', rtrim($row_ids, ','));
 
-        if (is_array($row_ids)) {
-            for ($i = 0; $i < count($row_ids); $i++) {
-                // Update the prices when re-ordering
-                $id = absint($row_ids[ $i ]);
-                if (
-                    EEM_Price::instance()->update(
-                        array('PRC_order' => $i + 1),
-                        array(array('PRC_ID' => $id))
-                    ) === false
-                ) {
-                    $success = false;
-                }
-            }
-        } else {
-            $success = false;
+        $all_updated = true;
+        foreach ($row_ids as $i => $row_id) {
+            // Update the prices when re-ordering
+            $fields_n_values = ['PRC_order' => $i + 1];
+            $query_params    = [['PRC_ID' => absint($row_id)]];
+            // any failure will toggle $all_updated to false
+            $all_updated =
+                $row_id && EEM_Price::instance()->update($fields_n_values, $query_params) !== false ? $all_updated
+                    : false;
         }
+        $success = $all_updated ? esc_html__('Price order was updated successfully.', 'event_espresso') : false;
+        $errors  = ! $all_updated ? esc_html__('An error occurred. The price order was not updated.', 'event_espresso')
+            : false;
 
-        $errors = ! $success ? esc_html__('An error occurred. The price order was not updated.', 'event_espresso') : false;
-
-        echo wp_json_encode(array('return_data' => false, 'success' => $success, 'errors' => $errors));
+        echo wp_json_encode(['return_data' => false, 'success' => $success, 'errors' => $errors]);
         die();
     }
 
 
-
-
-
-
-    /**************************************************************************************************************************************************************
-     ********************************************************************  TICKET PRICE TYPES  ******************************************************************
-     **************************************************************************************************************************************************************/
+    /******************************************************************************************************************
+     ***********************************************  TICKET PRICE TYPES  *********************************************
+     ******************************************************************************************************************/
 
 
     /**
-     *        generates HTML for main Prices Admin page
+     * generates HTML for main Prices Admin page
      *
-     * @access protected
      * @return void
+     * @throws EE_Error
      */
     protected function _price_types_overview_list_table()
     {
         $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-            'add_new_price_type',
-            'add_type',
-            array(),
-            'add-new-h2'
-        );
-        $this->admin_page_title .= $this->_learn_more_about_pricing_link();
+                'add_new_price_type',
+                'add_type',
+                [],
+                'add-new-h2'
+            );
+        $this->_admin_page_title .= $this->_learn_more_about_pricing_link();
         $this->_search_btn_label = esc_html__('Price Types', 'event_espresso');
-        $this->display_admin_list_table_page_with_no_sidebar();
+        $this->display_admin_list_table_page_with_sidebar();
     }
 
 
     /**
-     *    retrieve data for Price Types List table
+     * retrieve data for Price Types List table
      *
-     * @access public
-     * @param  int     $per_page how many prices displayed per page
-     * @param  boolean $count    return the count or objects
-     * @param  boolean $trashed  whether the current view is of the trash can - eww yuck!
-     * @return mixed (int|array)  int = count || array of price objects
+     * @param int  $per_page how many prices displayed per page
+     * @param bool $count    return the count or objects
+     * @param bool $trashed  whether the current view is of the trash can - eww yuck!
+     * @return EE_Soft_Delete_Base_Class[]|int int = count || array of price objects
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function get_price_types_overview_data($per_page = 10, $count = false, $trashed = false)
+    public function get_price_types_overview_data(int $per_page = 10, bool $count = false, bool $trashed = false)
     {
-
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         // start with an empty array
-
         require_once(PRICING_ADMIN . 'Price_Types_List_Table.class.php');
-        require_once(EE_MODELS . 'EEM_Price_Type.model.php');
 
-        $this->_req_data['orderby'] = empty($this->_req_data['orderby']) ? '' : $this->_req_data['orderby'];
-        $order = (isset($this->_req_data['order']) && ! empty($this->_req_data['order'])) ? $this->_req_data['order']
-            : 'ASC';
-        switch ($this->_req_data['orderby']) {
+        $orderby = $this->request->getRequestParam('orderby', '');
+        $order   = $this->request->getRequestParam('order', 'ASC');
+
+        switch ($orderby) {
             case 'name':
-                $orderby = array('PRT_name' => $order);
+                $orderby = ['PRT_name' => $order];
                 break;
             default:
-                $orderby = array('PRT_order' => $order);
+                $orderby = ['PRT_order' => $order];
         }
 
-
-        $current_page = isset($this->_req_data['paged']) && ! empty($this->_req_data['paged'])
-            ? $this->_req_data['paged'] : 1;
-        $per_page = isset($this->_req_data['perpage']) && ! empty($this->_req_data['perpage'])
-            ? $this->_req_data['perpage'] : $per_page;
+        $current_page = $this->request->getRequestParam('paged', 1, DataType::INTEGER);
+        $per_page     = $this->request->getRequestParam('perpage', $per_page, DataType::INTEGER);
 
         $offset = ($current_page - 1) * $per_page;
-        $limit = array($offset, $per_page);
+        $limit  = [$offset, $per_page];
 
-        $_where = array('PRT_deleted' => $trashed, 'PBT_ID' => array('!=', 1));
+        $where = ['PRT_deleted' => $trashed, 'PBT_ID' => ['!=', 1]];
 
-        if (isset($this->_req_data['s'])) {
-            $sstr = '%' . $this->_req_data['s'] . '%';
-            $_where['OR'] = array(
-                'PRT_name' => array('LIKE', $sstr),
-            );
+        $search_term = $this->request->getRequestParam('s');
+        if ($search_term) {
+            $where['OR'] = [
+                'PRT_name' => ['LIKE', "%{$search_term}%"],
+            ];
         }
-        $query_params = array(
-            $_where,
+        $query_params = [
+            $where,
             'order_by' => $orderby,
             'limit'    => $limit,
-        );
-        if ($count) {
-            return EEM_Price_Type::instance()->count_deleted_and_undeleted($query_params);
-        } else {
-            return EEM_Price_Type::instance()->get_all_deleted_and_undeleted($query_params);
-        }
-
-        // EEH_Debug_Tools::printr( $price_types, '$price_types  <br /><span style="font-size:10px;font-weight:normal;">' . __FILE__ . '<br />line no: ' . __LINE__ . '</span>', 'auto' );
+        ];
+        return $count
+            ? EEM_Price_Type::instance()->count_deleted_and_undeleted($query_params)
+            : EEM_Price_Type::instance()->get_all_deleted_and_undeleted($query_params);
     }
 
 
     /**
-     *        _edit_price_type_details
+     * _edit_price_type_details
      *
-     * @access protected
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _edit_price_type_details()
     {
-
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-
         // grab price type ID
-        $PRT_ID = isset($this->_req_data['id']) && ! empty($this->_req_data['id']) ? absint($this->_req_data['id'])
-            : false;
+        $PRT_ID = $this->request->getRequestParam('id', 0, DataType::INTEGER);
         // change page title based on request action
         switch ($this->_req_action) {
             case 'add_new_price_type':
@@ -1037,37 +969,50 @@ class Pricing_Admin_Page extends EE_Admin_Page
         $this->_admin_page_title = $PRT_ID ? $this->_admin_page_title . ' # ' . $PRT_ID : $this->_admin_page_title;
 
         if ($PRT_ID) {
-            $price_type = EEM_Price_Type::instance()->get_one_by_ID($PRT_ID);
-            $additional_hidden_fields = array('PRT_ID' => array('type' => 'hidden', 'value' => $PRT_ID));
+            $price_type               = EEM_Price_Type::instance()->get_one_by_ID($PRT_ID);
+            $additional_hidden_fields = ['PRT_ID' => ['type' => 'hidden', 'value' => $PRT_ID]];
             $this->_set_add_edit_form_tags('update_price_type', $additional_hidden_fields);
         } else {
             $price_type = EEM_Price_Type::instance()->get_new_price_type();
             $this->_set_add_edit_form_tags('insert_price_type');
         }
 
-        $this->_template_args['PRT_ID'] = $PRT_ID;
+        if (! $price_type instanceof EE_Price_Type) {
+            throw new RuntimeException(
+                sprintf(
+                    esc_html__(
+                        'A valid Price Type could not be retrieved from the database with ID: %1$s',
+                        'event_espresso'
+                    ),
+                    $PRT_ID
+                )
+            );
+        }
+
+        $this->_template_args['PRT_ID']     = $PRT_ID;
         $this->_template_args['price_type'] = $price_type;
 
-
-        $base_types = EEM_Price_Type::instance()->get_base_types();
-        $select_values = array();
+        $base_types    = EEM_Price_Type::instance()->get_base_types();
+        $select_values = [];
         foreach ($base_types as $ref => $text) {
             if ($ref == EEM_Price_Type::base_type_base_price) {
                 // do not allow creation of base_type_base_prices because that's a system only base type.
                 continue;
             }
-            $values[] = array('id' => $ref, 'text' => $text);
+            $select_values[] = ['id' => $ref, 'text' => $text];
         }
-
 
         $this->_template_args['base_type_select'] = EEH_Form_Fields::select_input(
             'base_type',
-            $values,
+            $select_values,
             $price_type->base_type(),
             'id="price-type-base-type-slct"'
         );
+
         $this->_template_args['learn_more_about_pricing_link'] = $this->_learn_more_about_pricing_link();
-        $redirect_URL = add_query_arg(array('action' => 'price_types'), $this->_admin_base_url);
+        $this->_template_args['admin_page_content']            = $this->_edit_price_type_details_meta_box();
+
+        $redirect_URL = add_query_arg(['action' => 'price_types'], $this->_admin_base_url);
         $this->_set_publish_post_box_vars('id', $PRT_ID, false, $redirect_URL);
         // the details template wrapper
         $this->display_admin_page_with_sidebar();
@@ -1075,33 +1020,13 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        declare price type details page metaboxes
+     * _edit_price_type_details_meta_box
      *
-     * @access protected
-     * @return void
+     * @return string
      */
-    protected function _price_type_details_meta_boxes()
+    public function _edit_price_type_details_meta_box(): string
     {
-        add_meta_box(
-            'edit-price-details-mbox',
-            esc_html__('Price Type Details', 'event_espresso'),
-            array($this, '_edit_price_type_details_meta_box'),
-            $this->wp_page_slug,
-            'normal',
-            'high'
-        );
-    }
-
-
-    /**
-     *        _edit_price_type_details_meta_box
-     *
-     * @access public
-     * @return void
-     */
-    public function _edit_price_type_details_meta_box()
-    {
-        echo EEH_Template::display_template(
+        return EEH_Template::display_template(
             PRICING_TEMPLATE_PATH . 'pricing_type_details_main_meta_box.template.php',
             $this->_template_args,
             true
@@ -1110,66 +1035,50 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        set_price_type_column_values
-     *
-     * @access protected
-     * @return void
+     * @return array
      */
-    protected function set_price_type_column_values()
+    protected function set_price_type_column_values(): array
     {
-
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        $base_type = ! empty($this->_req_data['base_type']) ? $this->_req_data['base_type']
-            : EEM_Price_Type::base_type_base_price;
-
+        $base_type  = $this->request->getRequestParam(
+            'base_type',
+            EEM_Price_Type::base_type_base_price,
+            DataType::INTEGER
+        );
+        $is_percent = $this->request->getRequestParam('PRT_is_percent', 0, DataType::INTEGER);
+        $order      = $this->request->getRequestParam('PRT_order', 0, DataType::INTEGER);
         switch ($base_type) {
             case EEM_Price_Type::base_type_base_price:
-                $this->_req_data['PBT_ID'] = EEM_Price_Type::base_type_base_price;
-                $this->_req_data['PRT_is_percent'] = 0;
-                $this->_req_data['PRT_order'] = 0;
+                $is_percent = 0;
+                $order      = 0;
                 break;
 
             case EEM_Price_Type::base_type_discount:
-                $this->_req_data['PBT_ID'] = EEM_Price_Type::base_type_discount;
-                break;
-
             case EEM_Price_Type::base_type_surcharge:
-                $this->_req_data['PBT_ID'] = EEM_Price_Type::base_type_surcharge;
                 break;
 
             case EEM_Price_Type::base_type_tax:
-                $this->_req_data['PBT_ID'] = EEM_Price_Type::base_type_tax;
-                $this->_req_data['PRT_is_percent'] = 1;
+                $is_percent = 1;
                 break;
-        }/**/
+        }
 
-        $set_column_values = array(
-            'PRT_name'       => $this->_req_data['PRT_name'],
-            'PBT_ID'         => absint($this->_req_data['PBT_ID']),
-            'PRT_is_percent' => absint($this->_req_data['PRT_is_percent']),
-            'PRT_order'      => absint($this->_req_data['PRT_order']),
+        return [
+            'PBT_ID'         => $base_type,
+            'PRT_name'       => $this->request->getRequestParam('PRT_name', ''),
+            'PRT_is_percent' => $is_percent,
+            'PRT_order'      => $order,
             'PRT_deleted'    => 0,
-        );
-
-        return $set_column_values;
+        ];
     }
 
 
     /**
-     *        _insert_or_update_price_type
-     *
-     * @param boolean $new_price_type - whether to insert or update
-     * @access protected
+     * @param bool $new_price_type - whether to insert or update
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _insert_or_update_price_type($new_price_type = false)
+    protected function _insert_or_update_price_type(bool $new_price_type = false)
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        require_once(EE_MODELS . 'EEM_Price_Type.model.php');
-        $PRT = EEM_Price_Type::instance();
-
         // why be so pessimistic ???  : (
         $success = 0;
 
@@ -1177,132 +1086,93 @@ class Pricing_Admin_Page extends EE_Admin_Page
         // is this a new Price ?
         if ($new_price_type) {
             // run the insert
-            if ($PRT_ID = $PRT->insert($set_column_values)) {
+            if ($PRT_ID = EEM_Price_Type::instance()->insert($set_column_values)) {
                 $success = 1;
             }
             $action_desc = 'created';
         } else {
-            $PRT_ID = absint($this->_req_data['PRT_ID']);
+            $PRT_ID = $this->request->getRequestParam('PRT_ID', 0, DataType::INTEGER);
             // run the update
-            $where_cols_n_values = array('PRT_ID' => $PRT_ID);
-            if ($PRT->update($set_column_values, array($where_cols_n_values))) {
+            $where_cols_n_values = ['PRT_ID' => $PRT_ID];
+            if (EEM_Price_Type::instance()->update($set_column_values, [$where_cols_n_values])) {
                 $success = 1;
             }
             $action_desc = 'updated';
         }
 
-        $query_args = array('action' => 'edit_price_type', 'id' => $PRT_ID);
+        $query_args = ['action' => 'edit_price_type', 'id' => $PRT_ID];
         $this->_redirect_after_action($success, 'Price Type', $action_desc, $query_args);
     }
 
 
     /**
-     *        _trash_or_restore_price_type
-     *
-     * @param boolean $trash - whether to move item to trash (TRUE) or restore it (FALSE)
-     * @access protected
+     * @param bool $trash - whether to move item to trash (TRUE) or restore it (FALSE)
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _trash_or_restore_price_type($trash = true)
+    protected function _trash_or_restore_price_type(bool $trash = true)
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        require_once(EE_MODELS . 'EEM_Price_Type.model.php');
-        $PRT = EEM_Price_Type::instance();
-
-        $success = 1;
-        $PRT_deleted = $trash ? true : false;
-        // Checkboxes
-        if (! empty($this->_req_data['checkbox']) && is_array($this->_req_data['checkbox'])) {
-            // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['checkbox']) > 1 ? 2 : 1;
-            $what = count($this->_req_data['checkbox']) > 1 ? 'Price Types' : 'Price Type';
-            // cycle thru checkboxes
-            while (list($PRT_ID, $value) = each($this->_req_data['checkbox'])) {
-                if (! $PRT->update_by_ID(array('PRT_deleted' => $PRT_deleted), $PRT_ID)) {
-                    $success = 0;
-                }
-            }
-        } else {
-            // grab single id and delete
-            $PRT_ID = isset($this->_req_data['id']) ? absint($this->_req_data['id']) : 0;
-            if (empty($PRT_ID) || ! $PRT->update_by_ID(array('PRT_deleted' => $PRT_deleted), $PRT_ID)) {
-                $success = 0;
-            }
-            $what = 'Price Type';
-        }
-
-        $query_args = array('action' => 'price_types');
+        $entity_model = EEM_Price_Type::instance();
+        $action       = $trash ? EE_Admin_List_Table::ACTION_TRASH : EE_Admin_List_Table::ACTION_RESTORE;
+        $success      = $this->trashRestoreDeleteEntities($entity_model, 'id', $action, 'PRT_deleted');
         if ($success) {
-            if ($trash) {
-                $msg = $success > 1
-                    ? esc_html__('The Price Types have been trashed.', 'event_espresso')
-                    : esc_html__(
-                        'The Price Type has been trashed.',
+            $msg = $trash
+                ? esc_html(
+                    _n(
+                        'The Price Type has been trashed',
+                        'The Price Types have been trashed',
+                        $success,
                         'event_espresso'
-                    );
-            } else {
-                $msg = $success > 1
-                    ? esc_html__('The Price Types have been restored.', 'event_espresso')
-                    : esc_html__(
-                        'The Price Type has been restored.',
+                    )
+                )
+                : esc_html(
+                    _n(
+                        'The Price Type has been restored',
+                        'The Price Types have been restored',
+                        $success,
                         'event_espresso'
-                    );
-            }
+                    )
+                );
             EE_Error::add_success($msg);
         }
-
-        $this->_redirect_after_action(false, '', '', $query_args, true);
+        $this->_redirect_after_action('', '', '', ['action' => 'price_types'], true);
     }
 
 
     /**
-     *        _delete_price_type
-     *
-     * @access protected
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _delete_price_type()
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-
-        $PRT = EEM_Price_Type::instance();
-
-        $success = 1;
-        // Checkboxes
-        if (! empty($this->_req_data['checkbox'])) {
-            // if array has more than one element than success message should be plural
-            $success = count($this->_req_data['checkbox']) > 1 ? 2 : 1;
-            $what = $PRT->item_name($success);
-            // cycle thru bulk action checkboxes
-            while (list($PRT_ID, $value) = each($this->_req_data['checkbox'])) {
-                if (! $PRT->delete_permanently_by_ID($PRT_ID)) {
-                    $success = 0;
-                }
-            }
-        }
-
-
-        $query_args = array('action' => 'price_types');
-        $this->_redirect_after_action($success, $what, 'deleted', $query_args);
+        $entity_model = EEM_Price_Type::instance();
+        $deleted      = $this->trashRestoreDeleteEntities($entity_model, 'id');
+        $this->_redirect_after_action(
+            $deleted,
+            $entity_model->item_name($deleted),
+            'deleted',
+            ['action' => 'price_types']
+        );
     }
 
 
     /**
-     *        _learn_more_about_pricing_link
-     *
-     * @access protected
      * @return string
      */
-    protected function _learn_more_about_pricing_link()
+    protected function _learn_more_about_pricing_link(): string
     {
-        return '<a class="hidden" style="margin:0 20px; cursor:pointer; font-size:12px;" >' . esc_html__(
-            'learn more about how pricing works',
-            'event_espresso'
-        ) . '</a>';
+        return '
+            <a class="hidden" style="margin:0 20px; cursor:pointer; font-size:12px;" >
+                ' . esc_html__('learn more about how pricing works', 'event_espresso') . '
+            </a>';
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     protected function _tax_settings()
     {
         $this->_set_add_edit_form_tags('update_tax_settings');
@@ -1313,56 +1183,49 @@ class Pricing_Admin_Page extends EE_Admin_Page
 
 
     /**
-     * @return \EE_Form_Section_Proper
-     * @throws \EE_Error
+     * @return EE_Form_Section_Proper
+     * @throws EE_Error
      */
-    protected function tax_settings_form()
+    protected function tax_settings_form(): EE_Form_Section_Proper
     {
+        $tax_settings = EE_Config::instance()->tax_settings;
         return new EE_Form_Section_Proper(
-            array(
+            [
                 'name'            => 'tax_settings_form',
                 'html_id'         => 'tax_settings_form',
+                'html_class'      => 'padding',
                 'layout_strategy' => new EE_Div_Per_Section_Layout(),
                 'subsections'     => apply_filters(
                     'FHEE__Pricing_Admin_Page__tax_settings_form__form_subsections',
-                    array(
+                    [
                         'tax_settings' => new EE_Form_Section_Proper(
-                            array(
+                            [
                                 'name'            => 'tax_settings_tbl',
                                 'html_id'         => 'tax_settings_tbl',
                                 'html_class'      => 'form-table',
                                 'layout_strategy' => new EE_Admin_Two_Column_Layout(),
-                                'subsections'     => array(
+                                'subsections'     => [
                                     'prices_displayed_including_taxes' => new EE_Yes_No_Input(
-                                        array(
+                                        [
                                             'html_label_text'         => esc_html__(
-                                                "Show Prices With Taxes Included?",
-                                                'event_espresso'
+                                            'Show Prices With Taxes Included?',
+                                            'event_espresso'
                                             ),
                                             'html_help_text'          => esc_html__(
-                                                'Indicates whether or not to display prices with the taxes included',
-                                                'event_espresso'
+                                            'Indicates whether or not to display prices with the taxes included',
+                                            'event_espresso'
                                             ),
-                                            'default'                 => isset(
-                                                EE_Registry::instance()
-                                                    ->CFG
-                                                    ->tax_settings
-                                                    ->prices_displayed_including_taxes
-                                            )
-                                                ? EE_Registry::instance()
-                                                    ->CFG
-                                                    ->tax_settings
-                                                    ->prices_displayed_including_taxes
-                                                : true,
+                                            'default'                 => $tax_settings->prices_displayed_including_taxes
+                                                                         ?? true,
                                             'display_html_label_text' => false,
-                                        )
+                                        ]
                                     ),
-                                ),
-                            )
+                                ],
+                            ]
                         ),
-                    )
+                    ]
                 ),
-            )
+            ]
         );
     }
 
@@ -1370,13 +1233,16 @@ class Pricing_Admin_Page extends EE_Admin_Page
     /**
      * _update_tax_settings
      *
-     * @since 4.9.13
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.9.13
      */
     public function _update_tax_settings()
     {
-        if (! isset(EE_Registry::instance()->CFG->tax_settings)) {
-            EE_Registry::instance()->CFG->tax_settings = new EE_Tax_Config();
+        $tax_settings = EE_Config::instance()->tax_settings;
+        if (! $tax_settings instanceof EE_Tax_Config) {
+            $tax_settings = new EE_Tax_Config();
         }
         try {
             $tax_form = $this->tax_settings_form();
@@ -1389,11 +1255,8 @@ class Pricing_Admin_Page extends EE_Admin_Page
                     // grab validated data from form
                     $valid_data = $tax_form->valid_data();
                     // set data on config
-                    EE_Registry::instance()
-                        ->CFG
-                        ->tax_settings
-                        ->prices_displayed_including_taxes
-                        = $valid_data['tax_settings']['prices_displayed_including_taxes'];
+                    $tax_settings->prices_displayed_including_taxes =
+                        $valid_data['tax_settings']['prices_displayed_including_taxes'];
                 } else {
                     if ($tax_form->submission_error_message() !== '') {
                         EE_Error::add_error(
@@ -1409,14 +1272,14 @@ class Pricing_Admin_Page extends EE_Admin_Page
             EE_Error::add_error($e->get_error(), __FILE__, __FUNCTION__, __LINE__);
         }
 
-        $what = 'Tax Settings';
+        $what    = 'Tax Settings';
         $success = $this->_update_espresso_configuration(
             $what,
-            EE_Registry::instance()->CFG->tax_settings,
+            $tax_settings,
             __FILE__,
             __FUNCTION__,
             __LINE__
         );
-        $this->_redirect_after_action($success, $what, 'updated', array('action' => 'tax_settings'));
+        $this->_redirect_after_action($success, $what, 'updated', ['action' => 'tax_settings']);
     }
 }

--- a/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
+++ b/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
@@ -789,7 +789,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
      */
     public function adjustTicketRelations(EEM_Base $entity_model, $entity_ID, string $action, int $result)
     {
-        if (! $entity_ID || (float)$result < 1) {
+        if (! $entity_ID || (float) $result < 1) {
             return;
         }
 

--- a/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
+++ b/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
@@ -850,9 +850,9 @@ class Pricing_Admin_Page extends EE_Admin_Page
             $fields_n_values = ['PRC_order' => $i + 1];
             $query_params    = [['PRC_ID' => absint($row_id)]];
             // any failure will toggle $all_updated to false
-            $all_updated =
-                $row_id && EEM_Price::instance()->update($fields_n_values, $query_params) !== false ? $all_updated
-                    : false;
+            $all_updated = $row_id && EEM_Price::instance()->update($fields_n_values, $query_params) !== false
+                ? $all_updated
+                : false;
         }
         $success = $all_updated ? esc_html__('Price order was updated successfully.', 'event_espresso') : false;
         $errors  = ! $all_updated ? esc_html__('An error occurred. The price order was not updated.', 'event_espresso')

--- a/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
+++ b/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
@@ -451,11 +451,11 @@ class Pricing_Admin_Page extends EE_Admin_Page
     protected function _price_overview_list_table()
     {
         $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-                'add_new_price',
-                'add',
-                [],
-                'add-new-h2'
-            );
+            'add_new_price',
+            'add',
+            [],
+            'add-new-h2'
+        );
         $this->_admin_page_title .= $this->_learn_more_about_pricing_link();
         $this->_search_btn_label = esc_html__('Default Prices', 'event_espresso');
         $this->display_admin_list_table_page_with_sidebar();
@@ -787,12 +787,8 @@ class Pricing_Admin_Page extends EE_Admin_Page
      * @throws ReflectionException
      * @since $VID:$
      */
-    public function adjustTicketRelations(
-        EEM_Base $entity_model,
-                 $entity_ID,
-        string   $action,
-        int      $result
-    ) {
+    public function adjustTicketRelations(EEM_Base $entity_model, $entity_ID, string $action, int $result)
+    {
         if (! $entity_ID || (float)$result < 1) {
             return;
         }
@@ -881,11 +877,11 @@ class Pricing_Admin_Page extends EE_Admin_Page
     protected function _price_types_overview_list_table()
     {
         $this->_admin_page_title .= ' ' . $this->get_action_link_or_button(
-                'add_new_price_type',
-                'add_type',
-                [],
-                'add-new-h2'
-            );
+            'add_new_price_type',
+            'add_type',
+            [],
+            'add-new-h2'
+        );
         $this->_admin_page_title .= $this->_learn_more_about_pricing_link();
         $this->_search_btn_label = esc_html__('Price Types', 'event_espresso');
         $this->display_admin_list_table_page_with_sidebar();
@@ -1208,12 +1204,12 @@ class Pricing_Admin_Page extends EE_Admin_Page
                                     'prices_displayed_including_taxes' => new EE_Yes_No_Input(
                                         [
                                             'html_label_text'         => esc_html__(
-                                            'Show Prices With Taxes Included?',
-                                            'event_espresso'
+                                                'Show Prices With Taxes Included?',
+                                                'event_espresso'
                                             ),
                                             'html_help_text'          => esc_html__(
-                                            'Indicates whether or not to display prices with the taxes included',
-                                            'event_espresso'
+                                                'Indicates whether or not to display prices with the taxes included',
+                                                'event_espresso'
                                             ),
                                             'default'                 => $tax_settings->prices_displayed_including_taxes
                                                                          ?? true,

--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -21,6 +21,23 @@ if (! class_exists('WP_List_Table')) {
  */
 abstract class EE_Admin_List_Table extends WP_List_Table
 {
+    const ACTION_COPY    = 'duplicate';
+
+    const ACTION_DELETE  = 'delete';
+
+    const ACTION_EDIT    = 'edit';
+
+    const ACTION_RESTORE = 'restore';
+
+    const ACTION_TRASH   = 'trash';
+
+    protected static $actions = [
+        self::ACTION_COPY,
+        self::ACTION_DELETE,
+        self::ACTION_EDIT,
+        self::ACTION_RESTORE,
+        self::ACTION_TRASH,
+    ];
 
     /**
      * holds the data that will be processed for the table
@@ -713,7 +730,7 @@ abstract class EE_Admin_List_Table extends WP_List_Table
      */
     public function single_row_columns($item)
     {
-        list($columns, $hidden, $sortable, $primary) = $this->get_column_info();
+        [$columns, $hidden, $sortable, $primary] = $this->get_column_info();
 
         foreach ($columns as $column_name => $column_display_name) {
 

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -3994,4 +3994,192 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         );
         return $this->_template_args['success'];
     }
+
+
+    /**
+     * @param EEM_Base      $entity_model
+     * @param string        $entity_PK_name name of the primary key field used as a request param, ie: id, ID, etc
+     * @param string        $action         one of the EE_Admin_List_Table::ACTION_* constants: delete, restore, trash
+     * @param string        $delete_column  name of the field that denotes whether entity is trashed
+     * @param callable|null $callback       called after entity is trashed, restored, or deleted
+     * @return int|float
+     * @throws EE_Error
+     */
+    protected function trashRestoreDeleteEntities(
+        EEM_Base $entity_model,
+        string $entity_PK_name,
+        string $action = EE_Admin_List_Table::ACTION_DELETE,
+        string $delete_column = '',
+        callable $callback = null
+    ) {
+        $entity_PK      = $entity_model->get_primary_key_field();
+        $entity_PK_name = $entity_PK_name ?: $entity_PK->get_name();
+        $entity_PK_type = $this->resolveEntityFieldDataType($entity_PK);
+        // grab ID if deleting a single entity
+        if ($this->request->requestParamIsSet($entity_PK_name)) {
+            $ID = $this->request->getRequestParam($entity_PK_name, 0, $entity_PK_type);
+            return $this->trashRestoreDeleteEntity($entity_model, $ID, $action, $delete_column, $callback) ? 1 : 0;
+        }
+        // or grab checkbox array if bulk deleting
+        $checkboxes = $this->request->getRequestParam('checkbox', [], $entity_PK_type, true);
+        if (empty($checkboxes)) {
+            return 0;
+        }
+        $success = 0;
+        $IDs     = array_keys($checkboxes);
+        // cycle thru bulk action checkboxes
+        foreach ($IDs as $ID) {
+            // increment $success
+            if ($this->trashRestoreDeleteEntity($entity_model, $ID, $action, $delete_column, $callback)) {
+                $success++;
+            }
+        }
+        $count = (int)count($checkboxes);
+        // if multiple entities were deleted successfully, then $deleted will be full count of deletions,
+        // otherwise it will be a fraction of ( actual deletions / total entities to be deleted )
+        return $success === $count ? $count : $success / $count;
+    }
+
+
+    /**
+     * @param EE_Primary_Key_Field_Base $entity_PK
+     * @return string
+     * @throws EE_Error
+     * @since   $VID:$
+     */
+    private function resolveEntityFieldDataType(EE_Primary_Key_Field_Base $entity_PK): string
+    {
+        $entity_PK_type = $entity_PK->getSchemaType();
+        switch ($entity_PK_type) {
+            case 'boolean':
+                return 'bool';
+            case 'integer':
+                return 'int';
+            case 'number':
+                return 'float';
+            case 'string':
+                return 'string';
+        }
+        throw new RuntimeException(
+            sprintf(
+                esc_html__(
+                    '"%1$s" is an invalid schema type for the %2$s primary key.',
+                    'event_espresso'
+                ),
+                $entity_PK_type,
+                $entity_PK->get_name()
+            )
+        );
+    }
+
+
+    /**
+     * @param EEM_Base      $entity_model
+     * @param int|string    $entity_ID
+     * @param string        $action        one of the EE_Admin_List_Table::ACTION_* constants: delete, restore, trash
+     * @param string        $delete_column name of the field that denotes whether entity is trashed
+     * @param callable|null $callback      called after entity is trashed, restored, or deleted
+     * @return bool
+     */
+    protected function trashRestoreDeleteEntity(
+        EEM_Base $entity_model,
+        $entity_ID,
+        string $action,
+        string $delete_column,
+        callable $callback = null
+    ) {
+        $entity_ID = absint($entity_ID);
+        if (! $entity_ID) {
+            $this->trashRestoreDeleteError($action, $entity_model);
+        }
+        $result = 0;
+        try {
+            switch ($action) {
+                case EE_Admin_List_Table::ACTION_DELETE:
+                    $result = (bool)$entity_model->delete_permanently_by_ID($entity_ID);
+                    break;
+                case EE_Admin_List_Table::ACTION_RESTORE:
+                    $this->validateDeleteColumn($entity_model, $delete_column);
+                    $result = $entity_model->update_by_ID([$delete_column => 0], $entity_ID);
+                    break;
+                case EE_Admin_List_Table::ACTION_TRASH:
+                    $this->validateDeleteColumn($entity_model, $delete_column);
+                    $result = $entity_model->update_by_ID([$delete_column => 1], $entity_ID);
+                    break;
+            }
+        } catch (Exception $exception) {
+            $this->trashRestoreDeleteError($action, $entity_model, $exception);
+        }
+        if (is_callable($callback)) {
+            call_user_func_array($callback, [$entity_model, $entity_ID, $action, $result, $delete_column]);
+        }
+        return $result;
+    }
+
+
+    /**
+     * @param EEM_Base $entity_model
+     * @param string   $delete_column
+     * @since $VID:$
+     */
+    private function validateDeleteColumn(EEM_Base $entity_model, string $delete_column)
+    {
+        if (empty($delete_column)) {
+            throw new DomainException(
+                sprintf(
+                    esc_html__(
+                        'You need to specify the name of the "delete column" on the %2$s model, in order to trash or restore an entity.',
+                        'event_espresso'
+                    ),
+                    $entity_model->get_this_model_name()
+                )
+            );
+        }
+        if (! $entity_model->has_field($delete_column)) {
+            throw new DomainException(
+                sprintf(
+                    esc_html__(
+                        'The %1$s field does not exist on the %2$s model.',
+                        'event_espresso'
+                    ),
+                    $delete_column,
+                    $entity_model->get_this_model_name()
+                )
+            );
+        }
+    }
+
+
+    /**
+     * @param EEM_Base       $entity_model
+     * @param Exception|null $exception
+     * @param string         $action
+     * @since $VID:$
+     */
+    private function trashRestoreDeleteError(string $action, EEM_Base $entity_model, ?Exception $exception = null)
+    {
+        if ($exception instanceof Exception) {
+            throw new RuntimeException(
+                sprintf(
+                    esc_html__(
+                        'Could not %1$s the %2$s because the following error occurred: %3$s',
+                        'event_espresso'
+                    ),
+                    $action,
+                    $entity_model->get_this_model_name(),
+                    $exception->getMessage()
+                )
+            );
+        }
+        throw new RuntimeException(
+            sprintf(
+                esc_html__(
+                    'Could not %1$s the %2$s because an invalid ID was received.',
+                    'event_espresso'
+                ),
+                $action,
+                $entity_model->get_this_model_name()
+            )
+        );
+    }
 }

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -4034,7 +4034,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
                 $success++;
             }
         }
-        $count = (int)count($checkboxes);
+        $count = (int) count($checkboxes);
         // if multiple entities were deleted successfully, then $deleted will be full count of deletions,
         // otherwise it will be a fraction of ( actual deletions / total entities to be deleted )
         return $success === $count ? $count : $success / $count;
@@ -4096,7 +4096,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         try {
             switch ($action) {
                 case EE_Admin_List_Table::ACTION_DELETE:
-                    $result = (bool)$entity_model->delete_permanently_by_ID($entity_ID);
+                    $result = (bool) $entity_model->delete_permanently_by_ID($entity_ID);
                     break;
                 case EE_Admin_List_Table::ACTION_RESTORE:
                     $this->validateDeleteColumn($entity_model, $delete_column);


### PR DESCRIPTION
Similar to previous PRs, this one:

- replaces all uses of the legacy admin request data with the new Request class
- autoformats and cleans up the code