### PR TITLE
Remove wp_kses() from Critical Pages dropdown select output

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -1387,7 +1387,7 @@ class General_Settings_Admin_Page extends EE_Admin_Page
             }
         }
         if ($echo) {
-            echo wp_kses($output, AllowedTags::getAllowedTags());
+            echo $output;
             return '';
         }
         return $output;


### PR DESCRIPTION
Event Espresso -> General Settings -> Critical Pages is broken, the dropdowns no longer show anything other than 'Main Page'.

Master: https://monosnap.com/file/XhUlsufgQRkyjPFj1sWYR6o0Amsjgj

This branch: https://monosnap.com/file/LPKV6QTF3l5YsUu48v0lI4QCs14bni

This branch simply removes the wp_kses() call wrapped around the options output.
