### PR TITLE
Add OptionEngine to WordPressOption

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -383,7 +383,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     protected function _update_espresso_page_settings()
     {
-		$this->core_config = EE_Registry::instance()->CFG->core;
+        $this->core_config = EE_Registry::instance()->CFG->core;
         // capture incoming request data && set page IDs
         $this->core_config->reg_page_id       = $this->request->getRequestParam(
             'reg_page_id',

--- a/core/helpers/EEH_Array.helper.php
+++ b/core/helpers/EEH_Array.helper.php
@@ -226,4 +226,98 @@ class EEH_Array extends EEH_Base
         }
         return is_string($element) ? addslashes($element) : $element;
     }
+
+
+	/**
+	 * link https://stackoverflow.com/a/3877494
+	 *
+	 * @param array $array_1
+	 * @param array $array_2
+	 * @return array
+	 * @since   $VID:$
+	 */
+	public static function array_diff_recursive(array $array_1, array $array_2): array
+	{
+		$diff = [];
+		foreach ($array_1 as $key => $value) {
+			if (array_key_exists($key, $array_2)) {
+				if (is_array($value)) {
+					$inner_diff = EEH_Array::array_diff_recursive($value, $array_2[ $key ]);
+					if (count($inner_diff)) {
+						$diff[ $key ] = $inner_diff;
+					}
+				} else {
+					if ($value != $array_2[ $key ]) {
+						$diff[ $key ] = $value;
+					}
+				}
+			} else {
+				$diff[ $key ] = $value;
+			}
+		}
+		return $diff;
+	}
+
+
+	/**
+	 * converts multidimensional arrays into a single depth associative array
+	 * or converts arrays of any depth into a readable string representation
+	 *
+	 * 	$example = [
+	 * 		'a' => 'A',
+	 * 		'b' => 'B',
+	 * 		'c' => [
+	 * 			'd' => 'D',
+	 * 			'e' => 'E',
+	 * 			'f' => [ 'G', 'H', 'I' ],
+	 * 		],
+	 * 		[ 'J', 'K' ],
+	 *		'L',
+	 * 		'M',
+	 * 		'n' => [
+	 * 			'o' => 'P'
+	 * 		],
+	 * 	];
+	 *
+	 *	print_r( EEH_Array::flattenArray($example) );
+	 *
+	 * 	Array (
+	 * 		[a] => A
+	 * 		[b] => B
+	 * 		[c] => [ d:D, e:E, f:[ G, H, I ] ]
+	 * 		[0] => [ J, K ]
+	 * 		[1] => L
+	 * 		[2] => M
+	 * 		[n] => [ o:P ]
+	 * 	)
+	 *
+	 *	print_r( EEH_Array::flattenArray($example, true) );
+	 *
+	 * 	"a:A, b:B, c:[ d:D, e:E, f:[ G, H, I ] ], [ J, K ], L, M, n:[ o:P ]"
+ 	 *
+	 * @param array $array		the array to be flattened
+	 * @param bool  $to_string	[true] will flatten the entire array down into a string
+	 *                         	[false] will only flatten sub-arrays down into strings and return a array
+	 * @param bool  $top_level	used for formatting purposes only, best to leave this alone as it's set internally
+	 * @return array|false|string
+	 * @since $VID:$
+	 */
+	public static function flattenArray(array $array, bool $to_string = false, bool $top_level = true)
+	{
+		$flat_array = [];
+		foreach ($array as $key => $value) {
+			$flat_array[ $key ] = is_array($value)
+				? EEH_Array::flattenArray($value, true, false)
+				: $value;
+		}
+		if (! $to_string) {
+			return $flat_array;
+		}
+		$flat = '';
+		foreach ($flat_array as $key => $value) {
+			$flat .= is_int($key) ? "$value, " : "$key:$value, ";
+		}
+		$flat = substr($flat, 0, -2);
+		return $top_level ? $flat : "[ $flat ]";
+	}
 }

--- a/core/helpers/EEH_Array.helper.php
+++ b/core/helpers/EEH_Array.helper.php
@@ -228,96 +228,96 @@ class EEH_Array extends EEH_Base
     }
 
 
-	/**
-	 * link https://stackoverflow.com/a/3877494
-	 *
-	 * @param array $array_1
-	 * @param array $array_2
-	 * @return array
-	 * @since   $VID:$
-	 */
-	public static function array_diff_recursive(array $array_1, array $array_2): array
-	{
-		$diff = [];
-		foreach ($array_1 as $key => $value) {
-			if (array_key_exists($key, $array_2)) {
-				if (is_array($value)) {
-					$inner_diff = EEH_Array::array_diff_recursive($value, $array_2[ $key ]);
-					if (count($inner_diff)) {
-						$diff[ $key ] = $inner_diff;
-					}
-				} else {
-					if ($value != $array_2[ $key ]) {
-						$diff[ $key ] = $value;
-					}
-				}
-			} else {
-				$diff[ $key ] = $value;
-			}
-		}
-		return $diff;
-	}
+    /**
+     * link https://stackoverflow.com/a/3877494
+     *
+     * @param array $array_1
+     * @param array $array_2
+     * @return array
+     * @since   $VID:$
+     */
+    public static function array_diff_recursive(array $array_1, array $array_2): array
+    {
+        $diff = [];
+        foreach ($array_1 as $key => $value) {
+            if (array_key_exists($key, $array_2)) {
+                if (is_array($value)) {
+                    $inner_diff = EEH_Array::array_diff_recursive($value, $array_2[ $key ]);
+                    if (count($inner_diff)) {
+                        $diff[ $key ] = $inner_diff;
+                    }
+                } else {
+                    if ($value != $array_2[ $key ]) {
+                        $diff[ $key ] = $value;
+                    }
+                }
+            } else {
+                $diff[ $key ] = $value;
+            }
+        }
+        return $diff;
+    }
 
 
-	/**
-	 * converts multidimensional arrays into a single depth associative array
-	 * or converts arrays of any depth into a readable string representation
-	 *
-	 * 	$example = [
-	 * 		'a' => 'A',
-	 * 		'b' => 'B',
-	 * 		'c' => [
-	 * 			'd' => 'D',
-	 * 			'e' => 'E',
-	 * 			'f' => [ 'G', 'H', 'I' ],
-	 * 		],
-	 * 		[ 'J', 'K' ],
-	 *		'L',
-	 * 		'M',
-	 * 		'n' => [
-	 * 			'o' => 'P'
-	 * 		],
-	 * 	];
-	 *
-	 *	print_r( EEH_Array::flattenArray($example) );
-	 *
-	 * 	Array (
-	 * 		[a] => A
-	 * 		[b] => B
-	 * 		[c] => [ d:D, e:E, f:[ G, H, I ] ]
-	 * 		[0] => [ J, K ]
-	 * 		[1] => L
-	 * 		[2] => M
-	 * 		[n] => [ o:P ]
-	 * 	)
-	 *
-	 *	print_r( EEH_Array::flattenArray($example, true) );
-	 *
-	 * 	"a:A, b:B, c:[ d:D, e:E, f:[ G, H, I ] ], [ J, K ], L, M, n:[ o:P ]"
- 	 *
-	 * @param array $array		the array to be flattened
-	 * @param bool  $to_string	[true] will flatten the entire array down into a string
-	 *                         	[false] will only flatten sub-arrays down into strings and return a array
-	 * @param bool  $top_level	used for formatting purposes only, best to leave this alone as it's set internally
-	 * @return array|false|string
-	 * @since $VID:$
-	 */
-	public static function flattenArray(array $array, bool $to_string = false, bool $top_level = true)
-	{
-		$flat_array = [];
-		foreach ($array as $key => $value) {
-			$flat_array[ $key ] = is_array($value)
-				? EEH_Array::flattenArray($value, true, false)
-				: $value;
-		}
-		if (! $to_string) {
-			return $flat_array;
-		}
-		$flat = '';
-		foreach ($flat_array as $key => $value) {
-			$flat .= is_int($key) ? "$value, " : "$key:$value, ";
-		}
-		$flat = substr($flat, 0, -2);
-		return $top_level ? $flat : "[ $flat ]";
-	}
+    /**
+     * converts multidimensional arrays into a single depth associative array
+     * or converts arrays of any depth into a readable string representation
+     *
+     *  $example = [
+     *      'a' => 'A',
+     *      'b' => 'B',
+     *      'c' => [
+     *          'd' => 'D',
+     *          'e' => 'E',
+     *          'f' => [ 'G', 'H', 'I' ],
+     *      ],
+     *      [ 'J', 'K' ],
+     *      'L',
+     *      'M',
+     *      'n' => [
+     *          'o' => 'P'
+     *      ],
+     *  ];
+     *
+     *  print_r( EEH_Array::flattenArray($example) );
+     *
+     *  Array (
+     *      [a] => A
+     *      [b] => B
+     *      [c] => [ d:D, e:E, f:[ G, H, I ] ]
+     *      [0] => [ J, K ]
+     *      [1] => L
+     *      [2] => M
+     *      [n] => [ o:P ]
+     *  )
+     *
+     *  print_r( EEH_Array::flattenArray($example, true) );
+     *
+     *  "a:A, b:B, c:[ d:D, e:E, f:[ G, H, I ] ], [ J, K ], L, M, n:[ o:P ]"
+     *
+     * @param array $array      the array to be flattened
+     * @param bool  $to_string  [true] will flatten the entire array down into a string
+     *                          [false] will only flatten sub-arrays down into strings and return a array
+     * @param bool  $top_level  used for formatting purposes only, best to leave this alone as it's set internally
+     * @return array|false|string
+     * @since $VID:$
+     */
+    public static function flattenArray(array $array, bool $to_string = false, bool $top_level = true)
+    {
+        $flat_array = [];
+        foreach ($array as $key => $value) {
+            $flat_array[ $key ] = is_array($value)
+                ? EEH_Array::flattenArray($value, true, false)
+                : $value;
+        }
+        if (! $to_string) {
+            return $flat_array;
+        }
+        $flat = '';
+        foreach ($flat_array as $key => $value) {
+            $flat .= is_int($key) ? "$value, " : "$key:$value, ";
+        }
+        $flat = substr($flat, 0, -2);
+        return $top_level ? $flat : "[ $flat ]";
+    }
 }

--- a/core/helpers/EEH_Debug_Tools.helper.php
+++ b/core/helpers/EEH_Debug_Tools.helper.php
@@ -611,7 +611,7 @@ class EEH_Debug_Tools
         $converted = str_replace(['$', '_', 'this->'], ['', ' ', ''], $var_name);
         $words = explode(' ', $converted);
         $words = array_map(
-            function($word) {
+            function ($word) {
                 return $word === 'id' || $word === 'Id' ? 'ID' : $word;
             },
             $words

--- a/core/services/database/OptionEngine.php
+++ b/core/services/database/OptionEngine.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace EventEspresso\core\services\database;
+
+/**
+ * Class OptionEngine
+ * used internally by WordPressOption to facilitate regular site options and network options
+ *
+ * @author  Brent Christensen
+ * @package EventEspresso\core\services\database
+ * @since   $VID:$
+ */
+class OptionEngine
+{
+
+	/**
+	 * @var   bool
+	 */
+	private $is_network_option;
+
+	/**
+	 * @var   int
+	 */
+	private $network_ID;
+
+
+	/**
+	 * @param bool $is_network_option
+	 */
+	public function __construct(bool $is_network_option = false)
+	{
+		$this->is_network_option = $is_network_option;
+		$this->network_ID        = get_current_network_id();
+	}
+
+
+	/**
+	 * @param string $option_name
+	 * @param mixed  $default_value
+	 * @return false|mixed|void
+	 */
+	public function getOption(string $option_name, $default_value)
+	{
+		return $this->is_network_option
+			? get_option($option_name, $default_value)
+			: get_network_option($this->network_ID, $option_name, $default_value);
+	}
+
+
+	/**
+	 * @param string $option_name
+	 * @param mixed  $value
+	 * @param string $autoload
+	 * @return bool
+	 */
+	public function addOption(string $option_name, $value, string $autoload): bool
+	{
+		return $this->is_network_option
+			? add_option($option_name, $value, '', $autoload)
+			: add_network_option($this->network_ID, $option_name, $value);
+	}
+
+
+	/**
+	 * @param string $option_name
+	 * @param mixed  $value
+	 * @return bool
+	 */
+	public function updateOption(string $option_name, $value): bool
+	{
+		return $this->is_network_option
+			? update_option($option_name, $value)
+			: update_network_option($this->network_ID, $option_name, $value);
+	}
+
+
+	/**
+	 * @param string $option_name
+	 * @return bool
+	 */
+	public function deleteOption(string $option_name): bool
+	{
+		return $this->is_network_option
+			? delete_option($option_name)
+			: delete_network_option($this->network_ID, $option_name);
+	}
+}

--- a/core/services/database/OptionEngine.php
+++ b/core/services/database/OptionEngine.php
@@ -12,7 +12,6 @@ namespace EventEspresso\core\services\database;
  */
 class OptionEngine
 {
-
     /**
      * @var   bool
      */

--- a/core/services/database/OptionEngine.php
+++ b/core/services/database/OptionEngine.php
@@ -13,75 +13,75 @@ namespace EventEspresso\core\services\database;
 class OptionEngine
 {
 
-	/**
-	 * @var   bool
-	 */
-	private $is_network_option;
+    /**
+     * @var   bool
+     */
+    private $is_network_option;
 
-	/**
-	 * @var   int
-	 */
-	private $network_ID;
-
-
-	/**
-	 * @param bool $is_network_option
-	 */
-	public function __construct(bool $is_network_option = false)
-	{
-		$this->is_network_option = $is_network_option;
-		$this->network_ID        = get_current_network_id();
-	}
+    /**
+     * @var   int
+     */
+    private $network_ID;
 
 
-	/**
-	 * @param string $option_name
-	 * @param mixed  $default_value
-	 * @return false|mixed|void
-	 */
-	public function getOption(string $option_name, $default_value)
-	{
-		return $this->is_network_option
-			? get_option($option_name, $default_value)
-			: get_network_option($this->network_ID, $option_name, $default_value);
-	}
+    /**
+     * @param bool $is_network_option
+     */
+    public function __construct(bool $is_network_option = false)
+    {
+        $this->is_network_option = $is_network_option;
+        $this->network_ID        = get_current_network_id();
+    }
 
 
-	/**
-	 * @param string $option_name
-	 * @param mixed  $value
-	 * @param string $autoload
-	 * @return bool
-	 */
-	public function addOption(string $option_name, $value, string $autoload): bool
-	{
-		return $this->is_network_option
-			? add_option($option_name, $value, '', $autoload)
-			: add_network_option($this->network_ID, $option_name, $value);
-	}
+    /**
+     * @param string $option_name
+     * @param mixed  $default_value
+     * @return false|mixed|void
+     */
+    public function getOption(string $option_name, $default_value)
+    {
+        return $this->is_network_option
+            ? get_network_option($this->network_ID, $option_name, $default_value)
+            : get_option($option_name, $default_value);
+    }
 
 
-	/**
-	 * @param string $option_name
-	 * @param mixed  $value
-	 * @return bool
-	 */
-	public function updateOption(string $option_name, $value): bool
-	{
-		return $this->is_network_option
-			? update_option($option_name, $value)
-			: update_network_option($this->network_ID, $option_name, $value);
-	}
+    /**
+     * @param string $option_name
+     * @param mixed  $value
+     * @param string $autoload
+     * @return bool
+     */
+    public function addOption(string $option_name, $value, string $autoload): bool
+    {
+        return $this->is_network_option
+            ? add_network_option($this->network_ID, $option_name, $value)
+            : add_option($option_name, $value, '', $autoload);
+    }
 
 
-	/**
-	 * @param string $option_name
-	 * @return bool
-	 */
-	public function deleteOption(string $option_name): bool
-	{
-		return $this->is_network_option
-			? delete_option($option_name)
-			: delete_network_option($this->network_ID, $option_name);
-	}
+    /**
+     * @param string $option_name
+     * @param mixed  $value
+     * @return bool
+     */
+    public function updateOption(string $option_name, $value): bool
+    {
+        return $this->is_network_option
+            ? update_network_option($this->network_ID, $option_name, $value)
+            : update_option($option_name, $value);
+    }
+
+
+    /**
+     * @param string $option_name
+     * @return bool
+     */
+    public function deleteOption(string $option_name): bool
+    {
+        return $this->is_network_option
+            ? delete_network_option($this->network_ID, $option_name)
+            : delete_option($option_name);
+    }
 }

--- a/core/services/database/WordPressOption.php
+++ b/core/services/database/WordPressOption.php
@@ -51,10 +51,10 @@ abstract class WordPressOption
      */
     private $value = WordPressOption::NOT_SET_YET;
 
-	/**
-	 * @var OptionEngine
-	 */
-	private $option_engine;
+    /**
+     * @var OptionEngine
+     */
+    private $option_engine;
 
 
     /**
@@ -66,15 +66,15 @@ abstract class WordPressOption
      * @param bool 	 $is_network_option		if true, will save the option to the network as opposed to the current blog
      */
     public function __construct(
-		string $option_name,
-		$default_value,
-		bool $autoload = false,
-		bool $is_network_option = false
-	) {
-		$this->setAutoload($autoload);
+        string $option_name,
+        $default_value,
+        bool $autoload = false,
+        bool $is_network_option = false
+    ) {
+        $this->setAutoload($autoload);
         $this->setDefaultValue($default_value);
         $this->setOptionName($option_name);
-		$this->option_engine = new OptionEngine($is_network_option);
+        $this->option_engine = new OptionEngine($is_network_option);
     }
 
 
@@ -110,10 +110,10 @@ abstract class WordPressOption
      */
     public function optionExists(): string
     {
-		return $this->option_engine->getOption(
-			$this->option_name,
-			WordPressOption::NOT_SET_YET
-		) !== WordPressOption::NOT_SET_YET;
+        return $this->option_engine->getOption(
+            $this->option_name,
+            WordPressOption::NOT_SET_YET
+        ) !== WordPressOption::NOT_SET_YET;
     }
 
 
@@ -145,15 +145,15 @@ abstract class WordPressOption
     public function updateOption($value): int
     {
         // don't update if value has not changed since last update
-		if ($this->valueIsUnchanged($value)) {
+        if ($this->valueIsUnchanged($value)) {
             return WordPressOption::UPDATE_NONE;
         }
-		$this->value = $value;
+        $this->value = $value;
         // because the options for updating differ when adding an option for the first time
         // we use the WordPressOption::NOT_SET_YET to determine if things already exist in the db
-		$updated = $this->optionExists()
-			? $this->option_engine->updateOption($this->option_name, $this->value)
-			: $this->option_engine->addOption($this->option_name, $this->value, $this->autoload());
+        $updated = $this->optionExists()
+            ? $this->option_engine->updateOption($this->option_name, $this->value)
+            : $this->option_engine->addOption($this->option_name, $this->value, $this->autoload());
 
         if ($updated) {
             return WordPressOption::UPDATE_SUCCESS;
@@ -162,16 +162,16 @@ abstract class WordPressOption
     }
 
 
-	private function valueIsUnchanged($value): bool
-	{
-		if (is_array($value) && is_array($this->value)) {
-			$diff = EEH_Array::array_diff_recursive($value, $this->value);
-			// $diff = array_diff($value, $this->value);
-			return empty($diff);
-		}
-		// emulate WP's method for checking equality
-		return $value === $this->value && maybe_serialize($value) === maybe_serialize($this->value);
-	}
+    private function valueIsUnchanged($value): bool
+    {
+        if (is_array($value) && is_array($this->value)) {
+            $diff = EEH_Array::array_diff_recursive($value, $this->value);
+            // $diff = array_diff($value, $this->value);
+            return empty($diff);
+        }
+        // emulate WP's method for checking equality
+        return $value === $this->value && maybe_serialize($value) === maybe_serialize($this->value);
+    }
 
 
     /**
@@ -183,15 +183,15 @@ abstract class WordPressOption
     }
 
 
-	/**
-	 * Deletes the option from the database
-	 * for the rest of the request
-	 *
-	 * @return bool
-	 * @since  $VID:$
-	 */
-	public function deleteOption(): bool
-	{
-		return $this->option_engine->deleteOption($this->option_name);
-	}
+    /**
+     * Deletes the option from the database
+     * for the rest of the request
+     *
+     * @return bool
+     * @since  $VID:$
+     */
+    public function deleteOption(): bool
+    {
+        return $this->option_engine->deleteOption($this->option_name);
+    }
 }

--- a/core/services/database/WordPressOption.php
+++ b/core/services/database/WordPressOption.php
@@ -62,8 +62,8 @@ abstract class WordPressOption
      *
      * @param string $option_name
      * @param mixed  $default_value
-     * @param bool   $autoload				if true, will load the option on EVERY request
-     * @param bool 	 $is_network_option		if true, will save the option to the network as opposed to the current blog
+     * @param bool   $autoload              if true, will load the option on EVERY request
+     * @param bool   $is_network_option     if true, will save the option to the network as opposed to the current blog
      */
     public function __construct(
         string $option_name,

--- a/core/services/database/WordPressOption.php
+++ b/core/services/database/WordPressOption.php
@@ -2,6 +2,8 @@
 
 namespace EventEspresso\core\services\database;
 
+use EEH_Array;
+
 /**
  * Class WordPressOption
  * This may seem like paving a cow path, but if you look around,
@@ -18,10 +20,10 @@ abstract class WordPressOption
     const NOT_SET_YET = 'wordpress-option-value-not-yet-set';
 
     /**
-     * WordPress makes it difficult to determine if an option was successfully saved or not
-     * which is sometimes really important to know if the information you are saving is critical.
+     * WordPress makes it difficult to determine if an option successfully saved or not,
+     * which is sometimes really important to know, especially if the information you are saving is critical.
      * The following options allow us to have a better chance of knowing when an update actually failed
-     * or when it just didn't update because the value hasn't changed, but everything is safe.
+     * or when everything is OK but it just didn't update because the value hasn't changed.
      */
     const UPDATE_SUCCESS = 1;
 
@@ -32,36 +34,47 @@ abstract class WordPressOption
     /**
      * @var boolean
      */
-    private $autoload;
+    private $autoload = false;
 
     /**
      * @var mixed
      */
-    private $default_value;
+    private $default_value = null;
 
     /**
      * @var string
      */
-    private $option_name;
+    private $option_name = '';
 
     /**
      * @var mixed
      */
     private $value = WordPressOption::NOT_SET_YET;
 
+	/**
+	 * @var OptionEngine
+	 */
+	private $option_engine;
+
 
     /**
      * WordPressOption constructor.
      *
-     * @param bool   $autoload
-     * @param mixed  $default_value
      * @param string $option_name
+     * @param mixed  $default_value
+     * @param bool   $autoload				if true, will load the option on EVERY request
+     * @param bool 	 $is_network_option		if true, will save the option to the network as opposed to the current blog
      */
-    public function __construct(string $option_name, $default_value, bool $autoload = false)
-    {
-        $this->setAutoload($autoload);
+    public function __construct(
+		string $option_name,
+		$default_value,
+		bool $autoload = false,
+		bool $is_network_option = false
+	) {
+		$this->setAutoload($autoload);
         $this->setDefaultValue($default_value);
         $this->setOptionName($option_name);
+		$this->option_engine = new OptionEngine($is_network_option);
     }
 
 
@@ -95,6 +108,18 @@ abstract class WordPressOption
     /**
      * @return string
      */
+    public function optionExists(): string
+    {
+		return $this->option_engine->getOption(
+			$this->option_name,
+			WordPressOption::NOT_SET_YET
+		) !== WordPressOption::NOT_SET_YET;
+    }
+
+
+    /**
+     * @return string
+     */
     public function getOptionName(): string
     {
         return $this->option_name;
@@ -107,7 +132,7 @@ abstract class WordPressOption
     public function loadOption()
     {
         if ($this->value === WordPressOption::NOT_SET_YET) {
-            $this->value = get_option($this->option_name, $this->default_value);
+            $this->value = $this->option_engine->getOption($this->option_name, $this->default_value);
         }
         return $this->value;
     }
@@ -120,22 +145,33 @@ abstract class WordPressOption
     public function updateOption($value): int
     {
         // don't update if value has not changed since last update
-        if ($value === $this->value) {
+		if ($this->valueIsUnchanged($value)) {
             return WordPressOption::UPDATE_NONE;
         }
+		$this->value = $value;
         // because the options for updating differ when adding an option for the first time
         // we use the WordPressOption::NOT_SET_YET to determine if things already exist in the db
-        if (get_option($this->option_name, WordPressOption::NOT_SET_YET) === WordPressOption::NOT_SET_YET) {
-            $updated = add_option($this->option_name, $value, '', $this->autoload());
-        } else {
-            $updated = update_option($this->option_name, $value);
-        }
+		$updated = $this->optionExists()
+			? $this->option_engine->updateOption($this->option_name, $this->value)
+			: $this->option_engine->addOption($this->option_name, $this->value, $this->autoload());
+
         if ($updated) {
-            $this->value = $value;
             return WordPressOption::UPDATE_SUCCESS;
         }
         return WordPressOption::UPDATE_ERROR;
     }
+
+
+	private function valueIsUnchanged($value): bool
+	{
+		if (is_array($value) && is_array($this->value)) {
+			$diff = EEH_Array::array_diff_recursive($value, $this->value);
+			// $diff = array_diff($value, $this->value);
+			return empty($diff);
+		}
+		// emulate WP's method for checking equality
+		return $value === $this->value && maybe_serialize($value) === maybe_serialize($this->value);
+	}
 
 
     /**
@@ -145,4 +181,17 @@ abstract class WordPressOption
     {
         return $this->autoload ? 'yes' : 'no';
     }
+
+
+	/**
+	 * Deletes the option from the database
+	 * for the rest of the request
+	 *
+	 * @return bool
+	 * @since  $VID:$
+	 */
+	public function deleteOption(): bool
+	{
+		return $this->option_engine->deleteOption($this->option_name);
+	}
 }


### PR DESCRIPTION
Discovered that ES doesn't use network options for storing data that is intended to be utilized network wide.

This PR adds a class called `OptionEngine` that can be configured to use either site or network options. This class is then used internally by `WordPressOption` for storing data where needed.