### PR TITLE
Remove fallback reCAPTCHA area ?

### DIFF
--- a/caffeinated/modules/recaptcha/templates/recaptcha.template.php
+++ b/caffeinated/modules/recaptcha/templates/recaptcha.template.php
@@ -12,14 +12,12 @@ if (! defined('EVENT_ESPRESSO_VERSION')) {
              data-theme="<?php echo esc_attr($recaptcha_theme); ?>" data-type="<?php echo esc_attr($recaptcha_type); ?>"
              data-callback="espresso_recaptcha_verification"></div>
         <noscript>
-            <div style="width: 302px; height: 352px;">
-                <div style="width: 302px; height: 352px; position: relative;">
-                    <div style="width: 302px; height: 352px; position: absolute;">
-                        <iframe
-                            src="https://www.google.com/recaptcha/api/fallback?k=<?php echo esc_attr($recaptcha_publickey); ?>"
-                            frameborder="0" scrolling="no" style="width: 302px; height:352px; border-style: none;">
-                        </iframe>
-                    </div>
+            <div style="position: relative;">
+                <div style="position: absolute;">
+                    <iframe
+                        src="https://www.google.com/recaptcha/api/fallback?k=<?php echo esc_attr($recaptcha_publickey); ?>"
+                        style="border-style: none;">
+                    </iframe>
                 </div>
             </div>
         </noscript>


### PR DESCRIPTION
Resolves: https://github.com/eventespresso/eventsmart.com-website/issues/973

As noted in the the above issue, when the recaptcha theme is black or white, there's two `g-recaptcha-response` text areas being rendered on the registration form page (at least on ES). Those were conflicting so I removed that extra area from the EE recaptcha template.

As of today, [gracaptcha mostly only needs](https://developers.google.com/recaptcha/docs/display#auto_render) the `g-recaptcha` div with the key and a callback.

Maybe I'm missing something, but I was not able to find the cause of why we needed that extra `<noscript>` area. So please note here if someone remembers the history of this template, because maybe this is not the best way to fix this issue. Looks like Brent was the one who created it.

Black white and invisible reCAPTCHA themes still seem to be working fine.

### Testing:
- Try if all the reCAPTCHA option variations still work in the Reg Form Settings, checking if the recaptcha passes on form submission etc. The setup that produced the issue was: https://monosnap.com/file/6cJ7c0I79pTdR04tOWTMSlURKeeyof