### PR TITLE
Fix Notices on Block Themes

### DIFF
--- a/core/services/shortcodes/ShortcodesManager.php
+++ b/core/services/shortcodes/ShortcodesManager.php
@@ -223,10 +223,10 @@ class ShortcodesManager
      */
     public function parseContentForShortcodes($content)
     {
-        $has_shortcode = false;
         if (empty($this->shortcodes)) {
-            return $has_shortcode;
+            return false;
         }
+        $has_shortcode = false;
         foreach ($this->shortcodes as $shortcode) {
             if (has_shortcode($content, $shortcode->getTag())) {
                 $shortcode->initializeShortcode();


### PR DESCRIPTION
This PR:

- fixes eventespresso/event-espresso-core#3845
- adds 2 new methods to `EE_Front_Controller`:
	- `prependNotices()` callback hooked into `the_content` filter
	- `printNotices()` escape and echo Espresso notices
