### PR TITLE
Kses - Part 2

### DIFF
--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -3722,10 +3722,13 @@ class Messages_Admin_Page extends EE_Admin_Page
     public function global_messages_settings_metabox_content()
     {
         $form = $this->_generate_global_settings_form();
-        echo wp_kses($form->form_open(
-            $this->add_query_args_and_nonce(['action' => 'update_global_settings'], EE_MSG_ADMIN_URL),
-            'POST'
-        ), AllowedTags::getWithFormTags());
+        echo wp_kses(
+            $form->form_open(
+                $this->add_query_args_and_nonce(['action' => 'update_global_settings'], EE_MSG_ADMIN_URL),
+                'POST'
+            ),
+            AllowedTags::getWithFormTags()
+        );
         echo wp_kses($form->get_html(), AllowedTags::getWithFormTags());
         echo wp_kses($form->form_close(), AllowedTags::getWithFormTags());
     }

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -3,6 +3,7 @@
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidIdentifierException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
 
 /**
  *
@@ -2479,7 +2480,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'button-primary reset-default-button'
         );
         $test_settings_html .= '</div><div style="clear:both"></div>';
-        echo $test_settings_html; // already escaped
+        echo wp_kses($test_settings_html, AllowedTags::getWithFormTags());
     }
 
 
@@ -2537,7 +2538,7 @@ class Messages_Admin_Page extends EE_Admin_Page
         }
         ?>
         <div style="float:right; margin-top:10px">
-            <?php echo $this->_get_help_tab_link('message_template_shortcodes'); // already escaped
+            <?php echo wp_kses($this->_get_help_tab_link('message_template_shortcodes'), AllowedTags::getAllowedTags());
             ?>
         </div>
         <p class="small-text">
@@ -2672,10 +2673,10 @@ class Messages_Admin_Page extends EE_Admin_Page
                 wp_nonce_field($args['action'] . '_nonce', $args['action'] . '_nonce', false);
                 $id = 'ee-' . sanitize_key($context_label['label']) . '-select';
                 ?>
-                <label for='<?php echo absint($id); ?>' class='screen-reader-text'>
+                <label for='<?php echo esc_attr($id); ?>' class='screen-reader-text'>
                     <?php esc_html_e('message context options', 'event_espresso'); ?>
                 </label>
-                <select id="<?php echo absint($id); ?>" name="context">
+                <select id="<?php echo esc_attr($id); ?>" name="context">
                     <?php
                     $context_templates = $template_group_object->context_templates();
                     if (is_array($context_templates)) :
@@ -2683,8 +2684,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                             $checked = ($context === $args['context']) ? 'selected' : '';
                             ?>
                             <option value="<?php echo esc_attr($context); ?>" <?php echo esc_attr($checked); ?>>
-                                <?php echo $context_details[ $context ]['label']; // already escaped
-                                ?>
+                                <?php echo esc_html($context_details[ $context ]['label']); ?>
                             </option>
                         <?php endforeach;
                     endif; ?>
@@ -2699,8 +2699,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                        value="<?php echo esc_attr($button_text); ?>"
                 />
             </form>
-            <?php echo $args['extra']; // already escaped
-            ?>
+            <?php echo wp_kses($args['extra'], AllowedTags::getWithFormTags()); ?>
         </div> <!-- end .ee-msg-switcher-container -->
         <?php
         $this->_context_switcher = ob_get_clean();
@@ -3723,13 +3722,12 @@ class Messages_Admin_Page extends EE_Admin_Page
     public function global_messages_settings_metabox_content()
     {
         $form = $this->_generate_global_settings_form();
-        // already escaped
-        echo $form->form_open(
+        echo wp_kses($form->form_open(
             $this->add_query_args_and_nonce(['action' => 'update_global_settings'], EE_MSG_ADMIN_URL),
             'POST'
-        );
-        echo $form->get_html();
-        echo $form->form_close();
+        ), AllowedTags::getWithFormTags());
+        echo wp_kses($form->get_html(), AllowedTags::getWithFormTags());
+        echo wp_kses($form->form_close(), AllowedTags::getWithFormTags());
     }
 
 

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -3797,7 +3797,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                         'update_settings'             => new EE_Submit_Input(
                             [
                                 'default'         => esc_html__('Update', 'event_espresso'),
-                                'html_label_text' => '&nbsp',
+                                'html_label_text' => '',
                             ]
                         ),
                     ]

--- a/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
@@ -18,13 +18,13 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
 
     <h4 class="admin-primary-mbox-h4">
         <?php
-        echo $event_name
+        echo ($event_name
             ? sprintf(
             /* translators: %s: event name */
                 esc_html__('%1$s Custom Template', 'event_espresso'),
                 $event_name
             )
-            : '';
+            : '');
         ?>
     </h4>
     <p><?php echo wp_kses($action_message, AllowedTags::getWithFormTags()); ?></p>

--- a/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var EE_Event[] $active_events
  * @var array      $active_messengers
@@ -8,14 +9,17 @@
  * @var string     $action_message
  * @var string     $edit_message_template_form_url
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div id="admin-primary-mbox-dv" class="admin-primary-mbox-dv">
 
     <h4 class="admin-primary-mbox-h4">
-        <?php echo $event_name ? esc_html($event_name . ' Custom Template') : ''; ?>
+        <?php echo ($event_name ? esc_html($event_name . ' Custom Template') : ''); ?>
     </h4>
-    <p><?php echo $action_message; // already escaped ?></p>
+    <p><?php echo wp_kses($action_message, AllowedTags::getWithFormTags()); ?></p>
 
     <form action="<?php echo esc_url_raw($edit_message_template_form_url); ?>"
           id='ee-msg-add-message-template-frm'
@@ -24,7 +28,7 @@
         <input type="hidden" id="evt_id" name="EVT_ID" value="<?php echo absint($EVT_ID) ?: ''; ?>" />
         <?php
         if (isset($hidden_fields)) {
-            echo $hidden_fields; // already escaped
+            echo wp_kses($hidden_fields, AllowedTags::getWithFormTags());
         } ?>
         <!--active_messengers -->
         <label for="MTP-messenger"><?php esc_html_e('Select Messenger', 'event_espresso'); ?></label>

--- a/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_main_add_meta_box.template.php
@@ -17,7 +17,15 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
 <div id="admin-primary-mbox-dv" class="admin-primary-mbox-dv">
 
     <h4 class="admin-primary-mbox-h4">
-        <?php echo ($event_name ? esc_html($event_name . ' Custom Template') : ''); ?>
+        <?php
+        echo $event_name
+            ? sprintf(
+            /* translators: %s: event name */
+                esc_html__('%1$s Custom Template', 'event_espresso'),
+                $event_name
+            )
+            : '';
+        ?>
     </h4>
     <p><?php echo wp_kses($action_message, AllowedTags::getWithFormTags()); ?></p>
 
@@ -33,8 +41,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
         <!--active_messengers -->
         <label for="MTP-messenger"><?php esc_html_e('Select Messenger', 'event_espresso'); ?></label>
         <select name="MTP_messenger" id="MTP-messenger">
-            <?php
-            foreach (array_keys($active_messengers) as $messenger) : ?>
+            <?php foreach (array_keys($active_messengers) as $messenger) : ?>
                 <option value="<?php echo esc_attr($messenger); ?>">
                     <?php echo esc_html(ucwords(str_replace('_', ' ', $messenger))); ?>
                 </option>

--- a/admin_pages/messages/templates/ee_msg_details_main_edit_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_main_edit_meta_box.template.php
@@ -1,10 +1,14 @@
 <?php
+
 /**
  * @var EE_Message_Template_Group $MTP
  * @var string                    $context
  * @var string                    $event_name
  * @var string[]                  $template_fields
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div id="admin-primary-mbox-dv" class="admin-primary-mbox-dv">
@@ -63,7 +67,7 @@
     <!-- we need to loop through the template_fields so we know our structure -->
     <?php
     if (isset($template_fields) && ! empty($template_fields) && ! is_wp_error($template_fields)) {
-        echo $template_fields; // already escaped
+        echo wp_kses($template_fields, AllowedTags::getWithFormTags());
     } else {
         ?>
         <p>

--- a/admin_pages/messages/templates/ee_msg_details_messenger_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_messenger_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var bool $active
  * @var string  $hide_off_message
@@ -6,6 +7,9 @@
  * @var string  $inactive_message_types
  * @var string  $messenger
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div class="<?php echo esc_attr($messenger); ?>-content">
@@ -37,7 +41,7 @@
             class="inactive-message-types mt-tab-container ui-widget-content-ui-state-default <?php echo esc_attr($hide_on_message); ?>"
         >
             <ul class="messenger-activation">
-                <?php echo $inactive_message_types; // already escaped ?>
+                <?php echo wp_kses($inactive_message_types, AllowedTags::getWithFormTags()); ?>
             </ul>
             <div class="ui-helper-clearfix"></div>
         </div>

--- a/admin_pages/messages/templates/ee_msg_details_messenger_mt_meta_box.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_messenger_mt_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var bool   $active
  * @var string $content
@@ -6,10 +7,13 @@
  * @var string $messenger
  * @var string $active_message_types
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div class="<?php echo esc_attr($messenger); ?>-content">
-    <?php echo $content; // already escaped ?>
+    <?php echo wp_kses($content, AllowedTags::getWithFormTags()); ?>
     <?php if (empty($inactive_message_types) && empty($active_message_types)) :
         echo '<p>'
              . esc_html__(
@@ -35,7 +39,7 @@
             class="mt-tab-container <?php echo esc_attr($hide_on_message); ?>"
         >
             <ul class="messenger-activation">
-                <?php echo $active_message_types; // already escaped ?>
+                <?php echo wp_kses($active_message_types, AllowedTags::getWithFormTags()); ?>
             </ul>
             <div class="ui-helper-clearfix"></div>
         </div>

--- a/admin_pages/messages/templates/ee_msg_details_mt_settings_tab_item.template.php
+++ b/admin_pages/messages/templates/ee_msg_details_mt_settings_tab_item.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var string $slug_id
  * @var string $class
@@ -6,6 +7,9 @@
  * @var string $content
  * @var string $mt_nonce
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <li id="<?php echo esc_attr($slug_id); ?>" class="ui-widget-content ui-corner-tr mt-tab <?php echo esc_attr($class); ?>">
@@ -16,6 +20,6 @@
         <br>
     </div>
     <strong class="ui-widget-header"><?php echo esc_attr($label); ?></strong>
-    <?php echo $content; // already escaped ?>
+    <?php echo wp_kses($content, AllowedTags::getWithFormTags()); ?>
     <span class="mt_nonce hidden"><?php echo esc_html($mt_nonce); ?></span>
 </li>

--- a/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
+++ b/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Template for control that activates/deactivates message template context
  * Variables in this template
@@ -10,6 +11,9 @@
  * @var string $context_label             The label for the context
  * @var int    $message_template_group_id The ID for the message template group this context belongs to.
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 $active_message   = sprintf(
     esc_html__(
         'The template for %1$s is currently %2$sactive%3$s.',
@@ -36,14 +40,14 @@ $context = esc_attr($context);
     <span class="spinner"></span>
     <div class="activate_context_on_off_toggle_container">
         <span id="on-off-nonce-<?php echo esc_attr($context); ?>" class="hidden">
-            <?php echo $nonce; // already escaped ?>
+            <?php echo wp_kses($nonce, AllowedTags::getWithFormTags()); ?>
         </span>
         <span class="ee-on-off-toggle-label">
-            <?php echo $is_active ? $active_message : $inactive_message; // vars already escaped ?>
+            <?php echo ($is_active ? wp_kses($active_message, AllowedTags::getAllowedTags()) : wp_kses($inactive_message, AllowedTags::getAllowedTags())); ?>
         </span>
         <div class="hidden js-data">
-            <span class="ee-active-message"><?php echo $active_message; // already escaped ?></span>
-            <span class="ee-inactive-message"><?php echo $inactive_message; // already escaped ?></span>
+            <span class="ee-active-message"><?php echo wp_kses($active_message, AllowedTags::getAllowedTags()); ?></span>
+            <span class="ee-inactive-message"><?php echo wp_kses($inactive_message, AllowedTags::getAllowedTags()); ?></span>
         </div>
         <div class="switch">
             <?php $checked = $is_active ? 'checked' : ''; ?>

--- a/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
+++ b/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
@@ -44,9 +44,9 @@ $context = esc_attr($context);
         </span>
         <span class="ee-on-off-toggle-label">
             <?php
-            echo $is_active
+            echo ($is_active
                 ? wp_kses($active_message, AllowedTags::getAllowedTags())
-                : wp_kses($inactive_message, AllowedTags::getAllowedTags());
+                : wp_kses($inactive_message, AllowedTags::getAllowedTags()));
             ?>
         </span>
         <div class="hidden js-data">

--- a/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
+++ b/admin_pages/messages/templates/ee_msg_editor_active_context_element.template.php
@@ -43,7 +43,11 @@ $context = esc_attr($context);
             <?php echo wp_kses($nonce, AllowedTags::getWithFormTags()); ?>
         </span>
         <span class="ee-on-off-toggle-label">
-            <?php echo ($is_active ? wp_kses($active_message, AllowedTags::getAllowedTags()) : wp_kses($inactive_message, AllowedTags::getAllowedTags())); ?>
+            <?php
+            echo $is_active
+                ? wp_kses($active_message, AllowedTags::getAllowedTags())
+                : wp_kses($inactive_message, AllowedTags::getAllowedTags());
+            ?>
         </span>
         <div class="hidden js-data">
             <span class="ee-active-message"><?php echo wp_kses($active_message, AllowedTags::getAllowedTags()); ?></span>

--- a/admin_pages/messages/templates/ee_msg_m_settings_content.template.php
+++ b/admin_pages/messages/templates/ee_msg_m_settings_content.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var bool       $on_off_status
  * @var string     $description
@@ -9,6 +10,9 @@
  * @var string     $template_form_fields
  * @var string[][] $hidden_fields
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div class="messenger-settings-content">
@@ -20,7 +24,7 @@
             </span>
         </div>
         <span id="on-off-nonce-<?php echo esc_attr($messenger); ?>" class="hidden">
-            <?php echo $nonce; // already escaped ?>
+            <?php echo wp_kses($nonce, AllowedTags::getAllowedTags()); ?>
         </span>
         <div class="switch">
             <?php $checked = $on_off_status ? 'checked' : ''; ?>
@@ -32,17 +36,17 @@
         </div>
     </div> <!-- end .activate_messages_on_off_toggle_container -->
     <div class="messenger-description">
-        <p><?php echo $description; // already escaped ?></p>
+        <p><?php echo wp_kses($description, AllowedTags::getAllowedTags()); ?></p>
     </div>
     <div class="messenger-settings<?php echo esc_attr($show_hide_edit_form); ?>">
         <span id="has_form_class" class="hidden">
             <?php echo trim($show_hide_edit_form); // already escaped ?>
         </span>
         <form method="POST" action="" class="mt-settings-form">
-            <?php echo $template_form_fields; // already escaped ?>
+            <?php echo wp_kses($template_form_fields, AllowedTags::getWithFormTags()); ?>
             <?php
             foreach ($hidden_fields as $name => $field) {
-                echo $field['field']; // already escaped
+                echo wp_kses($field['field'], AllowedTags::getWithFormTags());
             } ?>
             <input type="submit"
                    value="<?php esc_attr_e('Submit', 'event_espresso'); ?>"

--- a/admin_pages/messages/templates/ee_msg_messages_shortcodes_help_tab.template.php
+++ b/admin_pages/messages/templates/ee_msg_messages_shortcodes_help_tab.template.php
@@ -1,7 +1,11 @@
 <?php
+
 /**
  * @var string[] $shortcodes
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
     <p>
@@ -17,5 +21,5 @@
 <?php
 foreach ($shortcodes as $name => $description) : ?>
     <p><strong><?php echo esc_html($name); ?></strong></p>
-    <p><?php echo $description; // already escaped ?></p>
+    <p><?php echo wp_kses($description, AllowedTags::getWithFormTags()); ?></p>
 <?php endforeach; ?>

--- a/admin_pages/messages/templates/ee_msg_messages_shortcodes_help_tab.template.php
+++ b/admin_pages/messages/templates/ee_msg_messages_shortcodes_help_tab.template.php
@@ -22,4 +22,4 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
 foreach ($shortcodes as $name => $description) : ?>
     <p><strong><?php echo esc_html($name); ?></strong></p>
     <p><?php echo wp_kses($description, AllowedTags::getWithFormTags()); ?></p>
-<?php endforeach; ?>
+<?php endforeach;

--- a/admin_pages/messages/templates/ee_msg_mt_settings_content.template.php
+++ b/admin_pages/messages/templates/ee_msg_mt_settings_content.template.php
@@ -1,10 +1,14 @@
 <?php
+
 /**
  * @var string     $description
  * @var string     $show_form
  * @var string     $template_form_fields
  * @var string[][] $hidden_fields
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div class="mt-settings-content">
@@ -14,9 +18,9 @@
     <div class="mt-settings">
         <form method="POST" action="" class="mt-settings-form<?php echo esc_attr($show_form); ?>">
             <?php
-            echo $template_form_fields; // already escaped
+            echo wp_kses($template_form_fields, AllowedTags::getWithFormTags());
             foreach ($hidden_fields as $field) {
-                echo $field['field']; // already escaped
+                echo wp_kses($field['field'], AllowedTags::getWithFormTags());
             }
             ?>
             <input class='button-secondary mt-settings-submit no-drag'

--- a/admin_pages/messages/templates/template_pack_and_variations_metabox.template.php
+++ b/admin_pages/messages/templates/template_pack_and_variations_metabox.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This template is responsible for the template pack and variations metabox that appears on the Message Templates
  * editor.
@@ -11,21 +12,24 @@
  * @var string $template_pack_description      The description for the template packs for the given messenger.
  * @var string $template_variation_description The description for the template variations for the given messenger.
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 <div id="template-variations-selectors">
     <label for="MTP_template_pack">
-        <?php echo $template_pack_label; // already escaped ?>:&nbsp;
+        <?php echo wp_kses($template_pack_label, AllowedTags::getAllowedTags()); ?>:&nbsp;
     </label>
-    <?php echo $template_packs_selector; // already escaped ?>
+    <?php echo wp_kses($template_packs_selector, AllowedTags::getWithFormTags()); ?>
     <span class="spinner"></span>
     <p class="description">
-        <?php echo $template_pack_description; // already escaped ?>
+        <?php echo wp_kses($template_pack_description, AllowedTags::getAllowedTags()); ?>
     <p>
         <label for="MTP_template_variation">
-            <?php echo $template_variation_label; // already escaped ?>:&nbsp;
+            <?php echo wp_kses($template_variation_label, AllowedTags::getAllowedTags()); ?>:&nbsp;
         </label>
-        <?php echo $variations_selector; // already escaped ?>
+        <?php echo wp_kses($variations_selector, AllowedTags::getWithFormTags()); ?>
     <p class="description">
-        <?php echo $template_variation_description; // already escaped ?>
+        <?php echo wp_kses($template_variation_description, AllowedTags::getWithFormTags()); ?>
     </p>
 </div>

--- a/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
@@ -2,6 +2,7 @@
 
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\request\RequestInterface;
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
 
 /**
  * espresso_events_Messages_Hooks_Extend
@@ -161,14 +162,14 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
                 ),
                 '<strong>',
                 '</strong>',
-                '<a href="' . $msg_activate_url . '">',
+                '<a href="' . esc_url($msg_activate_url) . '">',
                 '</a>'
             );
             $error_content    = '<div class="error"><p>' . $error_msg . '</p></div>';
             $internal_content = '<div id="messages-error"><p>' . $error_msg . '</p></div>';
 
-            echo $error_content;
-            echo $internal_content;
+            echo wp_kses($error_content, AllowedTags::getAllowedTags());
+            echo wp_kses($internal_content, AllowedTags::getAllowedTags());
             return '';
         }
 
@@ -198,19 +199,18 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             $tabbed_content = $tabbed_content->get_error_message();
         }
 
-        $notices = '
-	<div id="espresso-ajax-loading" class="ajax-loader-grey">
-		<span class="ee-spinner ee-spin"></span>
-		<span class="hidden">' . esc_html__('loading...', 'event_espresso') . '</span>
-	</div>
-	<div class="ee-notices"></div>';
+        $notices = '<div id="espresso-ajax-loading" class="ajax-loader-grey">
+            <span class="ee-spinner ee-spin"></span>
+            <span class="hidden">' . esc_html__('loading...', 'event_espresso') . '</span>
+        </div>
+        <div class="ee-notices"></div>';
 
         if (defined('DOING_AJAX')) {
             return $tabbed_content;
         }
 
         do_action('AHEE__espresso_events_Messages_Hooks_Extend__messages_metabox__before_content');
-        echo $notices . '<div class="messages-tabs-content">' . $tabbed_content . '</div>';
+        echo wp_kses($notices . '<div class="messages-tabs-content">' . $tabbed_content . '</div>', AllowedTags::getWithFormTags());
         do_action('AHEE__espresso_events_Messages_Hooks_Extend__messages_metabox__after_content');
         return '';
     }

--- a/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/messages/espresso_events_Messages_Hooks_Extend.class.php
@@ -162,7 +162,7 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
                 ),
                 '<strong>',
                 '</strong>',
-                '<a href="' . esc_url($msg_activate_url) . '">',
+                '<a href="' . esc_url_raw($msg_activate_url) . '">',
                 '</a>'
             );
             $error_content    = '<div class="error"><p>' . $error_msg . '</p></div>';
@@ -192,14 +192,14 @@ class espresso_events_Messages_Hooks_Extend extends espresso_events_Messages_Hoo
             }
         }
 
-
         // we want this to be tabbed content so let's use the EEH_Tabbed_Content::display helper.
         $tabbed_content = EEH_Tabbed_Content::display($tabs);
         if ($tabbed_content instanceof WP_Error) {
             $tabbed_content = $tabbed_content->get_error_message();
         }
 
-        $notices = '<div id="espresso-ajax-loading" class="ajax-loader-grey">
+        $notices = '
+        <div id="espresso-ajax-loading" class="ajax-loader-grey">
             <span class="ee-spinner ee-spin"></span>
             <span class="hidden">' . esc_html__('loading...', 'event_espresso') . '</span>
         </div>


### PR DESCRIPTION
This is related to https://github.com/eventespresso/event-espresso-core/issues/3738 issue.

Applied `wp_kses` function to all printed variables in **Messages** menu.

Here is the testing checklist: https://trello.com/c/cQVC8NJY/1150-escaping-ee4-decaf-testing-checklist-pr-3775