### PR TITLE
Prevent a fatal error within PUE if update_plugins returns false

### DIFF
--- a/core/third_party_libs/pue/pue-client.php
+++ b/core/third_party_libs/pue/pue-client.php
@@ -1767,6 +1767,11 @@ if (! class_exists('PluginUpdateEngineChecker')):
          */
         public function injectUpdate($updates)
         {
+            // Fix for update_plugins returning false
+            if (! is_object($updates)) {
+                $updates = new stdClass();
+            }
+
             $state = get_site_option($this->optionName);
 
             //first remove any existing WP update message that might have snuck in before we have any return from our


### PR DESCRIPTION
If the `update_plugins` transient hasn't been set, or something is hooking in and just returning `false` (to prevent all plugin updates) then PUE throws a warning with PHP7.4 and a fatal in PHP8:

```
[31-May-2022 13:35:22 UTC] PHP Fatal error:  Uncaught Error: Attempt to modify property "response" on bool in /home/pebbloco/public_html/ee4/wp-content/plugins/event-espresso-core-reg/core/third_party_libs/pue/pue-client.php:1786
Stack trace:
#0 /home/pebbloco/public_html/ee4/wp-includes/class-wp-hook.php(309): PluginUpdateEngineChecker->injectUpdate()
#1 /home/pebbloco/public_html/ee4/wp-includes/plugin.php(189): WP_Hook->apply_filters()
#2 /home/pebbloco/public_html/ee4/wp-includes/option.php(1957): apply_filters()
#3 /home/pebbloco/public_html/ee4/wp-includes/update.php(780): get_site_transient()
#4 /home/pebbloco/public_html/ee4/wp-admin/menu.php(33): wp_get_update_data()
#5 /home/pebbloco/public_html/ee4/wp-admin/admin.php(158): require('/home/pebbloco/...')
#6 /home/pebbloco/public_html/ee4/wp-admin/index.php(10): require_once('/home/pebbloco/...')
#7 {main}
  thrown in /home/pebbloco/public_html/ee4/wp-content/plugins/event-espresso-core-reg/core/third_party_libs/pue/pue-client.php on line 1786
```

This PR prevents that from happening.

## How has this been tested
Add this code to your site:

`add_filter('site_transient_update_plugins', '__return_false', 9);`

You can add that to a custom functions plugin on your site, we have some documentation on creating one here:

https://eventespresso.com/wiki/create-site-specific-plugin-wordpress-site/ 

With **master** branch of EE4 core active.

Go to Dashboard -> Plugins.

Check your servers error logs, with PHP7.4 you should see a warning, like this:

`[31-May-2022 13:25:01 UTC] PHP Warning:  Creating default object from empty value in /home/pebbloco/public_html/ee4/wp-content/plugins/event-espresso-core-reg/core/third_party_libs/pue/pue-client.php on line 1787`

With PHP8 you'll get a fatal like the above.

Switch to this branch and retest. You should not get any more notices on PHP7.4 and no fatal on PHP8.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
