### PR TITLE
Fix Registrations CSV Report Filters

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1112,7 +1112,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
 
         $cols_n_values                    = [];
         $cols_n_values['CNT_ISO3']        = strtoupper(
-            $this->request->getRequestParam('cntry', '', $country->ISO3())
+            $this->request->getRequestParam('cntry', $country->ISO3())
         );
         $cols_n_values['CNT_name']        = $this->request->getRequestParam(
             "cntry[$CNT_ISO][CNT_name]",

--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -1,5 +1,6 @@
 <?php
 
+use EventEspresso\core\domain\services\admin\registrations\list_table\csv_reports\RegistrationsCsvReportParams;
 use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -87,8 +88,11 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
         $ID_column_name      .= ' : <span class="show-on-mobile-view-only" style="float:none">';
         $ID_column_name      .= esc_html__('Registrant Name', 'event_espresso');
         $ID_column_name      .= '</span> ';
-        $req_data            = $this->_admin_page->get_request_data();
-        if (isset($req_data['event_id'])) {
+
+        $EVT_ID = $this->_req_data['event_id'] ?? 0;
+        $DTT_ID = $this->_req_data['DTT_ID'] ?? 0;
+
+        if ($EVT_ID) {
             $this->_columns        = [
                 'cb'               => '<input type="checkbox" />', // Render a checkbox instead of text
                 '_REG_ID'          => $ID_column_name,
@@ -101,19 +105,6 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 'TXN_paid'         => esc_html__('Paid', 'event_espresso'),
                 'actions'          => esc_html__('Actions', 'event_espresso'),
             ];
-            $route_details = [
-                'route'         => 'registrations_report',
-                'extra_request' => [
-                    'EVT_ID'     => $this->_req_data['event_id'],
-                    'return_url' => $return_url,
-                ]
-            ];
-            if (isset($req_data['datetime_id']) && $req_data['datetime_id']) {
-                $route_details['extra_request']['DTT_ID'] = $req_data['datetime_id'];
-                $this->_bottom_buttons['report_datetime'] = $route_details;
-            } else {
-                $this->_bottom_buttons['report'] = $route_details;
-            }
         } else {
             $this->_columns        = [
                 'cb'               => '<input type="checkbox" />', // Render a checkbox instead of text
@@ -126,15 +117,13 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 '_REG_paid'        => esc_html__('Paid', 'event_espresso'),
                 'actions'          => esc_html__('Actions', 'event_espresso'),
             ];
-            $this->_bottom_buttons = [
-                'report_all' => [
-                    'route'         => 'registrations_report',
-                    'extra_request' => [
-                        'return_url' => $return_url,
-                    ],
-                ],
-            ];
         }
+
+        $csv_report = RegistrationsCsvReportParams::getRequestParams($return_url, $this->_req_data, $EVT_ID, $DTT_ID);
+        if (! empty($csv_report)) {
+            $this->_bottom_buttons['csv_reg_report'] = $csv_report;
+        }
+
         $this->_primary_column   = '_REG_ID';
         $this->_sortable_columns = [
             '_REG_date'     => ['_REG_date' => true],   // true means its already sorted

--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -89,8 +89,8 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
         $ID_column_name      .= esc_html__('Registrant Name', 'event_espresso');
         $ID_column_name      .= '</span> ';
 
-        $EVT_ID = $this->_req_data['event_id'] ?? 0;
-        $DTT_ID = $this->_req_data['DTT_ID'] ?? 0;
+        $EVT_ID = isset($this->_req_data['event_id']) ? $this->_req_data['event_id'] : 0;
+        $DTT_ID = isset($this->_req_data['DTT_ID']) ? $this->_req_data['DTT_ID'] : 0;
 
         if ($EVT_ID) {
             $this->_columns        = [
@@ -219,6 +219,8 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
      *    _get_table_filters
      *
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_table_filters()
     {

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -226,10 +226,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                 'add-registrant'      => esc_html__('Add New Registration', 'event_espresso'),
                 'add-attendee'        => esc_html__('Add Contact', 'event_espresso'),
                 'edit'                => esc_html__('Edit Contact', 'event_espresso'),
-                'report'              => esc_html__('Event Registrations CSV Report', 'event_espresso'),
-                'report_datetime'     => esc_html__('Datetime Registrations CSV Report', 'event_espresso'),
-                'report_all'          => esc_html__('All Registrations CSV Report', 'event_espresso'),
-                'report_filtered'     => esc_html__('Filtered CSV Report', 'event_espresso'),
+                'csv_reg_report'      => esc_html__('Registrations CSV Report', 'event_espresso'),
                 'contact_list_report' => esc_html__('Contact List Report', 'event_espresso'),
                 'contact_list_export' => esc_html__('Export Data', 'event_espresso'),
             ],
@@ -3252,6 +3249,12 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
         $EVT_ID = $this->request->requestParamIsSet('EVT_ID')
             ? $this->request->getRequestParam('EVT_ID', 0, 'int')
             : null;
+        \EEH_Debug_Tools::printr(
+            $method_name_for_getting_query_params,
+            '$method_name_for_getting_query_params',
+            __FILE__,
+            __LINE__
+        );
         if (! defined('EE_USE_OLD_CSV_REPORT_CLASS')) {
             $request_params = $this->request->requestParams();
             wp_redirect(
@@ -3267,7 +3270,6 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
                                 )
                             )
                         ),
-                        'use_filters' => EEH_Array::is_set($request_params, 'use_filters', false),
                         'job_handler' => urlencode('EventEspressoBatchRequest\JobHandlers\RegistrationsReport'),
                         'return_url'  => urlencode($this->request->getRequestParam('return_url', '', 'url')),
                     ]

--- a/admin_pages/registrations/assets/espresso_registrations_admin.css
+++ b/admin_pages/registrations/assets/espresso_registrations_admin.css
@@ -584,11 +584,12 @@
     color: hsl(207deg 5% 25%);
     display: inline-flex;
     font-size: .95rem;
+    margin-inline-end: 1rem !important;
     padding: .25rem 1.5rem .375rem .5rem;
-    margin: -.125rem .5rem 0;
 }
 .csv-report-notice__wrapper .dashicons-info {
     color: hsl(207deg 65% 50%);
     font-size: 1.5rem;
     top: 1px;
 }
+

--- a/admin_pages/registrations/assets/espresso_registrations_admin.css
+++ b/admin_pages/registrations/assets/espresso_registrations_admin.css
@@ -571,3 +571,24 @@
     margin: 2em 0 1em;
     padding: 1.5em 0 0;
 }
+
+#registrations-csv-report {
+    background-color: hsl(207deg 65% 50%);
+    color: white;
+}
+
+
+.csv-report-notice__wrapper {
+    align-items: center;
+    background-color: hsl(207deg 40% 87.5%);
+    color: hsl(207deg 5% 25%);
+    display: inline-flex;
+    font-size: .95rem;
+    padding: .25rem 1.5rem .375rem .5rem;
+    margin: -.125rem .5rem 0;
+}
+.csv-report-notice__wrapper .dashicons-info {
+    color: hsl(207deg 65% 50%);
+    font-size: 1.5rem;
+    top: 1px;
+}

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -326,12 +326,11 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             $item,
             $this->_cur_dtt_id
         );
-        $nonce                   = wp_create_nonce('checkin_nonce');
-        $toggle_active           = ! empty($this->_cur_dtt_id)
-                                   && EE_Registry::instance()->CAP->current_user_can(
-            'ee_edit_checkin',
-            'espresso_registrations_toggle_checkin_status',
-            $item->ID()
+        $nonce         = wp_create_nonce('checkin_nonce');
+        $toggle_active = ! empty($this->_cur_dtt_id) && EE_Registry::instance()->CAP->current_user_can(
+           'ee_edit_checkin',
+           'espresso_registrations_toggle_checkin_status',
+           $item->ID()
         )
             ? ' clickable trigger-checkin'
             : '';
@@ -379,10 +378,10 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             : '';
         // add group details
         $name_link .= '&nbsp;' . sprintf(
-                esc_html__('(%s of %s)', 'event_espresso'),
-                $item->count(),
-                $item->group_size()
-            );
+            esc_html__('(%s of %s)', 'event_espresso'),
+            $item->count(),
+            $item->group_size()
+        );
         // add regcode
         $link      = EE_Admin_Page::add_query_args_and_nonce(
             ['action' => 'view_registration', '_REG_ID' => $item->ID()],

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -328,9 +328,9 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         );
         $nonce         = wp_create_nonce('checkin_nonce');
         $toggle_active = ! empty($this->_cur_dtt_id) && EE_Registry::instance()->CAP->current_user_can(
-           'ee_edit_checkin',
-           'espresso_registrations_toggle_checkin_status',
-           $item->ID()
+            'ee_edit_checkin',
+            'espresso_registrations_toggle_checkin_status',
+            $item->ID()
         )
             ? ' clickable trigger-checkin'
             : '';

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -13,13 +13,17 @@ use EventEspresso\ui\browser\checkins\entities\CheckinStatusDashicon;
  */
 class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
 {
+    /**
+     * @var Extend_Registrations_Admin_Page
+     */
+    protected $_admin_page;
 
     /**
      * This property will hold the related Datetimes on an event IF the event id is included in the request.
      *
      * @var EE_Datetime[]
      */
-    protected $_dtts_for_event = array();
+    protected $_dtts_for_event = [];
 
 
     /**
@@ -37,6 +41,12 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      */
     protected $_cur_dtt_id = 0;
 
+    /**
+     * @var   array
+     * @since $VID:$
+     */
+    protected $_status;
+
 
     /**
      * EE_Event_Registrations_List_Table constructor.
@@ -50,33 +60,40 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     protected function _setup_data()
     {
-        $this->_data = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees($this->_per_page)
+        $this->_data           = $this->_view !== 'trash'
+            ? $this->_admin_page->get_event_attendees($this->_per_page)
             : $this->_admin_page->get_event_attendees($this->_per_page, false, true);
-        $this->_all_data_count = $this->_view !== 'trash' ? $this->_admin_page->get_event_attendees(
-            $this->_per_page,
-            true
-        ) : $this->_admin_page->get_event_attendees($this->_per_page, true, true);
+        $this->_all_data_count = $this->_view !== 'trash'
+            ? $this->_admin_page->get_event_attendees($this->_per_page, true)
+            : $this->_admin_page->get_event_attendees($this->_per_page, true, true);
     }
 
 
+    /**
+     * @throws ReflectionException
+     * @throws EE_Error
+     */
     protected function _set_properties()
     {
         $return_url = $this->getReturnUrl();
 
-        $EVT_ID = $this->_req_data['event_id'] ?? 0;
-        $DTT_ID = $this->_req_data['DTT_ID'] ?? 0;
+        $EVT_ID = isset($this->_req_data['event_id']) ? $this->_req_data['event_id'] : 0;
+        $DTT_ID = isset($this->_req_data['DTT_ID']) ? $this->_req_data['DTT_ID'] : 0;
 
-        $this->_wp_list_args = array(
+        $this->_wp_list_args = [
             'singular' => esc_html__('registrant', 'event_espresso'),
             'plural'   => esc_html__('registrants', 'event_espresso'),
             'ajax'     => true,
             'screen'   => $this->_admin_page->get_current_screen()->id,
-        );
-        $columns = array();
+        ];
+        $columns             = [];
         // $columns['_Reg_Status'] = '';
-        $this->_columns = array(
+        $this->_columns = [
             '_REG_att_checked_in' => '<span class="dashicons dashicons-yes ee-icon-size-18"></span>',
             'ATT_name'            => esc_html__('Registrant', 'event_espresso'),
             'ATT_email'           => esc_html__('Email Address', 'event_espresso'),
@@ -85,16 +102,16 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             '_REG_final_price'    => esc_html__('Price', 'event_espresso'),
             'TXN_paid'            => esc_html__('Paid', 'event_espresso'),
             'TXN_total'           => esc_html__('Total', 'event_espresso'),
-        );
+        ];
         // Add/remove columns when an event has been selected
         if (! empty($EVT_ID)) {
             // Render a checkbox column
-            $columns['cb'] = '<input type="checkbox" />';
+            $columns['cb']              = '<input type="checkbox" />';
             $this->_has_checkbox_column = true;
             // Remove the 'Event' column
             unset($this->_columns['Event']);
         }
-        $this->_columns = array_merge($columns, $this->_columns);
+        $this->_columns        = array_merge($columns, $this->_columns);
         $this->_primary_column = '_REG_att_checked_in';
 
         $csv_report = RegistrationsCsvReportParams::getRequestParams($return_url, $this->_req_data, $EVT_ID, $DTT_ID);
@@ -102,7 +119,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             $this->_bottom_buttons['csv_reg_report'] = $csv_report;
         }
 
-        $this->_sortable_columns = array(
+        $this->_sortable_columns = [
             /**
              * Allows users to change the default sort if they wish.
              * Returning a falsey on this filter will result in the default sort to be by firstname rather than last name.
@@ -111,18 +128,18 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
              * change the sorts on any list table involving registration contacts.  If you want to only change the filter
              * for a specific list table you can use the provided reference to this object instance.
              */
-            'ATT_name' => array(
+            'ATT_name' => [
                 'FHEE__EE_Registrations_List_Table___set_properties__default_sort_by_registration_last_name',
                 true,
                 $this,
-            )
-                ? array('ATT_lname' => true)
-                : array('ATT_fname' => true),
-            'Event'    => array('Event.EVT_name' => false),
-        );
-        $this->_hidden_columns = array();
-        $this->_evt = EEM_Event::instance()->get_one_by_ID($EVT_ID);
-        $this->_dtts_for_event = $this->_evt instanceof EE_Event ? $this->_evt->datetimes_ordered() : array();
+            ]
+                ? ['ATT_lname' => true]
+                : ['ATT_fname' => true],
+            'Event'    => ['Event.EVT_name' => false],
+        ];
+        $this->_hidden_columns   = [];
+        $this->_evt              = EEM_Event::instance()->get_one_by_ID($EVT_ID);
+        $this->_dtts_for_event   = $this->_evt instanceof EE_Event ? $this->_evt->datetimes_ordered() : [];
     }
 
 
@@ -149,74 +166,75 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      */
     protected function _get_table_filters()
     {
-        $filters = $where = array();
+        $filters        = $where = [];
         $current_EVT_ID = isset($this->_req_data['event_id']) ? (int) $this->_req_data['event_id'] : 0;
         if (empty($this->_dtts_for_event) || count($this->_dtts_for_event) === 1) {
             // this means we don't have an event so let's setup a filter dropdown for all the events to select
             // note possible capability restrictions
             if (! EE_Registry::instance()->CAP->current_user_can('ee_read_private_events', 'get_events')) {
-                $where['status**'] = array('!=', 'private');
+                $where['status**'] = ['!=', 'private'];
             }
             if (! EE_Registry::instance()->CAP->current_user_can('ee_read_others_events', 'get_events')) {
                 $where['EVT_wp_user'] = get_current_user_id();
             }
-            $events = EEM_Event::instance()->get_all(
-                array(
+            $events          = EEM_Event::instance()->get_all(
+                [
                     $where,
-                    'order_by' => array('Datetime.DTT_EVT_start' => 'DESC'),
-                )
+                    'order_by' => ['Datetime.DTT_EVT_start' => 'DESC'],
+                ]
             );
-            $evts[] = array(
+            $event_options[] = [
                 'id'   => 0,
                 'text' => esc_html__('To toggle Check-in status, select an event', 'event_espresso'),
-            );
-            $checked = 'checked';
-            /** @var EE_Event $evt */
-            foreach ($events as $evt) {
+            ];
+            $checked         = 'checked';
+            /** @var EE_Event $event */
+            foreach ($events as $event) {
                 // any registrations for this event?
-                if (! $evt->get_count_of_all_registrations()) {
+                if (! $event->get_count_of_all_registrations()) {
                     continue;
                 }
-                $evts[] = array(
-                    'id'    => $evt->ID(),
+                $event_options[] = [
+                    'id'    => $event->ID(),
                     'text'  => apply_filters(
                         'FHEE__EE_Event_Registrations___get_table_filters__event_name',
-                        $evt->get('EVT_name'),
-                        $evt
+                        $event->get('EVT_name'),
+                        $event
                     ),
-                    'class' => $evt->is_expired() ? 'ee-expired-event' : '',
-                );
-                if ($evt->ID() === $current_EVT_ID && $evt->is_expired()) {
+                    'class' => $event->is_expired() ? 'ee-expired-event' : '',
+                ];
+                if ($event->ID() === $current_EVT_ID && $event->is_expired()) {
                     $checked = '';
                 }
             }
             $event_filter = '<div class="ee-event-filter">';
-            $event_filter .= EEH_Form_Fields::select_input('event_id', $evts, $current_EVT_ID);
+            $event_filter .= EEH_Form_Fields::select_input('event_id', $event_options, $current_EVT_ID);
             $event_filter .= '<span class="ee-event-filter-toggle">';
             $event_filter .= '<input type="checkbox" id="js-ee-hide-expired-events" ' . $checked . '> ';
             $event_filter .= esc_html__('Hide Expired Events', 'event_espresso');
             $event_filter .= '</span>';
             $event_filter .= '</div>';
-            $filters[] = $event_filter;
+            $filters[]    = $event_filter;
         }
         if (! empty($this->_dtts_for_event)) {
             // DTT datetimes filter
             $this->_cur_dtt_id = isset($this->_req_data['DTT_ID']) ? $this->_req_data['DTT_ID'] : 0;
             if (count($this->_dtts_for_event) > 1) {
-                $dtts[0] = esc_html__('To toggle check-in status, select a datetime.', 'event_espresso');
-                foreach ($this->_dtts_for_event as $dtt) {
-                    $datetime_string = $dtt->name();
-                    $datetime_string = ! empty($datetime_string) ? ' (' . $datetime_string . ')' : '';
-                    $datetime_string = $dtt->start_date_and_time() . ' - ' . $dtt->end_date_and_time() . $datetime_string;
-                    $dtts[ $dtt->ID() ] = $datetime_string;
+                $datetimes[0] = esc_html__('To toggle check-in status, select a datetime.', 'event_espresso');
+                foreach ($this->_dtts_for_event as $datetime) {
+                    $datetime_string              = $datetime->name();
+                    $datetime_string              = ! empty($datetime_string) ? ' (' . $datetime_string . ')' : '';
+                    $datetime_string              =
+                        $datetime->start_date_and_time() . ' - ' . $datetime->end_date_and_time() . $datetime_string;
+                    $datetimes[ $datetime->ID() ] = $datetime_string;
                 }
-                $input = new EE_Select_Input(
-                    $dtts,
-                    array(
+                $input     = new EE_Select_Input(
+                    $datetimes,
+                    [
                         'html_name' => 'DTT_ID',
                         'html_id'   => 'DTT_ID',
                         'default'   => $this->_cur_dtt_id,
-                    )
+                    ]
                 );
                 $filters[] = $input->get_html_for_input();
                 $filters[] = '<input type="hidden" name="event_id" value="' . $current_EVT_ID . '">';
@@ -226,6 +244,9 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     protected function _add_view_counts()
     {
         $this->_views['all']['count'] = $this->_get_total_event_attendees();
@@ -238,9 +259,9 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      */
     protected function _get_total_event_attendees()
     {
-        $EVT_ID = isset($this->_req_data['event_id']) ? absint($this->_req_data['event_id']) : false;
-        $DTT_ID = $this->_cur_dtt_id;
-        $query_params = array();
+        $EVT_ID       = isset($this->_req_data['event_id']) ? absint($this->_req_data['event_id']) : false;
+        $DTT_ID       = $this->_cur_dtt_id;
+        $query_params = [];
         if ($EVT_ID) {
             $query_params[0]['EVT_ID'] = $EVT_ID;
         }
@@ -248,11 +269,11 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         if ($DTT_ID) {
             $query_params[0]['Ticket.Datetime.DTT_ID'] = $DTT_ID;
         }
-        $status_ids_array = apply_filters(
+        $status_ids_array          = apply_filters(
             'FHEE__Extend_Registrations_Admin_Page__get_event_attendees__status_ids_array',
-            array(EEM_Registration::status_id_pending_payment, EEM_Registration::status_id_approved)
+            [EEM_Registration::status_id_pending_payment, EEM_Registration::status_id_approved]
         );
-        $query_params[0]['STS_ID'] = array('IN', $status_ids_array);
+        $query_params[0]['STS_ID'] = ['IN', $status_ids_array];
         return EEM_Registration::instance()->count($query_params);
     }
 
@@ -271,6 +292,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      * @param EE_Registration $item
      * @return string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_cb($item)
     {
@@ -287,10 +309,11 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     public function column__REG_att_checked_in(EE_Registration $item)
     {
-        $attendee = $item->attendee();
+        $attendee      = $item->attendee();
         $attendee_name = $attendee instanceof EE_Attendee ? $attendee->full_name() : '';
 
         if ($this->_cur_dtt_id === 0 && count($this->_dtts_for_event) === 1) {
@@ -303,16 +326,16 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             $item,
             $this->_cur_dtt_id
         );
-        $nonce = wp_create_nonce('checkin_nonce');
-        $toggle_active = ! empty($this->_cur_dtt_id)
-                         && EE_Registry::instance()->CAP->current_user_can(
-                             'ee_edit_checkin',
-                             'espresso_registrations_toggle_checkin_status',
-                             $item->ID()
-                         )
+        $nonce                   = wp_create_nonce('checkin_nonce');
+        $toggle_active           = ! empty($this->_cur_dtt_id)
+                                   && EE_Registry::instance()->CAP->current_user_can(
+            'ee_edit_checkin',
+            'espresso_registrations_toggle_checkin_status',
+            $item->ID()
+        )
             ? ' clickable trigger-checkin'
             : '';
-        $mobile_view_content = ' <span class="show-on-mobile-view-only">' . $attendee_name . '</span>';
+        $mobile_view_content     = ' <span class="show-on-mobile-view-only">' . $attendee_name . '</span>';
         return '<span class="' . $checkin_status_dashicon->cssClasses() . $toggle_active . '"'
                . ' data-_regid="' . $item->ID() . '"'
                . ' data-dttid="' . $this->_cur_dtt_id . '"'
@@ -324,8 +347,9 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
 
     /**
      * @param EE_Registration $item
-     * @return mixed|string|void
+     * @return string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_ATT_name(EE_Registration $item)
     {
@@ -335,25 +359,33 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         }
         // edit attendee link
         $edit_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-            array('action' => 'view_registration', '_REG_ID' => $item->ID()),
+            ['action' => 'view_registration', '_REG_ID' => $item->ID()],
             REG_ADMIN_URL
         );
-        $name_link = EE_Registry::instance()->CAP->current_user_can(
+        $name_link    = EE_Registry::instance()->CAP->current_user_can(
             'ee_edit_contacts',
             'espresso_registrations_edit_attendee'
         )
-            ? '<a href="' . $edit_lnk_url . '" title="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
+            ? '<a href="'
+              . $edit_lnk_url
+              . '" title="'
+              . esc_attr__('View Registration Details', 'event_espresso')
+              . '">'
               . $item->attendee()->full_name()
               . '</a>'
             : $item->attendee()->full_name();
-        $name_link .= $item->count() === 1
+        $name_link    .= $item->count() === 1
             ? '&nbsp;<sup><div class="dashicons dashicons-star-filled lt-blue-icon ee-icon-size-8"></div></sup>	'
             : '';
         // add group details
-        $name_link .= '&nbsp;' . sprintf(esc_html__('(%s of %s)', 'event_espresso'), $item->count(), $item->group_size());
+        $name_link .= '&nbsp;' . sprintf(
+                esc_html__('(%s of %s)', 'event_espresso'),
+                $item->count(),
+                $item->group_size()
+            );
         // add regcode
-        $link = EE_Admin_Page::add_query_args_and_nonce(
-            array('action' => 'view_registration', '_REG_ID' => $item->ID()),
+        $link      = EE_Admin_Page::add_query_args_and_nonce(
+            ['action' => 'view_registration', '_REG_ID' => $item->ID()],
             REG_ADMIN_URL
         );
         $name_link .= '<br>';
@@ -367,15 +399,16 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
               . '</a>'
             : $item->reg_code();
         // status
-        $name_link .= '<br><span class="ee-status-text-small">';
-        $name_link .= EEH_Template::pretty_status($item->status_ID(), false, 'sentence');
-        $name_link .= '</span>';
-        $actions = array();
-        $DTT_ID = $this->_cur_dtt_id;
-        $latest_related_datetime = empty($DTT_ID) && ! empty($this->_req_data['event_id']) && $item instanceof EE_Registration
-            ? $item->get_latest_related_datetime()
-            : null;
-        $DTT_ID = $latest_related_datetime instanceof EE_Datetime
+        $name_link               .= '<br><span class="ee-status-text-small">';
+        $name_link               .= EEH_Template::pretty_status($item->status_ID(), false, 'sentence');
+        $name_link               .= '</span>';
+        $actions                 = [];
+        $DTT_ID                  = $this->_cur_dtt_id;
+        $latest_related_datetime =
+            empty($DTT_ID) && ! empty($this->_req_data['event_id'])
+                ? $item->get_latest_related_datetime()
+                : null;
+        $DTT_ID                  = $latest_related_datetime instanceof EE_Datetime
             ? $latest_related_datetime->ID()
             : $DTT_ID;
         if (
@@ -386,11 +419,11 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             )
         ) {
             $checkin_list_url = EE_Admin_Page::add_query_args_and_nonce(
-                array('action' => 'registration_checkins', '_REG_ID' => $item->ID(), 'DTT_ID' => $DTT_ID),
+                ['action' => 'registration_checkins', '_REG_ID' => $item->ID(), 'DTT_ID' => $DTT_ID],
                 REG_ADMIN_URL
             );
             // get the timestamps for this registration's checkins, related to the selected datetime
-            $timestamps = $item->get_many_related('Checkin', array(array('DTT_ID' => $DTT_ID)));
+            $timestamps = $item->get_many_related('Checkin', [['DTT_ID' => $DTT_ID]]);
             if (! empty($timestamps)) {
                 // get the last timestamp
                 $last_timestamp = end($timestamps);
@@ -399,7 +432,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
                     ? esc_html__('Checked In', 'event_espresso')
                     : esc_html__('Checked Out', 'event_espresso');
                 // get timestamp string
-                $timestamp_string = $last_timestamp->get_datetime('CHK_timestamp');
+                $timestamp_string   = $last_timestamp->get_datetime('CHK_timestamp');
                 $actions['checkin'] = '<a href="' . $checkin_list_url . '" title="'
                                       . esc_attr__(
                                           'View this registrant\'s check-ins/checkouts for the datetime',
@@ -416,6 +449,8 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
     /**
      * @param EE_Registration $item
      * @return string
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function column_ATT_email(EE_Registration $item)
     {
@@ -428,16 +463,17 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      * @param EE_Registration $item
      * @return bool|string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_Event(EE_Registration $item)
     {
         try {
-            $event = $this->_evt instanceof EE_Event ? $this->_evt : $item->event();
+            $event         = $this->_evt instanceof EE_Event ? $this->_evt : $item->event();
             $chkin_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-                array('action' => 'event_registrations', 'event_id' => $event->ID()),
+                ['action' => 'event_registrations', 'event_id' => $event->ID()],
                 REG_ADMIN_URL
             );
-            $event_label = EE_Registry::instance()->CAP->current_user_can(
+            $event_label   = EE_Registry::instance()->CAP->current_user_can(
                 'ee_read_checkins',
                 'espresso_registrations_registration_checkins'
             ) ? '<a href="' . $chkin_lnk_url . '" title="'
@@ -454,7 +490,9 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
 
     /**
      * @param EE_Registration $item
-     * @return mixed|string|void
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_PRC_name(EE_Registration $item)
     {
@@ -467,6 +505,8 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      *
      * @param EE_Registration $item
      * @return string
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function column__REG_final_price(EE_Registration $item)
     {
@@ -480,6 +520,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      * @param EE_Registration $item
      * @return string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_TXN_paid(EE_Registration $item)
     {
@@ -488,7 +529,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
                 return '<span class="reg-pad-rght"><div class="dashicons dashicons-yes green-icon"></div></span>';
             } else {
                 $view_txn_lnk_url = EE_Admin_Page::add_query_args_and_nonce(
-                    array('action' => 'view_transaction', 'TXN_ID' => $item->transaction_ID()),
+                    ['action' => 'view_transaction', 'TXN_ID' => $item->transaction_ID()],
                     TXN_ADMIN_URL
                 );
                 return EE_Registry::instance()->CAP->current_user_can(
@@ -521,14 +562,15 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
      * @param EE_Registration $item
      * @return string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_TXN_total(EE_Registration $item)
     {
-        $txn = $item->transaction();
-        $view_txn_url = add_query_arg(array('action' => 'view_transaction', 'TXN_ID' => $txn->ID()), TXN_ADMIN_URL);
+        $txn          = $item->transaction();
+        $view_txn_url = add_query_arg(['action' => 'view_transaction', 'TXN_ID' => $txn->ID()], TXN_ADMIN_URL);
         if ($item->get('REG_count') === 1) {
             $line_total_obj = $txn->total_line_item();
-            $txn_total = $line_total_obj instanceof EE_Line_Item
+            $txn_total      = $line_total_obj instanceof EE_Line_Item
                 ? $line_total_obj->get_pretty('LIN_total')
                 : esc_html__(
                     'View Transaction',

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -1263,14 +1263,16 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
      */
     public function get_event_attendees($per_page = 10, $count = false, $trash = false, $orderby = 'ATT_fname')
     {
-        // normalize some request params that get setup by the parent `get_registrations` method.
-        $request = $this->_req_data;
-        $request['orderby'] = ! empty($this->_req_data['orderby']) ? $this->_req_data['orderby'] : $orderby;
-        $request['order'] = ! empty($this->_req_data['order']) ? $this->_req_data['order'] : 'ASC';
+        // set some defaults, these will get overridden if included in the actual request parameters
+        $defaults = [
+            'orderby' => $orderby,
+            'order' => 'ASC',
+        ];
         if ($trash) {
-            $request['status'] = 'trash';
+            $defaults['status'] = 'trash';
         }
-        $query_params = $this->_get_checkin_query_params_from_request($request, $per_page, $count);
+        $query_params = $this->_get_checkin_query_params_from_request($defaults, $per_page, $count);
+
         /**
          * Override the default groupby added by EEM_Base so that sorts with multiple order bys work as expected
          *

--- a/caffeinated/admin/extend/registrations/assets/ee-newsletter-trigger.css
+++ b/caffeinated/admin/extend/registrations/assets/ee-newsletter-trigger.css
@@ -30,10 +30,6 @@
 
 }
 
-#selected-batch-send-trigger {
-	margin-left: 10px;
-}
-
 .js-shortcode-selection {
     cursor: pointer;
 }

--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -486,6 +486,8 @@ abstract class EE_Admin_List_Table extends WP_List_Table
         if (empty($filters)) {
             return;
         }
+
+        echo '<div class="ee-list-table-filters actions alignleft">';
         foreach ($filters as $filter) {
             echo wp_kses($filter, AllowedTags::getWithFormTags());
         }
@@ -501,6 +503,7 @@ abstract class EE_Admin_List_Table extends WP_List_Table
              . '" style="display:inline-block">'
              . esc_html__('Reset Filters', 'event_espresso')
              . '</a>';
+        echo '</div>';
     }
 
 

--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -490,11 +490,13 @@ abstract class EE_Admin_List_Table extends WP_List_Table
             echo wp_kses($filter, AllowedTags::getWithFormTags());
         }
         // add filter button at end
-        echo '<input type="submit" class="button-secondary" value="'
+        echo '<input type="submit" class="ee-list-table-filter-submit button button--secondary" value="'
              . esc_html__('Filter', 'event_espresso')
              . '" id="post-query-submit" />';
+        echo '<input type="hidden" id="ee-list-table-use-filters" name="use_filters" value="no"/>';
+
         // add reset filters button at end
-        echo '<a class="button button-secondary"  href="'
+        echo '<a class="button button--secondary"  href="'
              . esc_url_raw($this->_admin_page->get_current_page_view_url())
              . '" style="display:inline-block">'
              . esc_html__('Reset Filters', 'event_espresso')

--- a/core/admin/EE_Admin_List_Table.core.php
+++ b/core/admin/EE_Admin_List_Table.core.php
@@ -801,14 +801,14 @@ abstract class EE_Admin_List_Table extends WP_List_Table
         } else {
             echo '<div class="list-table-bottom-buttons alignleft actions">';
             foreach ($this->_bottom_buttons as $type => $action) {
-                $route         = isset($action['route']) ? $action['route'] : '';
-                $extra_request = isset($action['extra_request']) ? $action['extra_request'] : '';
+                $route         = $action['route'] ?? '';
+                $extra_request = $action['extra_request'] ?? '';
                 // already escaped
                 echo wp_kses($this->_admin_page->get_action_link_or_button(
                     $route,
                     $type,
                     $extra_request,
-                    'button button-secondary'
+                    'button button--secondary'
                 ), AllowedTags::getWithFormTags());
             }
             do_action('AHEE__EE_Admin_List_Table__extra_tablenav__after_bottom_buttons', $this, $this->_screen);

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -996,13 +996,14 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
             do_action('AHEE__EE_Admin_Page__route_admin_request', $this->_current_view, $this);
         }
         // right before calling the route, let's clean the _wp_http_referer
-        $this->request->setServerParam(
-            'REQUEST_URI',
-            remove_query_arg(
-                '_wp_http_referer',
-                wp_unslash($this->request->getServerParam('REQUEST_URI'))
-            )
+        $this->request->unSetRequestParam('_wp_http_referer');
+        $this->request->unSetServerParam('_wp_http_referer');
+        $cleaner_request_uri = remove_query_arg(
+            '_wp_http_referer',
+            wp_unslash($this->request->getServerParam('REQUEST_URI'))
         );
+        $this->request->setRequestParam('_wp_http_referer', $cleaner_request_uri);
+        $this->request->setServerParam('REQUEST_URI', $cleaner_request_uri);
         if (! empty($func)) {
             if (is_array($func)) {
                 [$class, $method] = $func;
@@ -1132,7 +1133,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         if ($sticky) {
             /** @var RequestInterface $request */
             $request = LoaderFactory::getLoader()->getShared(RequestInterface::class);
-            $request->unSetRequestParams(['_wp_http_referer', 'wp_referer']);
+            $request->unSetRequestParams(['_wp_http_referer', 'wp_referer'], true);
             foreach ($request->requestParams() as $key => $value) {
                 // do not add nonces
                 if (strpos($key, 'nonce') !== false) {

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -2844,12 +2844,11 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
             isset($this->_template_args['list_table_hidden_fields'])
                 ? $this->_template_args['list_table_hidden_fields']
                 : '';
-        $nonce_ref                                               = $this->_req_action . '_nonce';
-        $hidden_form_fields                                      .= '<input type="hidden" name="'
-                                                                    . $nonce_ref
-                                                                    . '" value="'
-                                                                    . wp_create_nonce($nonce_ref)
-                                                                    . '">';
+
+        $nonce_ref          = $this->_req_action . '_nonce';
+        $hidden_form_fields .= '
+            <input type="hidden" name="' . $nonce_ref . '" value="' . wp_create_nonce($nonce_ref) . '">';
+
         $this->_template_args['list_table_hidden_fields']        = $hidden_form_fields;
         // display message about search results?
         $search = $this->request->getRequestParam('s');

--- a/core/admin/EE_Admin_Page.core.php
+++ b/core/admin/EE_Admin_Page.core.php
@@ -1005,9 +1005,9 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         );
         if (! empty($func)) {
             if (is_array($func)) {
-                list($class, $method) = $func;
+                [$class, $method] = $func;
             } elseif (strpos($func, '::') !== false) {
-                list($class, $method) = explode('::', $func);
+                [$class, $method] = explode('::', $func);
             } else {
                 $class  = $this;
                 $method = $func;
@@ -3505,7 +3505,7 @@ abstract class EE_Admin_Page extends EE_Base implements InterminableInterface
         $action,
         $type = 'add',
         $extra_request = [],
-        $class = 'button-primary',
+        $class = 'button button--primary',
         $base_url = '',
         $exclude_nonce = false
     ) {

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -35,6 +35,7 @@
     align-items: center;
     display: inline-flex;
     flex-wrap: wrap;
+    height: auto;
 }
 .espresso-admin .tablenav {
     display: flex;
@@ -43,11 +44,11 @@
     width: 100%;
 }
 .espresso-admin .tablenav .actions {
-    padding: .5rem;
-    padding-inline-start: 0;
-    padding-inline-end: 1rem;
+    padding-block: .25rem;
+    padding-inline: 0;
 }
 .espresso-admin .tablenav .tablenav-pages {
+    margin-block: 0;
     margin-inline-start: auto;
     padding: .5rem;
     padding-inline-start: 1rem;
@@ -72,7 +73,7 @@
 }
 
 .espresso-admin .tablenav div {
-    margin-inline-end: 1rem;
+    margin-inline-end: .5rem;
 }
 
 

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -27,13 +27,55 @@
     top: 0;
 }
 
-.tablenav div {
-    margin-right: 15px;
+.espresso-admin .tablenav,
+.espresso-admin .tablenav,
+.espresso-admin .tablenav .actions,
+.espresso-admin .tablenav .tablenav-pages  {
+    align-content: center;
+    align-items: center;
+    display: inline-flex;
+    flex-wrap: wrap;
+}
+.espresso-admin .tablenav {
+    display: flex;
+    padding-block: .5rem;
+    padding-inline: 0;
+    width: 100%;
+}
+.espresso-admin .tablenav .actions {
+    padding: .5rem;
+    padding-inline-start: 0;
+    padding-inline-end: 1rem;
+}
+.espresso-admin .tablenav .tablenav-pages {
+    margin-inline-start: auto;
+    padding: .5rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 0;
 }
 
-.tablenav select {
-    margin: 0 1em 0 0 !important;
+.espresso-admin .tablenav > a,
+.espresso-admin .tablenav > span,
+.espresso-admin .tablenav > input,
+.espresso-admin .tablenav > select,
+.espresso-admin .tablenav > button,
+.espresso-admin .tablenav .actions > a,
+.espresso-admin .tablenav .actions > span,
+.espresso-admin .tablenav .actions > input,
+.espresso-admin .tablenav .actions > select,
+.espresso-admin .tablenav .actions > button,
+.espresso-admin .tablenav .actions > #doaction,
+.espresso-admin .tablenav .actions > #doaction2,
+.espresso-admin .tablenav .actions > #post-query-submit {
+    height: 2rem;
+    margin: .25rem;
+    margin-inline-end: .5rem;
 }
+
+.espresso-admin .tablenav div {
+    margin-inline-end: 1rem;
+}
+
 
 /*** Save buttons ***/
 #espresso_major_buttons_wrapper {
@@ -797,6 +839,11 @@ label.error {
 }
 
 /** LIST-TABLE-LEGEND **/
+.ee-list-table-legend-container {
+    clear: both;
+    padding-block: .25rem;
+}
+
 .ee-list-table-legend {
     margin-top: 0;
     padding: 5px;

--- a/core/admin/assets/ee-admin-page.css
+++ b/core/admin/assets/ee-admin-page.css
@@ -67,7 +67,6 @@
 .espresso-admin .tablenav .actions > #doaction,
 .espresso-admin .tablenav .actions > #doaction2,
 .espresso-admin .tablenav .actions > #post-query-submit {
-    height: 2rem;
     margin: .25rem;
     margin-inline-end: .5rem;
 }

--- a/core/admin/assets/ee-admin-page.js
+++ b/core/admin/assets/ee-admin-page.js
@@ -261,9 +261,7 @@ jQuery(document).ready(function($) {
 	}
 
 
-
-
-
-
-
+	$('.ee-list-table-filter-submit').click(function () {
+		$('#ee-list-table-use-filters').val('yes');
+	});
 });

--- a/core/domain/services/admin/registrations/list_table/QueryBuilder.php
+++ b/core/domain/services/admin/registrations/list_table/QueryBuilder.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\services\admin\registrations\list_table;
 
 use EE_Error;
 use EEH_DTT_Helper;
+use EEM_Base;
 use EEM_Registration;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -57,7 +58,9 @@ class QueryBuilder
         $this->request = $request;
         $this->registration_model = $registration_model;
         foreach ($extra_request_params as $key => $value) {
-            $this->request->setRequestParam($key, $value);
+            if (! $this->request->requestParamIsSet($key)) {
+                $this->request->setRequestParam($key, $value);
+            }
         }
         $this->view = $this->request->getRequestParam('status', '');
         $this->where_params = [];
@@ -79,7 +82,7 @@ class QueryBuilder
     {
         $query_params = [
             0                          => $this->getWhereClause(),
-            'caps'                     => EEM_Registration::caps_read_admin,
+            'caps'                     => EEM_Base::caps_read_admin,
             'default_where_conditions' => 'this_model_only',
         ];
         if (! $count_query) {

--- a/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
+++ b/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
@@ -79,4 +79,4 @@ class RegistrationsCsvReportParams
         </span>
     </span>';
     }
-}#ebf4f9
+}

--- a/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
+++ b/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
@@ -43,23 +43,27 @@ class RegistrationsCsvReportParams
 
         $route_details = [
             'route'         => 'registrations_report',
-            'extra_request' => [
-                'return_url' => $return_url,
-                'filters'    => array_diff_key(
-                    $request_params,
-                    [
-                        'page'          => '',
-                        'action'        => '',
-                        'default_nonce' => '',
-                    ]
-                ),
-            ],
+            'extra_request' => [ 'return_url' => $return_url ],
         ];
         if (! empty($EVT_ID)) {
             $route_details['extra_request']['EVT_ID'] = $EVT_ID;
         }
         if ($DTT_ID) {
             $route_details['extra_request']['DTT_ID'] = $DTT_ID;
+        }
+        if (
+            isset($request_params['month_range'])
+            || isset($request_params['EVT_CAT'])
+            || isset($request_params['_reg_status'])
+        ) {
+            $route_details['extra_request']['filters'] = array_diff_key(
+                $request_params,
+                [
+                    'page'          => '',
+                    'action'        => '',
+                    'default_nonce' => '',
+                ]
+            );
         }
         return $route_details;
     }

--- a/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
+++ b/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace EventEspresso\core\domain\services\admin\registrations\list_table\csv_reports;
+
+use EE_Admin_List_Table;
+use EE_Capabilities;
+
+/**
+ * Class RegistrationsCsvReportParams
+ *
+ * @author  Brent Christensen
+ * @package EventEspresso\core\domain\services\admin\registrations\list_table\csv_reports
+ * @since   $VID:$
+ */
+class RegistrationsCsvReportParams
+{
+    /**
+     * @param string $return_url
+     * @param array  $request_params
+     * @param int    $EVT_ID
+     * @param int    $DTT_ID
+     * @return array
+     */
+    public static function getRequestParams(
+        string $return_url,
+        array $request_params = [],
+        int $EVT_ID = 0,
+        int $DTT_ID = 0
+    ): array {
+        if (
+            ! EE_Capabilities::instance()->current_user_can(
+                'ee_read_registrations',
+                'espresso_registrations_registrations_reports',
+                $EVT_ID
+            )
+        ) {
+            return [];
+        }
+        add_action(
+            'AHEE__EE_Admin_List_Table__extra_tablenav__after_bottom_buttons',
+            [RegistrationsCsvReportParams::class, 'csvReportNotice']
+        );
+
+        $route_details = [
+            'route'         => 'registrations_report',
+            'extra_request' => [
+                'return_url' => $return_url,
+                'filters'    => array_diff_key(
+                    $request_params,
+                    [
+                        'page'          => '',
+                        'action'        => '',
+                        'default_nonce' => '',
+                    ]
+                ),
+            ],
+        ];
+        if (! empty($EVT_ID)) {
+            $route_details['extra_request']['EVT_ID'] = $EVT_ID;
+        }
+        if ($DTT_ID) {
+            $route_details['extra_request']['DTT_ID'] = $DTT_ID;
+        }
+        return $route_details;
+    }
+
+
+    public static function csvReportNotice()
+    {
+        echo '
+    <span class="csv-report-notice__wrapper">
+        <span class="dashicons dashicons-info"></span>
+        <span class="csv-report-notice__text">
+        ' .  esc_html('All Registration CSV Reports are now triggered by the preceding button') . '
+        </span>
+    </span>';
+    }
+}#ebf4f9

--- a/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
+++ b/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
@@ -36,6 +36,7 @@ class RegistrationsCsvReportParams
         ) {
             return [];
         }
+        unset($request_params['_wp_http_referer']);
         add_action(
             'AHEE__EE_Admin_List_Table__extra_tablenav__after_bottom_buttons',
             [RegistrationsCsvReportParams::class, 'csvReportNotice']

--- a/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
+++ b/core/domain/services/admin/registrations/list_table/csv_reports/RegistrationsCsvReportParams.php
@@ -22,11 +22,11 @@ class RegistrationsCsvReportParams
      * @return array
      */
     public static function getRequestParams(
-        string $return_url,
-        array $request_params = [],
-        int $EVT_ID = 0,
-        int $DTT_ID = 0
-    ): array {
+        $return_url,
+        $request_params = [],
+        $EVT_ID = 0,
+        $DTT_ID = 0
+    ) {
         if (
             ! EE_Capabilities::instance()->current_user_can(
                 'ee_read_registrations',
@@ -52,9 +52,8 @@ class RegistrationsCsvReportParams
             $route_details['extra_request']['DTT_ID'] = $DTT_ID;
         }
         if (
-            isset($request_params['month_range'])
-            || isset($request_params['EVT_CAT'])
-            || isset($request_params['_reg_status'])
+            isset($request_params['use_filters'])
+            && filter_var($request_params['use_filters'], FILTER_VALIDATE_BOOLEAN)
         ) {
             $route_details['extra_request']['filters'] = array_diff_key(
                 $request_params,

--- a/core/helpers/EEH_Template.helper.php
+++ b/core/helpers/EEH_Template.helper.php
@@ -553,7 +553,7 @@ class EEH_Template
      * @param string $title
      * @return string the html output for the button
      */
-    public static function get_button_or_link($url, $label, $class = 'button-primary', $icon = '', $title = '')
+    public static function get_button_or_link($url, $label, $class = 'button button--primary', $icon = '', $title = '')
     {
         $icon_html = '';
         if (! empty($icon)) {

--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -69,12 +69,10 @@ class RegistrationsReport extends JobHandlerFile
         );
         $job_parameters->add_extra_data('filepath', $filepath);
 
-
-        $filter_params = maybe_unserialize($job_parameters->request_datum('filters', []));
-
-        $query_params = is_array($filter_params) && ! empty($filter_params)
-            ? $filter_params
-            : [
+        if ($job_parameters->request_datum('use_filters', false)) {
+            $query_params = maybe_unserialize($job_parameters->request_datum('filters', []));
+        } else {
+            $query_params = [
                 [
                     'OR'                 => [
                         // don't include registrations from failed or abandoned transactions...
@@ -94,12 +92,13 @@ class RegistrationsReport extends JobHandlerFile
                 'force_join' => ['Transaction', 'Ticket', 'Attendee'],
                 'caps'       => EEM_Base::caps_read_admin,
             ];
-
-        if ($event_id) {
-            $query_params[0]['EVT_ID'] = $event_id;
-        } else {
-            $query_params['force_join'][] = 'Event';
+            if ($event_id) {
+                $query_params[0]['EVT_ID'] = $event_id;
+            } else {
+                $query_params['force_join'][] = 'Event';
+            }
         }
+
         if (! isset($query_params['force_join'])) {
             $query_params['force_join'] = ['Event', 'Transaction', 'Ticket', 'Attendee'];
         }

--- a/core/libraries/batch/JobHandlers/RegistrationsReport.php
+++ b/core/libraries/batch/JobHandlers/RegistrationsReport.php
@@ -57,43 +57,59 @@ class RegistrationsReport extends JobHandlerFile
     public function create_job(JobParameters $job_parameters)
     {
         $event_id = (int) $job_parameters->request_datum('EVT_ID', '0');
-        $DTT_ID = (int) $job_parameters->request_datum('DTT_ID', '0');
+        $DTT_ID   = (int) $job_parameters->request_datum('DTT_ID', '0');
         if (! EE_Capabilities::instance()->current_user_can('ee_read_registrations', 'generating_report')) {
-            throw new BatchRequestException(esc_html__('You do not have permission to view registrations', 'event_espresso'));
+            throw new BatchRequestException(
+                esc_html__('You do not have permission to view registrations', 'event_espresso')
+            );
         }
         $filepath = $this->create_file_from_job_with_name(
             $job_parameters->job_id(),
             $this->get_filename()
         );
         $job_parameters->add_extra_data('filepath', $filepath);
-        $query_params = apply_filters('FHEE__EE_Export__report_registration_for_event', array(
-            array(
-                'OR'                 => array(
-                    // don't include registrations from failed or abandoned transactions...
-                    'Transaction.STS_ID' => array(
-                        'NOT IN',
-                        array(
-                            EEM_Transaction::failed_status_code,
-                            EEM_Transaction::abandoned_status_code,
-                        ),
-                    ),
-                    // unless the registration is approved, in which case include it regardless of transaction status
-                    'STS_ID'             => EEM_Registration::status_id_approved,
-                ),
-                'Ticket.TKT_deleted' => array('IN', array(true, false)),
-            ),
-            'order_by'   => array('Transaction.TXN_ID' => 'asc', 'REG_count' => 'asc'),
-            'force_join' => array('Transaction', 'Ticket', 'Attendee'),
-            'caps'       => EEM_Base::caps_read_admin,
-        ), $event_id);
+
+
+        $filter_params = maybe_unserialize($job_parameters->request_datum('filters', []));
+
+        $query_params = is_array($filter_params) && ! empty($filter_params)
+            ? $filter_params
+            : [
+                [
+                    'OR'                 => [
+                        // don't include registrations from failed or abandoned transactions...
+                        'Transaction.STS_ID' => [
+                            'NOT IN',
+                            [
+                                EEM_Transaction::failed_status_code,
+                                EEM_Transaction::abandoned_status_code,
+                            ],
+                        ],
+                        // unless the registration is approved, in which case include it regardless of transaction status
+                        'STS_ID'             => EEM_Registration::status_id_approved,
+                    ],
+                    'Ticket.TKT_deleted' => ['IN', [true, false]],
+                ],
+                'order_by'   => ['Transaction.TXN_ID' => 'asc', 'REG_count' => 'asc'],
+                'force_join' => ['Transaction', 'Ticket', 'Attendee'],
+                'caps'       => EEM_Base::caps_read_admin,
+            ];
+
         if ($event_id) {
             $query_params[0]['EVT_ID'] = $event_id;
         } else {
             $query_params['force_join'][] = 'Event';
         }
         if (! isset($query_params['force_join'])) {
-            $query_params['force_join'] = array('Event', 'Transaction', 'Ticket', 'Attendee');
+            $query_params['force_join'] = ['Event', 'Transaction', 'Ticket', 'Attendee'];
         }
+
+        $query_params = apply_filters(
+            'FHEE__EE_Export__report_registration_for_event',
+            $query_params,
+            $event_id
+        );
+
         $job_parameters->add_extra_data('query_params', $query_params);
         $question_labels = $this->_get_question_labels($query_params);
         $job_parameters->add_extra_data('question_labels', $question_labels);
@@ -347,7 +363,7 @@ class RegistrationsReport extends JobHandlerFile
                     ARRAY_A,
                     'Payment_Method.PMD_admin_name as name, Payment.PAY_txn_id_chq_nmbr as gateway_txn_id, Payment.PAY_timestamp as payment_time'
                 );
-                list($payment_methods, $gateway_txn_ids_etc, $payment_times) = PaymentsInfoCSV::extractPaymentInfo($payments_info);
+                [$payment_methods, $gateway_txn_ids_etc, $payment_times] = PaymentsInfoCSV::extractPaymentInfo($payments_info);
             }
             $reg_csv_array[ (string) esc_html__('Payment Date(s)', 'event_espresso') ] = implode(',', $payment_times);
             $reg_csv_array[ (string) esc_html__('Payment Method(s)', 'event_espresso') ] = implode(",", $payment_methods);

--- a/core/services/request/Request.php
+++ b/core/services/request/Request.php
@@ -268,6 +268,18 @@ class Request implements InterminableInterface, RequestInterface, ReservedInstan
 
 
     /**
+     * remove param
+     *
+     * @param      $key
+     * @param bool $unset_from_global_too
+     */
+    public function unSetServerParam($key, $unset_from_global_too = false)
+    {
+        $this->server_params->unSetServerParam($key, $unset_from_global_too);
+    }
+
+
+    /**
      * remove params
      *
      * @param array $keys

--- a/core/services/request/RequestInterface.php
+++ b/core/services/request/RequestInterface.php
@@ -63,6 +63,15 @@ interface RequestInterface extends RequestTypeContextCheckerInterface
 
 
     /**
+     * remove param
+     *
+     * @param string $key
+     * @param bool   $unset_from_global_too
+     */
+    public function unSetServerParam($key, $unset_from_global_too = false);
+
+
+    /**
      * @param string $key
      * @return bool
      */

--- a/core/services/request/ServerParams.php
+++ b/core/services/request/ServerParams.php
@@ -93,7 +93,10 @@ class ServerParams
      */
     public function setServerParam($key, $value)
     {
-        $this->server[ $key ] = $this->sanitizer->clean($key, $value);
+        $clean_value = $this->sanitizer->clean($key, $value);
+        $this->server[ $key ] = $clean_value;
+        // modify global too
+        $_SERVER[ $key ] = $clean_value;
     }
 
 
@@ -103,6 +106,24 @@ class ServerParams
     public function serverParamIsSet($key)
     {
         return isset($this->server[ $key ]);
+    }
+
+
+    /**
+     * remove param
+     *
+     * @param string $key
+     * @param bool   $unset_from_global_too
+     */
+    public function unSetServerParam($key, $unset_from_global_too = false)
+    {
+        // because unset may not actually remove var
+        $this->server[ $key ] = null;
+        unset($this->server[ $key ]);
+        if ($unset_from_global_too) {
+            unset($_SERVER[ $key ]);
+        }
+
     }
 
 

--- a/core/services/request/ServerParams.php
+++ b/core/services/request/ServerParams.php
@@ -123,7 +123,6 @@ class ServerParams
         if ($unset_from_global_too) {
             unset($_SERVER[ $key ]);
         }
-
     }
 
 

--- a/tests/mocks/core/services/request/RequestMockBlank.php
+++ b/tests/mocks/core/services/request/RequestMockBlank.php
@@ -225,4 +225,9 @@ class RequestMockBlank implements RequestInterface
     public function mergeRequestParams(array $request_params)
     {
     }
+
+
+    public function unSetServerParam($key, $unset_from_global_too = false)
+    {
+    }
 }


### PR DESCRIPTION
In https://github.com/eventespresso/event-espresso-core/pull/3868 a bunch of work was done to reconfigure how the Registration CSV Reports worked, and amidst the flurry of changes, the ability to apply the reg list filters was lost. 
I missed that in my code reviews and it was also overlooked during testing.

This PR:

- extracts the logic for setting the CSV filter params for the csv reg report into a new class
- removes ALL of the various button labels for different CSV report buttons in favour of one single button
- adds an info notice after the reg CSV button so that people are aware that the functionality for all buttons has been combined
- reinstates the application of the filter query params to the CSV report if present

<img width="568" alt="Screenshot 2022-06-07 134355" src="https://user-images.githubusercontent.com/1751030/172478941-66e0964d-5a2f-4e6f-b26c-74a81c1f98f4.png">

