### PR TITLE
Handle Event Query `orderby` Params as Arrays

### DIFF
--- a/core/helpers/EEH_Event_Query.helper.php
+++ b/core/helpers/EEH_Event_Query.helper.php
@@ -3,6 +3,7 @@
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\loaders\LoaderFactory;
+use EventEspresso\core\services\request\DataType;
 use EventEspresso\core\services\request\RequestInterface;
 
 /**
@@ -107,7 +108,7 @@ class EEH_Event_Query
      * @param string $month
      * @param string $category
      * @param bool   $show_expired
-     * @param string $orderby
+     * @param array|string $orderby
      * @param string $sort
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -172,7 +173,7 @@ class EEH_Event_Query
 
 
     /**
-     * @param string $orderby
+     * @param array|string $orderby
      * @return array
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -180,7 +181,12 @@ class EEH_Event_Query
      */
     private static function _orderby($orderby = 'start_date')
     {
-        $event_query_orderby = self::getRequest()->getRequestParam('event_query_orderby', $orderby);
+        $event_query_orderby = self::getRequest()->getRequestParam(
+            'event_query_orderby',
+            (array) $orderby,
+            DataType::STRING,
+            true
+        );
         $event_query_orderby = is_array($event_query_orderby)
             ? $event_query_orderby
             : explode(',', $event_query_orderby);


### PR DESCRIPTION
fixes #3795

this PR ensures that the Event Query `orderby` param is handled as an array
