### PR TITLE
Remove call to wp_kses() to fix reCaptcha v2

### DIFF
--- a/modules/single_page_checkout/templates/registration_page_wrapper.template.php
+++ b/modules/single_page_checkout/templates/registration_page_wrapper.template.php
@@ -85,7 +85,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                 <div id="spco-<?php echo esc_attr($slug); ?>-dv"
                      class="spco-step-dv <?php echo esc_attr($reg_step->div_class()); ?>"
                 >
-                    <?php echo wp_kses($reg_step->display_reg_form(), AllowedTags::getWithFormTags()); ?>
+                    <?php echo $reg_step->display_reg_form(); // already escaped ?>
                     <?php do_action('AHEE__SPCO_after_reg_step_form', $slug, $next_step); ?>
                 </div>
                 <?php $step_nmbr++;


### PR DESCRIPTION
See #3879 

## Problem this Pull Request solves
A call to wp_kses() was added to the function with also adds the reCaptcha inputs and it broken that functionality when using reCaptcha v2.

This PR simply removes that call to what we had previously, a proper fix can be added later but this is causing issues for users currently.


## How has this been tested
See steps in #3879 

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
