### PR TITLE
Replace Legacy Request Data in General Settings Admin

### DIFF
--- a/admin_pages/general_settings/AdminOptionsSettings.php
+++ b/admin_pages/general_settings/AdminOptionsSettings.php
@@ -63,7 +63,7 @@ class AdminOptionsSettings extends FormHandler
      */
     public function generate()
     {
-        $form = new \EE_Form_Section_Proper(
+        $form = new EE_Form_Section_Proper(
             array(
                 'name'            => 'admin_option_settings',
                 'html_id'         => 'admin_option_settings',
@@ -160,7 +160,7 @@ class AdminOptionsSettings extends FormHandler
      *
      * @return string
      * @throws LogicException
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function display()
     {

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -592,8 +592,9 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     protected function getCountryIsoForSite(): string
     {
-        return ! empty(EE_Registry::instance()->CFG->organization->CNT_ISO) ? EE_Registry::instance(
-        )->CFG->organization->CNT_ISO : 'US';
+        return ! empty(EE_Registry::instance()->CFG->organization->CNT_ISO)
+            ? EE_Registry::instance()->CFG->organization->CNT_ISO
+            : 'US';
     }
 
 
@@ -1112,8 +1113,10 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         $cols_n_values['CNT_ISO3']        = strtoupper(
             $this->request->getRequestParam('cntry', '', $country->ISO3())
         );
-        $cols_n_values['CNT_name']        =
-            $this->request->getRequestParam("cntry[$CNT_ISO][CNT_name]", $country->name());
+        $cols_n_values['CNT_name']        = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_name]",
+            $country->name()
+        );
         $cols_n_values['CNT_cur_code']    = strtoupper(
             $this->request->getRequestParam(
                 "cntry[$CNT_ISO][CNT_cur_code]",

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -344,15 +344,15 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         EEH_Activation::verify_default_pages_exist();
         $this->_transient_garbage_collection();
 
-        $this->_template_args['values']             = $this->_yes_no_values;
+        $this->_template_args['values'] = $this->_yes_no_values;
 
-        $this->_template_args['reg_page_id']        = $this->core_config->reg_page_id ?? null;
-        $this->_template_args['reg_page_obj']       = isset($this->core_config->reg_page_id)
+        $this->_template_args['reg_page_id']  = $this->core_config->reg_page_id ?? null;
+        $this->_template_args['reg_page_obj'] = isset($this->core_config->reg_page_id)
             ? get_post($this->core_config->reg_page_id)
             : false;
 
-        $this->_template_args['txn_page_id']        = $this->core_config->txn_page_id ?? null;
-        $this->_template_args['txn_page_obj']       = isset($this->core_config->txn_page_id)
+        $this->_template_args['txn_page_id']  = $this->core_config->txn_page_id ?? null;
+        $this->_template_args['txn_page_obj'] = isset($this->core_config->txn_page_id)
             ? get_post($this->core_config->txn_page_id)
             : false;
 
@@ -361,8 +361,8 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             ? get_post($this->core_config->thank_you_page_id)
             : false;
 
-        $this->_template_args['cancel_page_id']     = $this->core_config->cancel_page_id ?? null;
-        $this->_template_args['cancel_page_obj']    = isset($this->core_config->cancel_page_id)
+        $this->_template_args['cancel_page_id']  = $this->core_config->cancel_page_id ?? null;
+        $this->_template_args['cancel_page_obj'] = isset($this->core_config->cancel_page_id)
             ? get_post($this->core_config->cancel_page_id)
             : false;
 
@@ -612,10 +612,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         /** @var EE_Country $country */
         return $country instanceof EE_Country && $country->ID() === $CNT_ISO
             ? $country
-            : EEM_Country::instance()
-                         ->get_one_by_ID(
-                             $CNT_ISO
-                         );
+            : EEM_Country::instance()->get_one_by_ID($CNT_ISO);
     }
 
 
@@ -634,24 +631,27 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         $CNT_ISO = $this->getCountryISO();
 
         $this->_template_args['values']    = $this->_yes_no_values;
-        $this->_template_args['countries'] = new EE_Question_Form_Input(EE_Question::new_instance([
-                                                                                                      'QST_ID'           => 0,
-                                                                                                      'QST_display_text' => esc_html__(
-                                                                                                          'Select Country',
-                                                                                                          'event_espresso'
-                                                                                                      ),
-                                                                                                      'QST_system'       => 'admin-country',
-                                                                                                  ]),
-                                                                        EE_Answer::new_instance([
-                                                                                                    'ANS_ID'    => 0,
-                                                                                                    'ANS_value' => $CNT_ISO,
-                                                                                                ]),
-                                                                        [
-                                                                            'input_id'       => 'country',
-                                                                            'input_name'     => 'country',
-                                                                            'input_prefix'   => '',
-                                                                            'append_qstn_id' => false,
-                                                                        ]);
+        $this->_template_args['countries'] = new EE_Question_Form_Input(
+            EE_Question::new_instance(
+                [
+                    'QST_ID'           => 0,
+                    'QST_display_text' => esc_html__('Select Country', 'event_espresso'),
+                    'QST_system'       => 'admin-country',
+                ]
+            ),
+            EE_Answer::new_instance(
+                [
+                    'ANS_ID'    => 0,
+                    'ANS_value' => $CNT_ISO,
+                ]
+            ),
+            [
+                'input_id'       => 'country',
+                'input_name'     => 'country',
+                'input_prefix'   => '',
+                'append_qstn_id' => false,
+            ]
+        );
 
         $country = $this->verifyOrGetCountryFromIso($CNT_ISO);
         add_filter('FHEE__EEH_Form_Fields__label_html', [$this, 'country_form_field_label_wrap'], 10);
@@ -909,7 +909,10 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                             ],
                             'STA_active' => [
                                 'type'             => 'RADIO_BTN',
-                                'label'            => esc_html__('State Appears in Dropdown Select Lists', 'event_espresso'),
+                                'label'            => esc_html__(
+                                    'State Appears in Dropdown Select Lists',
+                                    'event_espresso'
+                                ),
                                 'input_name'       => 'states[' . $STA_ID . ']',
                                 'options'          => $this->_yes_no_values,
                                 'use_desc_4_label' => true,
@@ -928,8 +931,8 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                         GEN_SET_ADMIN_URL
                     );
 
-                    $this->_template_args['states'][$STA_ID]['inputs']           = $inputs;
-                    $this->_template_args['states'][$STA_ID]['delete_state_url'] = $delete_state_url;
+                    $this->_template_args['states'][ $STA_ID ]['inputs']           = $inputs;
+                    $this->_template_args['states'][ $STA_ID ]['delete_state_url'] = $delete_state_url;
                 }
             }
         } else {
@@ -1056,10 +1059,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
         $success = EEM_State::instance()->delete_by_ID($STA_ID);
         if ($success !== false) {
-            do_action('AHEE__General_Settings_Admin_Page__delete_state__state_deleted',
-                      $CNT_ISO,
-                      $STA_ID,
-                      ['STA_abbrev' => $STA_abbrev]);
+            do_action(
+                'AHEE__General_Settings_Admin_Page__delete_state__state_deleted',
+                $CNT_ISO,
+                $STA_ID,
+                ['STA_abbrev' => $STA_abbrev]
+            );
             EE_Error::add_success(esc_html__('The State was deleted successfully.', 'event_espresso'));
         }
         if (defined('DOING_AJAX')) {
@@ -1363,15 +1368,15 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             foreach ($items as $item) {
                 $ID         = absint($item->ID);
                 $post_title = wp_strip_all_tags($item->post_title);
-                $pad    = str_repeat('&nbsp;', $level * 3);
-                $option = "\n\t";
-                $option .= '<option class="level-' . $level . '" ';
-                $option .= 'value="' . $ID . '" ';
-                $option .= $ID === absint($default) ? ' selected' : '';
-                $option .= '>';
-                $option .= "$pad {$post_title}";
-                $option .= '</option>';
-                $output .= $option;
+                $pad        = str_repeat('&nbsp;', $level * 3);
+                $option     = "\n\t";
+                $option     .= '<option class="level-' . $level . '" ';
+                $option     .= 'value="' . $ID . '" ';
+                $option     .= $ID === absint($default) ? ' selected' : '';
+                $option     .= '>';
+                $option     .= "$pad {$post_title}";
+                $option     .= '</option>';
+                $output     .= $option;
                 ob_start();
                 parent_dropdown($default, $item->ID, $level + 1);
                 $output .= ob_get_clean();

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1150,7 +1150,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         );
         $cols_n_values['CNT_active']      = $this->request->getRequestParam(
             "cntry[$CNT_ISO][CNT_active]",
-            $country->is_active(),
+            $country->isActive(),
             DataType::BOOL
         );
 

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1,9 +1,11 @@
 <?php
 
 use EventEspresso\admin_pages\general_settings\AdminOptionsSettings;
+use EventEspresso\admin_pages\general_settings\OrganizationSettings;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidFormSubmissionException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\services\request\DataType;
 use EventEspresso\core\services\request\sanitizers\AllowedTags;
 
 /**
@@ -19,12 +21,9 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 {
 
     /**
-     * _question_group
-     * holds the specific question group object for the question group details screen
-     *
-     * @var object
+     * @var EE_Core_Config
      */
-    protected $_question_group;
+    public $core_config;
 
 
     /**
@@ -57,9 +56,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     protected function _define_page_props()
     {
         $this->_admin_page_title = GEN_SET_LABEL;
-        $this->_labels           = [
-            'publishbox' => esc_html__('Update Settings', 'event_espresso'),
-        ];
+        $this->_labels           = ['publishbox' => esc_html__('Update Settings', 'event_espresso')];
     }
 
 
@@ -69,7 +66,6 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     protected function _set_page_routes()
     {
         $this->_page_routes = [
-
             'critical_pages'                => [
                 'func'       => '_espresso_page_settings',
                 'capability' => 'manage_options',
@@ -243,22 +239,29 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     public function admin_init()
     {
-        EE_Registry::$i18n_js_strings['invalid_server_response'] = wp_strip_all_tags(__(
-            'An error occurred! Your request may have been processed, but a valid response from the server was not received. Please refresh the page and try again.',
-            'event_espresso'
-        ));
-        EE_Registry::$i18n_js_strings['error_occurred']          = wp_strip_all_tags(__(
-            'An error occurred! Please refresh the page and try again.',
-            'event_espresso'
-        ));
-        EE_Registry::$i18n_js_strings['confirm_delete_state']    = wp_strip_all_tags(__(
-            'Are you sure you want to delete this State / Province?',
-            'event_espresso'
-        ));
-        $protocol                                                = is_ssl() ? 'https://' : 'http://';
+        $this->core_config = EE_Registry::instance()->CFG->core;
+
+        EE_Registry::$i18n_js_strings['invalid_server_response'] = wp_strip_all_tags(
+            esc_html__(
+                'An error occurred! Your request may have been processed, but a valid response from the server was not received. Please refresh the page and try again.',
+                'event_espresso'
+            )
+        );
+        EE_Registry::$i18n_js_strings['error_occurred']          = wp_strip_all_tags(
+            esc_html__(
+                'An error occurred! Please refresh the page and try again.',
+                'event_espresso'
+            )
+        );
+        EE_Registry::$i18n_js_strings['confirm_delete_state']    = wp_strip_all_tags(
+            esc_html__(
+                'Are you sure you want to delete this State / Province?',
+                'event_espresso'
+            )
+        );
         EE_Registry::$i18n_js_strings['ajax_url']                = admin_url(
             'admin-ajax.php?page=espresso_general_settings',
-            $protocol
+            is_ssl() ? 'https://' : 'http://'
         );
     }
 
@@ -295,7 +298,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         wp_enqueue_style('organization-css');
         $confirm_image_delete = [
             'text' => wp_strip_all_tags(
-                __(
+                esc_html__(
                     'Do you really want to delete this image? Please remember to save your settings to complete the removal.',
                     'event_espresso'
                 )
@@ -340,31 +343,29 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         // if not create the default pages and display an admin notice
         EEH_Activation::verify_default_pages_exist();
         $this->_transient_garbage_collection();
+
         $this->_template_args['values']             = $this->_yes_no_values;
-        $this->_template_args['reg_page_id']        = isset(EE_Registry::instance()->CFG->core->reg_page_id)
-            ? EE_Registry::instance()->CFG->core->reg_page_id
-            : null;
-        $this->_template_args['reg_page_obj']       = isset(EE_Registry::instance()->CFG->core->reg_page_id)
-            ? get_post(EE_Registry::instance()->CFG->core->reg_page_id)
+
+        $this->_template_args['reg_page_id']        = $this->core_config->reg_page_id ?? null;
+        $this->_template_args['reg_page_obj']       = isset($this->core_config->reg_page_id)
+            ? get_post($this->core_config->reg_page_id)
             : false;
-        $this->_template_args['txn_page_id']        = isset(EE_Registry::instance()->CFG->core->txn_page_id)
-            ? EE_Registry::instance()->CFG->core->txn_page_id
-            : null;
-        $this->_template_args['txn_page_obj']       = isset(EE_Registry::instance()->CFG->core->txn_page_id)
-            ? get_post(EE_Registry::instance()->CFG->core->txn_page_id)
+
+        $this->_template_args['txn_page_id']        = $this->core_config->txn_page_id ?? null;
+        $this->_template_args['txn_page_obj']       = isset($this->core_config->txn_page_id)
+            ? get_post($this->core_config->txn_page_id)
             : false;
-        $this->_template_args['thank_you_page_id']  = isset(EE_Registry::instance()->CFG->core->thank_you_page_id)
-            ? EE_Registry::instance()->CFG->core->thank_you_page_id
-            : null;
-        $this->_template_args['thank_you_page_obj'] = isset(EE_Registry::instance()->CFG->core->thank_you_page_id)
-            ? get_post(EE_Registry::instance()->CFG->core->thank_you_page_id)
+
+        $this->_template_args['thank_you_page_id']  = $this->core_config->thank_you_page_id ?? null;
+        $this->_template_args['thank_you_page_obj'] = isset($this->core_config->thank_you_page_id)
+            ? get_post($this->core_config->thank_you_page_id)
             : false;
-        $this->_template_args['cancel_page_id']     = isset(EE_Registry::instance()->CFG->core->cancel_page_id)
-            ? EE_Registry::instance()->CFG->core->cancel_page_id
-            : null;
-        $this->_template_args['cancel_page_obj']    = isset(EE_Registry::instance()->CFG->core->cancel_page_id)
-            ? get_post(EE_Registry::instance()->CFG->core->cancel_page_id)
+
+        $this->_template_args['cancel_page_id']     = $this->core_config->cancel_page_id ?? null;
+        $this->_template_args['cancel_page_obj']    = isset($this->core_config->cancel_page_id)
+            ? get_post($this->core_config->cancel_page_id)
             : false;
+
         $this->_set_add_edit_form_tags('update_espresso_page_settings');
         $this->_set_publish_post_box_vars(null, false, false, null, false);
         $this->_template_args['admin_page_content'] = EEH_Template::display_template(
@@ -384,29 +385,38 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     protected function _update_espresso_page_settings()
     {
         // capture incoming request data && set page IDs
-        EE_Registry::instance()->CFG->core->reg_page_id       = isset($this->_req_data['reg_page_id'])
-            ? absint($this->_req_data['reg_page_id'])
-            : EE_Registry::instance()->CFG->core->reg_page_id;
-        EE_Registry::instance()->CFG->core->txn_page_id       = isset($this->_req_data['txn_page_id'])
-            ? absint($this->_req_data['txn_page_id'])
-            : EE_Registry::instance()->CFG->core->txn_page_id;
-        EE_Registry::instance()->CFG->core->thank_you_page_id = isset($this->_req_data['thank_you_page_id'])
-            ? absint($this->_req_data['thank_you_page_id'])
-            : EE_Registry::instance()->CFG->core->thank_you_page_id;
-        EE_Registry::instance()->CFG->core->cancel_page_id    = isset($this->_req_data['cancel_page_id'])
-            ? absint($this->_req_data['cancel_page_id'])
-            : EE_Registry::instance()->CFG->core->cancel_page_id;
-
-        EE_Registry::instance()->CFG->core = apply_filters(
-            'FHEE__General_Settings_Admin_Page___update_espresso_page_settings__CFG_core',
-            EE_Registry::instance()->CFG->core,
-            $this->_req_data
+        $this->core_config->reg_page_id       = $this->request->getRequestParam(
+            'reg_page_id',
+            $this->core_config->reg_page_id,
+            DataType::INT
         );
-        $what                              = esc_html__('Critical Pages & Shortcodes', 'event_espresso');
+        $this->core_config->txn_page_id       = $this->request->getRequestParam(
+            'txn_page_id',
+            $this->core_config->txn_page_id,
+            DataType::INT
+        );
+        $this->core_config->thank_you_page_id = $this->request->getRequestParam(
+            'thank_you_page_id',
+            $this->core_config->thank_you_page_id,
+            DataType::INT
+        );
+        $this->core_config->cancel_page_id    = $this->request->getRequestParam(
+            'cancel_page_id',
+            $this->core_config->cancel_page_id,
+            DataType::INT
+        );
+
+        $this->core_config = apply_filters(
+            'FHEE__General_Settings_Admin_Page___update_espresso_page_settings__CFG_core',
+            $this->core_config,
+            $this->request->requestParams()
+        );
+
+        $what = esc_html__('Critical Pages & Shortcodes', 'event_espresso');
         $this->_redirect_after_action(
             $this->_update_espresso_configuration(
                 $what,
-                EE_Registry::instance()->CFG->core,
+                $this->core_config,
                 __FILE__,
                 __FUNCTION__,
                 __LINE__
@@ -435,11 +445,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     {
         $this->_template_args['admin_page_content'] = '';
         try {
-            /** @var EventEspresso\admin_pages\general_settings\OrganizationSettings $organization_settings_form */
-            $organization_settings_form                 = $this->loader->getShared(
-                'EventEspresso\admin_pages\general_settings\OrganizationSettings'
+            /** @var OrganizationSettings $organization_settings_form */
+            $organization_settings_form = $this->loader->getShared(OrganizationSettings::class);
+
+            $this->_template_args['admin_page_content'] = EEH_HTML::div(
+                $organization_settings_form->display(),
+                '',
+                'padding'
             );
-            $this->_template_args['admin_page_content'] = $organization_settings_form->display();
         } catch (Exception $e) {
             EE_Error::add_error($e->getMessage(), __FILE__, __FUNCTION__, __LINE__);
         }
@@ -457,11 +470,11 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     protected function _update_your_organization_settings()
     {
         try {
-            /** @var EventEspresso\admin_pages\general_settings\OrganizationSettings $organization_settings_form */
-            $organization_settings_form  = $this->loader->getShared(
-                'EventEspresso\admin_pages\general_settings\OrganizationSettings'
-            );
-            $success                     = $organization_settings_form->process($this->_req_data);
+            /** @var OrganizationSettings $organization_settings_form */
+            $organization_settings_form = $this->loader->getShared(OrganizationSettings::class);
+
+            $success = $organization_settings_form->process($this->request->requestParams());
+
             EE_Registry::instance()->CFG = apply_filters(
                 'FHEE__General_Settings_Admin_Page___update_your_organization_settings__CFG',
                 EE_Registry::instance()->CFG
@@ -527,7 +540,13 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     {
         try {
             $admin_options_settings_form = new AdminOptionsSettings(EE_Registry::instance());
-            $admin_options_settings_form->process($this->_req_data[ $admin_options_settings_form->slug() ]);
+            $admin_options_settings_form->process(
+                $this->request->getRequestParam(
+                    $admin_options_settings_form->slug(),
+                    [],
+                    DataType::OBJECT // need to change this to ARRAY after min PHP version gets bumped to 7+
+                )
+            );
             EE_Registry::instance()->CFG->admin = apply_filters(
                 'FHEE__General_Settings_Admin_Page___update_admin_option_settings__CFG_admin',
                 EE_Registry::instance()->CFG->admin
@@ -539,14 +558,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             apply_filters(
                 'FHEE__General_Settings_Admin_Page___update_admin_option_settings__success',
                 $this->_update_espresso_configuration(
-                    'Admin Options',
+                    esc_html__('Admin Options', 'event_espresso'),
                     EE_Registry::instance()->CFG->admin,
                     __FILE__,
                     __FUNCTION__,
                     __LINE__
                 )
             ),
-            'Admin Options',
+            esc_html__('Admin Options', 'event_espresso'),
             'updated',
             ['action' => 'admin_option_settings']
         );
@@ -557,13 +576,24 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
 
     /**
+     * @param string|null $default
      * @return string
      */
-    protected function getCountryIsoForSite()
+    protected function getCountryISO(?string $default = null): string
     {
-        return ! empty(EE_Registry::instance()->CFG->organization->CNT_ISO)
-            ? EE_Registry::instance()->CFG->organization->CNT_ISO
-            : 'US';
+        $default = $default ?? $this->getCountryIsoForSite();
+        $CNT_ISO = $this->request->getRequestParam('country', $default);
+        return strtoupper($CNT_ISO);
+    }
+
+
+    /**
+     * @return string
+     */
+    protected function getCountryIsoForSite(): string
+    {
+        return ! empty(EE_Registry::instance()->CFG->organization->CNT_ISO) ? EE_Registry::instance(
+        )->CFG->organization->CNT_ISO : 'US';
     }
 
 
@@ -577,12 +607,15 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    protected function verifyOrGetCountryFromIso($CNT_ISO, EE_Country $country = null)
+    protected function verifyOrGetCountryFromIso(string $CNT_ISO, ?EE_Country $country = null)
     {
         /** @var EE_Country $country */
         return $country instanceof EE_Country && $country->ID() === $CNT_ISO
             ? $country
-            : EEM_Country::instance()->get_one_by_ID($CNT_ISO);
+            : EEM_Country::instance()
+                         ->get_one_by_ID(
+                             $CNT_ISO
+                         );
     }
 
 
@@ -598,39 +631,31 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     protected function _country_settings()
     {
-        $CNT_ISO_for_site = $this->getCountryIsoForSite();
-        $CNT_ISO          = isset($this->_req_data['country'])
-            ? strtoupper(sanitize_text_field($this->_req_data['country']))
-            : $CNT_ISO_for_site;
+        $CNT_ISO = $this->getCountryISO();
 
-        // load field generator helper
+        $this->_template_args['values']    = $this->_yes_no_values;
+        $this->_template_args['countries'] = new EE_Question_Form_Input(EE_Question::new_instance([
+                                                                                                      'QST_ID'           => 0,
+                                                                                                      'QST_display_text' => esc_html__(
+                                                                                                          'Select Country',
+                                                                                                          'event_espresso'
+                                                                                                      ),
+                                                                                                      'QST_system'       => 'admin-country',
+                                                                                                  ]),
+                                                                        EE_Answer::new_instance([
+                                                                                                    'ANS_ID'    => 0,
+                                                                                                    'ANS_value' => $CNT_ISO,
+                                                                                                ]),
+                                                                        [
+                                                                            'input_id'       => 'country',
+                                                                            'input_name'     => 'country',
+                                                                            'input_prefix'   => '',
+                                                                            'append_qstn_id' => false,
+                                                                        ]);
 
-        $this->_template_args['values'] = $this->_yes_no_values;
-
-        $this->_template_args['countries'] = new EE_Question_Form_Input(
-            EE_Question::new_instance(
-                [
-                    'QST_ID'           => 0,
-                    'QST_display_text' => esc_html__('Select Country', 'event_espresso'),
-                    'QST_system'       => 'admin-country',
-                ]
-            ),
-            EE_Answer::new_instance(
-                [
-                    'ANS_ID'    => 0,
-                    'ANS_value' => $CNT_ISO,
-                ]
-            ),
-            [
-                'input_id'       => 'country',
-                'input_name'     => 'country',
-                'input_prefix'   => '',
-                'append_qstn_id' => false,
-            ]
-        );
-        $country                           = $this->verifyOrGetCountryFromIso($CNT_ISO_for_site);
-        add_filter('FHEE__EEH_Form_Fields__label_html', [$this, 'country_form_field_label_wrap'], 10, 2);
-        add_filter('FHEE__EEH_Form_Fields__input_html', [$this, 'country_form_field_input__wrap'], 10, 2);
+        $country = $this->verifyOrGetCountryFromIso($CNT_ISO);
+        add_filter('FHEE__EEH_Form_Fields__label_html', [$this, 'country_form_field_label_wrap'], 10);
+        add_filter('FHEE__EEH_Form_Fields__input_html', [$this, 'country_form_field_input__wrap'], 10);
         $this->_template_args['country_details_settings'] = $this->display_country_settings(
             $country->ID(),
             $country
@@ -663,13 +688,11 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public function display_country_settings($CNT_ISO = '', EE_Country $country = null)
+    public function display_country_settings(string $CNT_ISO = '', ?EE_Country $country = null): string
     {
+        $CNT_ISO          = $this->getCountryISO($CNT_ISO);
         $CNT_ISO_for_site = $this->getCountryIsoForSite();
 
-        $CNT_ISO = isset($this->_req_data['country'])
-            ? strtoupper(sanitize_text_field($this->_req_data['country']))
-            : $CNT_ISO;
         if (! $CNT_ISO) {
             return '';
         }
@@ -701,11 +724,11 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 'input_name' => 'cntry[' . $CNT_ISO . ']',
                 'class'      => 'small-text',
             ],
-            'RGN_ID'          => [
-                'type'       => 'TEXT',
-                'input_name' => 'cntry[' . $CNT_ISO . ']',
-                'class'      => 'small-text',
-            ],
+            // 'RGN_ID'          => [
+            //     'type'       => 'TEXT',
+            //     'input_name' => 'cntry[' . $CNT_ISO . ']',
+            //     'class'      => 'ee-input-size--small',
+            // ],
             'CNT_name'        => [
                 'type'       => 'TEXT',
                 'input_name' => 'cntry[' . $CNT_ISO . ']',
@@ -824,9 +847,8 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 ]
             );
             die();
-        } else {
-            return $country_details_settings;
         }
+        return $country_details_settings;
     }
 
 
@@ -841,12 +863,9 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public function display_country_states($CNT_ISO = '', EE_Country $country = null)
+    public function display_country_states(string $CNT_ISO = '', ?EE_Country $country = null): string
     {
-
-        $CNT_ISO = isset($this->_req_data['country'])
-            ? sanitize_text_field($this->_req_data['country'])
-            : $CNT_ISO;
+        $CNT_ISO = $this->getCountryISO($CNT_ISO);
         if (! $CNT_ISO) {
             return '';
         }
@@ -854,7 +873,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         remove_all_filters('FHEE__EEH_Form_Fields__label_html');
         remove_all_filters('FHEE__EEH_Form_Fields__input_html');
         add_filter('FHEE__EEH_Form_Fields__label_html', [$this, 'state_form_field_label_wrap'], 10, 2);
-        add_filter('FHEE__EEH_Form_Fields__input_html', [$this, 'state_form_field_input__wrap'], 10, 2);
+        add_filter('FHEE__EEH_Form_Fields__input_html', [$this, 'state_form_field_input__wrap'], 10);
         $states = EEM_State::instance()->get_all_states_for_these_countries([$CNT_ISO => $CNT_ISO]);
         if (empty($states)) {
             /** @var EventEspresso\core\services\address\CountrySubRegionDao $countrySubRegionDao */
@@ -864,50 +883,53 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             if ($countrySubRegionDao instanceof EventEspresso\core\services\address\CountrySubRegionDao) {
                 $country = $this->verifyOrGetCountryFromIso($CNT_ISO, $country);
                 if ($countrySubRegionDao->saveCountrySubRegions($country)) {
-                    $states = EEM_State::instance()->get_all_states_for_these_countries(
-                        [$CNT_ISO => $CNT_ISO]
-                    );
+                    $states = EEM_State::instance()->get_all_states_for_these_countries([$CNT_ISO => $CNT_ISO]);
                 }
             }
         }
         if (is_array($states)) {
             foreach ($states as $STA_ID => $state) {
                 if ($state instanceof EE_State) {
-                    // STA_abbrev    STA_name    STA_active
-                    $state_input_types                                             = [
-                        'STA_abbrev' => [
-                            'type'       => 'TEXT',
-                            'input_name' => 'states[' . $STA_ID . ']',
-                            'class'      => 'small-text',
+                    $inputs = EE_Question_Form_Input::generate_question_form_inputs_for_object(
+                        $state,
+                        [
+                            'STA_abbrev' => [
+                                'type'             => 'TEXT',
+                                'label'            => esc_html__('Code', 'event_espresso'),
+                                'input_name'       => 'states[' . $STA_ID . ']',
+                                'class'            => 'small-text',
+                                'add_mobile_label' => true,
+                            ],
+                            'STA_name'   => [
+                                'type'             => 'TEXT',
+                                'label'            => esc_html__('Name', 'event_espresso'),
+                                'input_name'       => 'states[' . $STA_ID . ']',
+                                'class'            => 'regular-text',
+                                'add_mobile_label' => true,
+                            ],
+                            'STA_active' => [
+                                'type'             => 'RADIO_BTN',
+                                'label'            => esc_html__('State Appears in Dropdown Select Lists', 'event_espresso'),
+                                'input_name'       => 'states[' . $STA_ID . ']',
+                                'options'          => $this->_yes_no_values,
+                                'use_desc_4_label' => true,
+                                'add_mobile_label' => true,
+                            ],
+                        ]
+                    );
+
+                    $delete_state_url = EE_Admin_Page::add_query_args_and_nonce(
+                        [
+                            'action'     => 'delete_state',
+                            'STA_ID'     => $STA_ID,
+                            'CNT_ISO'    => $CNT_ISO,
+                            'STA_abbrev' => $state->abbrev(),
                         ],
-                        'STA_name'   => [
-                            'type'       => 'TEXT',
-                            'input_name' => 'states[' . $STA_ID . ']',
-                            'class'      => 'regular-text',
-                        ],
-                        'STA_active' => [
-                            'type'             => 'RADIO_BTN',
-                            'input_name'       => 'states[' . $STA_ID . ']',
-                            'options'          => $this->_yes_no_values,
-                            'use_desc_4_label' => true,
-                        ],
-                    ];
-                    $this->_template_args['states'][ $STA_ID ]['inputs']           =
-                        EE_Question_Form_Input::generate_question_form_inputs_for_object(
-                            $state,
-                            $state_input_types
-                        );
-                    $query_args                                                    = [
-                        'action'     => 'delete_state',
-                        'STA_ID'     => $STA_ID,
-                        'CNT_ISO'    => $CNT_ISO,
-                        'STA_abbrev' => $state->abbrev(),
-                    ];
-                    $this->_template_args['states'][ $STA_ID ]['delete_state_url'] =
-                        EE_Admin_Page::add_query_args_and_nonce(
-                            $query_args,
-                            GEN_SET_ADMIN_URL
-                        );
+                        GEN_SET_ADMIN_URL
+                    );
+
+                    $this->_template_args['states'][$STA_ID]['inputs']           = $inputs;
+                    $this->_template_args['states'][$STA_ID]['delete_state_url'] = $delete_state_url;
                 }
             }
         } else {
@@ -935,30 +957,23 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 ]
             );
             die();
-        } else {
-            return $state_details_settings;
         }
+        return $state_details_settings;
     }
 
 
     /**
-     *        add_new_state
-     *
-     * @access    public
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     public function add_new_state()
     {
-
         $success = true;
-
-        $CNT_ISO = isset($this->_req_data['CNT_ISO'])
-            ? strtoupper(sanitize_text_field($this->_req_data['CNT_ISO']))
-            : false;
+        $CNT_ISO = $this->getCountryISO('');
         if (! $CNT_ISO) {
             EE_Error::add_error(
                 esc_html__('No Country ISO code or an invalid Country ISO code was received.', 'event_espresso'),
@@ -968,9 +983,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             );
             $success = false;
         }
-        $STA_abbrev = isset($this->_req_data['STA_abbrev'])
-            ? sanitize_text_field($this->_req_data['STA_abbrev'])
-            : false;
+        $STA_abbrev = $this->request->getRequestParam('STA_abbrev');
         if (! $STA_abbrev) {
             EE_Error::add_error(
                 esc_html__('No State ISO code or an invalid State ISO code was received.', 'event_espresso'),
@@ -980,9 +993,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             );
             $success = false;
         }
-        $STA_name = isset($this->_req_data['STA_name'])
-            ? sanitize_text_field($this->_req_data['STA_name'])
-            : false;
+        $STA_name = $this->request->getRequestParam('STA_name');
         if (! $STA_name) {
             EE_Error::add_error(
                 esc_html__('No State name or an invalid State name was received.', 'event_espresso'),
@@ -1009,7 +1020,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             echo wp_json_encode(array_merge($notices, ['return_data' => $CNT_ISO]));
             die();
         } else {
-            $this->_redirect_after_action($success, 'State', 'added', ['action' => 'country_settings']);
+            $this->_redirect_after_action(
+                $success,
+                esc_html__('State', 'event_espresso'),
+                'added',
+                ['action' => 'country_settings']
+            );
         }
     }
 
@@ -1020,18 +1036,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     public function delete_state()
     {
-        $CNT_ISO    = isset($this->_req_data['CNT_ISO'])
-            ? strtoupper(sanitize_text_field($this->_req_data['CNT_ISO']))
-            : false;
-        $STA_ID     = isset($this->_req_data['STA_ID'])
-            ? sanitize_text_field($this->_req_data['STA_ID'])
-            : false;
-        $STA_abbrev = isset($this->_req_data['STA_abbrev'])
-            ? sanitize_text_field($this->_req_data['STA_abbrev'])
-            : false;
+        $CNT_ISO    = $this->getCountryISO();
+        $STA_ID     = $this->request->getRequestParam('STA_ID');
+        $STA_abbrev = $this->request->getRequestParam('STA_abbrev');
+
         if (! $STA_ID) {
             EE_Error::add_error(
                 esc_html__('No State ID or an invalid State ID was received.', 'event_espresso'),
@@ -1044,12 +1056,10 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
         $success = EEM_State::instance()->delete_by_ID($STA_ID);
         if ($success !== false) {
-            do_action(
-                'AHEE__General_Settings_Admin_Page__delete_state__state_deleted',
-                $CNT_ISO,
-                $STA_ID,
-                ['STA_abbrev' => $STA_abbrev]
-            );
+            do_action('AHEE__General_Settings_Admin_Page__delete_state__state_deleted',
+                      $CNT_ISO,
+                      $STA_ID,
+                      ['STA_abbrev' => $STA_abbrev]);
             EE_Error::add_success(esc_html__('The State was deleted successfully.', 'event_espresso'));
         }
         if (defined('DOING_AJAX')) {
@@ -1060,7 +1070,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         } else {
             $this->_redirect_after_action(
                 $success,
-                'State',
+                esc_html__('State', 'event_espresso'),
                 'deleted',
                 ['action' => 'country_settings']
             );
@@ -1076,13 +1086,11 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     protected function _update_country_settings()
     {
-        // grab the country ISO code
-        $CNT_ISO = isset($this->_req_data['country'])
-            ? strtoupper(sanitize_text_field($this->_req_data['country']))
-            : false;
+        $CNT_ISO = $this->getCountryISO();
         if (! $CNT_ISO) {
             EE_Error::add_error(
                 esc_html__('No Country ISO code or an invalid Country ISO code was received.', 'event_espresso'),
@@ -1090,68 +1098,62 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 __FUNCTION__,
                 __LINE__
             );
-
             return;
         }
-        $cols_n_values             = [];
-        $cols_n_values['CNT_ISO3'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_ISO3'])
-            ? strtoupper(sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_ISO3']))
-            : false;
-        $cols_n_values['RGN_ID']   = isset($this->_req_data['cntry'][ $CNT_ISO ]['RGN_ID'])
-            ? absint($this->_req_data['cntry'][ $CNT_ISO ]['RGN_ID'])
-            : null;
-        $cols_n_values['CNT_name'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_name'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_name'])
-            : null;
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code'])) {
-            $cols_n_values['CNT_cur_code'] = strtoupper(
-                sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_code'])
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single'])) {
-            $cols_n_values['CNT_cur_single'] = sanitize_text_field(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_single']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural'])) {
-            $cols_n_values['CNT_cur_plural'] = sanitize_text_field(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_plural']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign'])) {
-            $cols_n_values['CNT_cur_sign'] = sanitize_text_field(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4'])) {
-            $cols_n_values['CNT_cur_sign_b4'] = absint(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_sign_b4']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc'])) {
-            $cols_n_values['CNT_cur_dec_plc'] = absint(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_plc']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk'])) {
-            $cols_n_values['CNT_cur_dec_mrk'] = sanitize_text_field(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_dec_mrk']
-            );
-        }
-        if (isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds'])) {
-            $cols_n_values['CNT_cur_thsnds'] = sanitize_text_field(
-                $this->_req_data['cntry'][ $CNT_ISO ]['CNT_cur_thsnds']
-            );
-        }
-        $cols_n_values['CNT_tel_code'] = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_tel_code'])
-            ? sanitize_text_field($this->_req_data['cntry'][ $CNT_ISO ]['CNT_tel_code'])
-            : null;
-        $cols_n_values['CNT_is_EU']    = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_is_EU'])
-            ? absint($this->_req_data['cntry'][ $CNT_ISO ]['CNT_is_EU'])
-            : false;
-        $cols_n_values['CNT_active']   = isset($this->_req_data['cntry'][ $CNT_ISO ]['CNT_active'])
-            ? absint($this->_req_data['cntry'][ $CNT_ISO ]['CNT_active'])
-            : false;
+
+        $country = $this->verifyOrGetCountryFromIso($CNT_ISO);
+
+        $cols_n_values                    = [];
+        $cols_n_values['CNT_ISO3']        = strtoupper(
+            $this->request->getRequestParam('cntry', '', $country->ISO3())
+        );
+        $cols_n_values['CNT_name']        =
+            $this->request->getRequestParam("cntry[$CNT_ISO][CNT_name]", $country->name());
+        $cols_n_values['CNT_cur_code']    = strtoupper(
+            $this->request->getRequestParam(
+                "cntry[$CNT_ISO][CNT_cur_code]",
+                $country->currency_code()
+            )
+        );
+        $cols_n_values['CNT_cur_single']  = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_single]",
+            $country->currency_name_single()
+        );
+        $cols_n_values['CNT_cur_plural']  = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_plural]",
+            $country->currency_name_plural()
+        );
+        $cols_n_values['CNT_cur_sign']    = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_sign]",
+            $country->currency_sign()
+        );
+        $cols_n_values['CNT_cur_sign_b4'] = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_sign_b4]",
+            $country->currency_sign_before(),
+            DataType::BOOL
+        );
+        $cols_n_values['CNT_cur_dec_plc'] = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_dec_plc]",
+            $country->currency_decimal_places()
+        );
+        $cols_n_values['CNT_cur_dec_mrk'] = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_dec_mrk]",
+            $country->currency_decimal_mark()
+        );
+        $cols_n_values['CNT_cur_thsnds']  = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_cur_thsnds]",
+            $country->currency_thousands_separator()
+        );
+        $cols_n_values['CNT_tel_code']    = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_tel_code]",
+            $country->telephoneCode()
+        );
+        $cols_n_values['CNT_active']      = $this->request->getRequestParam(
+            "cntry[$CNT_ISO][CNT_active]",
+            $country->is_active(),
+            DataType::BOOL
+        );
+
         // allow filtering of country data
         $cols_n_values = apply_filters(
             'FHEE__General_Settings_Admin_Page___update_country_settings__cols_n_values',
@@ -1163,20 +1165,20 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         // run the update
         $success = EEM_Country::instance()->update($cols_n_values, $where_cols_n_values);
 
-        if (isset($this->_req_data['states']) && is_array($this->_req_data['states']) && $success !== false) {
-            // allow filtering of states data
-            $states = apply_filters(
-                'FHEE__General_Settings_Admin_Page___update_country_settings__states',
-                $this->_req_data['states']
-            );
+        // allow filtering of states data
+        $states = apply_filters(
+            'FHEE__General_Settings_Admin_Page___update_country_settings__states',
+            $this->request->getRequestParam('states', [], DataType::STRING, true)
+        );
 
+        if (! empty($states) && $success !== false) {
             // loop thru state data ( looks like : states[75][STA_name] )
             foreach ($states as $STA_ID => $state) {
                 $cols_n_values = [
                     'CNT_ISO'    => $CNT_ISO,
                     'STA_abbrev' => sanitize_text_field($state['STA_abbrev']),
                     'STA_name'   => sanitize_text_field($state['STA_name']),
-                    'STA_active' => (bool) absint($state['STA_active']),
+                    'STA_active' => filter_var($state['STA_active'], FILTER_VALIDATE_BOOLEAN),
                 ];
                 // where values
                 $where_cols_n_values = [['STA_ID' => $STA_ID]];
@@ -1217,12 +1219,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        form_form_field_label_wrap
+     * form_form_field_label_wrap
      *
      * @param string $label
-     * @return        string
+     * @return string
      */
-    public function country_form_field_label_wrap($label, $required_text)
+    public function country_form_field_label_wrap(string $label): string
     {
         return '
 			<tr>
@@ -1233,12 +1235,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        form_form_field_input__wrap
+     * form_form_field_input__wrap
      *
-     * @param string $label
-     * @return        string
+     * @param string $input
+     * @return string
      */
-    public function country_form_field_input__wrap($input, $label)
+    public function country_form_field_input__wrap(string $input): string
     {
         return '
 				<td class="general-settings-country-input-td">
@@ -1249,25 +1251,25 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
 
     /**
-     *        form_form_field_label_wrap
+     * form_form_field_label_wrap
      *
      * @param string $label
      * @param string $required_text
-     * @return        string
+     * @return string
      */
-    public function state_form_field_label_wrap($label, $required_text)
+    public function state_form_field_label_wrap(string $label, string $required_text): string
     {
         return $required_text;
     }
 
 
     /**
-     *        form_form_field_input__wrap
+     * form_form_field_input__wrap
      *
-     * @param string $label
-     * @return        string
+     * @param string $input
+     * @return string
      */
-    public function state_form_field_input__wrap($input, $label)
+    public function state_form_field_input__wrap(string $input): string
     {
         return '
 				<td class="general-settings-country-state-input-td">
@@ -1285,18 +1287,15 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @param int $ee_page_id
      * @return string
      */
-    public static function edit_view_links($ee_page_id)
+    public static function edit_view_links(int $ee_page_id): string
     {
-        $links = '<a href="'
-                 . add_query_arg(
-                     ['post' => $ee_page_id, 'action' => 'edit'],
-                     admin_url('post.php')
-                 )
-                 . '" >'
-                 . esc_html__('Edit', 'event_espresso')
-                 . '</a>';
-        $links .= ' &nbsp;|&nbsp; ';
-        $links .= '<a href="' . get_permalink($ee_page_id) . '" >' . esc_html__('View', 'event_espresso') . '</a>';
+        $edit_url = add_query_arg(
+            ['post' => $ee_page_id, 'action' => 'edit'],
+            admin_url('post.php')
+        );
+        $links    = '<a href="' . esc_url_raw($edit_url) . '" >' . esc_html__('Edit', 'event_espresso') . '</a>';
+        $links    .= ' &nbsp;|&nbsp; ';
+        $links    .= '<a href="' . get_permalink($ee_page_id) . '" >' . esc_html__('View', 'event_espresso') . '</a>';
 
         return $links;
     }
@@ -1305,12 +1304,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     /**
      * displays page and shortcode status for critical EE pages
      *
-     * @param WP page object $ee_page
+     * @param WP_Post $ee_page
+     * @param string  $shortcode
      * @return string
      */
-    public static function page_and_shortcode_status($ee_page, $shortcode)
+    public static function page_and_shortcode_status(WP_Post $ee_page, string $shortcode): string
     {
-
         // page status
         if (isset($ee_page->post_status) && $ee_page->post_status == 'publish') {
             $pg_colour = 'green';
@@ -1344,8 +1343,12 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      * @param bool $echo
      * @return string;
      */
-    public static function page_settings_dropdown($default = 0, $parent = 0, $level = 0, $echo = true)
-    {
+    public static function page_settings_dropdown(
+        int $default = 0,
+        int $parent = 0,
+        int $level = 0,
+        bool $echo = true
+    ): string {
         global $wpdb;
         $items  = $wpdb->get_results(
             $wpdb->prepare(
@@ -1358,7 +1361,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
         if ($items) {
             $level = absint($level);
             foreach ($items as $item) {
-                $ID = absint($item->ID);
+                $ID         = absint($item->ID);
                 $post_title = wp_strip_all_tags($item->post_title);
                 $pad    = str_repeat('&nbsp;', $level * 3);
                 $option = "\n\t";
@@ -1387,8 +1390,9 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     public function load_scripts_styles_privacy_settings()
     {
-        $form_handler =
-            $this->loader->getShared('EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler');
+        $form_handler = $this->loader->getShared(
+            'EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler'
+        );
         $form_handler->enqueueStylesAndScripts();
     }
 
@@ -1402,9 +1406,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     {
         $this->_set_add_edit_form_tags('update_privacy_settings');
         $this->_set_publish_post_box_vars(null, false, false, null, false);
-        $form_handler                               =
-            $this->loader->getShared('EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler');
-        $this->_template_args['admin_page_content'] = $form_handler->display();
+        $form_handler                               = $this->loader->getShared(
+            'EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler'
+        );
+        $this->_template_args['admin_page_content'] = EEH_HTML::div(
+            $form_handler->display(),
+            '',
+            'padding'
+        );
         $this->display_admin_page_with_sidebar();
     }
 
@@ -1416,8 +1425,9 @@ class General_Settings_Admin_Page extends EE_Admin_Page
      */
     public function updatePrivacySettings()
     {
-        $form_handler =
-            $this->loader->getShared('EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler');
+        $form_handler = $this->loader->getShared(
+            'EventEspresso\core\domain\services\admin\privacy\forms\PrivacySettingsFormHandler'
+        );
         $success      = $form_handler->process($this->get_request_data());
         $this->_redirect_after_action(
             $success,

--- a/core/db_classes/EE_Country.class.php
+++ b/core/db_classes/EE_Country.class.php
@@ -13,8 +13,10 @@ class EE_Country extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Country|mixed
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array())
+    public static function new_instance($props_n_values = [])
     {
         $has_object = parent::_check_for_object($props_n_values, __CLASS__);
         return $has_object ? $has_object : new self($props_n_values);
@@ -24,8 +26,10 @@ class EE_Country extends EE_Base_Class
     /**
      * @param array $props_n_values
      * @return EE_Country
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance_from_db($props_n_values = array())
+    public static function new_instance_from_db($props_n_values = [])
     {
         return new self($props_n_values, true);
     }
@@ -35,6 +39,8 @@ class EE_Country extends EE_Base_Class
      * Gets the country name
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function name()
     {
@@ -43,9 +49,37 @@ class EE_Country extends EE_Base_Class
 
 
     /**
+     * Whether the country is active/enabled
+     *
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function isActive()
+    {
+        return (bool) $this->get('CNT_active');
+    }
+
+
+    /**
+     * Gets the country ISO3
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function ISO3()
+    {
+        return $this->get('CNT_ISO3');
+    }
+
+
+    /**
      * gets the country's currency code
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_code()
     {
@@ -57,6 +91,8 @@ class EE_Country extends EE_Base_Class
      * gets the country's currency sign/symbol
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_sign()
     {
@@ -69,6 +105,8 @@ class EE_Country extends EE_Base_Class
      * Currency name singular
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_name_single()
     {
@@ -80,6 +118,8 @@ class EE_Country extends EE_Base_Class
      * Currency name plural
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_name_plural()
     {
@@ -91,10 +131,12 @@ class EE_Country extends EE_Base_Class
      * currency_sign_before - ie: $TRUE  or  FALSE$
      *
      * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_sign_before()
     {
-        return $this->get('CNT_cur_sign_b4');
+        return (bool) $this->get('CNT_cur_sign_b4');
     }
 
 
@@ -102,6 +144,8 @@ class EE_Country extends EE_Base_Class
      * currency_decimal_places : 2 = 0.00   3 = 0.000
      *
      * @return integer
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_decimal_places()
     {
@@ -113,6 +157,8 @@ class EE_Country extends EE_Base_Class
      * currency_decimal_mark :   (comma) ',' = 0,01   or   (decimal) '.' = 0.01
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_decimal_mark()
     {
@@ -124,9 +170,47 @@ class EE_Country extends EE_Base_Class
      * currency thousands separator:   (comma) ',' = 1,000   or   (decimal) '.' = 1.000
      *
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function currency_thousands_separator()
     {
         return $this->get('CNT_cur_thsnds');
+    }
+
+
+    /**
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    public function isEU()
+    {
+        return (bool) $this->get('CNT_is_EU');
+    }
+
+
+    /**
+     * Country Telephone Code: +1
+     *
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    public function telephoneCode()
+    {
+        return $this->get('CNT_tel_code');
+    }
+
+
+    /**
+     * @deprecated $VID:$
+     * @return bool
+     */
+    public function is_active()
+    {
+        return $this->isActive();
     }
 }


### PR DESCRIPTION
Similar to previous PRs, this one:

- replaces all uses of the legacy admin request data with the new Request class
- autoformats and cleans up the code