### PR TITLE
More EDTR UI Fixes & Updates

### DIFF
--- a/admin_pages/about/About_Admin_Page.core.php
+++ b/admin_pages/about/About_Admin_Page.core.php
@@ -78,6 +78,7 @@ class About_Admin_Page extends EE_Admin_Page
             'default' => array(
                 'nav'           => array(
                     'label' => esc_html__('About', 'event_espresso'),
+                    'icon' => 'dashicons-welcome-learn-more',
                     'order' => 20,
                 ),
                 'require_nonce' => false,
@@ -85,6 +86,7 @@ class About_Admin_Page extends EE_Admin_Page
             'credits' => array(
                 'nav'           => array(
                     'label' => esc_html__('Credits', 'event_espresso'),
+                    'icon' => 'dashicons-thumbs-up',
                     'order' => 30,
                 ),
                 'require_nonce' => false,
@@ -93,6 +95,7 @@ class About_Admin_Page extends EE_Admin_Page
             'decafvpro' => array(
                 'nav'           => array(
                     'label' => esc_html__('Decaf vs Regular', 'event_espresso'),
+                    'icon' => 'dashicons-editor-code',
                     'order' => 40,
                 ),
                 'require_nonce' => false,
@@ -100,6 +103,7 @@ class About_Admin_Page extends EE_Admin_Page
             'reviews'   => array(
                 'nav'           => array(
                     'label' => esc_html__('Reviews', 'event_espresso'),
+                    'icon' => 'dashicons-star-filled',
                     'order' => 50,
                 ),
                 'require_nonce' => false,

--- a/admin_pages/about/templates/credits.template.php
+++ b/admin_pages/about/templates/credits.template.php
@@ -52,75 +52,7 @@ $tEEm_members = [
         ],
     ],
 ];
-?>
 
-<p class="about-description">
-    <?php esc_html_e(
-        'Event Espresso is created by an international team of passionate individuals with a drive to empower your events!',
-        'event_espresso'
-    ); ?>
-</p>
-<?php
-foreach ($tEEm_members as $tEEm => $members) {
-    echo '
-<h3 class="wp-people-group">' . $tEEm . '</h3>
-<ul class="ee-card-grid ee-card-grid-4-cols ee-credits-tEEm" id="' . sanitize_key($tEEm) . '">';
-    foreach ($members as $id => $person) {
-        echo espressoPerson($id, $person['email'], $person['name'], $person['desc']);
-    }
-    echo '
-</ul>';
-}
-?>
-<h3 class="wp-people-group"><?php esc_html_e('Contributor Recognition', 'event_espresso'); ?></h3>
-<p class="description">
-    <?php
-    printf(
-        esc_html__(
-            'For every major release we want to recognize the people who contributed to the release via a GitHub pull request. Want to see your name listed here? %sWhen you submit a pull request that gets included in a major release%s, we\'ll add your name here linked to your GitHub profile.',
-            'event_espresso'
-        ),
-        '<a href="https://github.com/eventespresso/event-espresso-core" title="Contribute to Event Espresso by making a pull request via GitHub" target="_blank">',
-        '</a>'
-    );
-    ?>
-</p>
-<p class="wp-credits-list">
-<ul>
-    <li><a href="https://github.com/Veraxus" target='_blank'>Matt Van Andel</a></li>
-    <li><a href="https://github.com/jonathan-dejong" target='_blank'>Jonathan de Jong</a></li>
-    <li><a href="https://github.com/richardtape" target='_blank'>Richard Tape</a></li>
-    <li><a href="https://github.com/robert-osborne" target='_blank'>Robert Osborne</a></li>
-    <li><a href="https://github.com/rgunawans" target='_blank'>Robby Gunawan Sutanto</a></li>
-</ul>
-
-</p>
-<h3 class="wp-people-group"><?php esc_html_e('External Libraries', 'event_espresso'); ?></h3>
-<p class="description">
-    <?php
-    printf(
-        esc_html__(
-            'Along with the libraries %sincluded with WordPress%s, Event Espresso utilizes the following third party libraries:',
-            'event_espresso'
-        ),
-        '<a href="credits.php">',
-        '</a>'
-    );
-    ?>
-</p>
-<p class="wp-credits-list">
-    <a href="https://openexchangerates.github.io/accounting.js/" target='_blank'>accounting.js</a>,
-    <a href="https://dompdf.github.io/" target='_blank'>dompdf</a>,
-    <a href="https://zurb.com/playground/jquery-joyride-feature-tour-plugin" target='_blank'>joyride2</a>,
-    <a href="https://kint-php.github.io/kint/" target='_blank'>Kint</a>,
-    <a href="https://momentjs.com/" target='_blank'>Moment.js</a>,
-    <a href="https://github.com/qTip2/qTip2" target='_blank'>qTip2</a>,
-    <a href="https://trentrichardson.com/examples/timepicker/" target='_blank'>jQuery UI Timepicker</a>,
-    <a href="https://github.com/jhogendorn/jQuery-serializeFullArray" target='_blank'>SerializeFullArray</a>,
-    <a href="https://github.com/jzaefferer/jquery-validation" target='_blank'>jQuery Validation</a>
-</p>
-
-<?php
 function espressoPerson($id, $email, $name, $desc): string
 {
     return '
@@ -134,6 +66,7 @@ function espressoPerson($id, $email, $name, $desc): string
         </p>
     </li>';
 }
+
 function esp_gravatar_profile($email)
 {
     return esc_url_raw('https://www.gravatar.com/' . md5($email));
@@ -142,7 +75,85 @@ function esp_gravatar_profile($email)
 function esp_gravatar_image($email, $name)
 {
     $email = md5($email);
-    $name = esc_attr($name);
-    $url = esc_url_raw("https://0.gravatar.com/avatar/{$email}?s=60");
+    $name  = esc_attr($name);
+    $url   = esc_url_raw("https://0.gravatar.com/avatar/{$email}?s=60");
     return "<img src='{$url}' class='gravatar' alt='{$name}'/>";
 }
+
+?>
+
+<div class='ee-admin-container'>
+    <div class='padding'>
+
+        <h4>
+            <?php esc_html_e(
+                'Event Espresso is created by an international team of passionate individuals with a drive to empower your events!',
+                'event_espresso'
+            ); ?>
+        </h4>
+
+        <div class='ee-credits-tEEm'>
+            <?php
+            foreach ($tEEm_members as $tEEm => $members) {
+                echo '
+            <h3 class="wp-people-group">' . $tEEm . '</h3>
+            <ul class="ee-card-grid ee-card-grid-4-cols" id="' . sanitize_key($tEEm) . '">';
+                foreach ($members as $id => $person) {
+                    echo espressoPerson($id, $person['email'], $person['name'], $person['desc']);
+                }
+                echo '
+            </ul>';
+            }
+            ?>
+        </div>
+
+        <h3 class="wp-people-group"><?php esc_html_e('Contributor Recognition', 'event_espresso'); ?></h3>
+        <p class="description">
+            <?php
+            printf(
+                esc_html__(
+                    'For every major release we want to recognize the people who contributed to the release via a GitHub pull request. Want to see your name listed here? %sWhen you submit a pull request that gets included in a major release%s, we\'ll add your name here linked to your GitHub profile.',
+                    'event_espresso'
+                ),
+                '<a href="https://github.com/eventespresso/event-espresso-core" title="Contribute to Event Espresso by making a pull request via GitHub" target="_blank">',
+                '</a>'
+            );
+            ?>
+        </p>
+        <p class="wp-credits-list">
+        <ul>
+            <li><a href="https://github.com/Veraxus" target='_blank'>Matt Van Andel</a></li>
+            <li><a href="https://github.com/jonathan-dejong" target='_blank'>Jonathan de Jong</a></li>
+            <li><a href="https://github.com/richardtape" target='_blank'>Richard Tape</a></li>
+            <li><a href="https://github.com/robert-osborne" target='_blank'>Robert Osborne</a></li>
+            <li><a href="https://github.com/rgunawans" target='_blank'>Robby Gunawan Sutanto</a></li>
+        </ul>
+
+        </p>
+        <h3 class="wp-people-group"><?php esc_html_e('External Libraries', 'event_espresso'); ?></h3>
+        <p class="description">
+            <?php
+            printf(
+                esc_html__(
+                    'Along with the libraries %sincluded with WordPress%s, Event Espresso utilizes the following third party libraries:',
+                    'event_espresso'
+                ),
+                '<a href="credits.php">',
+                '</a>'
+            );
+            ?>
+        </p>
+        <p class="wp-credits-list">
+            <a href="https://openexchangerates.github.io/accounting.js/" target='_blank'>accounting.js</a>,
+            <a href="https://dompdf.github.io/" target='_blank'>dompdf</a>,
+            <a href="https://zurb.com/playground/jquery-joyride-feature-tour-plugin" target='_blank'>joyride2</a>,
+            <a href="https://kint-php.github.io/kint/" target='_blank'>Kint</a>,
+            <a href="https://momentjs.com/" target='_blank'>Moment.js</a>,
+            <a href="https://github.com/qTip2/qTip2" target='_blank'>qTip2</a>,
+            <a href="https://trentrichardson.com/examples/timepicker/" target='_blank'>jQuery UI Timepicker</a>,
+            <a href="https://github.com/jhogendorn/jQuery-serializeFullArray" target='_blank'>SerializeFullArray</a>,
+            <a href="https://github.com/jzaefferer/jquery-validation" target='_blank'>jQuery Validation</a>
+        </p>
+
+    </div>
+</div>

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -434,7 +434,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             // template settings
             'template_settings'      => [
                 'nav'           => [
-                    'label' => esc_html__( 'Templates', 'event_espresso'),
+                    'label' => esc_html__('Templates', 'event_espresso'),
                     'icon' => 'dashicons-layout',
                     'order' => 30,
                 ],

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -266,6 +266,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'default'                => [
                 'nav'           => [
                     'label' => esc_html__('Overview', 'event_espresso'),
+                    'icon' => 'dashicons-list-view',
                     'order' => 10,
                 ],
                 'list_table'    => 'Events_Admin_List_Table',
@@ -296,6 +297,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'create_new'             => [
                 'nav'           => [
                     'label'      => esc_html__('Add New Event', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'order'      => 5,
                     'persistent' => false,
                 ],
@@ -348,6 +350,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'edit'                   => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Event', 'event_espresso'),
+                    'icon' => 'dashicons-edit',
                     'order'      => 5,
                     'persistent' => false,
                     'url'        => $post_id
@@ -405,9 +408,10 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'default_event_settings' => [
                 'nav'           => [
                     'label' => esc_html__('Default Settings', 'event_espresso'),
+                    'icon' => 'dashicons-admin-generic',
                     'order' => 40,
                 ],
-                'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),
+                'metaboxes'     => array_merge(['_publish_post_box'], $this->_default_espresso_metaboxes),
                 'labels'        => [
                     'publishbox' => esc_html__('Update Settings', 'event_espresso'),
                 ],
@@ -430,7 +434,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             // template settings
             'template_settings'      => [
                 'nav'           => [
-                    'label' => esc_html__('Templates', 'event_espresso'),
+                    'label' => esc_html__( 'Templates', 'event_espresso'),
+                    'icon' => 'dashicons-layout',
                     'order' => 30,
                 ],
                 'metaboxes'     => $this->_default_espresso_metaboxes,
@@ -446,7 +451,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'add_category'           => [
                 'nav'           => [
                     'label'      => esc_html__('Add Category', 'event_espresso'),
-                    'order'      => 15,
+                    'icon' => 'dashicons-plus-alt',
+                    'order'      => 25,
                     'persistent' => false,
                 ],
                 'help_tabs'     => [
@@ -461,7 +467,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'edit_category'          => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Category', 'event_espresso'),
-                    'order'      => 15,
+                    'icon' => 'dashicons-edit',
+                    'order'      => 25,
                     'persistent' => false,
                     'url'        => $EVT_CAT_ID
                         ? add_query_arg(
@@ -482,6 +489,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'category_list'          => [
                 'nav'           => [
                     'label' => esc_html__('Categories', 'event_espresso'),
+                    'icon' => 'dashicons-networking',
                     'order' => 20,
                 ],
                 'list_table'    => 'Event_Categories_Admin_List_Table',
@@ -509,6 +517,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             'preview_deletion'       => [
                 'nav'           => [
                     'label'      => esc_html__('Preview Deletion', 'event_espresso'),
+                    'icon' => 'dashicons-remove',
                     'order'      => 15,
                     'persistent' => false,
                     'url'        => '',

--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -298,7 +298,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 'nav'           => [
                     'label'      => esc_html__('Add New Event', 'event_espresso'),
                     'icon' => 'dashicons-plus-alt',
-                    'order'      => 5,
+                    'order'      => 15,
                     'persistent' => false,
                 ],
                 'metaboxes'     => ['_register_event_editor_meta_boxes'],
@@ -351,7 +351,7 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
                 'nav'           => [
                     'label'      => esc_html__('Edit Event', 'event_espresso'),
                     'icon' => 'dashicons-edit',
-                    'order'      => 5,
+                    'order'      => 15,
                     'persistent' => false,
                     'url'        => $post_id
                         ? EE_Admin_Page::add_query_args_and_nonce(

--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -147,6 +147,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             'critical_pages'        => [
                 'nav'           => [
                     'label' => esc_html__('Critical Pages', 'event_espresso'),
+                    'icon' => 'dashicons-warning',
                     'order' => 50,
                 ],
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),
@@ -161,6 +162,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             'default'               => [
                 'nav'           => [
                     'label' => esc_html__('Your Organization', 'event_espresso'),
+                    'icon' => 'dashicons-admin-home',
                     'order' => 20,
                 ],
                 'help_tabs'     => [
@@ -175,6 +177,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             'admin_option_settings' => [
                 'nav'           => [
                     'label' => esc_html__('Admin Options', 'event_espresso'),
+                    'icon' => 'dashicons-admin-settings',
                     'order' => 60,
                 ],
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),
@@ -189,6 +192,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             'country_settings'      => [
                 'nav'           => [
                     'label' => esc_html__('Countries', 'event_espresso'),
+                    'icon' => 'dashicons-admin-site',
                     'order' => 70,
                 ],
                 'help_tabs'     => [
@@ -202,6 +206,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             'privacy_settings'      => [
                 'nav'           => [
                     'label' => esc_html__('Privacy', 'event_espresso'),
+                    'icon' => 'dashicons-privacy',
                     'order' => 80,
                 ],
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),

--- a/admin_pages/general_settings/OrganizationSettings.php
+++ b/admin_pages/general_settings/OrganizationSettings.php
@@ -160,6 +160,7 @@ class OrganizationSettings extends FormHandler
                     'organization_city'       => new EE_Text_Input(
                         [
                             'html_name'       => 'organization_city',
+                            'html_class'      => 'ee-input-size--reg',
                             'html_label_text' => esc_html__('City', 'event_espresso'),
                             'default'         => $this->organization_config->get_pretty('city'),
                             'required'        => false,
@@ -170,6 +171,7 @@ class OrganizationSettings extends FormHandler
                         [
                             EE_Country_Select_Input::OPTION_GET_KEY => EE_Country_Select_Input::OPTION_GET_ALL,
                             'html_name'                             => 'organization_country',
+                            'html_class'                            => 'ee-input-size--reg',
                             'html_label_text'                       => esc_html__('Country', 'event_espresso'),
                             'default'                               => $this->organization_config->CNT_ISO,
                             'required'                              => false,
@@ -206,6 +208,7 @@ class OrganizationSettings extends FormHandler
                     'organization_zip'        => new EE_Text_Input(
                         [
                             'html_name'       => 'organization_zip',
+                            'html_class'      => 'ee-input-size--small',
                             'html_label_text' => esc_html__('Zip/Postal Code', 'event_espresso'),
                             'default'         => $this->organization_config->get_pretty('zip'),
                             'required'        => false,
@@ -230,6 +233,7 @@ class OrganizationSettings extends FormHandler
                     'organization_phone'      => new EE_Text_Input(
                         [
                             'html_name'       => 'organization_phone',
+                            'html_class'      => 'ee-input-size--small',
                             'html_label_text' => esc_html__('Phone Number', 'event_espresso'),
                             'html_help_text'  => esc_html__(
                                 'The phone number for your organization.',
@@ -242,6 +246,7 @@ class OrganizationSettings extends FormHandler
                     'organization_vat'        => new EE_Text_Input(
                         [
                             'html_name'       => 'organization_vat',
+                            'html_class'      => 'ee-input-size--reg',
                             'html_label_text' => esc_html__('VAT/Tax Number', 'event_espresso'),
                             'html_help_text'  => esc_html__(
                                 'The VAT/Tax Number may be displayed on invoices and receipts.',

--- a/admin_pages/general_settings/assets/organization.css
+++ b/admin_pages/general_settings/assets/organization.css
@@ -113,10 +113,15 @@
     }
 }
 
+
 #site_license_key {
-    margin-right: 10px;
+    margin-right: .5rem;
+    max-width: calc(100% - 3rem) !important;
 }
 #site_license_key + .dashicons.dashicons-admin-network {
     font-size: 2rem;
-    margin: .25rem
+    margin: .5rem .25rem 0
+}
+.espresso-admin input.ee_media_url {
+    max-width: calc(100% - 4rem) !important;
 }

--- a/admin_pages/general_settings/templates/espresso_page_settings.template.php
+++ b/admin_pages/general_settings/templates/espresso_page_settings.template.php
@@ -52,12 +52,12 @@
                         </option>
                         <?php General_Settings_Admin_Page::page_settings_dropdown($reg_page_id); // already escaped ?>
                     </select>
-                    <span>
+                    <div class="ee-page-status__wrapper">
                     <?php echo General_Settings_Admin_Page::page_and_shortcode_status(
                         $reg_page_obj,
                         '[ESPRESSO_CHECKOUT]'
                     ); // already escaped ?>
-                </span>
+                    </div>
                     <br />
                     <p class="description">
                         <?php printf(
@@ -99,12 +99,12 @@
                         </option>
                         <?php General_Settings_Admin_Page::page_settings_dropdown($txn_page_id); // already escaped ?>
                     </select>
-                    <span>
+                    <div class='ee-page-status__wrapper'>
                     <?php echo General_Settings_Admin_Page::page_and_shortcode_status(
                         $txn_page_obj,
                         '[ESPRESSO_TXN_PAGE]'
                     ); // already escaped ?>
-                </span>
+                    </div>
                     <br />
                     <p class="description">
                         <?php printf(
@@ -142,12 +142,12 @@
                         </option>
                         <?php General_Settings_Admin_Page::page_settings_dropdown($thank_you_page_id); // already escaped ?>
                     </select>
-                    <span>
+                    <div class='ee-page-status__wrapper'>
                     <?php echo General_Settings_Admin_Page::page_and_shortcode_status(
                         $thank_you_page_obj,
                         '[ESPRESSO_THANK_YOU]'
                     ); // already escaped ?>
-                </span>
+                    </div>
                     <br />
                     <p class="description">
                         <?php printf(
@@ -185,12 +185,12 @@
                         </option>
                         <?php General_Settings_Admin_Page::page_settings_dropdown($cancel_page_id); // already escaped ?>
                     </select>
-                    <span>
+                    <div class='ee-page-status__wrapper'>
                     <?php echo General_Settings_Admin_Page::page_and_shortcode_status(
                         $cancel_page_obj,
                         '[ESPRESSO_CANCELLED]'
                     ); // already escaped ?>
-                </span>
+                    </div>
                     <br />
                     <p class="description">
                         <?php printf(

--- a/admin_pages/maintenance/Maintenance_Admin_Page.core.php
+++ b/admin_pages/maintenance/Maintenance_Admin_Page.core.php
@@ -162,6 +162,7 @@ class Maintenance_Admin_Page extends EE_Admin_Page
             'default'        => [
                 'nav'           => [
                     'label' => esc_html__('Maintenance', 'event_espresso'),
+                    'icon' => 'dashicons-admin-tools',
                     'order' => 10,
                 ],
                 'require_nonce' => false,
@@ -169,6 +170,7 @@ class Maintenance_Admin_Page extends EE_Admin_Page
             'data_reset'     => [
                 'nav'           => [
                     'label' => esc_html__('Reset/Delete Data', 'event_espresso'),
+                    'icon' => 'dashicons-trash',
                     'order' => 20,
                 ],
                 'require_nonce' => false,
@@ -176,6 +178,7 @@ class Maintenance_Admin_Page extends EE_Admin_Page
             'datetime_tools' => [
                 'nav'           => [
                     'label' => esc_html__('Datetime Utilities', 'event_espresso'),
+                    'icon' => 'dashicons-calendar-alt',
                     'order' => 25,
                 ],
                 'require_nonce' => false,
@@ -183,6 +186,7 @@ class Maintenance_Admin_Page extends EE_Admin_Page
             'system_status'  => [
                 'nav'           => [
                     'label' => esc_html__("System Information", "event_espresso"),
+                    'icon' => 'dashicons-info',
                     'order' => 30,
                 ],
                 'require_nonce' => false,

--- a/admin_pages/messages/Messages_Admin_Page.core.php
+++ b/admin_pages/messages/Messages_Admin_Page.core.php
@@ -584,6 +584,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'default'                  => [
                 'nav'           => [
                     'label' => esc_html__('Message Activity', 'event_espresso'),
+                    'icon' => 'dashicons-email',
                     'order' => 10,
                 ],
                 'list_table'    => 'EE_Message_List_Table',
@@ -593,6 +594,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'global_mtps'              => [
                 'nav'           => [
                     'label' => esc_html__('Default Message Templates', 'event_espresso'),
+                    'icon' => 'dashicons-layout',
                     'order' => 20,
                 ],
                 'list_table'    => 'Messages_Template_List_Table',
@@ -627,6 +629,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'custom_mtps'              => [
                 'nav'           => [
                     'label' => esc_html__('Custom Message Templates', 'event_espresso'),
+                    'icon' => 'dashicons-admin-customizer',
                     'order' => 30,
                 ],
                 'help_tabs'     => [],
@@ -635,6 +638,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'add_new_message_template' => [
                 'nav'           => [
                     'label'      => esc_html__('Add New Message Templates', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'order'      => 5,
                     'persistent' => false,
                 ],
@@ -649,6 +653,7 @@ class Messages_Admin_Page extends EE_Admin_Page
                 ],
                 'nav'           => [
                     'label'      => esc_html__('Edit Message Templates', 'event_espresso'),
+                    'icon' => 'dashicons-edit-large',
                     'order'      => 5,
                     'persistent' => false,
                     'url'        => '',
@@ -682,6 +687,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'display_preview_message'  => [
                 'nav'           => [
                     'label'      => esc_html__('Message Preview', 'event_espresso'),
+                    'icon' => 'dashicons-visibility-bar',
                     'order'      => 5,
                     'url'        => '',
                     'persistent' => false,
@@ -697,6 +703,7 @@ class Messages_Admin_Page extends EE_Admin_Page
             'settings'                 => [
                 'nav'           => [
                     'label' => esc_html__('Settings', 'event_espresso'),
+                    'icon' => 'dashicons-admin-generic',
                     'order' => 40,
                 ],
                 'metaboxes'     => ['_messages_settings_metaboxes'],

--- a/admin_pages/messages/assets/ee_message_admin.css
+++ b/admin_pages/messages/assets/ee_message_admin.css
@@ -4,17 +4,19 @@
 }
 
 .ee-msg-admin-header {
-    display: grid;
-    grid-gap: 0;
-    grid-template-columns: 2fr 1.5fr 1.5rem var(--ee-admin-sidebar-width);
-    grid-template-areas:
-    "msg-header-1 msg-header-2 postbox-1";
-    margin-block-start: 2.25rem;
+    align-items: center;
+    display: flex;
+    flex-flow:  row wrap;
+    background: white;
+    box-sizing: border-box;
+    margin-block-end: 1rem;
+    padding: 1rem;
+    width: 100%;
 }
 
-.espresso-admin #ee-msg-edit-frm  #post-body.columns-2 #postbox-container-1 {
+/* .espresso-admin #ee-msg-edit-frm  #post-body.columns-2 #postbox-container-1 {
     margin-block-start: -5.5rem;
-}
+} */
 
 #mtp_valid_shortcodes .shortcode-field-table {
     margin-top: 12px;
@@ -59,13 +61,13 @@
 
 .ee-msg-switcher-container {
     align-items: center;
-    background: white;
     display: flex;
     flex-flow: row wrap;
-    grid-area: msg-header-2;
     margin: 0;
-    padding: 1rem 1rem 1rem 0;
     width: 100%;
+}
+.ee-msg-switcher-container select {
+    width: 16rem;
 }
 
 #mtp_valid_shortcodes .shortcode-field-table {
@@ -430,7 +432,7 @@ h4 + .ee-messages-shortcodes-chooser-wrap {
     align-items: center;
     background: white;
     display: flex;
-    grid-area: msg-header-1;
+    /* grid-area: msg-header-1; */
     padding: 1rem 0 1rem 1rem;
     --ee-switch-size: 1.5rem;
     --ee-switch-size-btn: calc(var(--ee-switch-size) * .75);

--- a/admin_pages/payments/Payments_Admin_Page.core.php
+++ b/admin_pages/payments/Payments_Admin_Page.core.php
@@ -126,6 +126,7 @@ class Payments_Admin_Page extends EE_Admin_Page
         $payment_method_list_config = array(
             'nav'           => array(
                 'label' => esc_html__('Payment Methods', 'event_espresso'),
+                'icon' => 'dashicons-bank',
                 'order' => 10,
             ),
             'metaboxes'     => $this->_default_espresso_metaboxes,
@@ -145,6 +146,7 @@ class Payments_Admin_Page extends EE_Admin_Page
             'payment_settings' => array(
                 'nav'           => array(
                     'label' => esc_html__('Settings', 'event_espresso'),
+                    'icon' => 'dashicons-admin-generic',
                     'order' => 20,
                 ),
                 'help_tabs'     => array(
@@ -159,6 +161,7 @@ class Payments_Admin_Page extends EE_Admin_Page
             'payment_log'      => array(
                 'nav'           => array(
                     'label' => esc_html__("Logs", 'event_espresso'),
+                    'icon' => 'dashicons-text-page',
                     'order' => 30,
                 ),
                 'list_table'    => 'Payment_Log_Admin_List_Table',

--- a/admin_pages/registration_form/Registration_Form_Admin_Page.core.php
+++ b/admin_pages/registration_form/Registration_Form_Admin_Page.core.php
@@ -128,7 +128,8 @@ class Registration_Form_Admin_Page extends EE_Admin_Page
         $this->_page_config = [
             'default' => [
                 'nav'           => [
-                    'label' => esc_html__('Questions', 'event_espresso'),
+                    'label' =>  esc_html__('Questions', 'event_espresso'),
+                    'icon' => 'dashicons-editor-help',
                     'order' => 10,
                 ],
                 'list_table'    => 'Registration_Form_Questions_Admin_List_Table',
@@ -152,7 +153,8 @@ class Registration_Form_Admin_Page extends EE_Admin_Page
 
             'question_groups' => [
                 'nav'           => [
-                    'label' => esc_html__('Question Groups', 'event_espresso'),
+                    'label' =>  esc_html__('Question Groups', 'event_espresso'),
+                    'icon' => 'dashicons-forms',
                     'order' => 20,
                 ],
                 'metaboxes'     => $this->_default_espresso_metaboxes,
@@ -168,6 +170,7 @@ class Registration_Form_Admin_Page extends EE_Admin_Page
             'edit_question' => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Question', 'event_espresso'),
+                    'icon' => 'dashicons-edit-large',
                     'order'      => 15,
                     'persistent' => false,
                     'url'        => isset($this->_req_data['question_id'])

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -547,6 +547,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'default'           => [
                 'nav'           => [
                     'label' => esc_html__('Overview', 'event_espresso'),
+                    'icon' => 'dashicons-list-view',
                     'order' => 5,
                 ],
                 'help_tabs'     => [
@@ -577,6 +578,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'view_registration' => [
                 'nav'           => [
                     'label'      => esc_html__('REG Details', 'event_espresso'),
+                    'icon' => 'dashicons-clipboard',
                     'order'      => 15,
                     'url'        => $REG_ID
                         ? add_query_arg(['_REG_ID' => $REG_ID], $this->_current_page_view_url)
@@ -610,6 +612,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'new_registration'  => [
                 'nav'           => [
                     'label'      => esc_html__('Add New Registration', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'url'        => '#',
                     'order'      => 15,
                     'persistent' => false,
@@ -623,6 +626,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'add_new_attendee'  => [
                 'nav'           => [
                     'label'      => esc_html__('Add Contact', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'order'      => 15,
                     'persistent' => false,
                 ],
@@ -635,6 +639,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'edit_attendee'     => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Contact', 'event_espresso'),
+                    'icon' => 'dashicons-edit-large',
                     'order'      => 15,
                     'persistent' => false,
                     'url'        => $ATT_ID
@@ -650,6 +655,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             'contact_list'      => [
                 'nav'           => [
                     'label' => esc_html__('Contact List', 'event_espresso'),
+                    'icon' => 'dashicons-id-alt',
                     'order' => 20,
                 ],
                 'list_table'    => 'EE_Attendee_Contact_List_Table',
@@ -1170,7 +1176,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             $filter_header_decorator = $this->loader->getNew($admin_page_header_decorator);
             $header_text = $filter_header_decorator->getHeaderText($header_text);
         }
-        $this->_template_args['admin_page_header'] = $header_text;
+        $this->_template_args['before_list_table']  = $header_text;
         $this->_template_args['after_list_table']  = $this->_display_legend($this->_registration_legend_items());
         $this->display_admin_list_table_page_with_no_sidebar();
     }

--- a/admin_pages/support/Support_Admin_Page.core.php
+++ b/admin_pages/support/Support_Admin_Page.core.php
@@ -57,6 +57,7 @@ class Support_Admin_Page extends EE_Admin_Page
             'default'    => array(
                 'nav'           => array(
                     'label' => esc_html__('Support', 'event_espresso'),
+                    'icon' => 'dashicons-sos',
                     'order' => 30,
                 ),
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, array('_support_boxes')),
@@ -65,6 +66,7 @@ class Support_Admin_Page extends EE_Admin_Page
             'developers' => array(
                 'nav'           => array(
                     'label' => esc_html__('Developers', 'event_espresso'),
+                    'icon' => 'dashicons-coffee',
                     'order' => 50,
                 ),
                 'metaboxes'     => $this->_default_espresso_metaboxes,
@@ -73,6 +75,7 @@ class Support_Admin_Page extends EE_Admin_Page
             'shortcodes' => array(
                 'nav'           => array(
                     'label' => esc_html__('Shortcodes', 'event_espresso'),
+                    'icon' => 'dashicons-shortcode',
                     'order' => 60,
                 ),
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, array('_shortcodes_boxes')),

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -154,6 +154,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
             'default'          => [
                 'nav'           => [
                     'label' => esc_html__('Overview', 'event_espresso'),
+                    'icon' => 'dashicons-list-view',
                     'order' => 10,
                 ],
                 'list_table'    => 'EE_Admin_Transactions_List_Table',
@@ -176,6 +177,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
             'view_transaction' => [
                 'nav'       => [
                     'label'      => esc_html__('View Transaction', 'event_espresso'),
+                    'icon' => 'dashicons-cart',
                     'order'      => 5,
                     'url'        => $TXN_ID
                         ? add_query_arg(['TXN_ID' => $TXN_ID], $this->_current_page_view_url)

--- a/admin_pages/venues/Venues_Admin_Page.core.php
+++ b/admin_pages/venues/Venues_Admin_Page.core.php
@@ -225,6 +225,7 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'default'             => [
                 'nav'           => [
                     'label' => esc_html__('Overview', 'event_espresso'),
+                    'icon' => 'dashicons-list-view',
                     'order' => 10,
                 ],
                 'list_table'    => 'Venues_Admin_List_Table',
@@ -248,7 +249,8 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'create_new'          => [
                 'nav'           => [
                     'label'      => esc_html__('Add Venue', 'event_espresso'),
-                    'order'      => 5,
+                    'icon' => 'dashicons-plus-alt',
+                    'order'      => 15,
                     'persistent' => false,
                 ],
                 'help_tabs'     => [
@@ -286,7 +288,8 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'edit'                => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Venue', 'event_espresso'),
-                    'order'      => 5,
+                    'icon' => 'dashicons-edit-large',
+                    'order'      => 15,
                     'persistent' => false,
                     'url'        => $VNU_ID
                         ? add_query_arg(['post' => $VNU_ID], $this->_current_page_view_url)
@@ -327,6 +330,7 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'google_map_settings' => [
                 'nav'           => [
                     'label' => esc_html__('Google Maps', 'event_espresso'),
+                    'icon' => 'dashicons-location-alt',
                     'order' => 40,
                 ],
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),
@@ -342,7 +346,8 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'add_category'        => [
                 'nav'           => [
                     'label'      => esc_html__('Add Category', 'event_espresso'),
-                    'order'      => 15,
+                    'icon' => 'dashicons-plus-alt',
+                    'order'      => 25,
                     'persistent' => false,
                 ],
                 'metaboxes'     => ['_publish_post_box'],
@@ -357,7 +362,8 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'edit_category'       => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Category', 'event_espresso'),
-                    'order'      => 15,
+                    'icon' => 'dashicons-edit-large',
+                    'order'      => 25,
                     'persistent' => false,
                     'url'        => $EVT_CAT_ID
                         ? add_query_arg(['EVT_CAT_ID' => $EVT_CAT_ID], $this->_current_page_view_url)
@@ -375,6 +381,7 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
             'category_list'       => [
                 'nav'           => [
                     'label' => esc_html__('Categories', 'event_espresso'),
+                    'icon' => 'dashicons-networking',
                     'order' => 20,
                 ],
                 'list_table'    => 'Venue_Categories_Admin_List_Table',

--- a/caffeinated/admin/extend/about/Extend_About_Admin_Page.core.php
+++ b/caffeinated/admin/extend/about/Extend_About_Admin_Page.core.php
@@ -63,6 +63,7 @@ class Extend_About_Admin_Page extends About_Admin_Page
             'default'  => array(
                 'nav'           => array(
                     'label' => esc_html__('What\'s New', 'event_espresso'),
+                    'icon' => 'dashicons-bell',
                     'order' => 10,
                 ),
                 'require_nonce' => false,
@@ -70,6 +71,7 @@ class Extend_About_Admin_Page extends About_Admin_Page
             'overview' => array(
                 'nav'           => array(
                     'label' => esc_html__('About', 'event_espresso'),
+                    'icon' => 'dashicons-info',
                     'order' => 20,
                 ),
                 'require_nonce' => false,
@@ -77,6 +79,7 @@ class Extend_About_Admin_Page extends About_Admin_Page
             'credits'  => array(
                 'nav'           => array(
                     'label' => esc_html__('Credits', 'event_espresso'),
+                    'icon' => 'dashicons-thumbs-up',
                     'order' => 30,
                 ),
                 'require_nonce' => false,
@@ -90,6 +93,7 @@ class Extend_About_Admin_Page extends About_Admin_Page
             'reviews'  => array(
                 'nav'           => array(
                     'label' => esc_html__('Reviews', 'event_espresso'),
+                    'icon' => 'dashicons-star-filled',
                     'order' => 50,
                 ),
                 'require_nonce' => false,

--- a/caffeinated/admin/extend/about/templates/ee4-overview.template.php
+++ b/caffeinated/admin/extend/about/templates/ee4-overview.template.php
@@ -1,218 +1,254 @@
-<div class="headline-feature">
-    <h2 class="about-headline-callout"><?php esc_html_e('Welcome to Event Espresso 4!', 'event_espresso'); ?></h2>
-    <p>
-        <?php printf(
-            esc_html__(
-                'Manage your events from your WordPress dashboard. Reduce your admin, reduce your costs, make your life easier! This is the Caffeinated/Regular version of Event Espresso, but we also have a hosted version called %sEvent Smart%s for customers that want to cut back on their hosting and security expenses.',
-                'event_espresso'
-            ),
-            '<a href="https://eventsmart.com//?utm_source=ee4_decaf&amp;utm_medium=link&amp;utm_campaign=espresso_about_tab&amp;utm_content=EE4+Caffeinated">',
-            '</a>'
-        ); ?>
-    </p>
-    <h2>
-        <?php esc_html_e(
-            'Powering 40,000+ event websites; $100 million in ticket sales per year!',
-            'event_espresso'
-        ); ?>
-    </h2>
-    <p>
-        <?php printf(
-            esc_html__(
-                'Event Espresso is a %sWordPress event manager%s which makes it easy for you to register attendees for classes, workshops, events, trainings, conferences or concerts, all from your WordPress website. Event Espresso events are created from the WordPress admin area. You can create signup forms to collect information about your attendees, accept payments, and create reports. The lite version of the plugin provides everything that you need to manage your event using WordPress.',
-                'event_espresso'
-            ),
-            '<a href="https://eventespresso.com/?utm_source=wordpress_org&amp;utm_medium=link&amp;utm_campaign=espresso_about_tab&amp;utm_content=EE4+Decaf" rel="nofollow">',
-            '</a>'
-        ); ?>
-    </p>
-</div>
-<div class="feature-section has-3-columns is-fullwidth three-col">
-    <div class="column col">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('publish_meta_box'); ?>">
-        <h3><?php esc_html_e('Optimized aesthetic', 'event_espresso'); ?></h3>
-        <p>
+<div class='ee-admin-container'>
+    <div class='padding'>
+        <div class="headline-feature">
+            <h2 class="about-headline-callout"><?php
+                esc_html_e('Welcome to Event Espresso 4!', 'event_espresso'); ?></h2>
+            <p>
+                <?php
+                printf(
+                    esc_html__(
+                        'Manage your events from your WordPress dashboard. Reduce your admin, reduce your costs, make your life easier! This is the Caffeinated/Regular version of Event Espresso, but we also have a hosted version called %sEvent Smart%s for customers that want to cut back on their hosting and security expenses.',
+                        'event_espresso'
+                    ),
+                    '<a href="https://eventsmart.com//?utm_source=ee4_decaf&amp;utm_medium=link&amp;utm_campaign=espresso_about_tab&amp;utm_content=EE4+Caffeinated">',
+                    '</a>'
+                ); ?>
+            </p>
+            <h2>
+                <?php
+                esc_html_e(
+                    'Powering 40,000+ event websites; $100 million in ticket sales per year!',
+                    'event_espresso'
+                ); ?>
+            </h2>
+            <p>
+                <?php
+                printf(
+                    esc_html__(
+                        'Event Espresso is a %sWordPress event manager%s which makes it easy for you to register attendees for classes, workshops, events, trainings, conferences or concerts, all from your WordPress website. Event Espresso events are created from the WordPress admin area. You can create signup forms to collect information about your attendees, accept payments, and create reports. The lite version of the plugin provides everything that you need to manage your event using WordPress.',
+                        'event_espresso'
+                    ),
+                    '<a href="https://eventespresso.com/?utm_source=wordpress_org&amp;utm_medium=link&amp;utm_campaign=espresso_about_tab&amp;utm_content=EE4+Decaf" rel="nofollow">',
+                    '</a>'
+                ); ?>
+            </p>
+        </div>
+        <div class="feature-section has-3-columns is-fullwidth three-col">
+            <div class="column col">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('publish_meta_box'); ?>">
+                <h3><?php
+                    esc_html_e('Optimized aesthetic', 'event_espresso'); ?></h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'The Event Espresso 4 dashboard has a fresh, uncluttered design that embraces clarity and simplicity.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('registrations-overview'); ?>">
+                <h3><?php
+                    esc_html_e('Integrated management', 'event_espresso'); ?></h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'We’ve made it easier to know who your customers are and how they’ve done business with you over time.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col last-feature">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('refined-bookkeeping'); ?>">
+                <h3><?php
+                    esc_html_e('Easy bookkeeping', 'event_espresso'); ?></h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Registrations, payment, and transactions have been substantially improved in Event Espresso 4.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="feature-section has-2-columns is-fullwidth two-col">
+            <div class="column col">
+                <h3><?php
+                    esc_html_e('Higher customer retention', 'event_espresso'); ?></h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'The Event Espresso 4 registration process is faster than ever. With quick ticket selections, single page check-out, and customizable notifications! Registration that can scale to your business needs.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+                <h4><?php
+                    esc_html_e('Ticket selection boxes on any post page or post', 'event_espresso'); ?></h4>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Customers can easily register for classes, events, or conferences, in just a few simple steps. No matter how you use it, Event Espresso 4 will adapt to a multitude of different ticketing and pricing scenarios.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col last-feature about-colors-img">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('registration-page-large'); ?>">
+            </div>
+        </div>
+
+        <div class="feature-section has-2-columns is-fullwidth two-col">
+            <div class="column col">
+                <h3><?php
+                    esc_html_e('Refined event management', 'event_espresso'); ?></h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'The new event management screen lets you survey your events at a glance. Want more information? Click to view more. Quickly add/edit prices, dates, or information in any event.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+                <h4><?php
+                    esc_html_e('Smoother price types, taxes, and price modifiers', 'event_espresso'); ?></h4>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Price Types allow you to create new prices that adjust the default ticket (base) price for your system-default ticket',
+                        'event_espresso'
+                    ); ?>.
+                </p>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Easily categorize a price modifier and indicate how that price gets applied to the running total when a transaction occurs.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col last-feature about-themes-img">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('event-management'); ?>">
+            </div>
+        </div>
+
+        <hr>
+
+        <h2 class="about-headline-callout">
             <?php
             esc_html_e(
-                'The Event Espresso 4 dashboard has a fresh, uncluttered design that embraces clarity and simplicity.',
+                'People Like You Manage Event Registration with WordPress',
                 'event_espresso'
             ); ?>
-        </p>
-    </div>
-    <div class="column col">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('registrations-overview'); ?>">
-        <h3><?php esc_html_e('Integrated management', 'event_espresso'); ?></h3>
-        <p>
-            <?php esc_html_e(
-                'We’ve made it easier to know who your customers are and how they’ve done business with you over time.',
-                'event_espresso'
-            ); ?>
-        </p>
-    </div>
-    <div class="column col last-feature">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('refined-bookkeeping'); ?>">
-        <h3><?php esc_html_e('Easy bookkeeping', 'event_espresso'); ?></h3>
-        <p>
-            <?php esc_html_e(
-                'Registrations, payment, and transactions have been substantially improved in Event Espresso 4.',
-                'event_espresso'
-            ); ?>
-        </p>
-    </div>
-</div>
+        </h2>
+        <div class="feature-section has-2-columns is-fullwidth two-col">
+            <div class="column col">
+                <p>
+                    <?php
+                    printf(
+                        esc_html__(
+                            'Trusted by thousands, Event Espresso is the best WordPress event online registration and ticketing manager plugin–and the best supported with full-time support. Turn your existing blog or website into a %sfully-featured event management website%s and a new way to make money. With Event Espresso you get it all; everything from custom registration forms and emails, seating limits, multiple price options, and discount codes to printable tickets.',
+                            'event_espresso'
+                        ),
+                        '<strong>',
+                        '</strong>'
+                    ); ?>
+                </p>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Event Espresso works perfectly for classes, workshops, fundraisers, sporting, trainings, conferences, networking, religion, social, non-profit, and nearly any other type of event.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col">
+                <p>
+                    <?php
+                    printf(
+                        esc_html__(
+                            'Our online event registration software can %smake your organization more profitable and efficient%s by helping you save money on registration and ticketing fees, reduce the countless hours of time you spend manually processing registrations, create a “green” and paperless event registration process and you will be open for business to accept registrations and payment 24/7.',
+                            'event_espresso'
+                        ),
+                        '<strong>',
+                        '</strong>'
+                    ); ?>
+                </p>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'If you\'re doing event registration and ticketing any other way, then you’re wasting time and money. We offer packages and prices to fit any budget, so get started with your online event registration and ticketing management system today.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+            </div>
+        </div>
 
-<hr>
+        <div class="feature-section has-2-columns is-fullwidth two-col">
+            <div class="column col">
+                <h3>
+                    <?php
+                    esc_html_e(
+                        'Turn your blog into a complete event registration and management system',
+                        'event_espresso'
+                    ); ?>
+                </h3>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'Create a beautiful event page with ticket selection, venue details, and an integrated single page checkout system. With WordPress, Event Espresso, and Espresso Arabica 2014 (based on the "Twenty Fourteen" theme by WordPress), your events will certainly sell out faster than ever!',
+                        'event_espresso'
+                    ); ?>
+                </p>
+                <p>
+                    <?php
+                    esc_html_e(
+                        'With a striking design that does not compromise the simplicity of WordPress and Event Espresso 4, Espresso Arabica 2014 will be the best event theme on the market.',
+                        'event_espresso'
+                    ); ?>
+                </p>
+                <p>
+                    <?php
+                    echo sprintf(
+                        esc_html__('%sLearn more >>%s', 'event_espresso'),
+                        '<a href="https://eventespresso.com/wiki/setup-event-espresso-arabica-theme/">',
+                        '</a>'
+                    ); ?>
+                </p>
+            </div>
+            <div class="column col">
+                <img src="<?php
+                echo EEH_Template::getScreenshotUrl('single-event-page'); ?>">
+            </div>
+        </div>
 
-<div class="feature-section has-2-columns is-fullwidth two-col">
-    <div class="column col">
-        <h3><?php esc_html_e('Higher customer retention', 'event_espresso'); ?></h3>
-        <p>
-            <?php esc_html_e(
-                'The Event Espresso 4 registration process is faster than ever. With quick ticket selections, single page check-out, and customizable notifications! Registration that can scale to your business needs.',
-                'event_espresso'
-            ); ?>
-        </p>
-        <h4><?php esc_html_e('Ticket selection boxes on any post page or post', 'event_espresso'); ?></h4>
-        <p>
-            <?php esc_html_e(
-                'Customers can easily register for classes, events, or conferences, in just a few simple steps. No matter how you use it, Event Espresso 4 will adapt to a multitude of different ticketing and pricing scenarios.',
-                'event_espresso'
-            ); ?>
-        </p>
-    </div>
-    <div class="column col last-feature about-colors-img">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('registration-page-large'); ?>">
-    </div>
-</div>
+        <hr>
 
-<div class="feature-section has-2-columns is-fullwidth two-col">
-    <div class="column col">
-        <h3><?php esc_html_e('Refined event management', 'event_espresso'); ?></h3>
-        <p>
-            <?php esc_html_e(
-                'The new event management screen lets you survey your events at a glance. Want more information? Click to view more. Quickly add/edit prices, dates, or information in any event.',
-                'event_espresso'
-            ); ?>
-        </p>
-        <h4><?php esc_html_e('Smoother price types, taxes, and price modifiers', 'event_espresso'); ?></h4>
-        <p>
-            <?php esc_html_e(
-                'Price Types allow you to create new prices that adjust the default ticket (base) price for your system-default ticket',
-                'event_espresso'
-            ); ?>.
-        </p>
-        <p>
-            <?php esc_html_e(
-                'Easily categorize a price modifier and indicate how that price gets applied to the running total when a transaction occurs.',
-                'event_espresso'
-            ); ?>
-        </p>
-    </div>
-    <div class="column col last-feature about-themes-img">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('event-management'); ?>">
-    </div>
-</div>
-
-<hr>
-
-<h2 class="about-headline-callout">
-    <?php esc_html_e(
-        'People Like You Manage Event Registration with WordPress',
-        'event_espresso'
-    ); ?>
-</h2>
-<div class="feature-section has-2-columns is-fullwidth two-col">
-    <div class="column col">
-        <p>
-            <?php printf(
-                esc_html__(
-                    'Trusted by thousands, Event Espresso is the best WordPress event online registration and ticketing manager plugin–and the best supported with full-time support. Turn your existing blog or website into a %sfully-featured event management website%s and a new way to make money. With Event Espresso you get it all; everything from custom registration forms and emails, seating limits, multiple price options, and discount codes to printable tickets.',
-                    'event_espresso'
-                ),
-                '<strong>',
-                '</strong>'
-            ); ?>
-        </p>
-        <p>
-            <?php esc_html_e(
-                'Event Espresso works perfectly for classes, workshops, fundraisers, sporting, trainings, conferences, networking, religion, social, non-profit, and nearly any other type of event.',
-                'event_espresso'
-            ); ?>
-        </p>
-    </div>
-    <div class="column col">
-        <p>
-            <?php printf(
-                esc_html__(
-                    'Our online event registration software can %smake your organization more profitable and efficient%s by helping you save money on registration and ticketing fees, reduce the countless hours of time you spend manually processing registrations, create a “green” and paperless event registration process and you will be open for business to accept registrations and payment 24/7.',
-                    'event_espresso'
-                ),
-                '<strong>',
-                '</strong>'
-            ); ?>
-        </p>
-        <p>
+        <h2 class="about-headline-callout">
             <?php
-            esc_html_e(
-                'If you\'re doing event registration and ticketing any other way, then you’re wasting time and money. We offer packages and prices to fit any budget, so get started with your online event registration and ticketing management system today.',
-                'event_espresso'
-            ); ?>
-        </p>
+            esc_html_e('Pick a theme, any theme', 'event_espresso'); ?>
+        </h2>
+        <div class="feature-section has-1-column is-fullwidth is-wide one-col">
+            <div class="column col">
+                <p><?php
+                    esc_html_e(
+                        'We’ve made it super easy to integrate Event Espresso with almost any properly coded WordPress theme, including many of the thousands of themes available on WordPress.org. The image below shows the same Event Espresso ticketing page across three diffrent WordPress themes.',
+                        'event_espresso'
+                    ); ?></p>
+                <p>
+                    <img class="about-overview-img"
+                         src="<?php
+                         echo EEH_Template::getScreenshotUrl('multiple-themes'); ?>"
+                    />
+                </p>
+            </div>
+        </div>
     </div>
 </div>
-
-<div class="feature-section has-2-columns is-fullwidth two-col">
-    <div class="column col">
-        <h3>
-            <?php esc_html_e(
-                'Turn your blog into a complete event registration and management system',
-                'event_espresso'
-            ); ?>
-        </h3>
-        <p>
-            <?php esc_html_e(
-                'Create a beautiful event page with ticket selection, venue details, and an integrated single page checkout system. With WordPress, Event Espresso, and Espresso Arabica 2014 (based on the "Twenty Fourteen" theme by WordPress), your events will certainly sell out faster than ever!',
-                'event_espresso'
-            ); ?>
-        </p>
-        <p>
-            <?php esc_html_e(
-                'With a striking design that does not compromise the simplicity of WordPress and Event Espresso 4, Espresso Arabica 2014 will be the best event theme on the market.',
-                'event_espresso'
-            ); ?>
-        </p>
-        <p>
-            <?php echo sprintf(
-                esc_html__('%sLearn more >>%s', 'event_espresso'),
-                '<a href="https://eventespresso.com/wiki/setup-event-espresso-arabica-theme/">',
-                '</a>'
-            ); ?>
-        </p>
-    </div>
-    <div class="column col">
-        <img src="<?php echo EEH_Template::getScreenshotUrl('single-event-page'); ?>">
-    </div>
-</div>
-
-<hr>
-
-<h2 class="about-headline-callout">
-    <?php esc_html_e('Pick a theme, any theme', 'event_espresso'); ?>
-</h2>
-<div class="feature-section has-1-column is-fullwidth is-wide one-col">
-    <div class="column col">
-        <p><?php
-            esc_html_e(
-                'We’ve made it super easy to integrate Event Espresso with almost any properly coded WordPress theme, including many of the thousands of themes available on WordPress.org. The image below shows the same Event Espresso ticketing page across three diffrent WordPress themes.',
-                'event_espresso'
-            ); ?></p>
-        <p>
-            <img class="about-overview-img"
-                 src="<?php echo EEH_Template::getScreenshotUrl('multiple-themes'); ?>"
-            />
-        </p>
-    </div>
-</div>
-<hr>
-
 

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -173,9 +173,10 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
         $new_page_config['template_settings'] = [
             'nav'           => [
                 'label' => esc_html__('Templates', 'event_espresso'),
+                'icon' => 'dashicons-layout',
                 'order' => 30,
             ],
-            'metaboxes'     => array_merge($this->_default_espresso_metaboxes, ['_publish_post_box']),
+            'metaboxes'     => array_merge(['_publish_post_box'], $this->_default_espresso_metaboxes),
             'help_tabs'     => [
                 'general_settings_templates_help_tab' => [
                     'title'    => esc_html__('Templates', 'event_espresso'),

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -162,6 +162,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 'ticket_list_table' => [
                     'nav'           => [
                         'label' => esc_html__('Default Tickets', 'event_espresso'),
+                        'icon'  => 'dashicons-tickets-alt',
                         'order' => 60,
                     ],
                     'list_table'    => 'Tickets_List_Table',

--- a/caffeinated/admin/extend/messages/Extend_Messages_Admin_Page.core.php
+++ b/caffeinated/admin/extend/messages/Extend_Messages_Admin_Page.core.php
@@ -37,6 +37,7 @@ class Extend_Messages_Admin_Page extends Messages_Admin_Page
         $this->_page_config['custom_mtps'] = array(
             'nav'           => array(
                 'label' => esc_html__('Custom Message Templates', 'event_espresso'),
+                'icon' => 'dashicons-art',
                 'order' => 30,
             ),
             'list_table'    => 'Custom_Messages_Template_List_Table',

--- a/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Admin_Page.core.php
@@ -194,7 +194,7 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
 
         $new_page_config = array(
 
-            'question_groups' => array(//dashicons-editor-help
+            'question_groups' => array(
                 'nav'           => array(
                     'label' => esc_html__('Question Groups', 'event_espresso'),
                     'icon' => 'dashicons-forms',

--- a/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Admin_Page.core.php
@@ -194,9 +194,10 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
 
         $new_page_config = array(
 
-            'question_groups' => array(
+            'question_groups' => array(//dashicons-editor-help
                 'nav'           => array(
                     'label' => esc_html__('Question Groups', 'event_espresso'),
+                    'icon' => 'dashicons-forms',
                     'order' => 20,
                 ),
                 'list_table'    => 'Registration_Form_Question_Groups_Admin_List_Table',
@@ -221,7 +222,8 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
             'add_question' => array(
                 'nav'           => array(
                     'label'      => esc_html__('Add Question', 'event_espresso'),
-                    'order'      => 5,
+                    'icon' => 'dashicons-plus-alt',
+                    'order'      => 15,
                     'persistent' => false,
                 ),
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, array('_publish_post_box')),
@@ -237,7 +239,8 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
             'add_question_group' => array(
                 'nav'           => array(
                     'label'      => esc_html__('Add Question Group', 'event_espresso'),
-                    'order'      => 5,
+                    'icon' => 'dashicons-plus-alt',
+                    'order'      => 25,
                     'persistent' => false,
                 ),
                 'metaboxes'     => array_merge($this->_default_espresso_metaboxes, array('_publish_post_box')),
@@ -253,7 +256,8 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
             'edit_question_group' => array(
                 'nav'           => array(
                     'label'      => esc_html__('Edit Question Group', 'event_espresso'),
-                    'order'      => 5,
+                    'icon' => 'dashicons-edit-large',
+                    'order'      => 25,
                     'persistent' => false,
                     'url'        => isset($this->_req_data['question_group_id']) ? add_query_arg(
                         array('question_group_id' => $this->_req_data['question_group_id']),
@@ -273,6 +277,7 @@ class Extend_Registration_Form_Admin_Page extends Registration_Form_Admin_Page
             'view_reg_form_settings' => array(
                 'nav'           => array(
                     'label' => esc_html__('Reg Form Settings', 'event_espresso'),
+                    'icon' => 'dashicons-admin-generic',
                     'order' => 40,
                 ),
                 'labels'        => array(

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -98,6 +98,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             'reports'               => array(
                 'nav'           => array(
                     'label' => esc_html__('Reports', 'event_espresso'),
+                    'icon' => 'dashicons-chart-bar',
                     'order' => 30,
                 ),
                 'help_tabs'     => array(
@@ -111,6 +112,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             'event_registrations'   => array(
                 'nav'           => array(
                     'label'      => esc_html__('Event Check-In', 'event_espresso'),
+                    'icon' => 'dashicons-yes-alt',
                     'order'      => 10,
                     'persistent' => true,
                 ),
@@ -143,6 +145,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             'registration_checkins' => array(
                 'nav'           => array(
                     'label'      => esc_html__('Check-In Records', 'event_espresso'),
+                    'icon' => 'dashicons-list-view',
                     'order'      => 15,
                     'persistent' => false,
                     'url'        => '',

--- a/caffeinated/admin/extend/support/Extend_Support_Admin_Page.core.php
+++ b/caffeinated/admin/extend/support/Extend_Support_Admin_Page.core.php
@@ -33,6 +33,7 @@ class Extend_Support_Admin_Page extends Support_Admin_Page
             'faq' => array(
                 'nav'           => array(
                     'label' => esc_html__('FAQ', 'event_espresso'),
+                    'icon' => 'dashicons-editor-help',
                     'order' => 40,
                 ),
                 'metaboxes'     => array('_espresso_news_post_box', '_espresso_links_post_box'),

--- a/caffeinated/admin/extend/transactions/Extend_Transactions_Admin_Page.core.php
+++ b/caffeinated/admin/extend/transactions/Extend_Transactions_Admin_Page.core.php
@@ -61,6 +61,7 @@ class Extend_Transactions_Admin_Page extends Transactions_Admin_Page
             'reports' => array(
                 'nav'           => array(
                     'label' => esc_html__('Reports', 'event_espresso'),
+                    'icon' => 'dashicons-chart-bar',
                     'order' => 20,
                 ),
                 'help_tabs'     => array(

--- a/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
+++ b/caffeinated/admin/new/pricing/Pricing_Admin_Page.core.php
@@ -58,24 +58,24 @@ class Pricing_Admin_Page extends EE_Admin_Page
             ],
             'add_new_price'               => [
                 'func'       => '_edit_price_details',
-                'args'       => ['new_price' => true],
+                // 'args'       => ['new_price' => true],
                 'capability' => 'ee_edit_default_prices',
             ],
             'edit_price'                  => [
                 'func'       => '_edit_price_details',
-                'args'       => ['new_price' => false],
+                // 'args'       => ['new_price' => false],
                 'capability' => 'ee_edit_default_price',
                 'obj_id'     => $PRC_ID,
             ],
             'insert_price'                => [
                 'func'       => '_insert_or_update_price',
-                'args'       => ['new_price' => true],
+                'args'       => ['insert' => true],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_prices',
             ],
             'update_price'                => [
                 'func'       => '_insert_or_update_price',
-                'args'       => ['new_price' => false],
+                'args'       => ['insert' => false],
                 'noheader'   => true,
                 'capability' => 'ee_edit_default_price',
                 'obj_id'     => $PRC_ID,
@@ -172,6 +172,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'default'            => [
                 'nav'           => [
                     'label' => esc_html__('Default Pricing', 'event_espresso'),
+                    'icon' => 'dashicons-money-alt',
                     'order' => 10,
                 ],
                 'list_table'    => 'Prices_List_Table',
@@ -195,6 +196,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'add_new_price'      => [
                 'nav'           => [
                     'label'      => esc_html__('Add New Default Price', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'order'      => 20,
                     'persistent' => false,
                 ],
@@ -213,6 +215,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'edit_price'         => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Default Price', 'event_espresso'),
+                    'icon' => 'dashicons-edit-large',
                     'order'      => 20,
                     'url'        => $PRC_ID
                         ? add_query_arg(['id' => $PRC_ID], $this->_current_page_view_url)
@@ -234,6 +237,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'price_types'        => [
                 'nav'           => [
                     'label' => esc_html__('Price Types', 'event_espresso'),
+                    'icon' => 'dashicons-networking',
                     'order' => 30,
                 ],
                 'list_table'    => 'Price_Types_List_Table',
@@ -257,6 +261,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'add_new_price_type' => [
                 'nav'           => [
                     'label'      => esc_html__('Add New Price Type', 'event_espresso'),
+                    'icon' => 'dashicons-plus-alt',
                     'order'      => 40,
                     'persistent' => false,
                 ],
@@ -275,6 +280,7 @@ class Pricing_Admin_Page extends EE_Admin_Page
             'edit_price_type'    => [
                 'nav'           => [
                     'label'      => esc_html__('Edit Price Type', 'event_espresso'),
+                    'icon' => 'dashicons-edit-large',
                     'order'      => 40,
                     'persistent' => false,
                 ],
@@ -291,9 +297,10 @@ class Pricing_Admin_Page extends EE_Admin_Page
                 'require_nonce' => false,
             ],
             'tax_settings'       => [
-                'nav'           => [
+                'nav' => [
                     'label' => esc_html__('Tax Settings', 'event_espresso'),
-                    'order' => 40,
+                    'icon' => 'dashicons-sticky',
+                    'order' => 50,
                 ],
                 'labels'        => [
                     'publishbox' => esc_html__('Update Tax Settings', 'event_espresso'),

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1475,9 +1475,9 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
 
             $this->_nav_tabs[ $slug ] = [
                 'url'       => $config['nav']['url'] ?? EE_Admin_Page::add_query_args_and_nonce(
-                        ['action' => $slug],
-                        $this->_admin_base_url
-                    ),
+                    ['action' => $slug],
+                    $this->_admin_base_url
+                ),
                 'link_text' => $this->navTabLabel($config['nav'], $slug),
                 'css_class' => $this->_req_action === $slug ? $css_class . ' nav-tab-active' : $css_class,
                 'order'     => $config['nav']['order'] ?? $i,

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1454,8 +1454,8 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
      */
     protected function _set_nav_tabs()
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
         $i = 0;
+        $only_tab = count($this->_page_config) < 2;
         foreach ($this->_page_config as $slug => $config) {
             if (! is_array($config) || empty($config['nav'])) {
                 continue;
@@ -1470,21 +1470,17 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
                 // no nav tab because current user does not have access.
                 continue;
             }
-            $css_class                = isset($config['css_class']) ? $config['css_class'] . ' ' : '';
+            $css_class = isset($config['css_class']) ? $config['css_class'] . ' ' : '';
+            $css_class .= $only_tab ? ' ee-only-tab' : '';
+
             $this->_nav_tabs[ $slug ] = [
-                'url'       => isset($config['nav']['url'])
-                    ? $config['nav']['url']
-                    : EE_Admin_Page::add_query_args_and_nonce(
+                'url'       => $config['nav']['url'] ?? EE_Admin_Page::add_query_args_and_nonce(
                         ['action' => $slug],
                         $this->_admin_base_url
                     ),
-                'link_text' => isset($config['nav']['label'])
-                    ? $config['nav']['label']
-                    : ucwords(
-                        str_replace('_', ' ', $slug)
-                    ),
-                'css_class' => $this->_req_action === $slug ? $css_class . 'nav-tab-active' : $css_class,
-                'order'     => isset($config['nav']['order']) ? $config['nav']['order'] : $i,
+                'link_text' => $this->navTabLabel($config['nav'], $slug),
+                'css_class' => $this->_req_action === $slug ? $css_class . ' nav-tab-active' : $css_class,
+                'order'     => $config['nav']['order'] ?? $i,
             ];
             $i++;
         }
@@ -1501,6 +1497,18 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         usort($this->_nav_tabs, [$this, '_sort_nav_tabs']);
     }
 
+
+    private function navTabLabel(array $nav_tab, string $slug): string
+    {
+        $label = $nav_tab['label'] ?? ucwords(str_replace('_', ' ', $slug));
+        $icon = $nav_tab['icon'] ?? null;
+        $icon = $icon ? '<span class="dashicons ' . $icon . '"></span>' : '';
+        return '
+            <span class="ee-admin-screen-tab__label">
+                ' . $icon . '
+                <span class="ee-nav-label__text">' . $label . '</span>
+            </span>';
+    }
 
     /**
      * _set_current_labels
@@ -3189,7 +3197,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         // let's generate the html using the EEH_Tabbed_Content helper.
         // We do this here so that it's possible for child classes to add in nav tabs dynamically at the last minute
         // (rather than setting in the page_routes array)
-        return EEH_Tabbed_Content::display_admin_nav_tabs($this->_nav_tabs);
+        return EEH_Tabbed_Content::display_admin_nav_tabs($this->_nav_tabs, $this->page_slug);
     }
 
 

--- a/core/admin/assets/admin-menu-styles.css
+++ b/core/admin/assets/admin-menu-styles.css
@@ -6,6 +6,7 @@
 :root {
 
     --ee-color-white: hsl(207, 0%, 100%);
+    --ee-color-may-as-well-be-white: hsl(207, 0%, 97.5%);
     --ee-color-almost-white: hsl(207, 0%, 95%);
     --ee-color-off-white: hsl(207, 0%, 90%);
     --ee-status-color-pink: hsl(340, 100%, 70%);
@@ -187,7 +188,7 @@
 
     --ee-border-color: hsla(var(--ee-btn-secondary-hue), 2%, 70%, 1);
     --ee-border-color-table-row: hsla(var(--ee-btn-secondary-hue), 0%, 90%, 1);
-    --ee-table-row-stripe-bg: hsl(207, 25%, 98%);
+    --ee-table-row-stripe-bg: var(--ee-color-may-as-well-be-white);
 
     --ee-admin-sidebar-width: 100%;
 

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -603,7 +603,7 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
 
 
 .espresso-admin .postbox:not([style*="display: none;"]) + .postbox {
-    margin-block-start: 1rem;
+    margin-block-start: 1rem !important;
 }
 
 .post-type-espresso_events #wpcontent {

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -228,11 +228,16 @@
     }
 }
 
+.ee-page-status__wrapper {
+    display: inline-flex;
+    height: var(--ee-input-height);
+}
+
 .ee-page-status {
     border-radius: 1rem;
-    margin-inline: 1rem;
-    padding-block-start: 0.25rem;
-    padding-block-end: 0.45rem;
+    display: inline-block;
+    line-height: 2;
+    margin: .25rem;
     padding-inline: 1.5rem;
 }
 .ee-page-status strong{
@@ -241,6 +246,8 @@
 }
 
 .espresso-admin.wp-core-ui {
+    background-color: var(--ee-color-almost-white);
+    color: var(--ee-font-color);
     font-size: 100%;
 }
 .espresso-admin.wp-core-ui #wpcontent {
@@ -270,7 +277,7 @@
     }
 }
 
-
+#sample-permalink a,
 div.espresso-admin a:not(.ee-link):not(.ee-text-link):not(.nav-tab):not(.button):not(.submitdelete):not(.ee-add-on-btn):not(.add-new-h2):not(.page-title-action):not(.button-primary):not(.button-secondary) {
     border: 2px solid transparent;
     box-shadow: none !important;
@@ -281,10 +288,12 @@ div.espresso-admin a:not(.ee-link):not(.ee-text-link):not(.nav-tab):not(.button)
     padding-inline: .25rem;
     text-decoration: none;
 }
+#sample-permalink a:hover,
 div.espresso-admin  :not(.manage-column) > a:not(.ee-link):not(.ee-text-link):not(.nav-tab):not(.button):not(.submitdelete):not(.add-new-h2):not(.page-title-action):not(.button-primary):not(.button-secondary):hover {
     color: var(--ee-btn-primary-hover);
     border-color: var(--ee-btn-primary-hover);
 }
+#sample-permalink a:focus,
 div.espresso-admin :not(.manage-column) > a:not(.ee-link):not(.ee-text-link):not(.nav-tab):not(.button):not(.submitdelete):not(.add-new-h2):not(.page-title-action):not(.button-primary):not(.button-secondary):focus,
 div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not(.button--secondary):not(.ee-filter-tag__close-btn):not(.toggle-row):not(.wp-switch-editor):focus {
     color: var(--ee-btn-primary-focus);
@@ -314,20 +323,141 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
 }
 
 .espresso-admin.wp-core-ui .wrap .nav-tab-wrapper {
+    align-items: center;
+    border: none !important;
+    display: flex;
+    flex-wrap: wrap;
     margin-bottom: unset;
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab {
+    align-items: center;
+    background: var(--ee-color-off-white);
+    border: none;
+    border-top: 4px solid var(--ee-status-color-pale-grey);
+    border-bottom: 1px solid var(--ee-color-off-white);
+    box-shadow: none !important;
+    color: var(--ee-font-color-light);
+    display: flex;
+    float: none;
+    font-size: 1rem;
+    line-height: 1rem;
+    margin: 0;
+    margin-inline-end: 0.25em;
+    padding: 0.375rem 0.5rem;
+    text-decoration: none;
+    white-space: nowrap;
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab:last-child {
+    margin-inline-end: 0;
+}
+/* .espresso-admin.wp-core-ui .wrap .nav-tab-wrapper.ee-nav-tabs--5 .nav-tab,
+.espresso-admin.wp-core-ui .wrap .nav-tab-wrapper.ee-nav-tabs--6 .nav-tab {
+    font-size: .975rem;
+    line-height: .975rem;
+    margin-inline-end: 0.4em;
+    padding: 0.75rem .975rem;
+} */
+.espresso-admin.wp-core-ui .wrap .nav-tab:hover {
+    background: var(--ee-color-white);
+    border-top: 4px solid var(--ee-btn-primary);
+    border-bottom: 1px solid var(--ee-color-off-white);
+    color: var(--ee-btn-primary);
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab.nav-tab-active,
+.espresso-admin.wp-core-ui .wrap .nav-tab.nav-tab-active:hover {
+    background: var(--ee-color-white);
+    border-top: 4px solid var(--ee-btn-primary);
+    border-bottom: 1px solid var(--ee-color-white);
+    color: var(--ee-btn-primary);
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab:focus {
+    background: var(--ee-color-white);
+    border-top: 4px solid var(--ee-btn-primary-high-constrast);
+    color: var(--ee-btn-primary-high-constrast);
+}
+.espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label {
+    align-items: center;
+    display: inline-flex;
+    font-size: .85rem;
+    margin: 0;
+}
+
+.espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label .dashicons {
+    color: var(--ee-font-color-light);
+    margin-inline-end: 0.25rem;
+    font-size: 1.25rem;
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab-active  .ee-admin-screen-tab__label .dashicons {
+    color: var(--ee-btn-primary);
+}
+.espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label .dashicons.dashicons-admin-settings {
+    font-size: 1.5rem;
+    inset-inline-start: -.125rem;
+    position: relative;
+    inset-block-start:  -.125rem;
+}
+
+/* hide nav tabs on extensions page (unless there is more than one) */
+.espresso-admin.wp-core-ui .wrap .nav-tab-wrapper.ee-nav-tabs--1.ee-nav-tabs--espresso_packages {
+    display: none;
+}
+
+.espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label .ee-nav-label__text {
+    display: none;
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab:not(.nav-tab-active) .ee-admin-screen-tab__label .dashicons {
+    margin-inline-end: 0;
+}
+.espresso-admin.wp-core-ui .wrap .nav-tab-active .ee-admin-screen-tab__label .ee-nav-label__text {
+    display: inline-flex;
+}
+
+@media only screen and (min-width: 600px) {
+    .espresso-admin.wp-core-ui .wrap .nav-tab {
+        margin-inline-end: 0.5em;
+        padding: 0.75rem 1rem;
+    }
+    .espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label {
+        font-size: 1rem;
+        margin-inline-end: 0.5rem;
+    }
+    .espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label .dashicons,
+    .espresso-admin.wp-core-ui .wrap .nav-tab:not(.nav-tab-active) .ee-admin-screen-tab__label .dashicons {
+        margin-inline-end: 0.5rem;
+    }
+    .espresso-admin.wp-core-ui .wrap .ee-admin-screen-tab__label .ee-nav-label__text {
+        display: inline-flex;
+    }
+}
+
+.espresso-admin.wp-core-ui .about-wrap .point-releases {
+    background: var(--ee-color-white);
+    padding: 1rem 2rem;
+    margin-bottom: 1rem;
+    margin-top: 0 !important;
+}
+.espresso-admin.wp-core-ui .about-wrap h2 {
+    color: var(--ee-font-color);
+    font-weight: 800;
+}
+.espresso-admin.wp-core-ui .about-wrap .changelog h3 {
+    margin-top: 0 !important;
+}
+
+.espresso-admin #poststuff {
+    padding-block-start: 0 !important;
 }
 
 .espresso-admin #post-body,
 .espresso-admin #poststuff #post-body {
-    padding-block-start: 1.25rem;
+    padding-block-start: 0 !important;
     margin-inline-end: unset;
 }
 
-.espresso-admin #post-body,
+/* .espresso-admin #post-body, */
 .espresso-admin #post-body-content {
     margin-block-end: 1rem;
 }
-
 
 .espresso-admin .postbox .inside {
     margin: 0;
@@ -340,17 +470,47 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
 .espresso-admin #post-body.columns-2 #post-body-content,
 .espresso-admin #post-body.columns-2 #postbox-container-2 {
     margin: 0;
-    padding: 0;
+    /* padding: 0; */
     width: calc(100% - 1rem - var(--ee-admin-sidebar-width));
 }
 
 .espresso-admin #poststuff #post-body.columns-2 #post-body-content,
 .espresso-admin #poststuff #post-body.columns-2 #postbox-container-2 {
-    padding-block: 0;
-    padding-inline: 0;
+    margin-block-end: 1rem;
+    /* padding-block: 0;
+    padding-inline: 0; */
     width: calc(100% - 1rem - var(--ee-admin-sidebar-width));
 }
 
+
+.espresso-admin.wp-core-ui:not(.event-espresso_page_espresso_packages) #post-body-content {
+    background: var(--ee-color-white);
+    border: none;
+    border-radius: .125rem;
+    box-shadow: var(--ee-box-shadow);
+    box-sizing: border-box;
+    color: var(--ee-font-color);
+    font-size: 1rem;
+    margin: 0;
+    outline: none;
+    padding-block: .5rem;
+    padding-inline: .5rem;
+}
+
+
+@media only screen and (min-width: 600px) {
+    .espresso-admin.wp-core-ui:not(.event-espresso_page_espresso_packages) #post-body-content {
+        padding-block: .75rem;
+        padding-inline: .75rem;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
+    .espresso-admin.wp-core-ui:not(.event-espresso_page_espresso_packages) #post-body-content {
+        padding-block: 1rem;
+        padding-inline: 1rem;
+    }
+}
 
 .espresso-admin #post-body.columns-2 #post-body-content > div,
 .espresso-admin #post-body.columns-2 #postbox-container-2 > div {
@@ -426,8 +586,8 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
 }
 
 
-.ee-admin-container,
 .espresso-admin .postbox,
+:not(#post-body-content) > .ee-admin-container,
 .espresso-admin #espresso-default-admin #post-body-content > .wrap {
     background: var(--ee-color-white);
     border: none;
@@ -442,7 +602,7 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
 }
 
 
-.espresso-admin .postbox + .postbox {
+.espresso-admin .postbox:not([style*="display: none;"]) + .postbox {
     margin-block-start: 1rem;
 }
 
@@ -497,6 +657,10 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
         grid-gap: 1rem;
         width: unset;
     }
+}
+
+
+@media only screen and (max-width: 1024px) {
 
 	.wp-admin .ee-admin-container > .padding,
     .espresso-admin .ee-admin-container > .padding,
@@ -510,43 +674,39 @@ div.espresso-admin.wp-core-ui button:not(.ee-btn-base):not(.button--primary):not
     .espresso-admin #post-body.columns-2 #post-body-content > div#wp_user_settings_form,
     .espresso-admin #ee-msg-edit-frm  #post-body.columns-1 #post-body-content > div.admin-primary-mbox-dv,
     .espresso-admin #ee-msg-edit-frm  #post-body.columns-2 #post-body-content > div.admin-primary-mbox-dv {
-        padding-block: 1rem;
-        padding-inline: 1.5rem;
+        padding-block: .5rem;
+        padding-inline: .75rem;
     }
-
 }
 
-@media only screen and (max-width: 600px) {
 
+@media only screen and (max-width: 600px) {
+    .wp-admin .ee-admin-container > .padding,
+    .espresso-admin .ee-admin-container > .padding,
+    .espresso-admin #post-body .postbox .inside,
+    .espresso-admin #post-body #post-body-content > .form-table,
+    .espresso-admin #espresso-default-admin #post-body-content > .wrap,
+    .espresso-admin #post-body.columns-1 #post-body-content > .padding,
+    .espresso-admin #post-body.columns-2 #post-body-content > .padding,
+    .espresso-admin #post-body.columns-1 #postbox-container-2 > .padding,
+    .espresso-admin #post-body.columns-2 #postbox-container-2 > .padding,
+    .espresso-admin #post-body.columns-2 #post-body-content > div#wp_user_settings_form,
+    .espresso-admin #ee-msg-edit-frm  #post-body.columns-1 #post-body-content > div.admin-primary-mbox-dv,
+    .espresso-admin #ee-msg-edit-frm  #post-body.columns-2 #post-body-content > div.admin-primary-mbox-dv {
+        padding-inline: .25rem;
+    }
     .espresso-admin #post-body.columns-2 {
         display: flex;
         flex-direction: column;
         margin: 0;
         width: unset;
     }
-
-	.wp-admin .ee-admin-container > .padding,
-    .espresso-admin .ee-admin-container > .padding,
-    .espresso-admin #post-body .postbox .inside,
-    .espresso-admin #post-body #post-body-content > .form-table,
-    .espresso-admin #espresso-default-admin #post-body-content > .wrap,
-    .espresso-admin #post-body.columns-1 #post-body-content > .padding,
-    .espresso-admin #post-body.columns-2 #post-body-content > .padding,
-    .espresso-admin #post-body.columns-1 #postbox-container-2 > .padding,
-    .espresso-admin #post-body.columns-2 #postbox-container-2 > .padding,
-    .espresso-admin #post-body.columns-2 #post-body-content > div#wp_user_settings_form,
-    .espresso-admin #ee-msg-edit-frm  #post-body.columns-1 #post-body-content > div.admin-primary-mbox-dv,
-    .espresso-admin #ee-msg-edit-frm  #post-body.columns-2 #post-body-content > div.admin-primary-mbox-dv {
-        padding-inline: .5rem;
-    }
-
     .espresso-admin #espresso-default-admin {
         margin: 0;
         margin-inline-start: -5px;
         width: calc(100% + 10px);
     }
 }
-
 
 .espresso-admin #edit-slug-box,
 .espresso-admin #edit-slug-box #view-post-btn {
@@ -941,7 +1101,7 @@ table .espresso-radio-btn-options-ul .nano-lbl,
 .inside table .espresso-radio-btn-options-ul .nano-lbl {
     display: inline-block;
     width: 5.8%;
-    min-width: 66px;
+    min-width: min(66px, 100%);
     max-width: 80px;
 }
 
@@ -952,7 +1112,7 @@ table .espresso-radio-btn-options-ul .micro-lbl,
 .inside table .espresso-radio-btn-options-ul .micro-lbl {
     display: inline-block;
     width: 12%;
-    min-width: 100px;
+    min-width: min(100px, 100%);
     max-width: 120px;
 }
 
@@ -963,7 +1123,7 @@ table .espresso-radio-btn-options-ul .tiny-lbl,
 .inside table .espresso-radio-btn-options-ul .tiny-lbl {
     display: inline-block;
     width: 24.4%;
-    min-width: 200px;
+    min-width: min(200px, 100%);
     max-width: 243px;
 }
 
@@ -974,7 +1134,7 @@ table .espresso-radio-btn-options-ul .small-lbl,
 .inside table .espresso-radio-btn-options-ul .small-lbl {
     display: inline-block;
     width: 33%;
-    min-width: 162px;
+    min-width: min(162px, 100%);
     max-width: 321px;
 }
 
@@ -985,7 +1145,7 @@ table .espresso-radio-btn-options-ul .medium-lbl,
 .inside table .espresso-radio-btn-options-ul .medium-lbl {
     display: inline-block;
     width: 49%;
-    min-width: 400px;
+    min-width: min(400px, 100%);
     max-width: 486px;
     margin-block-end: 1rem;
 }
@@ -997,12 +1157,13 @@ table .espresso-radio-btn-options-ul .big-lbl,
 .inside table .espresso-radio-btn-options-ul .big-lbl {
     display: inline-block;
     width: 99%;
-    min-width: 486px;
+    min-width: min(486px, 100%);
 }
 
 #admin-page-header {
     clear: both;
-    padding: .25rem 0 0;
+    margin-block-end: 1rem;
+    padding: 0;
 }
 
 .admin-page-header-edit-lnk {
@@ -1773,20 +1934,56 @@ label.error {
     font-size: unset;
     width: 100%;
 }
+.espresso-admin .ee-admin-two-column-layout tr {
+    display: flex;
+    flex-flow: row wrap;
+}
 .espresso-admin .form-table td,
 .espresso-admin .form-table th,
 .espresso-admin .form-table td p {
     font-size: unset;
+    margin: 0;
     padding: 0;
-    padding-block: 0.75rem;
-    padding-inline: 0.75rem;
+    padding-block: 0.25rem;
+    padding-inline: 0.25rem;
     vertical-align: top;
+    width: -webkit-fill-available;
+}
+@media only screen and (min-width: 600px) {
+    .espresso-admin .form-table td,
+    .espresso-admin .form-table th,
+    .espresso-admin .form-table td p {
+        padding-block: 0.5rem;
+        padding-inline: 0.5rem;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
+    .espresso-admin .form-table td,
+    .espresso-admin .form-table th,
+    .espresso-admin .form-table td p {
+        padding-block: 0.75rem;
+        padding-inline: 0.75rem;
+    }
+}
+
+.espresso-admin .form-table td p {
     width: auto;
+}
+.espresso-admin .ee-admin-two-column-layout th,
+.espresso-admin .ee-admin-two-column-layout td {
+    min-width: clamp(16rem, 50%, 32rem);
+    max-width: clamp(32rem, 100%, 64rem);
+}
+.espresso-admin .form-table th {
+    margin-block-end: -1rem;
+    padding-block-end: 0;
 }
 .espresso-admin .form-table td p.description,
 .espresso-admin .form-table td span.description {
     background: hsl(203, 37.5%, 97.5%);
     border-radius: .25rem;
+    box-sizing: border-box;
     display: inline-block;
     margin: 0;
     margin-block: .25rem;
@@ -1806,10 +2003,10 @@ label.error {
 
     .espresso-admin .form-table th {
         padding-block-start: 1.5rem;
-        padding-block-end: 0;
+        padding-block-end: .125rem;
     }
     .espresso-admin .form-table td {
-        padding-block-start: 0;
+        padding-block-start: .125rem;
     }
 
     .espresso-admin .wp-list-table .column-primary {
@@ -2893,7 +3090,15 @@ body.espresso-admin #contextual-help-wrap strong {
 }
 
 
-.ee-card-grid.ee-credits-tEEm {
+.ee-credits-tEEm {
+    background: var(--ee-color-may-as-well-be-white);
+    padding-block-start: 2.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline: 3rem;
+    margin-block-end: 2rem;
+}
+
+.ee-credits-tEEm .ee-card-grid {
     display: flex;
     flex-flow: row wrap;
 }
@@ -2919,10 +3124,10 @@ body.espresso-admin #contextual-help-wrap strong {
 }
 
 .ee-card.ee-credits-person p a {
-    font-weight: 600;
-    margin-block-start: 1rem;
-    margin-block-end: .5rem;
-    text-decoration: none;
+    font-size: 1.15rem;
+    margin-block-start: 0.25rem;
+    margin-block-end: 0;
+    margin-inline-start: -0.5rem;
 }
 
 .ee-card.ee-credits-person p span {
@@ -2934,7 +3139,7 @@ body.espresso-admin #contextual-help-wrap strong {
 .ee-card.ee-credits-person img {
     aspect-ratio: 1;
     border-radius: 50%;
-    margin-inline-end: 1rem;
+    margin-inline-end: .5rem;
     height: 4rem;
     width: 4rem;
 }
@@ -3128,6 +3333,13 @@ body.espresso-admin #contextual-help-wrap strong {
     margin-block-end: .25rem;
 }
 
+.espresso-admin #post-body-content .ee-admin-two-column-layout tr:first-child tbody td[colspan="2"] h2 {
+    margin-block-start: 0;
+}
+.espresso-admin #post-body-content .form-table + .form-table {
+    margin-block-start: 2.5rem;
+}
+
 .espresso-admin #post-body-content .ee-admin-settings-hdr--new-feature {
     background-color: var(--ee-btn-primary);
     color: var(--ee-color-white);
@@ -3146,10 +3358,12 @@ body.espresso-admin #contextual-help-wrap strong {
     display: flex;
 }
 .ee-admin-page-nav-strip-wrap {
+    background: var(--ee-color-white);
     font-size: .9rem;
     justify-content: space-between;
     margin: 0;
-    margin-block: .75rem;
+    margin-block-end: 1rem;
+    padding: 1rem;
 }
 .ee-admin-page-nav-strip-item {
     margin-inline-start: 2rem;
@@ -3253,33 +3467,34 @@ body.espresso-admin #contextual-help-wrap strong {
 
 /* INPUTS */
 
-    .espresso-admin select.ee-input-size--tiny,
-    .espresso-admin textarea.ee-input-size--tiny,
-    .espresso-admin input.ee-input-size--tiny:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-        --ee-input-height: calc((var(--ee-button-height) * 0.71) + 1px);
-    }
+.espresso-admin select.ee-input-size--tiny,
+.espresso-admin textarea.ee-input-size--tiny,
+.espresso-admin input.ee-input-size--tiny:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+    --ee-input-height: calc((var(--ee-button-height) * 0.71) + 1px);
+}
 
-    .espresso-admin select.ee-input-size--small,
-    .espresso-admin textarea.ee-input-size--small,
-    .espresso-admin input.ee-input-size--small:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-        --ee-input-height: calc((var(--ee-button-height) * 0.89) + 1px);
-    }
+.espresso-admin select.ee-input-size--small,
+.espresso-admin textarea.ee-input-size--small,
+.espresso-admin input.ee-input-size--small:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+    --ee-input-height: calc((var(--ee-button-height) * 0.89) + 1px);
+}
 
-    .espresso-admin select.ee-input-size--reg,
-    .espresso-admin textarea.ee-input-size--reg,
-    .espresso-admin input.ee-input-size--reg:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-        --ee-input-height: calc(var(--ee-button-height) + 1px);
-    }
+.espresso-admin select.ee-input-size--reg,
+.espresso-admin textarea.ee-input-size--reg,
+.espresso-admin input.ee-input-size--reg:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+    --ee-input-height: calc(var(--ee-button-height) + 1px);
+}
 
 
-    .espresso-admin select.ee-input-size--big,
-    .espresso-admin textarea.ee-input-size--big,
-    .espresso-admin input.ee-input-size--big:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-        --ee-input-height: calc((var(--ee-button-height) * 1.78) + 1px);
-    }
+.espresso-admin select.ee-input-size--big,
+.espresso-admin textarea.ee-input-size--big,
+.espresso-admin input.ee-input-size--big:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+    --ee-input-height: calc((var(--ee-button-height) * 1.78) + 1px);
+}
 
-.espresso-admin select:not(.ee-input-base),
 .espresso-admin textarea,
+.espresso-admin select:not(.ee-input-base),
+.espresso-admin .select2-selection--single,
 .espresso-admin input:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
     align-content: center;
     align-items: center;
@@ -3298,11 +3513,13 @@ body.espresso-admin #contextual-help-wrap strong {
     justify-content: center;
     line-height: 2;
     margin: 0.25rem;
+    min-height: var(--ee-input-height);
     min-width: clamp(4rem, 50%, 16rem);
     max-width: 100%;
     outline: none !important;
     padding: 0;
-    padding-inline: var(--ee-button-height-forth);
+    padding-inline-start: var(--ee-button-height-forth);
+    padding-inline-end: calc(var(--ee-button-height) * .675);
     position: relative;
     text-align: start;
     top: 1px;
@@ -3316,37 +3533,46 @@ body.espresso-admin #contextual-help-wrap strong {
 .espresso-admin select,
 .espresso-admin textarea:not(.wp-editor-area):not(.iframe-embed-content),
 .espresso-admin input:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-    min-width: clamp(4rem, 25%, 16rem);
+    min-width: clamp(4rem, 50%, 16rem);
     max-width: clamp(24rem, 100%, 60rem);;
 }
 
-.espresso-admin select.ee-input-width--tiny,
-.espresso-admin textarea.ee-input-width--tiny,
-.espresso-admin input.ee-input-width--tiny:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-    min-width: clamp(3rem, 6.25%, 6rem);
-    max-width: clamp(6rem, 12.5%, 9rem);
-}
+@media screen and (min-width: 782px) {
+    .espresso-admin select,
+    .espresso-admin textarea:not(.wp-editor-area):not(.iframe-embed-content),
+    .espresso-admin input:not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+        min-width: clamp(8rem, 25%, 16rem);
+        max-width: clamp(16rem, 100%, 32rem);
+    }
 
-.espresso-admin select.ee-input-width--small,
-.espresso-admin textarea.ee-input-width--small,
-.espresso-admin input.ee-input-width--small:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-    min-width: clamp(4rem, 12.5%, 8rem);
-    max-width: clamp(8rem, 25%, 16rem);
-}
+    .espresso-admin select.ee-input-width--tiny,
+    .espresso-admin textarea.ee-input-width--tiny,
+    .espresso-admin input.ee-input-width--tiny:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+        min-width: clamp(3rem, 6.25%, 6rem);
+        max-width: clamp(6rem, 12.5%, 9rem);
+    }
 
-.espresso-admin select.ee-input-width--reg,
-.espresso-admin textarea.ee-input-width--reg,
-.espresso-admin input.ee-input-width--reg:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-    min-width: clamp(8rem, 25%, 16rem);
-    max-width: clamp(16rem, 50%, 32rem);
-}
+    .espresso-admin select.ee-input-width--small,
+    .espresso-admin textarea.ee-input-width--small,
+    .espresso-admin input.ee-input-width--small:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+        min-width: clamp(4rem, 12.5%, 8rem);
+        max-width: clamp(8rem, 25%, 16rem);
+    }
+
+    .espresso-admin select.ee-input-width--reg,
+    .espresso-admin textarea.ee-input-width--reg,
+    .espresso-admin input.ee-input-width--reg:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+        min-width: clamp(8rem, 25%, 16rem);
+        max-width: clamp(16rem, 50%, 32rem);
+    }
 
 
-.espresso-admin select.ee-input-width--big,
-.espresso-admin textarea.ee-input-width--big,
-.espresso-admin input.ee-input-width--big:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
-    min-width: clamp(16rem, 50%, 32rem);
-    max-width: clamp(32rem, 100%, 64rem);
+    .espresso-admin select.ee-input-width--big,
+    .espresso-admin textarea.ee-input-width--big,
+    .espresso-admin input.ee-input-width--big:not(.ee-input-base):not([type="radio"]):not([type="submit"]):not([type="button"]):not([type="checkbox"]) {
+        min-width: clamp(16rem, 50%, 32rem);
+        max-width: clamp(32rem, 100%, 64rem);
+    }
 }
 
 
@@ -3546,7 +3772,9 @@ body.espresso-admin #contextual-help-wrap strong {
     margin-block-end: -1.5rem;
 }
 .espresso-admin .wp-editor-expand #wp-content-wrap #wp-content-editor-tools {
-  border-bottom: unset;
+    background-color: unset;
+    border-bottom: unset;
+    max-width: 100%;
 }
 .espresso-admin #wp-content-wrap .wp-editor-container {
     margin-block-start: .5rem;
@@ -3595,8 +3823,16 @@ body.espresso-admin #contextual-help-wrap strong {
     border: none;
     box-shadow: none;
     margin: 0;
+    max-width: 100%;
     padding: 0;
 }
+
+.espresso-admin .mce-toolbar .mce-btn-group .mce-btn.mce-widget {
+    position: unset;
+    right: unset;
+    top: unset;
+}
+
 
 
 .espresso-admin .wp-editor-container .mce-toolbar {
@@ -3750,10 +3986,13 @@ body.espresso-admin #contextual-help-wrap strong {
 .espresso-admin.wp-core-ui .ee-list-table-actions a,
 .espresso-admin.wp-core-ui .pagination-links .button,
 .espresso-admin.wp-core-ui .button.button--icon-only,
-.espresso-admin.wp-core-ui .mce-toolbar .mce-btn button,
+/* .espresso-admin.wp-core-ui .mce-toolbar .mce-btn button, */
 .espresso-admin.wp-core-ui  #edit-slug-box .button.button-small.button--icon-only {
     aspect-ratio: 1;
-    padding: 0;
+    /* padding: 0; */
+    height: 2.5rem !important;
+    padding: 0 !important;
+    width: 2.5rem !important;
 }
 .espresso-admin.wp-core-ui .ee-list-table-actions a {
   color: var(--ee-font-color) !important;
@@ -4093,6 +4332,24 @@ body.espresso-admin #contextual-help-wrap strong {
 .espresso-admin.wp-core-ui .wp-editor-tabs button.wp-switch-editor,
 .espresso-admin.wp-core-ui .quicktags-toolbar input.button:not([type="checkbox"]):not([type="radio"]):not([type="submit"])  {
     margin-block-end: .5rem;
+}
+
+.espresso-admin.wp-core-ui .mce-toolbar .mce-ico {
+    color: var(--ee-button-text-color);
+    width: 1.8rem;
+    height: 1.8rem;
+    font-size: 1.8rem;
+}
+.espresso-admin.wp-core-ui .mce-toolbar .mce-open .mce-caret {
+    border-left-width: 9px !important;
+    border-right-width: 9px !important;
+    border-top-width: 12px !important;
+    font-size: 6rem !important;
+    margin: 0;
+    margin-block-start: 4px;
+}
+.espresso-admin.wp-core-ui .mce-toolbar .mce-btn.mce-active .mce-ico {
+    color: var(--ee-color-white);
 }
 
 @media screen and (max-width: 782px) {
@@ -4624,11 +4881,26 @@ body.espresso-admin #contextual-help-wrap strong {
     margin-inline:  0.5rem;
     min-width: 4rem;
 }
-/* .espresso-admin .tablenav select {
-    min-width: clamp(8rem, 12.5%, 16rem);
-    max-width: clamp(16rem, 25%, 32rem);
+.espresso-admin .tablenav select {
+    min-width: clamp(4rem,100%, 8rem);
+    max-width: 100%;
     width: fit-content;
-} */
+}
+@media only screen and (min-width: 600px) {
+    .espresso-admin .tablenav select {
+        min-width: clamp(4rem, 25%, 8rem);
+        max-width: clamp(16rem, 50%, 20rem);
+        width: fit-content;
+    }
+}
+@media only screen and (min-width: 1024px) {
+    .espresso-admin .tablenav select {
+        min-width: clamp(4rem, 12.5%, 8rem);
+        max-width: clamp(16rem, 25%, 20rem);
+        width: fit-content;
+    }
+}
+
 .espresso-admin .tablenav-paging-text {
     justify-content: space-evenly;
     min-width: 3rem;
@@ -5077,6 +5349,7 @@ body.espresso-admin #contextual-help-wrap strong {
     padding-block-start: 2rem;
     padding-block-end: 1rem;
     padding-inline: 1rem;
+    pointer-events: none;
     position: absolute;
     transition: opacity 250ms ease-in-out;
     z-index: 1;
@@ -5100,7 +5373,7 @@ body.espresso-admin #contextual-help-wrap strong {
     display: none;
 }
 @media screen and (max-width: 783px), screen and (min-width: 1600px) {
-    .espresso-admin .ee-modal-menu .ee-modal-menu__content.ee-admin-container {
+    .espresso-admin .ee-modal-menu:not(#post-body-content) > .ee-modal-menu__content.ee-admin-container {
         display: block;
         opacity: 1;
         background: transparent;

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -4539,7 +4539,6 @@ body.espresso-admin #contextual-help-wrap strong {
     color: var(--ee-font-color-light);
     font-size: 1rem;
     font-weight: 800;
-    /* padding-block-start: 1rem; */
 }
 
 .espresso-admin .wp-list-table.widefat thead th,
@@ -4549,12 +4548,10 @@ body.espresso-admin #contextual-help-wrap strong {
     background: var(--ee-color-almost-white);
     border-block-end: none;
     color: var(--ee-font-color-light);
-}
-.espresso-admin .wp-list-table.widefat thead th,
-.espresso-admin .wp-list-table.widefat thead td {
+    /* position: -webkit-sticky;
     position: sticky;
     top: 2rem;
-    z-index: 25;
+    z-index: 25; */
 }
 .admin-primary-mbox-tbl tfoot td,
 .admin-primary-mbox-tbl tfoot th,

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -1168,7 +1168,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * If there is no primary key on this model, $id is treated as primary key string
      *
      * @param mixed $id int or string, depending on the type of the model's primary key
-     * @return EE_Base_Class
+     * @return EE_Base_Class|mixed|null
      * @throws EE_Error
      */
     public function get_one_by_ID($id)
@@ -5526,15 +5526,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * refresh_entity_map_from_db
      * Makes sure the model object in the entity map at $id assumes the values
      * of the database (opposite of EE_base_Class::save())
      *
      * @param int|string $id
-     * @return EE_Base_Class
+     * @return EE_Base_Class|EE_Soft_Delete_Base_Class|mixed|null
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function refresh_entity_map_from_db($id)
     {

--- a/core/helpers/EEH_Tabbed_Content.helper.php
+++ b/core/helpers/EEH_Tabbed_Content.helper.php
@@ -83,7 +83,7 @@ class EEH_Tabbed_Content
      * @return string
      * @throws EE_Error
      */
-    public static function display_admin_nav_tabs($nav_tabs = [])
+    public static function display_admin_nav_tabs(array $nav_tabs = [], string $page_slug = '')
     {
         if (empty($nav_tabs)) {
             throw new EE_Error(
@@ -91,12 +91,16 @@ class EEH_Tabbed_Content
             );
         }
         $tab_content = '';
+        $tab_count = 0;
         foreach ($nav_tabs as $slug => $tab) {
+            $tab_count++;
             $tab_content .= self::tab($slug, false, $tab['link_text'], $tab['url'], $tab['css_class']);
         }
         $aria_label = esc_attr__('Secondary menu', 'event_espresso');
+        $css_class = "ee-nav-tabs--{$tab_count}";
+        $css_class .= $page_slug ? " ee-nav-tabs--$page_slug" : '';
         return "
-        <nav class='nav-tab-wrapper wp-clearfix' aria-label='{$aria_label}'>
+        <nav class='nav-tab-wrapper wp-clearfix {$css_class}' aria-label='{$aria_label}'>
             {$tab_content}
         </nav>
         ";

--- a/core/helpers/assets/ee_text_list_helper.css
+++ b/core/helpers/assets/ee_text_list_helper.css
@@ -1,20 +1,33 @@
 .ee-text-links  {
-	align-items: center;
+	/* align-items: center;
 	display: inline-flex;
 	flex-flow: row wrap;
 	justify-content: flex-start;
 	padding-block-start: 1.5rem;
-	padding-block-end: 1rem;
+	padding-block-end: 1rem; */
+	align-items: center;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+    padding-block-start: 1rem;
+    padding-block-end: 1rem;
+    padding-inline: 1.5rem;
+    background: var(--ee-color-white);
+    margin-block-start: -0.25rem;
+}
+
+#admin-page-header > .ee-text-links  {
+	margin-block-start: unset;
 }
 
 .ee-text-links .ee-text-link,
 .ee-text-links .ee-text-link-sep {
-	margin-block: .5rem;
-	margin-inline-end: 1rem;
+	margin-block: .375rem;
+	margin-inline-end: .75rem;
 }
 
 .ee-text-links .ee-text-link {
-	align-items: center;
+	/* align-items: center;
 	background-color: var(--ee-btn-secondary);
 	border-radius: 0.25rem;
 	border: 2px solid var(--ee-btn-secondary-focus);
@@ -28,10 +41,25 @@
 	padding-inline-end: 1.25rem;
 	padding-inline-start: 0.75rem;
 	text-decoration: none;
-    transition: all 200ms ease-in-out;
+    transition: all 200ms ease-in-out; */
+	align-items: center;
+    background-color: var(--ee-btn-secondary);
+    border-radius: 0.25rem;
+    color: var(--ee-font-color);
+    display: inline-flex;
+    font-size: .9rem;
+    height: 2rem;
+    justify-content: center;
+    line-height: 0;
+    outline: none !important;
+    padding-inline-end: 1.25rem;
+    padding-inline-start: 0.75rem;
+    text-decoration: none;
+    transition: all 100ms ease-in-out;
 }
 
 .ee-text-links .ee-text-link .dashicons {
+    font-size: 18px;
 	margin-inline-end: 0.5rem;
 	position: relative;
 	top: 1px;

--- a/core/libraries/form_sections/form_handlers/FormHandler.php
+++ b/core/libraries/form_sections/form_handlers/FormHandler.php
@@ -662,7 +662,7 @@ abstract class FormHandler implements FormHandlerInterface
                 )
             );
         }
-        return apply_filters(
+        return (array) apply_filters(
             'FHEE__EventEspresso_core_libraries_form_sections_form_handlers_FormHandler__process__valid_data',
             $this->form()->valid_data(),
             $this

--- a/core/libraries/form_sections/form_handlers/SequentialStepForm.php
+++ b/core/libraries/form_sections/form_handlers/SequentialStepForm.php
@@ -75,7 +75,7 @@ abstract class SequentialStepForm extends FormHandler implements SequentialStepF
      * @param string      $slug
      * @param string      $form_action
      * @param string      $form_config
-     * @param EE_Registry $registry
+     * @param EE_Registry|null $registry
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws DomainException
@@ -87,7 +87,7 @@ abstract class SequentialStepForm extends FormHandler implements SequentialStepF
         $slug,
         $form_action = '',
         $form_config = 'add_form_tags_and_submit',
-        EE_Registry $registry
+        ?EE_Registry $registry = null
     ) {
         $this->setOrder($order);
         parent::__construct($form_name, $admin_name, $slug, $form_action, $form_config, $registry);

--- a/core/libraries/form_sections/inputs/EE_Form_Input_Base.input.php
+++ b/core/libraries/form_sections/inputs/EE_Form_Input_Base.input.php
@@ -217,9 +217,7 @@ abstract class EE_Form_Input_Base extends EE_Form_Section_Validatable
         // ensure that "required" is set correctly
         $this->set_required(
             $this->_required,
-            isset($input_args['required_validation_error_message'])
-            ? $input_args['required_validation_error_message']
-            : null
+            $input_args['required_validation_error_message'] ?? null
         );
         // $this->_html_name_specified = isset( $input_args['html_name'] ) ? TRUE : FALSE;
         $this->_display_strategy->_construct_finalize($this);

--- a/core/libraries/form_sections/strategies/layout/EE_Admin_Two_Column_Layout.strategy.php
+++ b/core/libraries/form_sections/strategies/layout/EE_Admin_Two_Column_Layout.strategy.php
@@ -7,14 +7,24 @@
 class EE_Admin_Two_Column_Layout extends EE_Two_Column_Layout
 {
     /**
+     * @param EE_Form_Section_Proper $form
+     */
+    public function _construct_finalize(EE_Form_Section_Proper $form)
+    {
+        parent::_construct_finalize($form);
+        $this->_form_section->set_html_class('ee-admin-two-column-layout form-table');
+    }
+
+
+    /**
      * Overriding the parent table layout to include <tbody> tags
      *
      * @param array $additional_args
      * @return string
+     * @throws EE_Error
      */
     public function layout_form_begin($additional_args = array())
     {
-        $this->_form_section->set_html_class($this->_form_section->html_class() . ' form-table');
         return parent::layout_form_begin($additional_args);
     }
 
@@ -30,11 +40,16 @@ class EE_Admin_Two_Column_Layout extends EE_Two_Column_Layout
     public function layout_input($input)
     {
         if (
-            $input->get_display_strategy() instanceof EE_Text_Area_Display_Strategy
+            $input->get_display_strategy() instanceof EE_Select_Display_Strategy
+            || $input->get_display_strategy() instanceof EE_Text_Area_Display_Strategy
             || $input->get_display_strategy() instanceof EE_Text_Input_Display_Strategy
             || $input->get_display_strategy() instanceof EE_Admin_File_Uploader_Display_Strategy
         ) {
-            $input->set_html_class($input->html_class() . ' large-text');
+            $html_class = $input->html_class();
+            $html_class = strpos($html_class, 'ee-input-width') === false
+                ? "$html_class ee-input-width--big"
+                : $html_class;
+            $input->set_html_class($html_class);
         }
         if ($input instanceof EE_Text_Area_Input) {
             $input->set_rows(4);

--- a/core/libraries/form_sections/strategies/layout/EE_Two_Column_Layout.strategy.php
+++ b/core/libraries/form_sections/strategies/layout/EE_Two_Column_Layout.strategy.php
@@ -8,7 +8,7 @@ class EE_Two_Column_Layout extends EE_Form_Section_Layout_Base
     public function _construct_finalize(EE_Form_Section_Proper $form)
     {
         parent::_construct_finalize($form);
-        $this->_form_section->set_html_class( 'ee-two-column-layout');
+        $this->_form_section->set_html_class('ee-two-column-layout');
     }
 
 

--- a/core/libraries/form_sections/strategies/layout/EE_Two_Column_Layout.strategy.php
+++ b/core/libraries/form_sections/strategies/layout/EE_Two_Column_Layout.strategy.php
@@ -3,10 +3,21 @@
 class EE_Two_Column_Layout extends EE_Form_Section_Layout_Base
 {
     /**
+     * @param EE_Form_Section_Proper $form
+     */
+    public function _construct_finalize(EE_Form_Section_Proper $form)
+    {
+        parent::_construct_finalize($form);
+        $this->_form_section->set_html_class( 'ee-two-column-layout');
+    }
+
+
+    /**
      * Should be used to start teh form section (Eg a table tag, or a div tag, etc.)
      *
      * @param array $additional_args
      * @return string
+     * @throws EE_Error
      */
     public function layout_form_begin($additional_args = array())
     {

--- a/core/services/commands/CommandHandler.php
+++ b/core/services/commands/CommandHandler.php
@@ -24,11 +24,11 @@ abstract class CommandHandler implements CommandHandlerInterface
      * because the CommandBus utilizes method chaining.
      *
      * @param CommandInterface $command
-     * @return CommandHandler
+     * @return CommandHandlerInterface
      * @throws InvalidEntityException
      * @since 4.9.80.p
      */
-    public function verify(CommandInterface $command)
+    public function verify(CommandInterface $command): CommandHandlerInterface
     {
         $expected = str_replace('CommandHandler', 'Command', get_class($this));
         if (! $command instanceof $expected) {

--- a/core/services/commands/CommandHandlerInterface.php
+++ b/core/services/commands/CommandHandlerInterface.php
@@ -20,7 +20,7 @@ interface CommandHandlerInterface
      * @return CommandHandlerInterface
      * @since 4.9.80.p
      */
-    public function verify(CommandInterface $command);
+    public function verify(CommandInterface $command): CommandHandlerInterface;
 
     /**
      * Performs the command handler's logic.

--- a/tests/mocks/core/services/commands/MockCommandHandler.php
+++ b/tests/mocks/core/services/commands/MockCommandHandler.php
@@ -39,7 +39,7 @@ class MockCommandHandler implements CommandHandlerInterface
      * @throws InvalidEntityException
      * @since 4.9.80.p
      */
-    public function verify(CommandInterface $command)
+    public function verify(CommandInterface $command): CommandHandlerInterface
     {
         if (! $command instanceof $this->expected) {
             throw new InvalidEntityException($command, $this->expected);


### PR DESCRIPTION
These are some other UI updates for the EDTR and admin refresh that have been sitting in a branch on my local system that I wanted to move so that I don't have to keep rebasing it.

Most changes are fixes for responsive layouts, but the biggest visible change is a redesign to the editor tabs, ex:

<img width="677" alt="Screenshot 2022-06-03 105305" src="https://user-images.githubusercontent.com/1751030/171920410-29c05a6b-a35c-44d8-afc1-13671ba6315e.png">

<img width="670" alt="Screenshot 2022-06-03 105347" src="https://user-images.githubusercontent.com/1751030/171920419-4649c0b7-4df9-4328-85dd-4b55a164e3db.png">

works on older add-ons too:

<img width="410" alt="Screenshot 2022-06-03 105416" src="https://user-images.githubusercontent.com/1751030/171920460-6f2eb9a7-ee11-4aa9-a48e-001b502cfb1c.png">

although they have not been updated to show icons