### PR TITLE
Register Dependencies for Frontend Controller

### DIFF
--- a/core/EE_Registry.core.php
+++ b/core/EE_Registry.core.php
@@ -106,7 +106,7 @@ class EE_Registry implements ResettableInterface
     /**
      * RegistryContainer for holding addons which have registered themselves to work with EE core
      *
-     * @var EE_Addon[] $addons
+     * @var RegistryContainer|EE_Addon[] $addons
      */
     public $addons;
 
@@ -118,17 +118,17 @@ class EE_Registry implements ResettableInterface
     public $models = array();
 
     /**
-     * @var EED_Module[] $modules
+     * @var RegistryContainer|EED_Module[] $modules
      */
     public $modules;
 
     /**
-     * @var EES_Shortcode[] $shortcodes
+     * @var RegistryContainer|EES_Shortcode[] $shortcodes
      */
     public $shortcodes;
 
     /**
-     * @var WP_Widget[] $widgets
+     * @var RegistryContainer|WP_Widget[] $widgets
      */
     public $widgets;
 

--- a/core/services/shortcodes/LegacyShortcodesManager.php
+++ b/core/services/shortcodes/LegacyShortcodesManager.php
@@ -222,15 +222,15 @@ class LegacyShortcodesManager
         if (empty($this->registry->shortcodes) || ! $wp_query->is_main_query() || is_admin()) {
             return;
         }
-		// in case shortcode is loaded unexpectedly and deps haven't been set up correctly
-		EE_Dependency_Map::register_dependencies(
-			'EE_Front_Controller',
-			[
-				'EE_Registry' => EE_Dependency_Map::load_from_cache,
-				'EventEspresso\core\services\request\CurrentPage' => EE_Dependency_Map::load_from_cache,
-				'EE_Module_Request_Router' => EE_Dependency_Map::load_from_cache,
-			]
-		);
+        // in case shortcode is loaded unexpectedly and deps haven't been set up correctly
+        EE_Dependency_Map::register_dependencies(
+            'EE_Front_Controller',
+            [
+                'EE_Registry' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\CurrentPage' => EE_Dependency_Map::load_from_cache,
+                'EE_Module_Request_Router' => EE_Dependency_Map::load_from_cache,
+            ]
+        );
         global $wp;
         /** @var EE_Front_controller $Front_Controller */
         $Front_Controller = LoaderFactory::getLoader()->getShared('EE_Front_Controller');

--- a/core/services/shortcodes/LegacyShortcodesManager.php
+++ b/core/services/shortcodes/LegacyShortcodesManager.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\services\shortcodes;
 
 use EE_Config;
+use EE_Dependency_Map;
 use EE_Error;
 use EE_Front_controller;
 use EE_Registry;
@@ -221,6 +222,15 @@ class LegacyShortcodesManager
         if (empty($this->registry->shortcodes) || ! $wp_query->is_main_query() || is_admin()) {
             return;
         }
+		// in case shortcode is loaded unexpectedly and deps haven't been set up correctly
+		EE_Dependency_Map::register_dependencies(
+			'EE_Front_Controller',
+			[
+				'EE_Registry' => EE_Dependency_Map::load_from_cache,
+				'EventEspresso\core\services\request\CurrentPage' => EE_Dependency_Map::load_from_cache,
+				'EE_Module_Request_Router' => EE_Dependency_Map::load_from_cache,
+			]
+		);
         global $wp;
         /** @var EE_Front_controller $Front_Controller */
         $Front_Controller = LoaderFactory::getLoader()->getShared('EE_Front_Controller');


### PR DESCRIPTION
fixes #3779

this PR simply registers dependencies for  the frontend controller from within the `LegacyShortcodesManager` in case the frontend routing has not been configured for the current request