### PR TITLE
Datetime Registrations Button Issue

### DIFF
--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -101,15 +101,19 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 'TXN_paid'         => esc_html__('Paid', 'event_espresso'),
                 'actions'          => esc_html__('Actions', 'event_espresso'),
             ];
-            $this->_bottom_buttons = [
-                'report' => [
-                    'route'         => 'registrations_report',
-                    'extra_request' => [
-                        'EVT_ID'     => $this->_req_data['event_id'],
-                        'return_url' => $return_url,
-                    ],
-                ],
+            $route_details = [
+                'route'         => 'registrations_report',
+                'extra_request' => [
+                    'EVT_ID'     => $this->_req_data['event_id'],
+                    'return_url' => $return_url,
+                ]
             ];
+            if (isset($req_data['datetime_id']) && $req_data['datetime_id']) {
+                $route_details['extra_request']['DTT_ID'] = $req_data['datetime_id'];
+                $this->_bottom_buttons['report_datetime'] = $route_details;
+            } else {
+                $this->_bottom_buttons['report'] = $route_details;
+            }
         } else {
             $this->_columns        = [
                 'cb'               => '<input type="checkbox" />', // Render a checkbox instead of text


### PR DESCRIPTION
Fixed an issue on not displaying datetime registrations button on Registrations -> Overview tab.
Related PR: https://github.com/eventespresso/event-espresso-core/pull/3808