### PR TITLE
Added New Thousands Separators

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -812,6 +812,14 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                         'id'   => '&nbsp;',
                         'text' => esc_html__('(space)', 'event_espresso'),
                     ],
+                    [
+                        'id'   => '_',
+                        'text' => esc_html__('_ (underscore)', 'event_espresso'),
+                    ],
+                    [
+                        'id'   => "'",
+                        'text' => esc_html__("' (apostrophe)", 'event_espresso'),
+                    ],
                 ],
                 'use_desc_4_label' => true,
                 'disabled'         => $CNT_cur_disabled,


### PR DESCRIPTION
Fixes: https://github.com/eventespresso/event-espresso-core/issues/1042

<img width="692" alt="Screen Shot 2022-06-15 at 19 51 37" src="https://user-images.githubusercontent.com/29144542/173864812-95cba4f7-0040-42b3-a4e0-23828cdff988.png">

<img width="661" alt="Screen Shot 2022-06-15 at 19 52 26" src="https://user-images.githubusercontent.com/29144542/173864982-2ceedc17-0900-44b2-af8d-f18f30f8b981.png">

To see the new thousand separators, go to General Settings -> Countries and change **Currency Thousands Separator** option of one of countries and then select that country as the **Organization Country** in General Settings -> Your Organization menu.