### PR TITLE
Kses - Part 6

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1364,7 +1364,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 $option = "\n\t";
                 $option .= '<option class="level-' . $level . '" ';
                 $option .= 'value="' . $ID . '" ';
-                $option .= $ID === absint($default) ? ' selected="selected"' : '';
+                $option .= $ID === absint($default) ? ' selected' : '';
                 $option .= '>';
                 $option .= "$pad {$post_title}";
                 $option .= '</option>';

--- a/admin_pages/maintenance/templates/ee_migration_page.template.php
+++ b/admin_pages/maintenance/templates/ee_migration_page.template.php
@@ -279,7 +279,7 @@ if ($show_backup_db_text) { ?>
                                    type='radio'
                                    value="0"
                                 <?php echo ($mMode_level === EE_Maintenance_Mode::level_0_not_in_maintenance
-                                    ? 'checked="checked"'
+                                    ? 'checked'
                                     : '');
                                 ?>
                             />
@@ -303,7 +303,7 @@ if ($show_backup_db_text) { ?>
                                    type='radio'
                                    value="1"
                                 <?php echo ($mMode_level === EE_Maintenance_Mode::level_1_frontend_only_maintenance
-                                    ? 'checked="checked"'
+                                    ? 'checked'
                                     : '');
                                 ?>
                             />

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -850,7 +850,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                         . '" alt="' . esc_attr__('Inactive Email Tab', 'event_espresso') . '" />';
         $args['img3'] = '<div class="switch">'
                         . '<input class="ee-on-off-toggle ee-toggle-round-flat"'
-                        . ' type="checkbox" checked="checked">'
+                        . ' type="checkbox" checked>'
                         . '<label for="ee-on-off-toggle-on"></label>'
                         . '</div>';
         $args['img4'] = '<div class="switch">'

--- a/admin_pages/messages/help_tabs/messages_settings_messengers.help_tab.php
+++ b/admin_pages/messages/help_tabs/messages_settings_messengers.help_tab.php
@@ -44,7 +44,7 @@
             'event_espresso'
         ),
         '<div class="switch">'
-        . '<input class="ee-on-off-toggle ee-toggle-round-flat" type="checkbox" checked="checked" disabled>'
+        . '<input class="ee-on-off-toggle ee-toggle-round-flat" type="checkbox" checked disabled>'
         . '<label for="ee-on-off-toggle-on"></label>'
         . '</div>',
         '<div class="switch">'

--- a/admin_pages/payments/templates/payment_log_details.template.php
+++ b/admin_pages/payments/templates/payment_log_details.template.php
@@ -38,9 +38,9 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                     if ($payment_log->object() instanceof EE_Transaction) {
                         esc_html_e('Unknown', 'event_espresso');
                     } else {
-                        echo $payment_method
+                        echo ($payment_method
                             ? esc_html($payment_method->admin_name())
-                            : esc_html__("No Longer Exists", 'event_espresso');
+                            : esc_html__("No Longer Exists", 'event_espresso'));
                     }
                     ?>
                 </td>
@@ -52,9 +52,9 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                     </label>
                 </th>
                 <td>
-                    <?php echo $transaction
+                    <?php echo ($transaction
                         ? absint($transaction->ID())
-                        : esc_html__('Could not be determined', 'event_espresso');
+                        : esc_html__('Could not be determined', 'event_espresso'));
                     ?>
                 </td>
             </tr>

--- a/admin_pages/payments/templates/payment_log_details.template.php
+++ b/admin_pages/payments/templates/payment_log_details.template.php
@@ -55,7 +55,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                     <?php echo ($transaction
                         ? absint($transaction->ID())
                         : esc_html__('Could not be determined', 'event_espresso'));
-                    ?>
+?>
                 </td>
             </tr>
             <tr>

--- a/admin_pages/payments/templates/payment_log_details.template.php
+++ b/admin_pages/payments/templates/payment_log_details.template.php
@@ -54,8 +54,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                 <td>
                     <?php echo ($transaction
                         ? absint($transaction->ID())
-                        : esc_html__('Could not be determined', 'event_espresso'));
-?>
+                        : esc_html__('Could not be determined', 'event_espresso')); ?>
                 </td>
             </tr>
             <tr>

--- a/admin_pages/registration_form/espresso_events_Registration_Form_Hooks.class.php
+++ b/admin_pages/registration_form/espresso_events_Registration_Form_Hooks.class.php
@@ -143,7 +143,7 @@ class espresso_events_Registration_Form_Hooks extends EE_Admin_Hooks
                 foreach ($QSGs as $QSG) {
                     $QSG_ID          = absint($QSG->ID());
                     $checked         = in_array($QSG_ID, $EQGids, true) || $QSG->get('QSG_system') === 1
-                        ? ' checked="checked"'
+                        ? ' checked'
                         : '';
                     $visibility      = $QSG->get('QSG_system') === 1
                         ? ' style="visibility:hidden"'

--- a/admin_pages/registration_form/templates/questions_main_meta_box.template.php
+++ b/admin_pages/registration_form/templates/questions_main_meta_box.template.php
@@ -219,7 +219,7 @@ if ($QST_system === 'country') {
                     </th>
                     <td>
                         <input id="QST_max"
-                            <?php echo $max_max === EE_INF ? '' : 'max="' . esc_attr($max_max) . '"'; ?>
+                            <?php echo ($max_max === EE_INF ? '' : 'max="' . esc_attr($max_max) . '"'); ?>
                                min="1"
                                name="QST_max"
                                type="number"

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -1282,7 +1282,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
                     : '';
                 $checked                           = empty($existing_reg_payments)
                                                      || in_array($registration->ID(), $existing_reg_payments, true)
-                    ? ' checked="checked"'
+                    ? ' checked'
                     : '';
                 $disabled                          = $registration->final_price() > 0 ? '' : ' disabled';
                 $registrations_to_apply_payment_to .= EEH_HTML::tr(

--- a/admin_pages/transactions/templates/txn_admin_details_main_meta_box_txn_details.template.php
+++ b/admin_pages/transactions/templates/txn_admin_details_main_meta_box_txn_details.template.php
@@ -687,7 +687,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                        value="1"
                                        id="txn-admin-apply-payment-to-all-registrations-inp"
                                        name="txn_admin_payment[apply_to_all_registrations]"
-                                       checked="checked"
+                                       checked
                                 />
                                 <?php esc_html_e('ALL Registrations', 'event_espresso'); ?>
                             </label>
@@ -725,7 +725,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                 <input type="checkbox"
                                        value="1"
                                        name="txn_payments[send_notifications]"
-                                       checked="checked"
+                                       checked
                                        aria-checked="true"
                                        style="vertical-align: middle;"
                                 />

--- a/caffeinated/admin/extend/events/templates/event_registration_options.template.php
+++ b/caffeinated/admin/extend/events/templates/event_registration_options.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var EE_Event $_event
  * @var string   $active_status
@@ -7,10 +8,13 @@
  * @var string   $display_ticket_selector
  * @var string   $EVT_default_registration_status
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
     <p>
         <label><?php esc_html_e('Active Status: ', 'event_espresso'); ?></label>
-        <?php echo $active_status; // already escaped ?>
+        <?php echo wp_kses($active_status, AllowedTags::getAllowedTags()); ?>
     </p>
 
 <?php
@@ -54,5 +58,5 @@ $settings_array = apply_filters('FHEE__caffeinated_event_registration_options__t
 
 // echo
 foreach ($settings_array as $item) {
-    echo $item; // already escaped
+    echo wp_kses($item, AllowedTags::getWithFormTags());
 }

--- a/caffeinated/admin/extend/events/templates/event_type_metabox_contents.template.php
+++ b/caffeinated/admin/extend/events/templates/event_type_metabox_contents.template.php
@@ -5,6 +5,9 @@
  *
  * @var string $radio_list;
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 <div id="taxonomy-espresso_event_type" class="categorydiv">
     <ul id="espresso_event_type-tabs" class="category-tabs">
@@ -17,7 +20,7 @@
         ?>
         <ul id="espresso_event_typechecklist" data-wp-lists="list:espresso_event_type"
             class="categorychecklist form-no-clear">
-            <?php echo $radio_list; ?>
+            <?php echo wp_kses($radio_list, AllowedTags::getWithFormTags()); ?>
         </ul>
     </div>
 </div>

--- a/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
@@ -138,7 +138,7 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
             if (! empty($QSGs)) {
                 $html = count($QSGs) > 10 ? '<div style="height:250px;overflow:auto;">' : '';
                 foreach ($QSGs as $QSG) {
-                    $checked = in_array($QSG->ID(), $EQGids, true) ? ' checked="checked" ' : '';
+                    $checked = in_array($QSG->ID(), $EQGids, true) ? ' checked ' : '';
                     $edit_link = EE_Admin_Page::add_query_args_and_nonce(
                         array(
                             'action' => 'edit_question_group',

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -1365,7 +1365,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? 'TICKETNUM'
                 : $ticket_row,
             'datetime_ticket_checked' => in_array($display_row, $dtt_tkts, true)
-                ? ' checked="checked"'
+                ? ' checked'
                 : '',
             'ticket_selected'         => in_array($display_row, $dtt_tkts, true)
                 ? ' ticket-selected'
@@ -1465,7 +1465,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $TKT_taxable = '';
         } else {
             $TKT_taxable = $ticket->taxable()
-                ? ' checked="checked"'
+                ? ' checked'
                 : '';
         }
         if ($default) {
@@ -2045,7 +2045,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? ' ticket-selected'
                 : '',
             'ticket_datetime_checked'  => in_array($datetime_row, $tkt_datetimes, true)
-                ? ' checked="checked"'
+                ? ' checked'
                 : '',
             'DTT_name'                 => $default && empty($datetime)
                 ? 'DTTNAME'

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_attached_tickets_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_attached_tickets_row.template.php
@@ -1,4 +1,3 @@
-
 <?php
 
 /**
@@ -12,6 +11,9 @@
  * @var string $event_datetimes_name
  * @var string $add_new_datetime_ticket_help_link
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 <tr id="advanced-dtt-edit-row-<?php echo esc_attr($dtt_row); ?>" class="advanced-dtt-edit-row">
     <td colspan="7">
@@ -30,7 +32,7 @@
             <h4 class="datetime-tickets-heading"><?php esc_html_e('Assigned Tickets', 'event_espresso'); ?></h4>
 
             <ul class="datetime-tickets-list">
-                <?php echo $datetime_tickets_list; ?>
+                <?php echo wp_kses($datetime_tickets_list, AllowedTags::getWithFormTags()); ?>
             </ul>
 
 
@@ -39,7 +41,7 @@
                     esc_html_e(
                         'Add New Ticket',
                         'event_espresso'
-                    ); ?></h4><?php echo $add_new_datetime_ticket_help_link; ?><br>
+                    ); ?></h4><?php echo wp_kses($add_new_datetime_ticket_help_link, AllowedTags::getAllowedTags()); ?><br>
                 <table class="add-new-ticket-table">
                     <thead>
                     <tr valign="top">
@@ -107,12 +109,12 @@
                 <div class="ee-editor-footer-container">
                     <div class="ee-editor-id-container">
                         <span class="ee-item-id"><?php
-                            echo $DTT_ID
+                            echo ($DTT_ID
                                 ? sprintf(
                                     esc_html__('Datetime ID: %d', 'event_espresso'),
                                     $DTT_ID
                                 )
-                                : ''; ?></span>
+                                : ''); ?></span>
                     </div>
                     <div class="save-cancel-button-container">
                         <button data-context="short-ticket" data-datetime-row="<?php echo esc_attr($dtt_row); ?>"

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_dtt_tickets_list.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_dtt_tickets_list.template.php
@@ -10,14 +10,16 @@
  * @var string $TKT_name
  * @var string $tkt_status_class
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <li data-datetime-row="<?php echo esc_attr($dtt_row); ?>" data-context="datetime-ticket" data-ticket-row="<?php echo esc_attr($tkt_row); ?>"
-    class="datetime-ticket clickable<?php echo $ticket_selected;
-    echo $tkt_status_class; ?>">
+    class="datetime-ticket clickable <?php echo sanitize_html_class($ticket_selected); ?> <?php echo sanitize_html_class($tkt_status_class); ?>">
     <input type="checkbox" name="datetime_ticket[<?php echo esc_attr($dtt_row); ?>][<?php echo esc_attr($tkt_row); ?>]"
-           class="datetime-ticket-checkbox" value="1"<?php echo $datetime_ticket_checked; ?>>
-    <span class="ee-icon ee-icon-tickets ticket-list-ticket-name"><?php echo $TKT_name; ?></span>
+           class="datetime-ticket-checkbox" value="1" <?php echo esc_attr($datetime_ticket_checked); ?>>
+    <span class="ee-icon ee-icon-tickets ticket-list-ticket-name"><?php echo wp_kses($TKT_name, AllowedTags::getAllowedTags()); ?></span>
     <span class="clickable gear-icon dashicons dashicons-admin-generic" data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
           data-context="datetime-ticket" data-ticket-row="<?php echo esc_attr($tkt_row); ?>"></span>
 </li>

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_edit_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_edit_row.template.php
@@ -55,11 +55,11 @@
     </td>
     <td>
         <span data-context="datetime" data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
-              class="datetime-tickets-sold ee-numeric"><?php echo $dtt_sold; ?></span>
+              class="datetime-tickets-sold ee-numeric"><?php echo esc_html($dtt_sold); ?></span>
     </td>
     <?php if (apply_filters('FHEE__event_tickets_metabox__dtt_reserved', true)) : ?>
         <td>
-            <span class="datetime-tickets-reserved ee-numeric"><?php echo $dtt_reserved; ?></span>
+            <span class="datetime-tickets-reserved ee-numeric"><?php echo esc_html($dtt_reserved); ?></span>
         </td>
     <?php endif; ?>
 
@@ -74,7 +74,7 @@
               class="<?php echo esc_attr($trash_icon); ?> clickable"<?php echo $show_trash; ?>></span>
         <?php if ($reg_list_url !== '') : ?>
             <a href="<?php echo esc_url_raw($reg_list_url); ?>"
-               title="<?php esc_html_e('View registrations for this datetime.', 'event_espresso'); ?>"
+               title="<?php esc_attr_e('View registrations for this datetime.', 'event_espresso'); ?>"
                style="text-decoration: none;">
                 <span data-context="datetime" data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
                       class="dashicons dashicons-groups clickable"></span>

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_modifier_selector.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_modifier_selector.template.php
@@ -13,17 +13,20 @@
  * @var $selected_price_type_id int
  * @var $disabled bool
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
-<?php echo $price_modifier_selector; ?>
+<?php echo wp_kses($price_modifier_selector, AllowedTags::getWithFormTags()); ?>
 <?php if ($disabled) : ?>
     <input type="hidden" name="<?php echo esc_attr($main_name); ?>" value="<?php echo absint($selected_price_type_id); ?>">
 <?php endif; ?>
 
     <div class="ee-price-type-option-info hidden">
-        <?php echo $price_option_spans; ?>
+        <?php echo wp_kses($price_option_spans, AllowedTags::getWithFormTags()); ?>
     </div>
-    <input type="hidden" name="ee_price_selected[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>]"
+    <input type="hidden" name="ee_price_selected[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>]"
            class="ee-price-selected-operator" value="<?php echo esc_attr($price_selected_operator); ?>">
-    <input type="hidden" name="ee_price_selected[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>]"
+    <input type="hidden" name="ee_price_selected[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>]"
            class="ee-price-selected-is-percent" value="<?php echo esc_attr($price_selected_is_percent); ?>">
 

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_option_span.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_option_span.template.php
@@ -7,8 +7,11 @@
  * @var string $PRT_operator
  * @var string $PRT_is_percent
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 <section id="price-option-<?php echo absint($PRT_ID); ?>">
-    <span class="ee-price-operator hidden"><?php echo $PRT_operator; ?></span>
-    <span class="ee-PRT_is_percent hidden"><?php echo $PRT_is_percent; ?></span>
+    <span class="ee-price-operator hidden"><?php echo wp_kses($PRT_operator, AllowedTags::getAllowedTags()); ?></span>
+    <span class="ee-PRT_is_percent hidden"><?php echo wp_kses($PRT_is_percent, AllowedTags::getAllowedTags()); ?></span>
 </section>

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_type_base.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_price_type_base.template.php
@@ -10,21 +10,24 @@
  * @var string $price_selected_operator
  * @var string $price_selected_is_percent
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <input type="hidden"
-       name="edit_prices[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRT_ID]"
+       name="edit_prices[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRT_ID]"
        class="edit-price-PRT_ID"
        value="<?php echo absint($PRT_ID); ?>"
 />
-<span class="price-type-text"><?php echo $PRT_name; ?></span>
+<span class="price-type-text"><?php echo wp_kses($PRT_name, AllowedTags::getAllowedTags()); ?></span>
 <input type="hidden"
-       name="ee_price_selected_operator[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>]"
+       name="ee_price_selected_operator[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>]"
        class="ee-price-selected-operator"
        value="<?php echo esc_attr($price_selected_operator); ?>"
 />
 <input type="hidden"
-       name="ee_price_selected_operator[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>]"
+       name="ee_price_selected_operator[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>]"
        class="ee-price-selected-is-percent"
        value="<?php echo esc_attr($price_selected_is_percent); ?>"
 />

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_row_wrapper.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_row_wrapper.template.php
@@ -7,5 +7,7 @@
  * @var string $dtt_attached_tickets_row
  */
 
-echo $dtt_edit_row;
-echo $dtt_attached_tickets_row;
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
+echo wp_kses($dtt_edit_row, AllowedTags::getWithFormTags());
+echo wp_kses($dtt_attached_tickets_row, AllowedTags::getWithFormTags());

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_datetimes_list_item.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_datetimes_list_item.template.php
@@ -11,8 +11,7 @@
  * @var string $tkt_status_class;
  */
 ?>
-
-<li class="datetime-ticket clickable<?php echo $ticket_datetime_selected; ?><?php echo $tkt_status_class; ?>"
+<li class="datetime-ticket clickable <?php echo sanitize_html_class($ticket_datetime_selected); ?> <?php echo sanitize_html_class($tkt_status_class); ?>"
     data-context="ticket-datetime"
     data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
     data-ticket-row="<?php echo esc_attr($tkt_row); ?>"
@@ -20,10 +19,10 @@
     <input type="checkbox"
         name="ticket_datetime[<?php echo esc_attr($dtt_row); ?>][<?php echo esc_attr($tkt_row); ?>]"
         class="datetime-ticket-checkbox"
-        value="1"<?php echo $ticket_datetime_checked; ?>
+        value="1" <?php echo esc_attr($ticket_datetime_checked); ?>
     />
     <span class="dashicons dashicons-clock ee-icon-size-20"></span>
-    <span class="ticket-list-ticket-name"><?php echo $DTT_name; ?></span>
+    <span class="ticket-list-ticket-name"><?php echo esc_html($DTT_name); ?></span>
     <span class="clickable gear-icon dashicons dashicons-admin-generic"
         data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
         data-context="ticket-datetime"

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_js_structure.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_js_structure.template.php
@@ -17,11 +17,14 @@
  * @var string $new_available_datetime_ticket_list_item
  * @var string $new_available_ticket_datetime_list_item
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 <!-- edit datetime base form -->
 <table id="edit-datetime-form-holder" class="hidden">
     <tbody>
-    <?php echo $default_datetime_edit_row; ?>
+    <?php echo wp_kses($default_datetime_edit_row, AllowedTags::getWithFormTags()); ?>
     </tbody>
 </table>
 
@@ -29,42 +32,42 @@
 <!-- retrieved by js to set a new ticket row -->
 <table id="ticket-row-form-holder" class="hidden">
     <tbody>
-    <?php echo $default_ticket_row; ?>
+    <?php echo wp_kses($default_ticket_row, AllowedTags::getWithFormTags()); ?>
     </tbody>
 </table>
 
 
 <div id="default-base-price-info" class="hidden">
-    <span id="default-base-price-amount"><?php echo $default_base_price_amount; ?></span>
-    <span id="default-base-price-name"><?php echo $default_base_price_name; ?></span>
-    <span id="default-base-price-description"><?php echo $default_base_price_description; ?></span>
+    <span id="default-base-price-amount"><?php echo wp_kses($default_base_price_amount, AllowedTags::getWithFormTags()); ?></span>
+    <span id="default-base-price-name"><?php echo wp_kses($default_base_price_name, AllowedTags::getWithFormTags()); ?></span>
+    <span id="default-base-price-description"><?php echo wp_kses($default_base_price_description, AllowedTags::getWithFormTags()); ?></span>
 </div>
 
 
 <!-- this is retrieved by our js to set a new price row. Note this will also contain any default prices setup by event manager -->
 <table id="ticket-edit-row-initial-price-row" class="hidden">
     <tbody>
-    <?php echo $default_price_row; ?>
+    <?php echo wp_kses($default_price_row, AllowedTags::getWithFormTags()); ?>
     </tbody>
 </table>
 
 <!-- this is retrieved by our js when a brand new ticket is created (not from short-ticket context).  It contains all the default prices available. -->
 <table id="ticket-edit-row-default-price-rows" class="hidden">
     <tbody>
-    <?php echo $default_price_rows; ?>
+    <?php echo wp_kses($default_price_rows, AllowedTags::getWithFormTags()); ?>
     </tbody>
 </table>
 
 
 <!-- This is the selector and it ONLY lists price-modifiers (i.e. PBT_ID = 2 || 3).  It is used for new price rows added for EXISTING tickets (not new tickets) -->
 <div id="ticket-edit-row-price-modifier-selector" class="hidden">
-    <?php echo $default_price_modifier_selector_row; ?>
+    <?php echo wp_kses($default_price_modifier_selector_row, AllowedTags::getWithFormTags()); ?>
 </div>
 
 <!-- available tickets for datetime html -->
 <table id="edit-datetime-available-tickets-holder" class="hidden">
     <tbody>
-    <?php echo $default_available_tickets_for_datetime; ?>
+    <?php echo wp_kses($default_available_tickets_for_datetime, AllowedTags::getWithFormTags()); ?>
     </tbody>
 </table>
 
@@ -72,23 +75,23 @@
 <!-- this will always have existing tickets listed here.  When we create a new ticket they get added to this container so that if a new datetime is created it just pulls from here. -->
 <ul id="dtt-existing-available-ticket-list-items-holder" class="hidden datetime-tickets-list">
     <li class="hidden"></li>
-    <?php echo $existing_available_datetime_tickets_list; ?>
+    <?php echo wp_kses($existing_available_datetime_tickets_list, AllowedTags::getWithFormTags()); ?>
 </ul>
 
 
 <!-- same as above except for dtts -->
 <ul id="dtt-existing-available-datetime-list-items-holder" class="hidden datetime-tickets-list">
     <li class="hidden"></li>
-    <?php echo $existing_available_ticket_datetimes_list; ?>
+    <?php echo wp_kses($existing_available_ticket_datetimes_list, AllowedTags::getWithFormTags()); ?>
 </ul>
 
 <!-- single list item for a new available ticket created from a datetime -->
 <ul id="dtt-new-available-ticket-list-items-holder" class="hidden">
-    <?php echo $new_available_datetime_ticket_list_item; ?>
+    <?php echo wp_kses($new_available_datetime_ticket_list_item, AllowedTags::getWithFormTags()); ?>
 </ul>
 
 
 <!-- single list item for a new available datetime to add to our available ticket rows -->
 <ul id="dtt-new-available-datetime-list-items-holder" class="hidden">
-    <?php echo $new_available_ticket_datetime_list_item; ?>
+    <?php echo wp_kses($new_available_ticket_datetime_list_item, AllowedTags::getWithFormTags()); ?>
 </ul>

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_price_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_price_row.template.php
@@ -23,25 +23,28 @@
  * @var string $PRC_name
  * @var string $price_currency_symbol
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
-<tr id="price-row-<?php echo esc_attr($tkt_row); ?>-<?php echo absint($PRC_order); ?>" class="ee-active-price" valign="top">
+<tr id="price-row-<?php echo esc_attr($tkt_row); ?>-<?php echo esc_attr($PRC_order); ?>" class="ee-active-price" valign="top">
     <td>
-        <?php echo $price_type_selector; ?>
+        <?php echo wp_kses($price_type_selector, AllowedTags::getWithFormTags()); ?>
     </td>
     <td>
         <input type="hidden"
-               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_ID]"
+               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_ID]"
                class="edit-price-PRC_ID" value="<?php echo absint($PRC_ID); ?>">
         <input type="hidden"
-               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_is_default]"
+               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_is_default]"
                class="edit-price-PRC_is_default" value="<?php echo esc_attr($PRC_is_default); ?>">
         <input type="text" class="edit-price-PRC_name ee-text-inp"
-               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_name]"
+               name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_name]"
                value="<?php echo esc_attr($PRC_name); ?>">
     </td>
     <td>
-        <textarea name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_desc]"
+        <textarea name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_desc]"
                   class="edit-price-PRC_desc ee-full-textarea-inp"
                   placeholder="Edit the description for the price here"><?php echo esc_textarea($PRC_desc); ?></textarea>
     </td>
@@ -50,20 +53,20 @@
         <span class="ticket-price-info-display ticket-price-plus"<?php echo $show_plus; ?>>+</span>
         <span class="ticket-price-info-display ticket-price-minus"<?php echo $show_minus; ?>>-</span>
         <span class="ticket-price-info-display ticket-price-dollar-sign-display"<?php echo $show_currency_symbol; ?>>
-            <?php echo $price_currency_symbol; ?>
+            <?php echo esc_html($price_currency_symbol); ?>
         </span>
     </td>
     <td>
         <?php if ($disabled) : ?>
             <input type="hidden" size="1" class="edit-price-PRC_amount ee-numeric"
-                   name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_amount]"
+                   name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_amount]"
                    value="<?php echo esc_attr($PRC_amount); ?>">
             <input type="text" size="1" class="edit-price-PRC_amount ee-numeric"
-                   name="prices_archive[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_amount]"
+                   name="prices_archive[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_amount]"
                    value="<?php echo esc_attr($PRC_amount); ?>" disabled>
         <?php else : ?>
             <input type="text" size="1" class="edit-price-PRC_amount ee-numeric"
-                   name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_amount]"
+                   name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo esc_attr($PRC_order); ?>][PRC_amount]"
                    value="<?php echo esc_attr($PRC_amount); ?>">
         <?php endif; ?>
     </td>
@@ -75,19 +78,11 @@
         <?php if ($disabled) : ?>
             <span class="ee-lock-icon"></span>
         <?php else : ?>
-            <!-- <span class="gear-icon dashicons dashicons-admin-generic clickable" data-ticket-row="<?php echo esc_attr($tkt_row); ?>" data-context="price" data-price-row="<?php echo absint($PRC_order); ?>"></span> -->
             <span class="trash-icon dashicons dashicons-post-trash clickable" data-ticket-row="<?php echo esc_attr($tkt_row); ?>"
-                  data-context="price" data-price-row="<?php echo absint($PRC_order); ?>"<?php echo $show_trash_icon; ?>></span>
-            <button data-ticket-row="<?php echo esc_attr($tkt_row); ?>" data-price-row="<?php echo absint($PRC_order); ?>"
-                    data-context="price" class="ee-create-button"<?php echo $show_create_button; ?>><strong>+</strong>
+                  data-context="price" data-price-row="<?php echo esc_attr($PRC_order); ?>"<?php echo wp_kses($show_trash_icon, AllowedTags::getWithFormTags()); ?>></span>
+            <button data-ticket-row="<?php echo esc_attr($tkt_row); ?>" data-price-row="<?php echo esc_attr($PRC_order); ?>"
+                    data-context="price" class="ee-create-button"<?php echo wp_kses($show_create_button, AllowedTags::getWithFormTags()); ?>><strong>+</strong>
             </button>
         <?php endif; ?>
     </td>
 </tr>
-<!-- <tr id="extra-price-row-<?php echo esc_attr($tkt_row); ?>-<?php echo absint($PRC_order); ?>"> -->
-<!-- <td colspan="5"> -->
-<!-- <section class="extra-price-row" style="display:none"> -->
-<!-- <textarea name="<?php echo esc_attr($edit_prices_name); ?>[<?php echo esc_attr($tkt_row); ?>][<?php echo absint($PRC_order); ?>][PRC_desc]" class="edit-price-PRC_desc ee-full-textarea-inp" placeholder="Edit the description for the price here"><?php echo esc_textarea($PRC_desc); ?></textarea> -->
-<!-- </section> -->
-<!-- </td> -->
-<!-- </tr> -->

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_row.template.php
@@ -54,6 +54,9 @@
  * @var $show_price_modifier
  * @var $show_price_mod_button
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
 ?>
 <tr class="ee-ticket-sortable ticket-row <?php echo sanitize_html_class($ticket_archive_class);?>"
@@ -212,17 +215,17 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
     </td>
     <!-- TKT_sold -->
     <td>
-        <span class="ticket-display-row-TKT_sold"><?php echo $TKT_sold; ?></span>
+        <span class="ticket-display-row-TKT_sold"><?php echo esc_html($TKT_sold); ?></span>
     </td>
     <?php if (apply_filters('FHEE__event_tickets_metabox__tkt_reserved', true)) : ?>
     <!-- TKT_reserved -->
     <td>
-        <span class="ticket-display-row-TKT_reserved"><?php echo $TKT_reserved; ?></span>
+        <span class="ticket-display-row-TKT_reserved"><?php echo esc_html($TKT_reserved); ?></span>
     </td>
     <?php endif; ?>
     <!-- TKT_registrations -->
     <td>
-        <span class="ticket-display-row-TKT_registrations"><?php echo $TKT_registrations; ?></span>
+        <span class="ticket-display-row-TKT_registrations"><?php echo esc_html($TKT_registrations); ?></span>
     </td>
     <!-- actions -->
     <td>
@@ -405,8 +408,8 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
                                id="edit-ticket-TKT_required-<?php echo esc_attr($tkt_row); ?>"
                                value="1"
                             <?php
-                                echo $TKT_required ? ' checked="checked"' : '';
-                                echo $disabled ? ' disabled' : '';
+                                echo ($TKT_required ? ' checked' : '');
+                                echo ($disabled ? ' disabled' : '');
                             ?>
                         />
                         <?php esc_html_e(
@@ -463,7 +466,7 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
                     </tr>
                     </thead>
                     <tbody class="ticket-price-rows price-table-info"<?php echo $show_price_modifier; ?>>
-                    <?php echo $ticket_price_rows; ?>
+                    <?php echo wp_kses($ticket_price_rows, AllowedTags::getWithFormTags()); ?>
                     </tbody>
                     <tfoot>
                     <tr class="price-subtotal-row TKT-taxes-display"<?php echo $display_subtotal; ?>>
@@ -474,7 +477,7 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
                         </td>
                         <td class="ee-numeric">
                             <span class="TKT-taxable-subtotal-amount-display">
-                                <?php echo $TKT_subtotal_amount_display; ?>
+                                <?php echo wp_kses($TKT_subtotal_amount_display, AllowedTags::getWithFormTags()); ?>
                             </span>
                             <input type="hidden"
                                    value="<?php echo esc_attr($TKT_subtotal_amount); ?>"
@@ -485,20 +488,20 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
                         <td></td>
                         <td></td>
                     </tr>
-                    <?php echo $tax_rows; ?>
+                    <?php echo wp_kses($tax_rows, AllowedTags::getWithFormTags()); ?>
                     <tr class="price-total-row">
                         <td colspan="4" class="ee-numeric">
                             <strong><?php esc_html_e('Total', 'event_espresso'); ?></strong>
                         </td>
                         <td class="ee-numeric">
-                            <span id="price-total-amount-<?php echo esc_attr($tkt_row); ?>"><?php echo $TKT_price; ?></span>
+                            <span id="price-total-amount-<?php echo esc_attr($tkt_row); ?>"><?php echo wp_kses($TKT_price, AllowedTags::getAllowedTags()); ?></span>
                             <input type="hidden"
                                    name="<?php echo esc_attr($edit_tickets_name); ?>[<?php echo esc_attr($tkt_row); ?>][TKT_price]"
                                    class="edit-ticket-TKT_price"
                                    value="<?php echo esc_attr($TKT_price_amount); ?>"
                             />
                         </td>
-                        <td><?php echo $TKT_price_code; ?></td>
+                        <td><?php echo wp_kses($TKT_price_code, AllowedTags::getWithFormTags()); ?></td>
                         <td>
                             <input type="hidden"
                                    name="price_total_rows_ticket[<?php echo esc_attr($tkt_row); ?>]"
@@ -519,7 +522,7 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
             ); ?>
             </p>
             <ul class="datetime-tickets-list">
-                <?php echo $ticket_datetimes_list; ?>
+                <?php echo wp_kses($ticket_datetimes_list, AllowedTags::getWithFormTags()); ?>
             </ul>
 
             <?php do_action(
@@ -530,9 +533,9 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
             <div class="ee-editor-footer-container">
                 <div class="ee-editor-id-container">
                     <span class="ee-item-id"><?php
-                        echo $TKT_ID
+                        echo ($TKT_ID
                             ? sprintf(esc_html__('Ticket ID: %d', 'event_espresso'), $TKT_ID)
-                            : ''; ?></span>
+                            : ''); ?></span>
                 </div>
                 <div class="save-cancel-button-container">
                     <label for="edit-ticket-TKT_is_default_selector-<?php echo esc_attr($tkt_row); ?>">
@@ -545,7 +548,7 @@ $ticket_archive_class .= WP_DEBUG ? ' ee-wp-debug' : '';
                                class="edit-ticket-TKT_is_default_selector"
                                id="edit-ticket-TKT_is_default_selector-<?php echo esc_attr($tkt_row); ?>"
                                value="1"
-                               <?php echo $disabled ? ' disabled' : ''; ?>
+                               <?php echo ($disabled ? ' disabled' : ''); ?>
                         />
                     </label>
                     <input type="hidden"

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_tax_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_ticket_tax_row.template.php
@@ -15,11 +15,11 @@
 
 <tr class="ticket-tax-row TKT-taxes-display"<?php echo $display_tax; ?>>
     <td colspan="4" class="ee-numeric">
-        <span class="TKT-tax-label"><?php echo $tax_label; ?></span>
+        <span class="TKT-tax-label"><?php echo esc_html($tax_label); ?></span>
     </td>
     <td class="ee-numeric">
         <span id="TKT-tax-amount-display-<?php echo absint($tax_id); ?>-<?php echo esc_attr($tkt_row); ?>"
-              class="TKT-tax-amount-display"><?php echo $tax_added_display; ?></span>
+              class="TKT-tax-amount-display"><?php echo esc_html($tax_added_display); ?></span>
         <input type="hidden" name="TKT-tax_amount[]" id="TKT-tax-amount-<?php echo absint($tax_id); ?>-<?php echo esc_attr($tkt_row); ?>"
                class="TKT-tax-amount" value="<?php echo esc_attr($tax_added); ?>">
         <input type="hidden" name="TKT-tax_percentage[]"

--- a/caffeinated/admin/new/pricing/templates/event_tickets_metabox_main.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_metabox_main.template.php
@@ -15,6 +15,9 @@
  * @var string $ticket_js_structure
  * @var string $ee_collapsible_status
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div id="event-and-ticket-form-content">
@@ -30,7 +33,7 @@
                 ?>
         </span>
     </h3>
-    <?php echo $event_datetime_help_link; ?>
+    <?php echo wp_kses($event_datetime_help_link, AllowedTags::getAllowedTags()); ?>
     <div class="event-datetimes-container">
         <div class="save-cancel-button-container">
             <button class="button-secondary ee-create-button datetime-create-button" data-context="datetime">
@@ -57,7 +60,7 @@
             </tr>
             </thead>
             <tbody class="datetime-editing-dtts-tbody">
-            <?php echo $datetime_rows; ?>
+            <?php echo wp_kses($datetime_rows, AllowedTags::getWithFormTags()); ?>
             </tbody>
         </table>
         <div style="clear:both"></div>
@@ -67,7 +70,7 @@
             esc_html_e(
                 'Add New Datetime',
                 'event_espresso'
-            ); ?></h4><?php echo $add_new_dtt_help_link; ?>
+            ); ?></h4><?php echo wp_kses($add_new_dtt_help_link, AllowedTags::getAllowedTags()); ?>
         <div>
             <table id="add-new-event-datetime-table" class="datetime-edit-table">
                 <tr>
@@ -162,7 +165,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                <?php echo $ticket_rows; ?>
+                <?php echo wp_kses($ticket_rows, AllowedTags::getWithFormTags()); ?>
                 </tbody>
             </table> <!-- end .ticket-table -->
 
@@ -174,4 +177,4 @@
     </div>
 </div> <!-- end #event-and-ticket-form-content -->
 
-<?php echo $ticket_js_structure; ?>
+<?php echo ($ticket_js_structure); ?>

--- a/caffeinated/admin/new/pricing/templates/pricing_admin_overview.template.php
+++ b/caffeinated/admin/new/pricing/templates/pricing_admin_overview.template.php
@@ -1,8 +1,20 @@
+<?php
+
+/**
+ * template vars in use:
+ *
+ * @var $view_RLs
+ * @var $evt_prc_overview_url
+ * @var $status
+ * @var $list_table
+ */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
+?>
 <div id="evt-prc-overview-filters-dv">
     <ul class="subsubsub">
-        <?php use EventEspresso\core\services\request\sanitizers\AllowedTags;
-
-        foreach ($view_RLs as $view) : ?>
+        <?php foreach ($view_RLs as $view) : ?>
             <li class="">
                 <a class="<?php echo sanitize_html_class($view['class']); ?>" href="<?php echo esc_url_raw($view['url']); ?>">
                     <?php echo esc_html($view['label']); ?> <span class="count">(<?php echo esc_html($view['count']); ?>)</span>
@@ -10,7 +22,6 @@
             </li>
         <?php endforeach; ?>
     </ul>
-    <!--<div class="clear"></div>-->
 </div>
 
 <form id="event-price-overview-frm" action="<?php echo esc_url_raw($evt_prc_overview_url); ?>" method="post">

--- a/caffeinated/admin/new/pricing/templates/pricing_admin_overview.template.php
+++ b/caffeinated/admin/new/pricing/templates/pricing_admin_overview.template.php
@@ -1,9 +1,11 @@
 <div id="evt-prc-overview-filters-dv">
     <ul class="subsubsub">
-        <?php foreach ($view_RLs as $view) : ?>
+        <?php use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
+        foreach ($view_RLs as $view) : ?>
             <li class="">
                 <a class="<?php echo sanitize_html_class($view['class']); ?>" href="<?php echo esc_url_raw($view['url']); ?>">
-                    <?php echo $view['label']; ?> <span class="count">(<?php echo $view['count']; ?>)</span>
+                    <?php echo esc_html($view['label']); ?> <span class="count">(<?php echo esc_html($view['count']); ?>)</span>
                 </a>
             </li>
         <?php endforeach; ?>
@@ -15,6 +17,6 @@
     <?php // $list_table->search_box( $search['btn_label'], $search['callback'] ); ?>
     <input type="hidden" id="status" name="status" value="<?php echo esc_attr($status); ?>"/>
     <input type="hidden" id="per_page" name="per_page" value=""/>
-    <?php echo $list_table->display(); ?>
+    <?php echo wp_kses($list_table->display(), AllowedTags::getWithFormTags()); ?>
 </form>
 

--- a/caffeinated/admin/new/pricing/templates/pricing_type_details_main_meta_box.template.php
+++ b/caffeinated/admin/new/pricing/templates/pricing_type_details_main_meta_box.template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var EE_Price_Type $price_type
  * @var string $base_type_select

--- a/caffeinated/admin/new/pricing/templates/pricing_type_details_main_meta_box.template.php
+++ b/caffeinated/admin/new/pricing/templates/pricing_type_details_main_meta_box.template.php
@@ -3,6 +3,9 @@
  * @var EE_Price_Type $price_type
  * @var string $base_type_select
  */
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 ?>
 
 <div style="padding:1em;">
@@ -15,7 +18,7 @@
                 <label for="basic_type"><?php esc_html_e('Basic Type', 'event_espresso'); ?></label>
             </th>
             <td>
-                <?php echo $base_type_select; // already escaped ?><br/>
+                <?php echo wp_kses($base_type_select, AllowedTags::getWithFormTags()); ?><br/>
                 <p class="description">
                     <?php
                     printf(
@@ -45,14 +48,14 @@
                 <label><?php esc_html_e('Percentage or Fixed Amount?', 'event_espresso'); ?></label>
             </th>
             <td>
-                <?php $yes_checked = $price_type->is_percent() ? ' checked="checked"' : ''; ?>
+                <?php $yes_checked = $price_type->is_percent() ? 'checked' : ''; ?>
                 <label style="margin-right:15px;"><input type="radio" name="PRT_is_percent"
-                                                         value="1"<?php echo $yes_checked; ?> style="margin-right:5px;">
+                                                         value="1" <?php echo esc_attr($yes_checked); ?> style="margin-right:5px;">
                     <?php esc_html_e('Percentage', 'event_espresso'); ?>
                 </label>
-                <?php $no_checked = $price_type->is_percent() ? '' : ' checked="checked"'; ?>
+                <?php $no_checked = $price_type->is_percent() ? '' : 'checked'; ?>
                 <label style="margin-right:15px;"><input type="radio" name="PRT_is_percent"
-                                                         value="0"<?php echo $no_checked; ?> style="margin-right:5px;">
+                                                         value="0" <?php echo esc_attr($no_checked); ?> style="margin-right:5px;">
                     <?php esc_html_e('Fixed', 'event_espresso'); ?>
                 </label>
                 <p class="description"><?php

--- a/caffeinated/modules/event_single_caff/templates/admin-event-single-settings.template.php
+++ b/caffeinated/modules/event_single_caff/templates/admin-event-single-settings.template.php
@@ -1,4 +1,7 @@
 <?php
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 add_filter('FHEE__EEH_Form_Fields__label_html', '__return_empty_string');
 $values = EEH_Form_Fields::prep_answer_options(
     array(
@@ -96,7 +99,7 @@ $values = EEH_Form_Fields::prep_answer_options(
                 'espresso_update_event_single_order_nonce',
                 false
             ); ?>
-            <?php echo $event_single_display_order; ?>
+            <?php echo wp_kses($event_single_display_order, AllowedTags::getWithFormTags()); ?>
 
             <p class="description"><?php
                 esc_html_e(

--- a/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
+++ b/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
@@ -1,4 +1,7 @@
 <?php
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 add_filter('FHEE__EEH_Form_Fields__label_html', '__return_empty_string');
 
 $values = EEH_Form_Fields::prep_answer_options(
@@ -231,7 +234,7 @@ $description = EEH_Form_Fields::prep_answer_options(
                 'espresso_update_event_archive_order_nonce',
                 false
             ); ?>
-            <?php echo $event_archive_display_order; ?>
+            <?php echo wp_kses($event_archive_display_order, AllowedTags::getWithFormTags()); ?>
 
             <p class="description"><?php
                 esc_html_e(

--- a/caffeinated/modules/recaptcha_invisible/RecaptchaAdminSettings.php
+++ b/caffeinated/modules/recaptcha_invisible/RecaptchaAdminSettings.php
@@ -17,6 +17,7 @@ use EEH_HTML;
 use EEH_Template;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
 use InvalidArgumentException;
 use ReflectionException;
 
@@ -56,7 +57,7 @@ class RecaptchaAdminSettings
      */
     public function adminSettings()
     {
-        echo $this->settingsForm()->get_html_and_js();
+        echo wp_kses($this->settingsForm()->get_html_and_js(), AllowedTags::getWithFormTags());
     }
 
 

--- a/caffeinated/modules/ticket_selector_caff/templates/ticket_selector_price_details.template.php
+++ b/caffeinated/modules/ticket_selector_caff/templates/ticket_selector_price_details.template.php
@@ -1,4 +1,7 @@
 <?php
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 defined('EVENT_ESPRESSO_VERSION') || exit;
 
 /** @var boolean $display_ticket_price */
@@ -42,9 +45,9 @@ if ($display_ticket_price) { ?>
                 if ($ticket->base_price() instanceof EE_Price) { ?>
                     <tr>
                         <td data-th="<?php esc_html_e('Name', 'event_espresso'); ?>" class="small-text" colspan="2">
-                            <b><?php echo $ticket->base_price()->name(); ?></b></td>
+                            <b><?php echo wp_kses($ticket->base_price()->name(), AllowedTags::getAllowedTags()); ?></b></td>
                         <td data-th="<?php esc_html_e('Amount', 'event_espresso'); ?>"
-                            class="jst-rght small-text"><?php echo $ticket->base_price()->pretty_price(); ?></td>
+                            class="jst-rght small-text"><?php echo wp_kses($ticket->base_price()->pretty_price(), AllowedTags::getAllowedTags()); ?></td>
                     </tr>
                     <?php
                     $running_total = $ticket->base_price()->amount();
@@ -55,10 +58,10 @@ if ($display_ticket_price) { ?>
                 foreach ($ticket->price_modifiers() as $price_mod) { ?>
                     <tr>
                         <td data-th="<?php esc_html_e('Name', 'event_espresso'); ?>"
-                            class="jst-rght small-text"><?php echo $price_mod->name(); ?></td>
+                            class="jst-rght small-text"><?php echo wp_kses($price_mod->name(), AllowedTags::getAllowedTags()); ?></td>
                         <?php if ($price_mod->is_percent()) { ?>
                             <td data-th="<?php esc_html_e('Description', 'event_espresso'); ?>"
-                                class="small-text"><?php echo $price_mod->desc(); ?> <?php echo $price_mod->amount(); ?>
+                                class="small-text"><?php echo wp_kses($price_mod->desc(), AllowedTags::getAllowedTags()); ?> <?php echo wp_kses($price_mod->amount(), AllowedTags::getAllowedTags()); ?>
                                 %
                             </td>
                             <?php
@@ -69,7 +72,7 @@ if ($display_ticket_price) { ?>
                             <?php $new_sub_total = $price_mod->is_discount() ? $price_mod->amount() * -1
                                 : $price_mod->amount(); ?>
                             <td data-th="<?php esc_html_e('Description', 'event_espresso'); ?>"
-                                class="small-text"><?php echo $price_mod->desc(); ?></td>
+                                class="small-text"><?php echo wp_kses($price_mod->desc(), AllowedTags::getAllowedTags()); ?></td>
                             <?php $new_sub_total = $price_mod->is_discount() ? $price_mod->amount() * -1
                                 : $price_mod->amount(); ?>
                         <?php } ?>
@@ -98,9 +101,9 @@ if ($display_ticket_price) { ?>
                     <?php foreach ($ticket->get_ticket_taxes_for_admin() as $tax) { ?>
                         <tr>
                             <td data-th="<?php esc_html_e('Name', 'event_espresso'); ?>"
-                                class="jst-rght small-text"><?php echo $tax->name(); ?></td>
+                                class="jst-rght small-text"><?php echo wp_kses($tax->name(), AllowedTags::getAllowedTags()); ?></td>
                             <td data-th="<?php esc_html_e('Description', 'event_espresso'); ?>"
-                                class="jst-rght small-text"><?php echo $tax->amount(); ?>%
+                                class="jst-rght small-text"><?php echo wp_kses($tax->amount(), AllowedTags::getAllowedTags()); ?>%
                             </td>
                             <?php $tax_amount = $running_total * ($tax->amount() / 100); ?>
                             <td data-th="<?php esc_html_e('Amount', 'event_espresso'); ?>"

--- a/core/helpers/EEH_DTT_Helper.helper.php
+++ b/core/helpers/EEH_DTT_Helper.helper.php
@@ -967,7 +967,7 @@ class EEH_DTT_Helper
         usort($zone_data, '_wp_timezone_choice_usort_callback');
         $structure = array();
         if (empty($selected_zone)) {
-            $structure[] = '<option selected="selected" value="">' . esc_html__('Select a city', 'event_espresso') . '</option>';
+            $structure[] = '<option selected value="">' . esc_html__('Select a city', 'event_espresso') . '</option>';
         }
         foreach ($zone_data as $key => $zone) {
             // Build value in an array to join later
@@ -993,7 +993,7 @@ class EEH_DTT_Helper
             }
             // Build the value
             $value       = implode('/', $value);
-            $selected    = $value === $selected_zone ? ' selected="selected"' : '';
+            $selected    = $value === $selected_zone ? ' selected' : '';
             $structure[] = '<option value="' . esc_attr($value) . '"' . $selected . '>'
                            . esc_html($display)
                            . '</option>';

--- a/core/helpers/EEH_Form_Fields.helper.php
+++ b/core/helpers/EEH_Form_Fields.helper.php
@@ -388,7 +388,7 @@ class EEH_Form_Fields
         $name      = esc_attr($name);
         $class     = esc_attr($class);
         $tab_index = absint($tab_index);
-        $checked   = ! empty($default) && $default == $value ? 'checked="checked" ' : '';
+        $checked   = ! empty($default) && $default == $value ? 'checked ' : '';
         $required  = filter_var($required, FILTER_VALIDATE_BOOLEAN) ? 'required' : '';
         $input     = "
         <input name='{$name}[]' type='{$type}' id='{$id}' class='{$class}' value='{$value}' {$checked} {$required} tabindex='{$tab_index}'/>";
@@ -419,7 +419,7 @@ class EEH_Form_Fields
     {
         $options_array = [];
         foreach ($options as $value => $label) {
-            $selected        = ! empty($default) && $default == $value ? 'selected="selected"' : '';
+            $selected        = ! empty($default) && $default == $value ? 'selected' : '';
             $value           = esc_attr($value);
             $label           = wp_strip_all_tags($label);
             $options_array[] = "<option value='{$value}' {$selected}>{$label}</option>";
@@ -1129,7 +1129,7 @@ class EEH_Form_Fields
         $only_option = count($options, 1) == 1;
         if (! $only_option) {
             // if there is NO answer set and there are multiple options to choose from, then set the "please select" message as selected
-            $selected   = $answer === null ? ' selected="selected"' : '';
+            $selected   = $answer === null ? ' selected' : '';
             $input_html .= $add_please_select_option
                 ? "\n\t\t\t\t"
                   . '<option value=""' . $selected . '>'
@@ -1217,7 +1217,7 @@ class EEH_Form_Fields
         $key      = self::prep_answer($key, $use_html_entities);
         $value    = self::prep_answer($value, $use_html_entities);
         $value    = ! empty($value) ? $value : $key;
-        $selected = ($answer == $key || $only_option) ? 'selected="selected"' : '';
+        $selected = ($answer == $key || $only_option) ? 'selected' : '';
         return "\n\t\t\t\t"
                . '<option value="' . self::prep_option_value($key) . '" ' . $selected . '> '
                . $value
@@ -1303,7 +1303,7 @@ class EEH_Form_Fields
                     : self::get_label_size_class($OPT->value());
                 $desc    = $OPT->desc();// no self::prep_answer
                 $answer  = is_numeric($value) && empty($answer) ? 0 : $answer;
-                $checked = (string) $value == (string) $answer ? ' checked="checked"' : '';
+                $checked = (string) $value == (string) $answer ? ' checked' : '';
                 $opt     = '-' . sanitize_key($value);
 
                 $input_html .= "\n\t\t\t\t" . '<li' . $size . '>';
@@ -1412,7 +1412,7 @@ class EEH_Form_Fields
             $desc  = $OPT->desc();
             $opt   = '-' . sanitize_key($value);
 
-            $checked = is_array($answer) && in_array($text, $answer) ? ' checked="checked"' : '';
+            $checked = is_array($answer) && in_array($text, $answer) ? ' checked' : '';
 
             $input_html .= "\n\t\t\t\t" . '<li' . $size . '>';
             $input_html .= "\n\t\t\t\t\t" . '<label class="' . $radio_class . ' espresso-checkbox-lbl">';

--- a/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy.strategy.php
@@ -58,7 +58,7 @@ class EE_Checkbox_Display_Strategy extends EE_Compound_Input_Display_Strategy
             $html .= ' style="' . $input->html_style() . '"';
             $html .= ' value="' . esc_attr($value) . '"';
             $html .= ! empty($input_raw_value) && in_array($value, $input_raw_value, true)
-                ? ' checked="checked"'
+                ? ' checked'
                 : '';
             $html .= ' ' . $this->_input->other_html_attributes();
             $html .= ' data-question_label="' . $input->html_label_id() . '"';

--- a/core/libraries/form_sections/strategies/display/EE_Checkbox_Dropdown_Selector_Display_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/display/EE_Checkbox_Dropdown_Selector_Display_Strategy.strategy.php
@@ -164,7 +164,7 @@ class EE_Checkbox_Dropdown_Selector_Display_Strategy extends EE_Compound_Input_D
             $html .= $input->html_style() ? ' style="' . $input->html_style() . '"' : '';
             $html .= ' value="' . esc_attr($value) . '"';
             $html .= ! empty($input_raw_value) && in_array($value, $input_raw_value, true)
-                ? ' checked="checked"'
+                ? ' checked'
                 : '';
             $html .= ' ' . $this->_input->other_html_attributes();
             $html .= '>';

--- a/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy.strategy.php
+++ b/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy.strategy.php
@@ -70,7 +70,7 @@ class EE_Select_Display_Strategy extends EE_Display_Strategy_Base
             // even if this input uses EE_Text_Normalization if one of the array keys is a numeric string, like "123",
             // PHP will have converted it to a PHP integer (eg 123). So we need to make sure it's a string
             $unnormalized_value = $this->_input->get_normalization_strategy()->unnormalize_one($value);
-            $selected = $this->_check_if_option_selected($unnormalized_value) ? ' selected="selected"' : '';
+            $selected = $this->_check_if_option_selected($unnormalized_value) ? ' selected' : '';
             $html .= EEH_HTML::nl(0, 'option') . '<option value="' . esc_attr($unnormalized_value) . '"' . $selected . '>' . $display_text . '</option>';
         }
         EEH_HTML::indent(-1, 'option');

--- a/core/templates/json_linked_data_for_event.template.php
+++ b/core/templates/json_linked_data_for_event.template.php
@@ -67,7 +67,7 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
     <?php
     if ($event_image) {
         ?>,
-  "image": "<?php echo $event_image; ?>"
+  "image": "<?php echo esc_url_raw($event_image); ?>"
         <?php
     } ?>
     <?php do_action('AHEE__json_linked_data_for_event__template'); ?>

--- a/core/templates/notifications/persistent_admin_notice.template.php
+++ b/core/templates/notifications/persistent_admin_notice.template.php
@@ -1,4 +1,7 @@
 <?php
+
+use EventEspresso\core\services\request\sanitizers\AllowedTags;
+
 defined('EVENT_ESPRESSO_VERSION') || exit;
 /** @var string $persistent_admin_notice_name */
 /** @var string $persistent_admin_notice_message */
@@ -9,6 +12,6 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
     >
         <a><span class="dashicons dashicons-dismiss"></span><?php esc_html_e('Dismiss', 'event_espresso'); ?></a>
     </button>
-    <p><?php echo $persistent_admin_notice_message; // already escaped ?></p>
+    <p><?php echo wp_kses($persistent_admin_notice_message, AllowedTags::getWithFormTags()); ?></p>
     <div style="clear:both;"></div>
 </div>

--- a/modules/gateways/Invoice/lib/invoice_functions.php
+++ b/modules/gateways/Invoice/lib/invoice_functions.php
@@ -57,7 +57,7 @@ function espresso_invoice_template_files($class_file)
 function espresso_invoice_is_selected($input_item, $selected = '')
 {
     if ($input_item === $selected) {
-        return 'selected="selected"';
+        return 'selected';
     }
     return '';
 }

--- a/modules/ticket_selector/TicketSelectorRowStandard.php
+++ b/modules/ticket_selector/TicketSelectorRowStandard.php
@@ -322,7 +322,7 @@ class TicketSelectorRowStandard extends TicketSelectorRow
         $name  = "tkt-slctr-qty-{$this->EVT_ID}";
         $class = "ticket-selector-tbl-qty-slct";
         $id    = "{$class}-{$this->EVT_ID}-{$this->row}";
-        $checked = $this->total_tickets === 1 ? ' checked="checked"' : '';
+        $checked = $this->total_tickets === 1 ? ' checked' : '';
 
         $html = "<label class='ee-a11y-screen-reader-text' for='{$id}' >{$label}</label>";
         $html .= "<input type='radio'{$checked} name='{$name}' id='{$id}' class='{$class}' value='{$TKT}-1' title='' />";

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy_Test.php
@@ -46,10 +46,10 @@ class EE_Checkbox_Display_Strategy_Test extends EE_UnitTestCase
 	<input type="checkbox" name="form[input1][]" id="form-input1-foo" class="" style="" value="foo" data-question_label="form-input1-lbl">&nbsp;Foo
 </label>
 <label for="form-input1-bar" id="form-input1-bar-lbl" class="ee-checkbox-label-after micro-lbl">
-	<input type="checkbox" name="form[input1][]" id="form-input1-bar" class="" style="" value="bar" checked data-question_label="form-input1-lbl">&nbsp;Bar
+	<input type="checkbox" name="form[input1][]" id="form-input1-bar" class="" style="" value="bar" checked="checked" data-question_label="form-input1-lbl">&nbsp;Bar
 </label>
 <label for="form-input1-bazem" id="form-input1-bazem-lbl" class="ee-checkbox-label-after micro-lbl">
-	<input type="checkbox" name="form[input1][]" id="form-input1-bazem" class="" style="" value="baz&#039;em" checked data-question_label="form-input1-lbl">&nbsp;Baz
+	<input type="checkbox" name="form[input1][]" id="form-input1-bazem" class="" style="" value="baz&#039;em" checked="checked" data-question_label="form-input1-lbl">&nbsp;Baz
 </label>';
         $this->assertHTMLEquals($expected_output2, $input->get_html_for_input());
     }

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Checkbox_Display_Strategy_Test.php
@@ -46,10 +46,10 @@ class EE_Checkbox_Display_Strategy_Test extends EE_UnitTestCase
 	<input type="checkbox" name="form[input1][]" id="form-input1-foo" class="" style="" value="foo" data-question_label="form-input1-lbl">&nbsp;Foo
 </label>
 <label for="form-input1-bar" id="form-input1-bar-lbl" class="ee-checkbox-label-after micro-lbl">
-	<input type="checkbox" name="form[input1][]" id="form-input1-bar" class="" style="" value="bar" checked="checked" data-question_label="form-input1-lbl">&nbsp;Bar
+	<input type="checkbox" name="form[input1][]" id="form-input1-bar" class="" style="" value="bar" checked data-question_label="form-input1-lbl">&nbsp;Bar
 </label>
 <label for="form-input1-bazem" id="form-input1-bazem-lbl" class="ee-checkbox-label-after micro-lbl">
-	<input type="checkbox" name="form[input1][]" id="form-input1-bazem" class="" style="" value="baz&#039;em" checked="checked" data-question_label="form-input1-lbl">&nbsp;Baz
+	<input type="checkbox" name="form[input1][]" id="form-input1-bazem" class="" style="" value="baz&#039;em" checked data-question_label="form-input1-lbl">&nbsp;Baz
 </label>';
         $this->assertHTMLEquals($expected_output2, $input->get_html_for_input());
     }

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Radio_Button_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Radio_Button_Display_Strategy_Test.php
@@ -37,7 +37,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
         $this->assertEquals('1', $form->get_input('use_captcha')->raw_value());
         $this->assertHTMLEquals('
 <label for="test-use-captcha-1" id="test-use-captcha-1-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl" checked>&nbsp;Yes
+	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;Yes
 </label>
 <label for="test-use-captcha-0" id="test-use-captcha-0-lbl" class="ee-radio-label-after micro-lbl">
 	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl">&nbsp;No
@@ -54,7 +54,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
 	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl">&nbsp;Yes
 </label>
 <label for="test-use-captcha-0" id="test-use-captcha-0-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl" checked>&nbsp;No
+	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;No
 </label>
 <div class="clear-float">
 </div>', $form->get_input('use_captcha')->get_html_for_input());
@@ -87,7 +87,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
         $this->assertEquals("yes ma'am", $form->get_input('use_captcha')->raw_value());
         $this->assertHTMLEquals('
 <label for="test-use-captcha-yesmaam" id="test-use-captcha-yesmaam-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl" checked>&nbsp;Yes
+	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;Yes
 </label>
 <label for="test-use-captcha-nomaam" id="test-use-captcha-nomaam-lbl" class="ee-radio-label-after micro-lbl">
 	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl">&nbsp;No
@@ -104,7 +104,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
 	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl">&nbsp;Yes
 </label>
 <label for="test-use-captcha-nomaam" id="test-use-captcha-nomaam-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl" checked>&nbsp;No
+	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;No
 </label>
 <div class="clear-float">
 </div>', $form->get_input('use_captcha')->get_html_for_input());

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Radio_Button_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Radio_Button_Display_Strategy_Test.php
@@ -37,7 +37,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
         $this->assertEquals('1', $form->get_input('use_captcha')->raw_value());
         $this->assertHTMLEquals('
 <label for="test-use-captcha-1" id="test-use-captcha-1-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;Yes
+	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl" checked>&nbsp;Yes
 </label>
 <label for="test-use-captcha-0" id="test-use-captcha-0-lbl" class="ee-radio-label-after micro-lbl">
 	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl">&nbsp;No
@@ -54,7 +54,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
 	<input id="test-use-captcha-1" name="test[use_captcha]" type="radio" value="1" data-question_label="test-use-captcha-lbl">&nbsp;Yes
 </label>
 <label for="test-use-captcha-0" id="test-use-captcha-0-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;No
+	<input id="test-use-captcha-0" name="test[use_captcha]" type="radio" value="0" data-question_label="test-use-captcha-lbl" checked>&nbsp;No
 </label>
 <div class="clear-float">
 </div>', $form->get_input('use_captcha')->get_html_for_input());
@@ -87,7 +87,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
         $this->assertEquals("yes ma'am", $form->get_input('use_captcha')->raw_value());
         $this->assertHTMLEquals('
 <label for="test-use-captcha-yesmaam" id="test-use-captcha-yesmaam-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;Yes
+	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl" checked>&nbsp;Yes
 </label>
 <label for="test-use-captcha-nomaam" id="test-use-captcha-nomaam-lbl" class="ee-radio-label-after micro-lbl">
 	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl">&nbsp;No
@@ -104,7 +104,7 @@ class EE_Radio_Button_Display_Strategy_Test extends EE_UnitTestCase
 	<input id="test-use-captcha-yesmaam" name="test[use_captcha]" type="radio" value="yes ma&#039;am" data-question_label="test-use-captcha-lbl">&nbsp;Yes
 </label>
 <label for="test-use-captcha-nomaam" id="test-use-captcha-nomaam-lbl" class="ee-radio-label-after micro-lbl">
-	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl" checked="checked">&nbsp;No
+	<input id="test-use-captcha-nomaam" name="test[use_captcha]" type="radio" value="no ma&#039;am" data-question_label="test-use-captcha-lbl" checked>&nbsp;No
 </label>
 <div class="clear-float">
 </div>', $form->get_input('use_captcha')->get_html_for_input());

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy_Test.php
@@ -43,7 +43,7 @@ class EE_Select_Display_Strategy_Test extends EE_UnitTestCase{
 <select name="form[input1]" id="form-input1" >
 	<option value="foo">Foo</option>
 	<option value="bar">Bar</option>
-	<option value="baz&#039;em" selected>Baz</option>
+	<option value="baz&#039;em" selected="selected">Baz</option>
 </select>';
 		$this->assertHTMLEquals( $expected_output2, $input->get_html_for_input() );
 

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Display_Strategy_Test.php
@@ -43,7 +43,7 @@ class EE_Select_Display_Strategy_Test extends EE_UnitTestCase{
 <select name="form[input1]" id="form-input1" >
 	<option value="foo">Foo</option>
 	<option value="bar">Bar</option>
-	<option value="baz&#039;em" selected="selected">Baz</option>
+	<option value="baz&#039;em" selected>Baz</option>
 </select>';
 		$this->assertHTMLEquals( $expected_output2, $input->get_html_for_input() );
 

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Multiple_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Multiple_Display_Strategy_Test.php
@@ -42,8 +42,8 @@ class EE_Select_Multiple_Display_Strategy_Test extends EE_UnitTestCase{
 		$expected_output2 = '
 <select multiple id="form-input1" name="form[input1][]" class="" style="" >
 	<option value="foo">Foo</option>
-	<option value="bar" selected="selected">Bar</option>
-	<option value="baz&#039;em" selected="selected">Baz</option>
+	<option value="bar" selected>Bar</option>
+	<option value="baz&#039;em" selected>Baz</option>
 </select>';
 		$this->assertHTMLEquals( $expected_output2, $input->get_html_for_input() );
 

--- a/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Multiple_Display_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/display/EE_Select_Multiple_Display_Strategy_Test.php
@@ -42,8 +42,8 @@ class EE_Select_Multiple_Display_Strategy_Test extends EE_UnitTestCase{
 		$expected_output2 = '
 <select multiple id="form-input1" name="form[input1][]" class="" style="" >
 	<option value="foo">Foo</option>
-	<option value="bar" selected>Bar</option>
-	<option value="baz&#039;em" selected>Baz</option>
+	<option value="bar" selected="selected">Bar</option>
+	<option value="baz&#039;em" selected="selected">Baz</option>
 </select>';
 		$this->assertHTMLEquals( $expected_output2, $input->get_html_for_input() );
 


### PR DESCRIPTION
This is related to https://github.com/eventespresso/event-espresso-core/issues/3738 issue.

Applied `wp_kses` function to all printed variables in **Pricing** menu and its related sections including tickets and date-time forms.
Converted all `checked="checked"` to `checked` and `selected="selected"` to `selected` to be able to escape them by `esc_attr` function.

https://trello.com/c/n28Bch1y/1155-ee4-core-testing-checklist-pr-3796