### PR TITLE
Improve Allowed Tags Class

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1386,8 +1386,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             $this->_add_prices_to_ticket($prices_data, $ticket, $update_prices);
         }
         // however now we need to handle permanently deleting tickets via the ui.
-        //  Keep in mind that the ui does not allow deleting/archiving tickets that have ticket sold.
-        //  However, it does allow for deleting tickets that have no tickets sold,
+        // Keep in mind that the ui does not allow deleting/archiving tickets that have ticket sold.
+        // However, it does allow for deleting tickets that have no tickets sold,
         // in which case we want to get rid of permanently because there is no need to save in db.
         $old_tickets     = isset($old_tickets[0]) && $old_tickets[0] == '' ? [] : $old_tickets;
         $tickets_removed = array_diff($old_tickets, array_keys($saved_tickets));

--- a/core/services/request/sanitizers/AllowedTags.php
+++ b/core/services/request/sanitizers/AllowedTags.php
@@ -223,6 +223,7 @@ class AllowedTags
         return AllowedTags::$allowed_with_form_tags;
     }
 
+
     /**
      * @return array[]
      */

--- a/core/services/request/sanitizers/AllowedTags.php
+++ b/core/services/request/sanitizers/AllowedTags.php
@@ -63,6 +63,7 @@ class AllowedTags
         'itemscope'         => 1,
         'itemprop'          => 1,
         'content'           => 1,
+        'accept-charset'    => 1,
     ];
 
 
@@ -77,7 +78,6 @@ class AllowedTags
         'code',
         'div',
         'em',
-        'form',
         'h1',
         'h2',
         'h3',
@@ -86,13 +86,7 @@ class AllowedTags
         'h6',
         'hr',
         'i',
-        'iframe',
         'img',
-        'input',
-        'select',
-        'option',
-        'optgroup',
-        'label',
         'li',
         'ol',
         'p',
@@ -104,7 +98,6 @@ class AllowedTags
         'style',
         'table',
         'td',
-        'textarea',
         'tr',
         'ul',
     ];
@@ -120,6 +113,12 @@ class AllowedTags
      * @var array
      */
     private static $allowed_with_embed_tags;
+
+
+    /**
+     * @var array
+     */
+    private static $allowed_with_form_tags;
 
 
     /**
@@ -150,6 +149,28 @@ class AllowedTags
 
 
     /**
+     * merges additional tags and attributes into the WP global $allowedposttags
+     */
+    private static function initializeWithFormTags()
+    {
+        $all_tags = AllowedTags::getAllowedTags();
+        $form_tags = [
+            'form' => AllowedTags::$attributes,
+            'label' => AllowedTags::$attributes,
+            'input' => AllowedTags::$attributes,
+            'select' => AllowedTags::$attributes,
+            'option' => AllowedTags::$attributes,
+            'optgroup' => AllowedTags::$attributes,
+            'textarea' => AllowedTags::$attributes,
+            'button' => AllowedTags::$attributes,
+            'fieldset' => AllowedTags::$attributes,
+            'output' => AllowedTags::$attributes,
+        ];
+        AllowedTags::$allowed_with_form_tags = array_merge_recursive($all_tags, $form_tags);
+    }
+
+
+    /**
      * @return array[]
      */
     public static function getAllowedTags()
@@ -170,5 +191,17 @@ class AllowedTags
             AllowedTags::initializeWithEmbedTags();
         }
         return AllowedTags::$allowed_with_embed_tags;
+    }
+
+
+    /**
+     * @return array[]
+     */
+    public static function getWithFormTags()
+    {
+        if (empty(AllowedTags::$allowed_with_form_tags)) {
+            AllowedTags::initializeWithFormTags();
+        }
+        return AllowedTags::$allowed_with_form_tags;
     }
 }

--- a/core/services/request/sanitizers/AllowedTags.php
+++ b/core/services/request/sanitizers/AllowedTags.php
@@ -17,27 +17,52 @@ class AllowedTags
      * @var array[]
      */
     private static $attributes = [
-        'action'     => [],
-        'align'      => [],
-        'alt'        => [],
-        'class'      => [],
-        'data'       => [],
-        'for'        => [],
-        'height'     => [],
-        'href'       => [],
-        'id'         => [],
-        'method'     => [],
-        'name'       => [],
-        'novalidate' => [],
-        'rel'        => [],
-        'src'        => [],
-        'style'      => [],
-        'tabindex'   => [],
-        'target'     => [],
-        'title'      => [],
-        'type'       => [],
-        'value'      => [],
-        'width'      => [],
+        'data-*'            => 1,
+        'aria-*'            => 1,
+        'type'              => 1,
+        'value'             => 1,
+        'class'             => 1,
+        'id'                => 1,
+        'for'               => 1,
+        'style'             => 1,
+        'src'               => 1,
+        'alt'               => 1,
+        'title'             => 1,
+        'placeholder'       => 1,
+        'href'              => 1,
+        'rel'               => 1,
+        'target'            => 1,
+        'novalidate'        => 1,
+        'name'              => 1,
+        'tabindex'          => 1,
+        'action'            => 1,
+        'method'            => 1,
+        'width'             => 1,
+        'height'            => 1,
+        'selected'          => 1,
+        'checked'           => 1,
+        'readonly'          => 1,
+        'disabled'          => 1,
+        'required'          => 1,
+        'autocomplete'      => 1,
+        'min'               => 1,
+        'max'               => 1,
+        'step'              => 1,
+        'cols'              => 1,
+        'rows'              => 1,
+        'lang'              => 1,
+        'dir'               => 1,
+        'enctype'           => 1,
+        'multiple'          => 1,
+        'frameborder'       => 1,
+        'allow'             => 1,
+        'allowfullscreen'   => 1,
+        'label'             => 1,
+        'align'             => 1,
+        'itemtype'          => 1,
+        'itemscope'         => 1,
+        'itemprop'          => 1,
+        'content'           => 1,
     ];
 
 
@@ -64,6 +89,9 @@ class AllowedTags
         'iframe',
         'img',
         'input',
+        'select',
+        'option',
+        'optgroup',
         'label',
         'li',
         'ol',
@@ -81,6 +109,7 @@ class AllowedTags
         'ul',
     ];
 
+
     /**
      * @var array
      */
@@ -88,16 +117,35 @@ class AllowedTags
 
 
     /**
+     * @var array
+     */
+    private static $allowed_with_embed_tags;
+
+
+    /**
      * merges additional tags and attributes into the WP global $allowedposttags
      */
     private static function initializeAllowedTags()
     {
-        global $allowedposttags;
+        $allowed_post_tags = wp_kses_allowed_html('post');
         $allowed_tags = [];
         foreach (AllowedTags::$tags as $tag) {
             $allowed_tags[ $tag ] = AllowedTags::$attributes;
         }
-        AllowedTags::$allowed_tags = array_merge_recursive($allowedposttags, $allowed_tags);
+        AllowedTags::$allowed_tags = array_merge_recursive($allowed_post_tags, $allowed_tags);
+    }
+
+
+    /**
+     * merges additional tags and attributes into the WP global $allowedposttags
+     */
+    private static function initializeWithEmbedTags()
+    {
+        $all_tags = AllowedTags::getAllowedTags();
+        $embed_tags = [
+            'iframe' => AllowedTags::$attributes
+        ];
+        AllowedTags::$allowed_with_embed_tags = array_merge_recursive($all_tags, $embed_tags);
     }
 
 
@@ -110,5 +158,17 @@ class AllowedTags
             AllowedTags::initializeAllowedTags();
         }
         return AllowedTags::$allowed_tags;
+    }
+
+
+    /**
+     * @return array[]
+     */
+    public static function getWithEmbedTags()
+    {
+        if (empty(AllowedTags::$allowed_with_embed_tags)) {
+            AllowedTags::initializeWithEmbedTags();
+        }
+        return AllowedTags::$allowed_with_embed_tags;
     }
 }

--- a/core/services/request/sanitizers/AllowedTags.php
+++ b/core/services/request/sanitizers/AllowedTags.php
@@ -17,53 +17,53 @@ class AllowedTags
      * @var array[]
      */
     private static $attributes = [
-        'data-*'            => 1,
-        'aria-*'            => 1,
-        'type'              => 1,
-        'value'             => 1,
-        'class'             => 1,
-        'id'                => 1,
-        'for'               => 1,
-        'style'             => 1,
-        'src'               => 1,
-        'alt'               => 1,
-        'title'             => 1,
-        'placeholder'       => 1,
-        'href'              => 1,
-        'rel'               => 1,
-        'target'            => 1,
-        'novalidate'        => 1,
-        'name'              => 1,
-        'tabindex'          => 1,
+        'accept-charset'    => 1,
         'action'            => 1,
-        'method'            => 1,
-        'width'             => 1,
-        'height'            => 1,
-        'selected'          => 1,
-        'checked'           => 1,
-        'readonly'          => 1,
-        'disabled'          => 1,
-        'required'          => 1,
-        'autocomplete'      => 1,
-        'min'               => 1,
-        'max'               => 1,
-        'step'              => 1,
-        'cols'              => 1,
-        'rows'              => 1,
-        'lang'              => 1,
-        'dir'               => 1,
-        'enctype'           => 1,
-        'multiple'          => 1,
-        'frameborder'       => 1,
+        'alt'               => 1,
         'allow'             => 1,
         'allowfullscreen'   => 1,
-        'label'             => 1,
         'align'             => 1,
-        'itemtype'          => 1,
-        'itemscope'         => 1,
-        'itemprop'          => 1,
+        'aria-*'            => 1,
+        'autocomplete'      => 1,
+        'checked'           => 1,
+        'class'             => 1,
+        'cols'              => 1,
         'content'           => 1,
-        'accept-charset'    => 1,
+        'data-*'            => 1,
+        'dir'               => 1,
+        'disabled'          => 1,
+        'enctype'           => 1,
+        'for'               => 1,
+        'frameborder'       => 1,
+        'height'            => 1,
+        'href'              => 1,
+        'id'                => 1,
+        'itemprop'          => 1,
+        'itemscope'         => 1,
+        'itemtype'          => 1,
+        'label'             => 1,
+        'lang'              => 1,
+        'max'               => 1,
+        'method'            => 1,
+        'min'               => 1,
+        'multiple'          => 1,
+        'name'              => 1,
+        'novalidate'        => 1,
+        'placeholder'       => 1,
+        'readonly'          => 1,
+        'rel'               => 1,
+        'required'          => 1,
+        'rows'              => 1,
+        'selected'          => 1,
+        'src'               => 1,
+        'style'             => 1,
+        'step'              => 1,
+        'tabindex'          => 1,
+        'target'            => 1,
+        'title'             => 1,
+        'type'              => 1,
+        'value'             => 1,
+        'width'             => 1,
     ];
 
 
@@ -91,11 +91,9 @@ class AllowedTags
         'ol',
         'p',
         'pre',
-        'script',
         'small',
         'span',
         'strong',
-        'style',
         'table',
         'td',
         'tr',
@@ -122,7 +120,13 @@ class AllowedTags
 
 
     /**
-     * merges additional tags and attributes into the WP global $allowedposttags
+     * @var array
+     */
+    private static $allowed_with_script_and_style_tags;
+
+
+    /**
+     * merges additional tags and attributes into the WP post tags
      */
     private static function initializeAllowedTags()
     {
@@ -136,7 +140,7 @@ class AllowedTags
 
 
     /**
-     * merges additional tags and attributes into the WP global $allowedposttags
+     * merges embed tags and attributes into the EE all tags
      */
     private static function initializeWithEmbedTags()
     {
@@ -149,7 +153,7 @@ class AllowedTags
 
 
     /**
-     * merges additional tags and attributes into the WP global $allowedposttags
+     * merges form tags and attributes into the EE all tags
      */
     private static function initializeWithFormTags()
     {
@@ -167,6 +171,20 @@ class AllowedTags
             'output' => AllowedTags::$attributes,
         ];
         AllowedTags::$allowed_with_form_tags = array_merge_recursive($all_tags, $form_tags);
+    }
+
+
+    /**
+     * merges form script and style tags and attributes into the EE all tags
+     */
+    private static function initializeWithScriptAndStyleTags()
+    {
+        $all_tags = AllowedTags::getAllowedTags();
+        $script_and_style_tags = [
+            'script' => AllowedTags::$attributes,
+            'style' => AllowedTags::$attributes,
+        ];
+        AllowedTags::$allowed_with_script_and_style_tags = array_merge_recursive($all_tags, $script_and_style_tags);
     }
 
 
@@ -203,5 +221,16 @@ class AllowedTags
             AllowedTags::initializeWithFormTags();
         }
         return AllowedTags::$allowed_with_form_tags;
+    }
+
+    /**
+     * @return array[]
+     */
+    public static function getWithScriptAndStyleTags()
+    {
+        if (empty(AllowedTags::$allowed_with_script_and_style_tags)) {
+            AllowedTags::initializeWithScriptAndStyleTags();
+        }
+        return AllowedTags::$allowed_with_script_and_style_tags;
     }
 }


### PR DESCRIPTION
This is related to https://github.com/eventespresso/event-espresso-core/issues/3738 issue.

- Added many new attributes to the allowed list including `data-*` and `aria-*` attributes.
- Added some new tags to the list of allowed tags to make sure they're allowed any time.
- Added some new functions to get tags based on context.

I believe to improve the security we should remove `script` and `style` from the default tags.