### PR TITLE
Add Cap Checks to Routing

### DIFF
--- a/core/EE_Dependency_Map.core.php
+++ b/core/EE_Dependency_Map.core.php
@@ -776,10 +776,11 @@ class EE_Dependency_Map
                 null,
             ],
             'EventEspresso\core\services\routing\RouteHandler'                                                            => [
-                'EventEspresso\core\services\json\JsonDataNodeHandler' => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\loaders\Loader'           => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\request\Request'          => EE_Dependency_Map::load_from_cache,
-                'EventEspresso\core\services\routing\RouteCollection'  => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\services\capabilities\CapabilitiesChecker' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\json\JsonDataNodeHandler'                => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\loaders\Loader'                          => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'                         => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\routing\RouteCollection'                 => EE_Dependency_Map::load_from_cache,
             ],
             'EventEspresso\core\services\json\JsonDataNodeHandler'                                                        => [
                 'EventEspresso\core\services\json\JsonDataNodeValidator' => EE_Dependency_Map::load_from_cache,

--- a/core/domain/entities/routing/handlers/admin/ActivationRequests.php
+++ b/core/domain/entities/routing/handlers/admin/ActivationRequests.php
@@ -32,7 +32,6 @@ class ActivationRequests extends PrimaryRoute
      */
     protected function registerDependencies()
     {
-        $admin_dependencies = ['EE_Admin_Config' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute',
             AdminRoute::getDefaultDependencies()
@@ -43,7 +42,7 @@ class ActivationRequests extends PrimaryRoute
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage',
-            Route::getDefaultDependencies()
+            AdminRoute::getDefaultDependencies()
         );
     }
 

--- a/core/domain/entities/routing/handlers/admin/ActivationRequests.php
+++ b/core/domain/entities/routing/handlers/admin/ActivationRequests.php
@@ -2,10 +2,8 @@
 
 namespace EventEspresso\core\domain\entities\routing\handlers\admin;
 
-use EE_Dependency_Map;
 use EventEspresso\core\services\routing\PrimaryRoute;
 use EventEspresso\core\services\routing\Route;
-use EventEspresso\core\services\routing\Router;
 
 /**
  * Class ActivationRequests
@@ -37,15 +35,15 @@ class ActivationRequests extends PrimaryRoute
         $admin_dependencies = ['EE_Admin_Config' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute',
-            $admin_dependencies
+            AdminRoute::getDefaultDependencies()
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\handlers\admin\PueRequests',
-            Route::$default_dependencies
+            Route::getDefaultDependencies()
         );
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage',
-            $admin_dependencies
+            Route::getDefaultDependencies()
         );
     }
 

--- a/core/domain/entities/routing/handlers/admin/AdminRoute.php
+++ b/core/domain/entities/routing/handlers/admin/AdminRoute.php
@@ -4,6 +4,8 @@ namespace EventEspresso\core\domain\entities\routing\handlers\admin;
 
 use EE_Admin_Config;
 use EE_Dependency_Map;
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\domain\services\capabilities\CapCheck;
 use EventEspresso\core\services\routing\Route;
 use EventEspresso\core\domain\entities\routing\specifications\RouteMatchSpecificationInterface;
 use EventEspresso\core\services\json\JsonDataNode;
@@ -29,6 +31,16 @@ class AdminRoute extends Route
      */
     protected $admin_config;
 
+    /**
+     * @var array $default_dependencies
+     */
+    protected static $default_dependencies = [
+        'EE_Admin_Config'                             => EE_Dependency_Map::load_from_cache,
+        'EE_Dependency_Map'                           => EE_Dependency_Map::load_from_cache,
+        'EventEspresso\core\services\loaders\Loader'  => EE_Dependency_Map::load_from_cache,
+        'EventEspresso\core\services\request\Request' => EE_Dependency_Map::load_from_cache,
+    ];
+
 
     /**
      * Route constructor.
@@ -50,6 +62,21 @@ class AdminRoute extends Route
     ) {
         $this->admin_config = $admin_config;
         parent::__construct($dependency_map, $loader, $request, $data_node, $specification);
+    }
+
+
+    public function getCapCheck()
+    {
+        return new CapCheck('edit_posts', 'access Event Espresso admin route');
+    }
+
+
+    /**
+     * @return array
+     */
+    public static function getDefaultDependencies(): array
+    {
+        return self::$default_dependencies;
     }
 
 

--- a/core/domain/entities/routing/handlers/admin/EspressoEventsAdmin.php
+++ b/core/domain/entities/routing/handlers/admin/EspressoEventsAdmin.php
@@ -37,7 +37,7 @@ class EspressoEventsAdmin extends AdminRoute
     {
         $this->dependency_map->registerDependencies(
             'EventEspresso\core\domain\services\admin\events\default_settings\AdvancedEditorAdminFormSection',
-            ['EE_Admin_Config' => EE_Dependency_Map::load_from_cache]
+            AdminRoute::getDefaultDependencies()
         );
     }
 }

--- a/core/domain/entities/routing/handlers/frontend/PublicRoute.php
+++ b/core/domain/entities/routing/handlers/frontend/PublicRoute.php
@@ -33,12 +33,12 @@ abstract class PublicRoute extends Route
     /**
      * FrontendRequests constructor.
      *
-     * @param EE_Maintenance_Mode $maintenance_mode
-     * @param EE_Dependency_Map   $dependency_map
-     * @param LoaderInterface     $loader
-     * @param RequestInterface    $request
-     * @param JsonDataNode        $data_node
-     * @param RouteMatchSpecificationInterface $specification
+     * @param EE_Maintenance_Mode                   $maintenance_mode
+     * @param EE_Dependency_Map                     $dependency_map
+     * @param LoaderInterface                       $loader
+     * @param RequestInterface                      $request
+     * @param JsonDataNode|null                     $data_node
+     * @param RouteMatchSpecificationInterface|null $specification
      */
     public function __construct(
         EE_Maintenance_Mode $maintenance_mode,

--- a/core/domain/entities/routing/handlers/shared/RegularRequests.php
+++ b/core/domain/entities/routing/handlers/shared/RegularRequests.php
@@ -3,6 +3,18 @@
 namespace EventEspresso\core\domain\entities\routing\handlers\shared;
 
 use EE_Dependency_Map;
+use EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute;
+use EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventEditor;
+use EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin;
+use EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin;
+use EventEspresso\core\domain\entities\routing\handlers\admin\GutenbergEditor;
+use EventEspresso\core\domain\entities\routing\handlers\admin\PersonalDataRequests;
+use EventEspresso\core\domain\entities\routing\handlers\admin\PueRequests;
+use EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage;
+use EventEspresso\core\domain\entities\routing\handlers\frontend\FrontendRequests;
+use EventEspresso\core\domain\entities\routing\handlers\frontend\ShortcodeRequests;
+use EventEspresso\core\services\assets\AssetManifestFactory;
+use EventEspresso\core\services\assets\BaristaFactory;
 use EventEspresso\core\services\routing\PrimaryRoute;
 use EventEspresso\core\services\routing\Route;
 
@@ -116,33 +128,32 @@ class RegularRequests extends PrimaryRoute
      */
     protected function registerDependencies()
     {
-        $admin_dependencies = ['EE_Admin_Config' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
-        $public_dependencies = ['EE_Maintenance_Mode' => EE_Dependency_Map::load_from_cache] + Route::$default_dependencies;
-        $default_with_barista = [
-                                    'EventEspresso\core\services\assets\BaristaFactory' => EE_Dependency_Map::load_from_cache,
-                                ] + Route::$default_dependencies;
-        $default_with_manifest = [
-                                     'EventEspresso\core\services\assets\AssetManifestFactory' => EE_Dependency_Map::load_from_cache,
-                                 ] + Route::$default_dependencies;
+        $public = ['EE_Maintenance_Mode' => EE_Dependency_Map::load_from_cache] + Route::getDefaultDependencies();
+
+        $default_with_barista  = [BaristaFactory::class => EE_Dependency_Map::load_from_cache] +
+                                 Route::getDefaultDependencies();
+        $default_with_manifest = [AssetManifestFactory::class => EE_Dependency_Map::load_from_cache] +
+                                 Route::getDefaultDependencies();
+
         $default_routes = [
             // default dependencies
-            'EventEspresso\core\domain\entities\routing\handlers\admin\PueRequests'          => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\frontend\ShortcodeRequests' => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\RestApiRequests'     => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\SessionRequests'     => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\WordPressHeartbeat'  => Route::$default_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\AssetRequests'       => $default_with_barista,
-            'EventEspresso\core\domain\entities\routing\handlers\shared\GQLRequests'         => $default_with_manifest,
+            PueRequests::class          => Route::getDefaultDependencies(),
+            ShortcodeRequests::class    => Route::getDefaultDependencies(),
+            RestApiRequests::class      => Route::getDefaultDependencies(),
+            SessionRequests::class      => Route::getDefaultDependencies(),
+            WordPressHeartbeat::class   => Route::getDefaultDependencies(),
+            AssetRequests::class        => $default_with_barista,
+            GQLRequests::class          => $default_with_manifest,
             // admin dependencies
-            'EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute'           => $admin_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin'  => $admin_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventEditor'  => $admin_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin'  => $admin_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\admin\GutenbergEditor'      => $admin_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\admin\WordPressPluginsPage' => $admin_dependencies,
+            AdminRoute::class           => AdminRoute::getDefaultDependencies(),
+            EspressoEventsAdmin::class  => AdminRoute::getDefaultDependencies(),
+            EspressoEventEditor::class  => AdminRoute::getDefaultDependencies(),
+            EspressoLegacyAdmin::class  => AdminRoute::getDefaultDependencies(),
+            GutenbergEditor::class      => AdminRoute::getDefaultDependencies(),
+            WordPressPluginsPage::class => AdminRoute::getDefaultDependencies(),
             // public dependencies
-            'EventEspresso\core\domain\entities\routing\handlers\admin\PersonalDataRequests' => $public_dependencies,
-            'EventEspresso\core\domain\entities\routing\handlers\frontend\FrontendRequests'  => $public_dependencies,
+            PersonalDataRequests::class => $public,
+            FrontendRequests::class     => $public,
         ];
         foreach ($default_routes as $route => $dependencies) {
             $this->dependency_map->registerDependencies($route, $dependencies);

--- a/core/domain/services/capabilities/CapCheck.php
+++ b/core/domain/services/capabilities/CapCheck.php
@@ -32,18 +32,15 @@ class CapCheck implements CapCheckInterface
 
     /**
      * @param string|array $capability   - the capability to be checked, like: 'ee_edit_registrations',
-     *                                   or an array of capability strings
+     *                                     or an array of capability strings
      * @param string       $context      - what the user is attempting to do, like: 'Edit Registration'
-     * @param int          $ID           - (optional) ID for item where current_user_can is being called from
+     * @param int|string   $ID           - (optional) ID for item where current_user_can is being called from
      * @throws InvalidDataTypeException
      */
-    public function __construct($capability, $context, $ID = 0)
+    public function __construct($capability, string $context, $ID = 0)
     {
         if (! (is_string($capability) || is_array($capability))) {
             throw new InvalidDataTypeException('$capability', $capability, 'string or array');
-        }
-        if (! is_string($context)) {
-            throw new InvalidDataTypeException('$context', $context, 'string');
         }
         $this->capability = $capability;
         $this->context = strtolower(str_replace(' ', '_', $context));
@@ -63,7 +60,7 @@ class CapCheck implements CapCheckInterface
     /**
      * @return string
      */
-    public function context()
+    public function context(): string
     {
         return $this->context;
     }

--- a/core/domain/services/capabilities/CapabilitiesChecker.php
+++ b/core/domain/services/capabilities/CapabilitiesChecker.php
@@ -37,7 +37,7 @@ class CapabilitiesChecker implements CapabilitiesCheckerInterface
     /**
      * @return EE_Capabilities
      */
-    protected function capabilities()
+    protected function capabilities(): EE_Capabilities
     {
         return $this->capabilities;
     }
@@ -48,20 +48,25 @@ class CapabilitiesChecker implements CapabilitiesCheckerInterface
      * If any of the individual capability checks fails, then the command will NOT be executed.
      *
      * @param CapCheckInterface|CapCheckInterface[] $cap_check
+     * @param bool                                  $suppress_exceptions
      * @return bool
      * @throws InvalidClassException
      * @throws InsufficientPermissionsException
      */
-    public function processCapCheck($cap_check)
+    public function processCapCheck($cap_check, bool $suppress_exceptions = false): bool
     {
         if (is_array($cap_check)) {
+            $passed = true;
             foreach ($cap_check as $check) {
-                $this->processCapCheck($check);
+                $passed = $this->processCapCheck($check) ? $passed : false;
             }
-            return true;
+            return $passed;
         }
         // at this point, $cap_check should be an individual instance of CapCheck
         if (! $cap_check instanceof CapCheckInterface) {
+            if ($suppress_exceptions) {
+                return false;
+            }
             throw new InvalidClassException(
                 '\EventEspresso\core\domain\services\capabilities\CapCheckInterface'
             );
@@ -79,6 +84,9 @@ class CapabilitiesChecker implements CapabilitiesCheckerInterface
                     $cap_check->ID()
                 )
             ) {
+                if ($suppress_exceptions) {
+                    return false;
+                }
                 throw new InsufficientPermissionsException($cap_check->context());
             }
         }
@@ -87,15 +95,15 @@ class CapabilitiesChecker implements CapabilitiesCheckerInterface
 
 
     /**
-     * @param string $capability - the capability to be checked, like: 'ee_edit_registrations'
-     * @param string $context    - what the user is attempting to do, like: 'Edit Registration'
-     * @param int    $ID         - (optional) ID for item where current_user_can is being called from
+     * @param array|string $capability - the capability to be checked, like: 'ee_edit_registrations'
+     * @param string       $context    - what the user is attempting to do, like: 'Edit Registration'
+     * @param int|string   $ID         - (optional) ID for item where current_user_can is being called from
      * @return bool
      * @throws InvalidDataTypeException
      * @throws InsufficientPermissionsException
      * @throws InvalidClassException
      */
-    public function process($capability, $context, $ID = 0)
+    public function process($capability, string $context, $ID = 0): bool
     {
         return $this->processCapCheck(new CapCheck($capability, $context, $ID));
     }

--- a/core/domain/services/capabilities/CapabilitiesCheckerInterface.php
+++ b/core/domain/services/capabilities/CapabilitiesCheckerInterface.php
@@ -20,20 +20,21 @@ interface CapabilitiesCheckerInterface
      * If any of the individual capability checks fails, then the command will NOT be executed.
      *
      * @param CapCheckInterface|CapCheckInterface[] $cap_check
+     * @param bool                                  $suppress_exceptions
      * @return bool
      * @throws InvalidClassException
      * @throws InsufficientPermissionsException
      */
-    public function processCapCheck($cap_check);
+    public function processCapCheck($cap_check, bool $suppress_exceptions = false): bool;
 
 
     /**
-     * @param string $capability - the capability to be checked, like: 'ee_edit_registrations'
+     * @param array|string $capability - the capability to be checked, like: 'ee_edit_registrations'
      * @param string $context    - what the user is attempting to do, like: 'Edit Registration'
-     * @param int    $ID         - (optional) ID for item where current_user_can is being called from
+     * @param int|string    $ID         - (optional) ID for item where current_user_can is being called from
      * @return bool
      * @throws InsufficientPermissionsException
      * @throws InvalidClassException
      */
-    public function process($capability, $context, $ID = 0);
+    public function process($capability, string $context, $ID = 0): bool;
 }

--- a/core/services/commands/CommandRequiresCapCheckInterface.php
+++ b/core/services/commands/CommandRequiresCapCheckInterface.php
@@ -2,6 +2,8 @@
 
 namespace EventEspresso\core\services\commands;
 
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+
 /**
  * Interface CommandRequiresCapCheckInterface
  * this interface is used to identify Command classes
@@ -12,7 +14,7 @@ namespace EventEspresso\core\services\commands;
 interface CommandRequiresCapCheckInterface
 {
     /**
-     * @return \EventEspresso\core\domain\services\capabilities\CapCheck
+     * @return CapCheckInterface
      */
     public function getCapCheck();
 }

--- a/core/services/commands/registration/CreateRegistrationCommand.php
+++ b/core/services/commands/registration/CreateRegistrationCommand.php
@@ -9,6 +9,7 @@ use EE_Transaction;
 use EEM_Registration;
 use EventEspresso\core\domain\services\capabilities\CapCheck;
 use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\services\commands\Command;
 use EventEspresso\core\services\commands\CommandRequiresCapCheckInterface;
@@ -97,8 +98,8 @@ class CreateRegistrationCommand extends Command implements CommandRequiresCapChe
 
 
     /**
-     * @return \EventEspresso\core\domain\services\capabilities\CapCheckInterface
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
+     * @return CapCheckInterface
+     * @throws InvalidDataTypeException
      */
     public function getCapCheck()
     {

--- a/core/services/routing/Route.php
+++ b/core/services/routing/Route.php
@@ -5,6 +5,8 @@ namespace EventEspresso\core\services\routing;
 use DomainException;
 use EE_Dependency_Map;
 use EventEspresso\core\domain\entities\routing\specifications\RouteMatchSpecificationInterface;
+use EventEspresso\core\domain\services\capabilities\PublicCapabilities;
+use EventEspresso\core\domain\services\capabilities\RequiresCapCheckInterface;
 use EventEspresso\core\services\assets\AssetManagerInterface;
 use EventEspresso\core\services\assets\BaristaFactory;
 use EventEspresso\core\services\assets\BaristaInterface;
@@ -24,7 +26,7 @@ use EventEspresso\core\services\request\RequestInterface;
  * @author  Brent Christensen
  * @since   $VID:$
  */
-abstract class Route implements RouteInterface
+abstract class Route implements RouteInterface, RequiresCapCheckInterface
 {
     /**
      * @var AssetManagerInterface $asset_manager
@@ -74,11 +76,11 @@ abstract class Route implements RouteInterface
      * @var array $full_dependencies
      */
     protected static $full_dependencies = [
-        'EE_Dependency_Map'                                                                          => EE_Dependency_Map::load_from_cache,
-        'EventEspresso\core\services\loaders\Loader'                                                 => EE_Dependency_Map::load_from_cache,
-        'EventEspresso\core\services\request\Request'                                                => EE_Dependency_Map::load_from_cache,
-        'EventEspresso\core\services\json\JsonDataNode'                                              => EE_Dependency_Map::load_from_cache,
-        'EventEspresso\core\domain\entities\routing\specifications\RouteMatchSpecificationInterface' => EE_Dependency_Map::load_from_cache,
+        'EE_Dependency_Map'                             => EE_Dependency_Map::load_from_cache,
+        'EventEspresso\core\services\loaders\Loader'    => EE_Dependency_Map::load_from_cache,
+        'EventEspresso\core\services\request\Request'   => EE_Dependency_Map::load_from_cache,
+        'EventEspresso\core\services\json\JsonDataNode' => EE_Dependency_Map::load_from_cache,
+        RouteMatchSpecificationInterface::class         => EE_Dependency_Map::load_from_cache,
     ];
 
 
@@ -154,6 +156,12 @@ abstract class Route implements RouteInterface
     protected function dataNodeClass(): string
     {
         return '';
+    }
+
+
+    public function getCapCheck()
+    {
+        return new PublicCapabilities('', 'access Event Espresso route');
     }
 
 

--- a/tests/mocks/core/domain/services/capabilities/CapabilitiesCheckerMock.php
+++ b/tests/mocks/core/domain/services/capabilities/CapabilitiesCheckerMock.php
@@ -32,11 +32,12 @@ class CapabilitiesCheckerMock implements CapabilitiesCheckerInterface
      * If any of the individual capability checks fails, then the command will NOT be executed.
      *
      * @param CapCheckInterface|CapCheckInterface[] $cap_check
+     * @param bool                                  $suppress_exceptions
      * @return bool
      * @throws InvalidClassException
      * @throws InsufficientPermissionsException
      */
-    public function processCapCheck($cap_check)
+    public function processCapCheck($cap_check, bool $suppress_exceptions = false): bool
     {
         if(! $this->cap_check_passes) {
             throw new InsufficientPermissionsException($cap_check->context());
@@ -54,7 +55,7 @@ class CapabilitiesCheckerMock implements CapabilitiesCheckerInterface
      * @throws InsufficientPermissionsException
      * @throws InvalidClassException
      */
-    public function process($capability, $context, $ID = 0)
+    public function process($capability, string $context, $ID = 0): bool
     {
         return $this->processCapCheck(new CapCheckMock());
     }


### PR DESCRIPTION
This PR:

- adds `RequiresCapCheckInterface` to the base `Route` class
- injects the `CapChecker` class into `RouteHandler`
- retrieves each route's `CapCheck` object and processes it before handling route
- adds `$suppress_exceptions` parameter to `CapChecker` and toggles to `true` during routing
- adds default caps to public and admin routes
- updates typing, dependencies, and phpdocs