### PR TITLE
Fix Blank Max Registrations per Transaction on New Event

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1061,7 +1061,11 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             );
             $event_values['EVT_additional_limit']            = min(
                 apply_filters('FHEE__EE_Events_Admin__insert_update_cpt_item__EVT_additional_limit_max', 255),
-                $this->request->getRequestParam('additional_limit', null, 'int')
+                $this->request->getRequestParam(
+                    'additional_limit',
+                    EEM_Event::get_default_additional_limit(),
+                    'int'
+                )
             );
             $event_values['EVT_default_registration_status'] = $this->request->getRequestParam(
                 'EVT_default_registration_status',
@@ -1077,7 +1081,8 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
         // get event_object for other metaboxes...
         // though it would seem to make sense to just use $this->_event_model()->get_one_by_ID( $post_id )..
         // i have to setup where conditions to override the filters in the model
-        // that filter out autodraft and inherit statuses so we GET the inherit id!
+        // that filter out auto-draft and inherit statuses so we GET the inherit id!
+        /** @var EE_Event $event */
         $event = $this->_event_model()->get_one(
             [
                 [

--- a/core/admin/EE_Admin_Page_CPT.core.php
+++ b/core/admin/EE_Admin_Page_CPT.core.php
@@ -498,13 +498,10 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
         }
         ?>
         <p><strong><?php esc_html_e('Template', 'event_espresso') ?></strong></p>
-        <label class="screen-reader-text" for="page_template"><?php esc_html_e(
-            'Page Template',
-            'event_espresso'
-        ) ?></label>
-        <select
-            name="page_template" id="page_template"
-        >
+        <label class="screen-reader-text" for="page_template">
+            <?php esc_html_e('Page Template', 'event_espresso') ?>
+        </label>
+        <select name="page_template" id="page_template">
             <option value='default'><?php esc_html_e('Default Template', 'event_espresso'); ?></option>
             <?php page_template_dropdown($template); ?>
         </select>
@@ -526,19 +523,20 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
     {
         $post = get_post($id);
         if ('publish' !== get_post_status($post)) {
-            $return .= '<span id="view-post-btn"><a target="_blank" href="'
-                       . get_preview_post_link($id)
-                       . '" class="button button--secondary">'
-                       . esc_html__('Preview', 'event_espresso')
-                       . '</a></span>'
-                       . "\n";
+            $return .= '
+            <span id="view-post-btn">
+                <a target="_blank" href="' . get_preview_post_link($id) . '" class="button button--secondary">
+                    ' . esc_html__('Preview', 'event_espresso') . '
+                </a>
+            </span>
+            ';
         }
         return $return;
     }
 
 
     /**
-     * add our custom post stati dropdown on the wp post page for this cpt
+     * add our custom post status dropdown on the wp post page for this cpt
      *
      * @return void
      */
@@ -1108,9 +1106,7 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
      */
     public function add_custom_editor_default_title($title)
     {
-        return isset($this->_labels['editor_title'][ $this->_cpt_routes[ $this->_req_action ] ])
-            ? $this->_labels['editor_title'][ $this->_cpt_routes[ $this->_req_action ] ]
-            : $title;
+        return $this->_labels['editor_title'][ $this->_cpt_routes[ $this->_req_action ] ] ?? $title;
     }
 
 
@@ -1184,7 +1180,7 @@ abstract class EE_Admin_Page_CPT extends EE_Admin_Page
     public function revision_redirect($location, $status)
     {
         // get revision
-        $rev_id = isset($this->_req_data['revision']) ? $this->_req_data['revision'] : null;
+        $rev_id = $this->_req_data['revision'] ?? null;
         // can't do anything without revision so let's get out if not present
         if (empty($rev_id)) {
             return $location;

--- a/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
@@ -203,7 +203,7 @@ class EE_DMS_Core_4_12_0 extends EE_Data_Migration_Script_Base
 				EVT_visible_on datetime NULL DEFAULT NULL,
 				EVT_default_registration_status varchar(3),
 				EVT_phone varchar(45) DEFAULT NULL,
-				EVT_additional_limit tinyint(2) unsigned NOT NULL 10,
+				EVT_additional_limit tinyint(2) unsigned NOT NULL DEFAULT 10,
 				EVT_member_only tinyint(1) unsigned NOT NULL DEFAULT 0,
 				EVT_allow_overflow tinyint(1) unsigned NOT NULL DEFAULT 0,
 				EVT_timezone_string varchar(45) NULL,

--- a/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Core_4_12_0.dms.php
@@ -203,7 +203,7 @@ class EE_DMS_Core_4_12_0 extends EE_Data_Migration_Script_Base
 				EVT_visible_on datetime NULL DEFAULT NULL,
 				EVT_default_registration_status varchar(3),
 				EVT_phone varchar(45) DEFAULT NULL,
-				EVT_additional_limit tinyint(2) unsigned NULL,
+				EVT_additional_limit tinyint(2) unsigned NOT NULL 10,
 				EVT_member_only tinyint(1) unsigned NOT NULL DEFAULT 0,
 				EVT_allow_overflow tinyint(1) unsigned NOT NULL DEFAULT 0,
 				EVT_timezone_string varchar(45) NULL,

--- a/core/db_classes/EE_Datetime.class.php
+++ b/core/db_classes/EE_Datetime.class.php
@@ -192,7 +192,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * Set registration limit
      * set the maximum number of attendees that can be registered for this datetime slot
      *
-     * @param int $reg_limit
+     * @param int|float $reg_limit
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -250,7 +250,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function increaseSold($qty = 1, $also_decrease_reserved = true)
+    public function increaseSold(int $qty = 1, bool $also_decrease_reserved = true): bool
     {
         $qty = absint($qty);
         if ($also_decrease_reserved) {
@@ -291,7 +291,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function decreaseSold($qty = 1)
+    public function decreaseSold(int $qty = 1): bool
     {
         $qty = absint($qty);
         $success = $this->adjustNumericFieldsInDb(
@@ -320,7 +320,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function reserved()
+    public function reserved(): int
     {
         return $this->get_raw('DTT_reserved');
     }
@@ -336,10 +336,10 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function set_reserved($reserved)
+    public function set_reserved(int $reserved)
     {
         // reserved can not go below zero
-        $reserved = max(0, (int) $reserved);
+        $reserved = max(0, $reserved);
         $this->set('DTT_reserved', $reserved);
     }
 
@@ -355,7 +355,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function increaseReserved($qty = 1)
+    public function increaseReserved(int $qty = 1): bool
     {
         $qty = absint($qty);
         $success = $this->incrementFieldConditionallyInDb(
@@ -386,7 +386,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function decreaseReserved($qty = 1)
+    public function decreaseReserved(int $qty = 1): bool
     {
         $qty = absint($qty);
         $success = $this->adjustNumericFieldsInDb(
@@ -415,7 +415,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function sold_and_reserved()
+    public function sold_and_reserved(): int
     {
         return $this->sold() + $this->reserved();
     }
@@ -431,7 +431,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function name()
+    public function name(): string
     {
         return $this->get('DTT_name');
     }
@@ -447,7 +447,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function description()
+    public function description(): string
     {
         return $this->get('DTT_description');
     }
@@ -463,7 +463,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function is_primary()
+    public function is_primary(): bool
     {
         return $this->get('DTT_is_primary');
     }
@@ -479,7 +479,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function order()
+    public function order(): int
     {
         return $this->get('DTT_order');
     }
@@ -495,7 +495,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    public function parent()
+    public function parent(): int
     {
         return $this->get('DTT_parent');
     }
@@ -978,7 +978,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
     /**
      *    get the registration limit for this datetime slot
      *
-     * @return        mixed        int on success, FALSE on fail
+     * @return int|float                int = finite limit   EE_INF(float) = unlimited
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -994,7 +994,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
     /**
      *    have the tickets sold for this datetime, met or exceed the registration limit ?
      *
-     * @return        boolean
+     * @return boolean
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -1016,7 +1016,7 @@ class EE_Datetime extends EE_Soft_Delete_Base_Class
      *                               then this datetime IS effectively sold out.
      *                               However, there are cases where we just want to know the spaces
      *                               remaining for this particular datetime, hence the flag.
-     * @return int
+     * @return int|float
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException

--- a/core/db_classes/EE_Event.class.php
+++ b/core/db_classes/EE_Event.class.php
@@ -248,14 +248,14 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      *
      * @param bool $try_to_exclude_expired
      * @param bool $try_to_exclude_deleted
-     * @return EE_Datetime
+     * @return EE_Datetime|null
      * @throws EE_Error
      * @throws ReflectionException
      */
     public function primary_datetime(
         bool $try_to_exclude_expired = true,
         bool $try_to_exclude_deleted = true
-    ): EE_Datetime {
+    ): ?EE_Datetime {
         if (! empty($this->_Primary_Datetime)) {
             return $this->_Primary_Datetime;
         }
@@ -321,11 +321,11 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
-     * @return bool
+     * @return int
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function additional_limit(): bool
+    public function additional_limit(): int
     {
         return $this->get('EVT_additional_limit');
     }
@@ -343,22 +343,22 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function created(): bool
+    public function created(): string
     {
         return $this->get('EVT_created');
     }
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function description(): bool
+    public function description(): string
     {
         return $this->get('EVT_desc');
     }
@@ -422,55 +422,55 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function phone(): bool
+    public function phone(): string
     {
         return $this->get('EVT_phone');
     }
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function modified(): bool
+    public function modified(): string
     {
         return $this->get('EVT_modified');
     }
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function name(): bool
+    public function name(): string
     {
         return $this->get('EVT_name');
     }
 
 
     /**
-     * @return bool
+     * @return int
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function order(): bool
+    public function order(): int
     {
         return $this->get('EVT_order');
     }
 
 
     /**
-     * @return bool|string
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function default_registration_status()
+    public function default_registration_status(): string
     {
         $event_default_registration_status = $this->get('EVT_default_registration_status');
         return ! empty($event_default_registration_status)
@@ -483,11 +483,11 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      * @param int|null    $num_words
      * @param string|null $more
      * @param bool        $not_full_desc
-     * @return bool|string
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function short_description(?int $num_words = 55, string $more = null, bool $not_full_desc = false)
+    public function short_description(?int $num_words = 55, string $more = null, bool $not_full_desc = false): string
     {
         $short_desc = $this->get('EVT_short_desc');
         if (! empty($short_desc) || $not_full_desc) {
@@ -499,33 +499,33 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function slug(): bool
+    public function slug(): string
     {
         return $this->get('EVT_slug');
     }
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function timezone_string(): bool
+    public function timezone_string(): string
     {
         return $this->get('EVT_timezone_string');
     }
 
 
     /**
-     * @return bool
+     * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function visible_on(): bool
+    public function visible_on(): string
     {
         return $this->get('EVT_visible_on');
     }
@@ -554,11 +554,11 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
 
 
     /**
-     * @param $limit
+     * @param int $limit
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function set_additional_limit($limit)
+    public function set_additional_limit(int $limit)
     {
         $this->set('EVT_additional_limit', $limit);
     }
@@ -963,18 +963,18 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      *
      * @param array|null $tickets
      * @param bool       $filtered
-     * @return int
+     * @return int|float
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
      * @throws ReflectionException
      */
-    public function spaces_remaining(?array $tickets = [], ?bool $filtered = true): int
+    public function spaces_remaining(?array $tickets = [], ?bool $filtered = true)
     {
         $this->getAvailableSpacesCalculator()->setActiveTickets($tickets);
         $spaces_remaining = $this->getAvailableSpacesCalculator()->spacesRemaining();
         return $filtered
-            ? (int) apply_filters(
+            ? apply_filters(
                 'FHEE_EE_Event__spaces_remaining',
                 $spaces_remaining,
                 $this,
@@ -1042,7 +1042,7 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
     /**
      * This returns the total remaining spaces for sale on this event.
      *
-     * @return float|int
+     * @return int|float
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
@@ -1067,7 +1067,7 @@ class EE_Event extends EE_CPT_Base implements EEI_Line_Item_Object, EEI_Admin_Li
      *                              based on tickets sold.  Depending on setup and stage of sales, this
      *                              may appear to equal remaining tickets.  However, the more tickets are
      *                              sold out, the more accurate the "live" total is.
-     * @return float|int
+     * @return int|float
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException

--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -864,9 +864,9 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function sold()
+    public function sold(): int
     {
-        return $this->get_raw('TKT_sold');
+        return (int) $this->get_raw('TKT_sold');
     }
 
 
@@ -1012,9 +1012,9 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function reserved()
+    public function reserved(): int
     {
-        return $this->get_raw('TKT_reserved');
+        return (int) $this->get_raw('TKT_reserved');
     }
 
 

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -7,11 +7,9 @@ use EventEspresso\core\exceptions\ModelConfigurationException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\interfaces\ResettableInterface;
 use EventEspresso\core\services\container\Mirror;
-use EventEspresso\core\services\dependencies\DependencyResolver;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\loaders\LoaderInterface;
 use EventEspresso\core\services\orm\ModelFieldFactory;
-use EventEspresso\core\services\request\RequestInterface;
 
 /**
  * Class EEM_Base
@@ -99,7 +97,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     /**
      * @var EE_Index[] $_indexes
      */
-    protected $_indexes = array();
+    protected $_indexes = [];
 
     /**
      * Default strategy for getting where conditions on this model. This strategy is used to get default
@@ -142,6 +140,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * you can read the registration or not on the front-end (it just depends on your capabilities.)
      * This is 'Datetime.Event' on the Ticket model, because model queries for tickets that set "exclude_protected"
      * should hide tickets for datetimes for events that have a password set.
+     *
      * @var string |null
      */
     protected $model_chain_to_password = null;
@@ -173,12 +172,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_cap_restrictions = array(
-        self::caps_read       => array(),
-        self::caps_read_admin => array(),
-        self::caps_edit       => array(),
-        self::caps_delete     => array(),
-    );
+    protected $_cap_restrictions = [
+        self::caps_read       => [],
+        self::caps_read_admin => [],
+        self::caps_edit       => [],
+        self::caps_delete     => [],
+    ];
 
     /**
      * Array defining which cap restriction generators to use to create default
@@ -189,7 +188,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var EE_Restriction_Generator_Base[]
      */
-    protected $_cap_restriction_generators = array();
+    protected $_cap_restriction_generators = [];
 
     /**
      * constants used to categorize capability restrictions on EEM_Base::_caps_restrictions
@@ -210,12 +209,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_cap_contexts_to_cap_action_map = array(
+    protected $_cap_contexts_to_cap_action_map = [
         self::caps_read       => 'read',
         self::caps_read_admin => 'read',
         self::caps_edit       => 'edit',
         self::caps_delete     => 'delete',
-    );
+    ];
 
     /**
      * Timezone
@@ -243,7 +242,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var EE_Model_Field_Base[]
      */
-    private $_cache_foreign_key_to_fields = array();
+    private $_cache_foreign_key_to_fields = [];
 
     /**
      * Cached list of all the fields on the model, indexed by their name
@@ -293,6 +292,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * It would be false, however, if you could guarantee the model would only interact with EE data,
      * even if it uses a WP core table (eg event and venue models set this to false for that reason:
      * they can only read and insert events and venues custom post types, not arbitrary post types)
+     *
      * @var boolean
      */
     protected $_wp_core_model = false;
@@ -315,7 +315,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_valid_operators = array(
+    protected $_valid_operators = [
         '='           => '=',
         '<='          => '<=',
         '<'           => '<',
@@ -350,14 +350,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         'not_regexp'  => 'NOT REGEXP',
         'NOT REGEXP'  => 'NOT REGEXP',
         'not regexp'  => 'NOT REGEXP',
-    );
+    ];
 
     /**
      * operators that work like 'IN', accepting a comma-separated list of values inside brackets. Eg '(1,2,3)'
      *
      * @var array
      */
-    protected $_in_style_operators = array('IN', 'NOT IN');
+    protected $_in_style_operators = ['IN', 'NOT IN'];
 
     /**
      * operators that work like 'BETWEEN'.  Typically used for datetime calculations, i.e. "BETWEEN '12-1-2011' AND
@@ -365,27 +365,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    protected $_between_style_operators = array('BETWEEN');
+    protected $_between_style_operators = ['BETWEEN'];
 
     /**
      * Operators that work like SQL's like: input should be assumed to be a string, already prepared for a LIKE query.
+     *
      * @var array
      */
-    protected $_like_style_operators = array('LIKE', 'NOT LIKE');
+    protected $_like_style_operators = ['LIKE', 'NOT LIKE'];
+
     /**
      * operators that are used for handling NUll and !NULL queries.  Typically used for when checking if a row exists
      * on a join table.
      *
      * @var array
      */
-    protected $_null_style_operators = array('IS NOT NULL', 'IS NULL');
+    protected $_null_style_operators = ['IS NOT NULL', 'IS NULL'];
 
     /**
      * Allowed values for $query_params['order'] for ordering in queries
      *
      * @var array
      */
-    protected $_allowed_order_values = array('asc', 'desc', 'ASC', 'DESC');
+    protected $_allowed_order_values = ['asc', 'desc', 'ASC', 'DESC'];
 
     /**
      * When these are keys in a WHERE or HAVING clause, they are handled much differently
@@ -393,7 +395,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    private $_logic_query_param_keys = array('not', 'and', 'or', 'NOT', 'AND', 'OR');
+    private $_logic_query_param_keys = ['not', 'and', 'or', 'NOT', 'AND', 'OR'];
 
     /**
      * Allowed keys in $query_params arrays passed into queries. Note that 0 is meant to always be a
@@ -401,7 +403,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var array
      */
-    private $_allowed_query_params = array(
+    private $_allowed_query_params = [
         0,
         'limit',
         'order_by',
@@ -414,14 +416,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         'caps',
         'extra_selects',
         'exclude_protected',
-    );
+    ];
 
     /**
      * All the data types that can be used in $wpdb->prepare statements.
      *
      * @var array
      */
-    private $_valid_wpdb_data_types = array('%d', '%s', '%f');
+    private $_valid_wpdb_data_types = ['%d', '%s', '%f'];
 
     /**
      * @var EE_Registry $EE
@@ -443,7 +445,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @var CustomSelects
      */
-    protected $_custom_selections = array();
+    protected $_custom_selections = [];
 
     /**
      * key => value Entity Map using  array( EEM_Base::$_model_query_blog_id => array( ID => model object ) )
@@ -462,7 +464,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @var Mirror
      */
     private static $mirror;
-
 
 
     /**
@@ -542,7 +543,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     const default_where_conditions_none = 'none';
 
 
-
     /**
      * About all child constructors:
      * they should define the _tables, _fields and _model_relations arrays.
@@ -606,10 +606,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $this->_invalidate_field_caches();
         foreach ($this->_fields as $table_alias => $fields_for_table) {
             if (! array_key_exists($table_alias, $this->_tables)) {
-                throw new EE_Error(sprintf(esc_html__(
-                    "Table alias %s does not exist in EEM_Base child's _tables array. Only tables defined are %s",
-                    'event_espresso'
-                ), $table_alias, implode(",", $this->_fields)));
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__(
+                            "Table alias %s does not exist in EEM_Base child's _tables array. Only tables defined are %s",
+                            'event_espresso'
+                        ),
+                        $table_alias,
+                        implode(",", $this->_fields)
+                    )
+                );
             }
             foreach ($fields_for_table as $field_name => $field_obj) {
                 /** @var $field_obj EE_Model_Field_Base | EE_Primary_Key_Field_Base */
@@ -747,12 +753,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             if ($params[1]->getName() === 'model_field_factory') {
                 $arguments = [
                     $timezone,
-                    EEM_Base::getLoader()->getShared(ModelFieldFactory::class)
+                    EEM_Base::getLoader()->getShared(ModelFieldFactory::class),
                 ];
             } elseif ($model_class_Name === 'EEM_Form_Section') {
                 $arguments = [
                     EEM_Base::getLoader()->getShared('EventEspresso\core\services\form\meta\FormStatus'),
-                    $timezone
+                    $timezone,
                 ];
             } elseif ($model_class_Name === 'EEM_Form_Element') {
                 $arguments = [
@@ -783,7 +789,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // check if instance of Espresso_model already exists
         if (! static::$_instance instanceof static) {
             $arguments = EEM_Base::getModelArguments(static::class, (string) $timezone);
-            $model = new static(...$arguments);
+            $model     = new static(...$arguments);
             EEM_Base::getLoader()->share(static::class, $model, $arguments);
             static::$_instance = $model;
         }
@@ -794,7 +800,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // Espresso_model object
         return static::$_instance;
     }
-
 
 
     /**
@@ -858,11 +863,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * retrieve the status details from esp_status table as an array IF this model has the status table as a relation.
      *
-     * @param  boolean $translated return localized strings or JUST the array.
+     * @param boolean $translated return localized strings or JUST the array.
      * @return array
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -872,12 +876,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function status_array($translated = false)
     {
         if (! array_key_exists('Status', $this->_model_relations)) {
-            return array();
+            return [];
         }
-        $model_name = $this->get_this_model_name();
-        $status_type = str_replace(' ', '_', strtolower(str_replace('_', ' ', $model_name)));
-        $stati = EEM_Status::instance()->get_all(array(array('STS_type' => $status_type)));
-        $status_array = array();
+        $model_name   = $this->get_this_model_name();
+        $status_type  = str_replace(' ', '_', strtolower(str_replace('_', ' ', $model_name)));
+        $stati        = EEM_Status::instance()->get_all([['STS_type' => $status_type]]);
+        $status_array = [];
         foreach ($stati as $status) {
             $status_array[ $status->ID() ] = $status->get('STS_code');
         }
@@ -887,18 +891,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the EE_Base_Class objects which match the $query_params, by querying the DB.
      *
-     * @param array $query_params  @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     *                             or if you have the development copy of EE you can view this at the path:
-     *                             /docs/G--Model-System/model-query-params.md
+     * @param array $query_params             @see
+     *                                        https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     *                                        or if you have the development copy of EE you can view this at the path:
+     *                                        /docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class[]  *note that there is NO option to pass the output type. If you want results different
-     *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object IDs (if there is a primary key on the model.
-     *                                        if not, numerically indexed) Some full examples: get 10 transactions
-     *                                        which have Scottish attendees: EEM_Transaction::instance()->get_all(
-     *                                        array( array(
+     *                                        from EE_Base_Class[], use get_all_wpdb_results(). Array keys are object
+     *                                        IDs (if there is a primary key on the model. if not, numerically indexed)
+     *                                        Some full examples: get 10 transactions which have Scottish attendees:
+     *                                        EEM_Transaction::instance()->get_all( array( array(
      *                                        'OR'=>array(
      *                                        'Registration.Attendee.ATT_fname'=>array('like','Mc%'),
      *                                        'Registration.Attendee.ATT_fname*other'=>array('like','Mac%')
@@ -916,7 +920,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                        ));
      * @throws EE_Error
      */
-    public function get_all($query_params = array())
+    public function get_all($query_params = [])
     {
         if (
             isset($query_params['limit'])
@@ -928,15 +932,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Modifies the query parameters so we only get back model objects
      * that "belong" to the current user
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      */
-    public function alter_query_params_to_only_include_mine($query_params = array())
+    public function alter_query_params_to_only_include_mine($query_params = [])
     {
         $wp_user_field_name = $this->wp_user_field_name();
         if ($wp_user_field_name) {
@@ -944,7 +949,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $query_params;
     }
-
 
 
     /**
@@ -960,12 +964,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         try {
             if (! empty($this->_model_chain_to_wp_user)) {
                 $models_to_follow_to_wp_users = explode('.', $this->_model_chain_to_wp_user);
-                $last_model_name = end($models_to_follow_to_wp_users);
-                $model_with_fk_to_wp_users = EE_Registry::instance()->load_model($last_model_name);
-                $model_chain_to_wp_user = $this->_model_chain_to_wp_user . '.';
+                $last_model_name              = end($models_to_follow_to_wp_users);
+                $model_with_fk_to_wp_users    = EE_Registry::instance()->load_model($last_model_name);
+                $model_chain_to_wp_user       = $this->_model_chain_to_wp_user . '.';
             } else {
                 $model_with_fk_to_wp_users = $this;
-                $model_chain_to_wp_user = '';
+                $model_chain_to_wp_user    = '';
             }
             $wp_user_field = $model_with_fk_to_wp_users->get_foreign_key_to('WP_User');
             return $model_chain_to_wp_user . $wp_user_field->get_name();
@@ -973,7 +977,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             return false;
         }
     }
-
 
 
     /**
@@ -990,7 +993,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_model_chain_to_wp_user;
     }
-
 
 
     /**
@@ -1020,7 +1022,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * may want to preserve the WPDB results (eg, update, which first queries to make sure we have all the tables on
      * the model)
      *
-     * @param array  $query_params      @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params      @see
+     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -1034,11 +1037,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function _get_all_wpdb_results($query_params = array(), $output = ARRAY_A, $columns_to_select = null)
+    protected function _get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
         $this->_custom_selections = $this->getCustomSelection($query_params, $columns_to_select);
-        $model_query_info = $this->_create_model_query_info_carrier($query_params);
-        $select_expressions = $columns_to_select === null
+        $model_query_info         = $this->_create_model_query_info_carrier($query_params);
+        $select_expressions       = $columns_to_select === null
             ? $this->_construct_default_select_sql($model_query_info)
             : '';
         if ($this->_custom_selections instanceof CustomSelects) {
@@ -1049,7 +1052,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
 
         $SQL = "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return $this->_do_wpdb_query('get_results', array($SQL, $output));
+        return $this->_do_wpdb_query('get_results', [$SQL, $output]);
     }
 
 
@@ -1074,13 +1077,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets an array of rows from the database just like $wpdb->get_results would,
      * but you can use the model query params to more easily
      * take care of joins, field preparation etc.
      *
-     * @param array  $query_params      @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params      @see
+     *                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $output            ARRAY_A, OBJECT_K, etc. Just like
      * @param mixed  $columns_to_select , What columns to select. By default, we select all columns specified by the
      *                                  fields on the model, and the models we joined to in the query. However, you can
@@ -1093,11 +1096,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return array|stdClass[] like results of $wpdb->get_results($sql,OBJECT), (ie, output type is OBJECT)
      * @throws EE_Error
      */
-    public function get_all_wpdb_results($query_params = array(), $output = ARRAY_A, $columns_to_select = null)
+    public function get_all_wpdb_results($query_params = [], $output = ARRAY_A, $columns_to_select = null)
     {
         return $this->_get_all_wpdb_results($query_params, $output, $columns_to_select);
     }
-
 
 
     /**
@@ -1106,13 +1108,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param mixed $columns_to_select either a string to be inserted directly as the select statement,
      *                                 or an array where keys are aliases, and values are arrays where 0=>the selection
      *                                 SQL, and 1=>is the datatype
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     private function _construct_select_from_input($columns_to_select)
     {
         if (is_array($columns_to_select)) {
-            $select_sql_array = array();
+            $select_sql_array = [];
             foreach ($columns_to_select as $alias => $selection_and_datatype) {
                 if (! is_array($selection_and_datatype) || ! isset($selection_and_datatype[1])) {
                     throw new EE_Error(
@@ -1150,7 +1152,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Convenient wrapper for getting the primary key field's name. Eg, on Registration, this would be 'REG_ID'
      *
@@ -1179,10 +1180,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $model_object = $this->get_one(
             $this->alter_query_params_to_restrict_by_ID(
                 $id,
-                array('default_where_conditions' => EEM_Base::default_where_conditions_minimum_all)
+                ['default_where_conditions' => EEM_Base::default_where_conditions_minimum_all]
             )
         );
-        $className = $this->_get_class_name();
+        $className    = $this->_get_class_name();
         if ($model_object instanceof $className) {
             // make sure valid objects get added to the entity map
             // so that the next call to this method doesn't trigger another trip to the db
@@ -1192,7 +1193,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Alters query parameters to only get items with this ID are returned.
      * Takes into account that the ID might be a string produced by EEM_Base::get_index_primary_key_string(),
@@ -1200,13 +1200,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int   $id
      * @param array $query_params
-     * @return array of normal query params, @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @return array of normal query params, @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      */
-    public function alter_query_params_to_restrict_by_ID($id, $query_params = array())
+    public function alter_query_params_to_restrict_by_ID($id, $query_params = [])
     {
         if (! isset($query_params[0])) {
-            $query_params[0] = array();
+            $query_params[0] = [];
         }
         $conditions_from_id = $this->parse_index_primary_key_string($id);
         if ($conditions_from_id === null) {
@@ -1219,7 +1220,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets a single item for this model from the DB, given the $query_params. Only returns a single class, not an
      * array. If no item is found, null is returned.
@@ -1228,7 +1228,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return EE_Base_Class|EE_Soft_Delete_Base_Class|NULL
      * @throws EE_Error
      */
-    public function get_one($query_params = array())
+    public function get_one($query_params = [])
     {
         if (! is_array($query_params)) {
             EE_Error::doing_it_wrong(
@@ -1239,16 +1239,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         $query_params['limit'] = 1;
-        $items = $this->get_all($query_params);
+        $items                 = $this->get_all($query_params);
         if (empty($items)) {
             return null;
         }
         return array_shift($items);
     }
-
 
 
     /**
@@ -1271,7 +1270,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $current_field_value,
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         return $this->_get_consecutive(
@@ -1283,7 +1282,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $columns_to_select
         );
     }
-
 
 
     /**
@@ -1306,7 +1304,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $current_field_value,
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         return $this->_get_consecutive(
@@ -1318,7 +1316,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $columns_to_select
         );
     }
-
 
 
     /**
@@ -1340,7 +1337,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function next(
         $current_field_value,
         $field_to_order_by = null,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         $results = $this->_get_consecutive(
@@ -1353,7 +1350,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         return empty($results) ? null : reset($results);
     }
-
 
 
     /**
@@ -1375,7 +1371,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function previous(
         $current_field_value,
         $field_to_order_by = null,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         $results = $this->_get_consecutive(
@@ -1388,7 +1384,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         return empty($results) ? null : reset($results);
     }
-
 
 
     /**
@@ -1410,7 +1405,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $operand = '>',
         $field_to_order_by = null,
         $limit = 1,
-        $query_params = array(),
+        $query_params = [],
         $columns_to_select = null
     ) {
         // if $field_to_order_by is empty then let's assume we're ordering by the primary key.
@@ -1419,13 +1414,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $field_to_order_by = $this->get_primary_key_field()->get_name();
             } else {
                 if (WP_DEBUG) {
-                    throw new EE_Error(esc_html__(
-                        'EEM_Base::_get_consecutive() has been called with no $field_to_order_by argument and there is no primary key on the field.  Please provide the field you would like to use as the base for retrieving the next item(s).',
-                        'event_espresso'
-                    ));
+                    throw new EE_Error(
+                        esc_html__(
+                            'EEM_Base::_get_consecutive() has been called with no $field_to_order_by argument and there is no primary key on the field.  Please provide the field you would like to use as the base for retrieving the next item(s).',
+                            'event_espresso'
+                        )
+                    );
                 }
                 EE_Error::add_error(esc_html__('There was an error with the query.', 'event_espresso'));
-                return array();
+                return [];
             }
         }
         if (! is_array($query_params)) {
@@ -1437,16 +1434,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         // let's add the where query param for consecutive look up.
-        $query_params[0][ $field_to_order_by ] = array($operand, $current_field_value);
-        $query_params['limit'] = $limit;
+        $query_params[0][ $field_to_order_by ] = [$operand, $current_field_value];
+        $query_params['limit']                 = $limit;
         // set direction
-        $incoming_orderby = isset($query_params['order_by']) ? (array) $query_params['order_by'] : array();
+        $incoming_orderby         = isset($query_params['order_by']) ? (array) $query_params['order_by'] : [];
         $query_params['order_by'] = $operand === '>'
-            ? array($field_to_order_by => 'ASC') + $incoming_orderby
-            : array($field_to_order_by => 'DESC') + $incoming_orderby;
+            ? [$field_to_order_by => 'ASC'] + $incoming_orderby
+            : [$field_to_order_by => 'DESC'] + $incoming_orderby;
         // if $columns_to_select is empty then that means we're returning EE_Base_Class objects
         if (empty($columns_to_select)) {
             return $this->get_all($query_params);
@@ -1454,7 +1451,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // getting just the fields
         return $this->_get_all_wpdb_results($query_params, ARRAY_A, $columns_to_select);
     }
-
 
 
     /**
@@ -1478,7 +1474,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
     }
-
 
 
     /**
@@ -1506,33 +1501,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * This returns the date formats set for the given field name and also ensures that
      * $this->_timezone property is set correctly.
      *
-     * @since 4.6.x
      * @param string $field_name The name of the field the formats are being retrieved for.
      * @param bool   $pretty     Whether to return the pretty formats (true) or not (false).
-     * @throws EE_Error   If the given field_name is not of the EE_Datetime_Field type.
      * @return array formats in an array with the date format first, and the time format last.
+     * @throws EE_Error   If the given field_name is not of the EE_Datetime_Field type.
+     * @since 4.6.x
      */
     public function get_formats_for($field_name, $pretty = false)
     {
         $field_settings = $this->field_settings_for($field_name);
         // if not a valid EE_Datetime_Field then throw error
         if (! $field_settings instanceof EE_Datetime_Field) {
-            throw new EE_Error(sprintf(esc_html__(
-                'The field sent into EEM_Base::get_formats_for (%s) is not registered as a EE_Datetime_Field. Please check the spelling and make sure you are submitting the right field name to retrieve date_formats for.',
-                'event_espresso'
-            ), $field_name));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        'The field sent into EEM_Base::get_formats_for (%s) is not registered as a EE_Datetime_Field. Please check the spelling and make sure you are submitting the right field name to retrieve date_formats for.',
+                        'event_espresso'
+                    ),
+                    $field_name
+                )
+            );
         }
         // while we are here, let's make sure the timezone internally in EEM_Base matches what is stored on
         // the field.
         $this->_timezone = $field_settings->get_timezone();
-        return array($field_settings->get_date_format($pretty), $field_settings->get_time_format($pretty));
+        return [$field_settings->get_date_format($pretty), $field_settings->get_time_format($pretty)];
     }
-
 
 
     /**
@@ -1545,19 +1543,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Note: When requesting a formatted string, if the date or time format doesn't include seconds, for example,
      * the time returned, because it uses that format, will also NOT include seconds. For this reason, if you want
      * the time returned to be the current time down to the exact second, set $timestamp to true.
-     * @since 4.6.x
+     *
      * @param string $field_name       The field the current time is needed for.
      * @param bool   $timestamp        True means to return a unix timestamp. Otherwise a
      *                                 formatted string matching the set format for the field in the set timezone will
      *                                 be returned.
      * @param string $what             Whether to return the string in just the time format, the date format, or both.
-     * @throws EE_Error    If the given field_name is not of the EE_Datetime_Field type.
      * @return int|string  If the given field_name is not of the EE_Datetime_Field type, then an EE_Error
      *                                 exception is triggered.
+     * @throws EE_Error    If the given field_name is not of the EE_Datetime_Field type.
+     * @since 4.6.x
      */
     public function current_time_for_query($field_name, $timestamp = false, $what = 'both')
     {
-        $formats = $this->get_formats_for($field_name);
+        $formats  = $this->get_formats_for($field_name);
         $DateTime = new DateTime("now", new DateTimeZone($this->_timezone));
         if ($timestamp) {
             return $DateTime->format('U');
@@ -1575,7 +1574,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 break;
         }
     }
-
 
 
     /**
@@ -1600,12 +1598,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // just using this to ensure the timezone is set correctly internally
         $this->get_formats_for($field_name);
         // load EEH_DTT_Helper
-        $set_timezone = empty($timezone) ? EEH_DTT_Helper::get_timezone() : $timezone;
+        $set_timezone     = empty($timezone) ? EEH_DTT_Helper::get_timezone() : $timezone;
         $incomingDateTime = date_create_from_format($incoming_format, $timestring, new DateTimeZone($set_timezone));
         EEH_DTT_Helper::setTimezone($incomingDateTime, new DateTimeZone($this->_timezone));
         return \EventEspresso\core\domain\entities\DbSafeDateTime::createFromDateTime($incomingDateTime);
     }
-
 
 
     /**
@@ -1617,7 +1614,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_tables;
     }
-
 
 
     /**
@@ -1642,7 +1638,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                         EEM_Transaction::instance()->update(
      *                                         array('TXN_details'=>array('detail1'=>'monkey','detail2'=>'banana'),
      *                                         array(array('TXN_ID'=>34)));
-     * @param array   $query_params            @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array   $query_params            @see
+     *                                         https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      *                                         Eg, consider updating Question's QST_admin_label field is of type
      *                                         Simple_HTML. If you use this function to update that field to $new_value
      *                                         = (note replace 8's with appropriate opening and closing tags in the
@@ -1679,7 +1676,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         /**
          * Action called before a model update call has been made.
@@ -1712,7 +1709,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // as it's dangerous. says Mike August 8 2014
         // we want to make sure the default_where strategy is ignored
         $this->_ignore_where_strategy = true;
-        $wpdb_select_results = $this->_get_all_wpdb_results($query_params);
+        $wpdb_select_results          = $this->_get_all_wpdb_results($query_params);
         foreach ($wpdb_select_results as $wpdb_result) {
             // type cast stdClass as array
             $wpdb_result = (array) $wpdb_result;
@@ -1767,9 +1764,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             } else {
                 // we need to select a bunch of columns and then combine them into the the "index primary key string"s
                 $models_affected_key_columns = $this->_get_all_wpdb_results($query_params, ARRAY_A);
-                $model_objs_affected_ids = array();
+                $model_objs_affected_ids     = [];
                 foreach ($models_affected_key_columns as $row) {
-                    $combined_index_key = $this->get_index_primary_key_string($row);
+                    $combined_index_key                             = $this->get_index_primary_key_string($row);
                     $model_objs_affected_ids[ $combined_index_key ] = $combined_index_key;
                 }
             }
@@ -1788,20 +1785,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // if there is a primary key on this model, we can now do a slight optimization
             if ($this->has_primary_key_field()) {
                 // we already know what we want to update. So let's make the query simpler so it's a little more efficient
-                $query_params = array(
-                    array($this->primary_key_name() => array('IN', $model_objs_affected_ids)),
+                $query_params = [
+                    [$this->primary_key_name() => ['IN', $model_objs_affected_ids]],
                     'limit'                    => count($model_objs_affected_ids),
                     'default_where_conditions' => EEM_Base::default_where_conditions_none,
-                );
+                ];
             }
         }
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
-        $SQL = "UPDATE "
-               . $model_query_info->get_full_join_sql()
-               . " SET "
-               . $this->_construct_update_sql($fields_n_values)
-               . $model_query_info->get_where_sql();// note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
-        $rows_affected = $this->_do_wpdb_query('query', array($SQL));
+
+        $SQL = "UPDATE {$model_query_info->get_full_join_sql()} 
+                SET {$this->_construct_update_sql($fields_n_values)}
+                {$model_query_info->get_where_sql()}";
+        // note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
+        $rows_affected    = $this->_do_wpdb_query('query', [$SQL]);
         /**
          * Action called after a model update call has been made.
          *
@@ -1815,19 +1812,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Analogous to $wpdb->get_col, returns a 1-dimensional array where teh values
      * are teh values of the field specified (or by default the primary key field)
      * that matched the query params. Note that you should pass the name of the
      * model FIELD, not the database table's column name.
      *
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_select
      * @return array just like $wpdb->get_col()
      * @throws EE_Error
      */
-    public function get_col($query_params = array(), $field_to_select = null)
+    public function get_col($query_params = [], $field_to_select = null)
     {
         if ($field_to_select) {
             $field = $this->field_settings_for($field_to_select);
@@ -1836,28 +1833,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } else {
             // no primary key, just grab the first column
             $field_settings = $this->field_settings();
-            $field = reset($field_settings);
+            $field          = reset($field_settings);
         }
-        $model_query_info = $this->_create_model_query_info_carrier($query_params);
+        $model_query_info   = $this->_create_model_query_info_carrier($query_params);
         $select_expressions = $field->get_qualified_column();
-        $SQL = "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return $this->_do_wpdb_query('get_col', array($SQL));
+        $SQL                =
+            "SELECT $select_expressions " . $this->_construct_2nd_half_of_select_query($model_query_info);
+        return $this->_do_wpdb_query('get_col', [$SQL]);
     }
-
 
 
     /**
      * Returns a single column value for a single row from the database
      *
-     * @param array  $query_params    @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params    @see
+     *                                https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_select @see EEM_Base::get_col()
      * @return string
      * @throws EE_Error
      */
-    public function get_var($query_params = array(), $field_to_select = null)
+    public function get_var($query_params = [], $field_to_select = null)
     {
         $query_params['limit'] = 1;
-        $col = $this->get_col($query_params, $field_to_select);
+        $col                   = $this->get_col($query_params, $field_to_select);
         if (! empty($col)) {
             return reset($col);
         }
@@ -1865,35 +1863,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Makes the SQL for after "UPDATE table_X inner join table_Y..." and before "...WHERE". Eg "Question.name='party
      * time?', Question.desc='what do you think?',..." Values are filtered through wpdb->prepare to avoid against SQL
      * injection, but currently no further filtering is done
      *
-     * @global      $wpdb
      * @param array $fields_n_values array keys are field names on this model, and values are what those fields should
      *                               be updated to in the DB
      * @return string of SQL
      * @throws EE_Error
+     * @global      $wpdb
      */
     public function _construct_update_sql($fields_n_values)
     {
         /** @type WPDB $wpdb */
         global $wpdb;
-        $cols_n_values = array();
+        $cols_n_values = [];
         foreach ($fields_n_values as $field_name => $value) {
             $field_obj = $this->field_settings_for($field_name);
             // if the value is NULL, we want to assign the value to that.
             // wpdb->prepare doesn't really handle that properly
-            $prepared_value = $this->_prepare_value_or_use_default($field_obj, $fields_n_values);
-            $value_sql = $prepared_value === null ? 'NULL'
+            $prepared_value  = $this->_prepare_value_or_use_default($field_obj, $fields_n_values);
+            $value_sql       = $prepared_value === null ? 'NULL'
                 : $wpdb->prepare($field_obj->get_wpdb_data_type(), $prepared_value);
             $cols_n_values[] = $field_obj->get_qualified_column() . "=" . $value_sql;
         }
         return implode(",", $cols_n_values);
     }
-
 
 
     /**
@@ -1902,7 +1898,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * not just have a flag field on it switched
      * Wrapper for EEM_Base::delete_permanently()
      *
-     * @param mixed $id
+     * @param mixed   $id
      * @param boolean $allow_blocking
      * @return int the number of rows deleted
      * @throws EE_Error
@@ -1910,21 +1906,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function delete_permanently_by_ID($id, $allow_blocking = true)
     {
         return $this->delete_permanently(
-            array(
-                array($this->get_primary_key_field()->get_name() => $id),
+            [
+                [$this->get_primary_key_field()->get_name() => $id],
                 'limit' => 1,
-            ),
+            ],
             $allow_blocking
         );
     }
-
 
 
     /**
      * Deletes a single row from the DB given the model object's primary key value. (eg, EE_Attendee->ID()'s value).
      * Wrapper for EEM_Base::delete()
      *
-     * @param mixed $id
+     * @param mixed   $id
      * @param boolean $allow_blocking
      * @return int the number of rows deleted
      * @throws EE_Error
@@ -1932,14 +1927,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function delete_by_ID($id, $allow_blocking = true)
     {
         return $this->delete(
-            array(
-                array($this->get_primary_key_field()->get_name() => $id),
+            [
+                [$this->get_primary_key_field()->get_name() => $id],
                 'limit' => 1,
-            ),
+            ],
             $allow_blocking
         );
     }
-
 
 
     /**
@@ -1947,11 +1941,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * meaning if the model has a field that indicates its been "trashed" or
      * "soft deleted", we will just set that instead of actually deleting the rows.
      *
-     * @see EEM_Base::delete_permanently
      * @param array   $query_params
      * @param boolean $allow_blocking
      * @return int how many rows got deleted
      * @throws EE_Error
+     * @see EEM_Base::delete_permanently
      */
     public function delete($query_params, $allow_blocking = true)
     {
@@ -1959,13 +1953,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Deletes the model objects that meet the query params. Note: this method is overridden
      * in EEM_Soft_Delete_Base so that soft-deleted model objects are instead only flagged
      * as archived, not actually deleted
      *
-     * @param array   $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array   $query_params   @see
+     *                                https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param boolean $allow_blocking if TRUE, matched objects will only be deleted if there is no related model info
      *                                that blocks it (ie, there' sno other data that depends on this data); if false,
      *                                deletes regardless of other objects which may depend on it. Its generally
@@ -1990,20 +1984,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // deletion if there is no KEY column used in the WHERE statement of a deletion.
         // to get around this, we first do a SELECT, get all the IDs, and then run another query
         // to delete them
-        $items_for_deletion = $this->_get_all_wpdb_results($query_params);
+        $items_for_deletion           = $this->_get_all_wpdb_results($query_params);
         $columns_and_ids_for_deleting = $this->_get_ids_for_delete($items_for_deletion, $allow_blocking);
-        $deletion_where_query_part = $this->_build_query_part_for_deleting_from_columns_and_values(
+        $deletion_where_query_part    = $this->_build_query_part_for_deleting_from_columns_and_values(
             $columns_and_ids_for_deleting
         );
         /**
          * Allows client code to act on the items being deleted before the query is actually executed.
          *
-         * @param EEM_Base $this  The model instance being acted on.
-         * @param array    $query_params  The incoming array of query parameters influencing what gets deleted.
-         * @param bool     $allow_blocking @see param description in method phpdoc block.
-         * @param array $columns_and_ids_for_deleting       An array indicating what entities will get removed as
+         * @param EEM_Base $this                            The model instance being acted on.
+         * @param array    $query_params                    The incoming array of query parameters influencing what gets deleted.
+         * @param bool     $allow_blocking                  @see param description in method phpdoc block.
+         * @param array    $columns_and_ids_for_deleting    An array indicating what entities will get removed as
          *                                                  derived from the incoming query parameters.
-         *                                                  @see details on the structure of this array in the phpdocs
+         * @see details on the structure of this array in the phpdocs
          *                                                  for the `_get_ids_for_delete_method`
          *
          */
@@ -2016,14 +2010,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
         if ($deletion_where_query_part) {
             $model_query_info = $this->_create_model_query_info_carrier($query_params);
-            $table_aliases = array_keys($this->_tables);
-            $SQL = "DELETE "
-                   . implode(", ", $table_aliases)
-                   . " FROM "
-                   . $model_query_info->get_full_join_sql()
-                   . " WHERE "
-                   . $deletion_where_query_part;
-            $rows_deleted = $this->_do_wpdb_query('query', array($SQL));
+            $table_aliases    = array_keys($this->_tables);
+            $SQL              = "DELETE "
+                                . implode(", ", $table_aliases)
+                                . " FROM "
+                                . $model_query_info->get_full_join_sql()
+                                . " WHERE "
+                                . $deletion_where_query_part;
+            $rows_deleted     = $this->_do_wpdb_query('query', [$SQL]);
         } else {
             $rows_deleted = 0;
         }
@@ -2054,15 +2048,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     $this
                 )
             ) {
-                EEM_Extra_Meta::instance()->delete_permanently(array(
-                    0 => array(
-                        'EXM_type' => $this->get_this_model_name(),
-                        'OBJ_ID'   => array(
-                            'IN',
-                            $ids_for_removal
-                        )
-                    )
-                ));
+                EEM_Extra_Meta::instance()->delete_permanently([
+                                                                   0 => [
+                                                                       'EXM_type' => $this->get_this_model_name(),
+                                                                       'OBJ_ID'   => [
+                                                                           'IN',
+                                                                           $ids_for_removal,
+                                                                       ],
+                                                                   ],
+                                                               ]);
             }
         }
 
@@ -2077,7 +2071,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         do_action('AHEE__EEM_Base__delete__end', $this, $query_params, $rows_deleted, $columns_and_ids_for_deleting);
         return $rows_deleted;// how many supposedly got deleted
     }
-
 
 
     /**
@@ -2111,14 +2104,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 // if $ignore_this_model_obj was supplied, then for the query
                 // on that model needs to be told to ignore $ignore_this_model_obj
                 if ($ignored_model && $relation_name === $ignored_model->get_this_model_name()) {
-                    $related_model_objects = $relation_obj->get_all_related($this_model_obj_or_id, array(
-                        array(
-                            $ignored_model->get_primary_key_field()->get_name() => array(
+                    $related_model_objects = $relation_obj->get_all_related($this_model_obj_or_id, [
+                        [
+                            $ignored_model->get_primary_key_field()->get_name() => [
                                 '!=',
                                 $ignore_this_model_obj->ID(),
-                            ),
-                        ),
-                    ));
+                            ],
+                        ],
+                    ]);
                 } else {
                     $related_model_objects = $relation_obj->get_all_related($this_model_obj_or_id);
                 }
@@ -2134,35 +2127,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Builds the columns and values for items to delete from the incoming $row_results_for_deleting array.
+     *
      * @param array $row_results_for_deleting
      * @param bool  $allow_blocking
      * @return array   The shape of this array depends on whether the model `has_primary_key_field` or not.  If the
-     *                 model DOES have a primary_key_field, then the array will be a simple single dimension array where
-     *                 the key is the fully qualified primary key column and the value is an array of ids that will be
-     *                 deleted. Example:
-     *                      array('Event.EVT_ID' => array( 1,2,3))
-     *                 If the model DOES NOT have a primary_key_field, then the array will be a two dimensional array
-     *                 where each element is a group of columns and values that get deleted. Example:
-     *                      array(
-     *                          0 => array(
+     *                              model DOES have a primary_key_field, then the array will be a simple single
+     *                              dimension array where the key is the fully qualified primary key column and the
+     *                              value is an array of ids that will be deleted. Example: array('Event.EVT_ID' =>
+     *                              array( 1,2,3)) If the model DOES NOT have a primary_key_field, then the array will
+     *                              be a two dimensional array where each element is a group of columns and values that
+     *                              get deleted. Example: array(
+     *                              0 => array(
      *                              'Term_Relationship.object_id' => 1
      *                              'Term_Relationship.term_taxonomy_id' => 5
-     *                          ),
-     *                          1 => array(
+     *                              ),
+     *                              1 => array(
      *                              'Term_Relationship.object_id' => 1
      *                              'Term_Relationship.term_taxonomy_id' => 6
-     *                          )
-     *                      )
+     *                              )
+     *                              )
      * @throws EE_Error
      */
     protected function _get_ids_for_delete(array $row_results_for_deleting, $allow_blocking = true)
     {
-        $ids_to_delete_indexed_by_column = array();
+        $ids_to_delete_indexed_by_column = [];
         if ($this->has_primary_key_field()) {
-            $primary_table = $this->_get_main_table();
-            $primary_table_pk_field = $this->get_field_by_column($primary_table->get_fully_qualified_pk_column());
-            $other_tables = $this->_get_other_tables();
-            $ids_to_delete_indexed_by_column = $query = array();
+            $primary_table                   = $this->_get_main_table();
+            $primary_table_pk_field          =
+                $this->get_field_by_column($primary_table->get_fully_qualified_pk_column());
+            $other_tables                    = $this->_get_other_tables();
+            $ids_to_delete_indexed_by_column = $query = [];
             foreach ($row_results_for_deleting as $item_to_delete) {
                 // before we mark this item for deletion,
                 // make sure there's no related entities blocking its deletion (if we're checking)
@@ -2183,7 +2177,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         } elseif (count($this->get_combined_primary_key_fields()) > 1) {
             $fields = $this->get_combined_primary_key_fields();
             foreach ($row_results_for_deleting as $item_to_delete) {
-                $ids_to_delete_indexed_by_column_for_row = array();
+                $ids_to_delete_indexed_by_column_for_row = [];
                 foreach ($fields as $cpk_field) {
                     if ($cpk_field instanceof EE_Model_Field_Base) {
                         $ids_to_delete_indexed_by_column_for_row[ $cpk_field->get_qualified_column() ] =
@@ -2223,15 +2217,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (empty($ids_to_delete_indexed_by_column)) {
             return $query_part;
         } elseif ($this->has_primary_key_field()) {
-            $query = array();
+            $query = [];
             foreach ($ids_to_delete_indexed_by_column as $column => $ids) {
                 $query[] = $column . ' IN' . $this->_construct_in_value($ids, $this->_primary_key_field);
             }
             $query_part = ! empty($query) ? implode(' AND ', $query) : $query_part;
         } elseif (count($this->get_combined_primary_key_fields()) > 1) {
-            $ways_to_identify_a_row = array();
+            $ways_to_identify_a_row = [];
             foreach ($ids_to_delete_indexed_by_column as $ids_to_delete_indexed_by_column_for_each_row) {
-                $values_for_each_combined_primary_key_for_a_row = array();
+                $values_for_each_combined_primary_key_for_a_row = [];
                 foreach ($ids_to_delete_indexed_by_column_for_each_row as $column => $id) {
                     $values_for_each_combined_primary_key_for_a_row[] = $column . '=' . $id;
                 }
@@ -2245,9 +2239,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the model field by the fully qualified name
+     *
      * @param string $qualified_column_name eg 'Event_CPT.post_name' or $field_obj->get_qualified_column()
      * @return EE_Model_Field_Base
      */
@@ -2268,27 +2262,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Count all the rows that match criteria the model query params.
      * If $field_to_count isn't provided, the model's primary key is used. Otherwise, we count by field_to_count's
      * column
      *
-     * @param array  $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params   @see
+     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_count field on model to count by (not column name)
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
      * @return int
      * @throws EE_Error
      */
-    public function count($query_params = array(), $field_to_count = null, $distinct = false)
+    public function count($query_params = [], $field_to_count = null, $distinct = false)
     {
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
         if ($field_to_count) {
-            $field_obj = $this->field_settings_for($field_to_count);
+            $field_obj       = $this->field_settings_for($field_to_count);
             $column_to_count = $field_obj->get_qualified_column();
         } elseif ($this->has_primary_key_field()) {
-            $pk_field_obj = $this->get_primary_key_field();
+            $pk_field_obj    = $this->get_primary_key_field();
             $column_to_count = $pk_field_obj->get_qualified_column();
         } else {
             // there's no primary key
@@ -2296,7 +2290,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // we need to list out the columns for distinction;
             // otherwise we can just use star
             if ($distinct) {
-                $columns_to_use = array();
+                $columns_to_use = [];
                 foreach ($this->get_combined_primary_key_fields() as $field_obj) {
                     $columns_to_use[] = $field_obj->get_qualified_column();
                 }
@@ -2306,16 +2300,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
         $column_to_count = $distinct ? "DISTINCT " . $column_to_count : $column_to_count;
-        $SQL = "SELECT COUNT(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
-        return (int) $this->_do_wpdb_query('get_var', array($SQL));
+        $SQL             =
+            "SELECT COUNT(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
+        return (int) $this->_do_wpdb_query('get_var', [$SQL]);
     }
-
 
 
     /**
      * Sums up the value of the $field_to_sum (defaults to the primary key, which isn't terribly useful)
      *
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_sum name of field (array key in $_fields array)
      * @return float
      * @throws EE_Error
@@ -2329,9 +2324,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $field_obj = $this->get_primary_key_field();
         }
         $column_to_count = $field_obj->get_qualified_column();
-        $SQL = "SELECT SUM(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
-        $return_value = $this->_do_wpdb_query('get_var', array($SQL));
-        $data_type = $field_obj->get_wpdb_data_type();
+        $SQL             =
+            "SELECT SUM(" . $column_to_count . ")" . $this->_construct_2nd_half_of_select_query($model_query_info);
+        $return_value    = $this->_do_wpdb_query('get_var', [$SQL]);
+        $data_type       = $field_obj->get_wpdb_data_type();
         if ($data_type === '%d' || $data_type === '%s') {
             return (float) $return_value;
         }
@@ -2340,16 +2336,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Just calls the specified method on $wpdb with the given arguments
      * Consolidates a little extra error handling code
      *
      * @param string $wpdb_method
      * @param array  $arguments_to_provide
+     * @return mixed
      * @throws EE_Error
      * @global wpdb  $wpdb
-     * @return mixed
      */
     protected function _do_wpdb_query($wpdb_method, $arguments_to_provide)
     {
@@ -2357,18 +2352,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // because level 2 indicates the database needs updating and
         // is probably out of sync with the code
         if (! EE_Maintenance_Mode::instance()->models_can_query()) {
-            throw new EE_Error(sprintf(esc_html__(
-                "Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.",
-                "event_espresso"
-            )));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.",
+                        "event_espresso"
+                    )
+                )
+            );
         }
         /** @type WPDB $wpdb */
         global $wpdb;
         if (! method_exists($wpdb, $wpdb_method)) {
-            throw new EE_Error(sprintf(esc_html__(
-                'There is no method named "%s" on Wordpress\' $wpdb object',
-                'event_espresso'
-            ), $wpdb_method));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        'There is no method named "%s" on Wordpress\' $wpdb object',
+                        'event_espresso'
+                    ),
+                    $wpdb_method
+                )
+            );
         }
         if (WP_DEBUG) {
             $old_show_errors_value = $wpdb->show_errors;
@@ -2382,10 +2386,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 throw new EE_Error(sprintf(esc_html__('WPDB Error: "%s"', 'event_espresso'), $wpdb->last_error));
             }
             if ($result === false) {
-                throw new EE_Error(sprintf(esc_html__(
-                    'WPDB Error occurred, but no error message was logged by wpdb! The wpdb method called was "%1$s" and the arguments were "%2$s"',
-                    'event_espresso'
-                ), $wpdb_method, var_export($arguments_to_provide, true)));
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__(
+                            'WPDB Error occurred, but no error message was logged by wpdb! The wpdb method called was "%1$s" and the arguments were "%2$s"',
+                            'event_espresso'
+                        ),
+                        $wpdb_method,
+                        var_export($arguments_to_provide, true)
+                    )
+                );
             }
         } elseif ($result === false) {
             EE_Error::add_error(
@@ -2407,7 +2417,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Attempts to run the indicated WPDB method with the provided arguments,
      * and if there's an error tries to verify the DB is correct. Uses
@@ -2423,7 +2432,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         /** @type WPDB $wpdb */
         global $wpdb;
         $wpdb->last_error = null;
-        $result = call_user_func_array(array($wpdb, $wpdb_method), $arguments_to_provide);
+        $result           = call_user_func_array([$wpdb, $wpdb_method], $arguments_to_provide);
         // was there an error running the query? but we don't care on new activations
         // (we're going to setup the DB anyway on new activations)
         if (
@@ -2454,7 +2463,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Verifies the EE core database is up-to-date and records that we've done it on
      * EEM_Base::$_db_verification_level
@@ -2469,7 +2477,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         global $wpdb;
         // ok remember that we've already attempted fixing the core db, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_core;
-        $error_message = sprintf(
+        $error_message                    = sprintf(
             esc_html__(
                 'WPDB Error "%1$s" while running wpdb method "%2$s" with arguments %3$s. Automatically attempting to fix EE Core DB',
                 'event_espresso'
@@ -2481,7 +2489,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_System::instance()->initialize_db_if_no_migrations_required(false, true);
         return $error_message;
     }
-
 
 
     /**
@@ -2498,7 +2505,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         global $wpdb;
         // ok remember that we've already attempted fixing the addons dbs, in case the problem persists
         EEM_Base::$_db_verification_level = EEM_Base::db_verified_addons;
-        $error_message = sprintf(
+        $error_message                    = sprintf(
             esc_html__(
                 'WPDB AGAIN: Error "%1$s" while running the same method and arguments as before. Automatically attempting to fix EE Addons DB',
                 'event_espresso'
@@ -2510,7 +2517,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_System::instance()->initialize_addons();
         return $error_message;
     }
-
 
 
     /**
@@ -2533,7 +2539,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Set to easily debug the next X queries ran from this model.
      *
@@ -2543,7 +2548,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         $this->_show_next_x_db_queries = $count;
     }
-
 
 
     /**
@@ -2558,7 +2562,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Adds a relationship of the correct type between $modelObject and $otherModelObject.
      * There are the 3 cases:
@@ -2570,8 +2573,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * If one of the model Objects has not yet been saved to the database, it is saved before adding the entry in the
      * join table
      *
-     * @param        EE_Base_Class                     /int $thisModelObject
-     * @param        EE_Base_Class                     /int $id_or_obj EE_base_Class or ID of other Model Object
+     * @param EE_Base_Class                     /int $thisModelObject
+     * @param EE_Base_Class                     /int $id_or_obj EE_base_Class or ID of other Model Object
      * @param string $relationName                     , key in EEM_Base::_relations
      *                                                 an attendee to a group, you also want to specify which role they
      *                                                 will have in that group. So you would use this parameter to
@@ -2588,12 +2591,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $id_or_obj,
         $other_model_id_or_obj,
         $relationName,
-        $extra_join_model_fields_n_values = array()
+        $extra_join_model_fields_n_values = []
     ) {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->add_relation_to($id_or_obj, $other_model_id_or_obj, $extra_join_model_fields_n_values);
     }
-
 
 
     /**
@@ -2605,38 +2607,36 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * an error
      * 'hasAndBelongsToMany' relationships:removes any existing entry in the join table between the two models.
      *
-     * @param        EE_Base_Class /int $id_or_obj
-     * @param        EE_Base_Class /int $other_model_id_or_obj EE_Base_Class or ID of other Model Object
+     * @param EE_Base_Class /int $id_or_obj
+     * @param EE_Base_Class /int $other_model_id_or_obj EE_Base_Class or ID of other Model Object
      * @param string $relationName key in EEM_Base::_relations
-     * @return boolean of success
-     * @throws EE_Error
      * @param array  $where_query  This allows you to enter further query params for the relation to for relation to
      *                             methods that allow you to further specify extra columns to join by (such as HABTM).
      *                             Keep in mind that the only acceptable query_params is strict "col" => "value" pairs
      *                             because these will be inserted in any new rows created as well.
+     * @return boolean of success
+     * @throws EE_Error
      */
-    public function remove_relationship_to($id_or_obj, $other_model_id_or_obj, $relationName, $where_query = array())
+    public function remove_relationship_to($id_or_obj, $other_model_id_or_obj, $relationName, $where_query = [])
     {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->remove_relation_to($id_or_obj, $other_model_id_or_obj, $where_query);
     }
 
 
-
     /**
-     * @param mixed           $id_or_obj
-     * @param string          $relationName
-     * @param array           $where_query_params
+     * @param mixed  $id_or_obj
+     * @param string $relationName
+     * @param array  $where_query_params
      * @param EE_Base_Class[] objects to which relations were removed
      * @return \EE_Base_Class[]
      * @throws EE_Error
      */
-    public function remove_relations($id_or_obj, $relationName, $where_query_params = array())
+    public function remove_relations($id_or_obj, $relationName, $where_query_params = [])
     {
         $relation_obj = $this->related_settings_for($relationName);
         return $relation_obj->remove_relations($id_or_obj, $where_query_params);
     }
-
 
 
     /**
@@ -2646,17 +2646,17 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param mixed  $id_or_obj    EE_Base_Class child or its ID
      * @param string $model_name   like 'Event', 'Registration', etc. always singular
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class[]
      * @throws EE_Error
      */
     public function get_all_related($id_or_obj, $model_name, $query_params = null)
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->get_all_related($model_obj, $query_params);
     }
-
 
 
     /**
@@ -2671,13 +2671,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return int how many deleted
      * @throws EE_Error
      */
-    public function delete_related($id_or_obj, $model_name, $query_params = array())
+    public function delete_related($id_or_obj, $model_name, $query_params = [])
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->delete_all_related($model_obj, $query_params);
     }
-
 
 
     /**
@@ -2692,22 +2691,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return int how many deleted
      * @throws EE_Error
      */
-    public function delete_related_permanently($id_or_obj, $model_name, $query_params = array())
+    public function delete_related_permanently($id_or_obj, $model_name, $query_params = [])
     {
-        $model_obj = $this->ensure_is_obj($id_or_obj);
+        $model_obj         = $this->ensure_is_obj($id_or_obj);
         $relation_settings = $this->related_settings_for($model_name);
         return $relation_settings->delete_related_permanently($model_obj, $query_params);
     }
-
 
 
     /**
      * Instead of getting the related model objects, simply counts them. Ignores default_where_conditions by default,
      * unless otherwise specified in the $query_params
      *
-     * @param        int             /EE_Base_Class $id_or_obj
+     * @param int             /EE_Base_Class $id_or_obj
      * @param string $model_name     like 'Event', or 'Registration'
-     * @param array  $query_params   @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params   @see
+     *                               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_count name of field to count by. By default, uses primary key
      * @param bool   $distinct       if we want to only count the distinct values for the column then you can trigger
      *                               that by the setting $distinct to TRUE;
@@ -2717,7 +2716,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function count_related(
         $id_or_obj,
         $model_name,
-        $query_params = array(),
+        $query_params = [],
         $field_to_count = null,
         $distinct = false
     ) {
@@ -2727,21 +2726,21 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (! isset($query_params['default_where_conditions'])) {
             $query_params['default_where_conditions'] = EEM_Base::default_where_conditions_none;
         }
-        $this_model_name = $this->get_this_model_name();
-        $this_pk_field_name = $this->get_primary_key_field()->get_name();
+        $this_model_name                                                 = $this->get_this_model_name();
+        $this_pk_field_name                                              = $this->get_primary_key_field()->get_name();
         $query_params[0][ $this_model_name . "." . $this_pk_field_name ] = $id_or_obj;
         return $related_model->count($query_params, $field_to_count, $distinct);
     }
-
 
 
     /**
      * Instead of getting the related model objects, simply sums up the values of the specified field.
      * Note: ignores default_where_conditions by default, unless otherwise specified in the $query_params
      *
-     * @param        int           /EE_Base_Class $id_or_obj
+     * @param int           /EE_Base_Class $id_or_obj
      * @param string $model_name   like 'Event', or 'Registration'
-     * @param array  $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array  $query_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @param string $field_to_sum name of field to count by. By default, uses primary key
      * @return float
      * @throws EE_Error
@@ -2758,19 +2757,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         // we're just going to use the query params on the related model's normal get_all query,
         // except add a condition to say to match the current mod
         if (! isset($query_params['default_where_conditions'])) {
             $query_params['default_where_conditions'] = EEM_Base::default_where_conditions_none;
         }
-        $this_model_name = $this->get_this_model_name();
-        $this_pk_field_name = $this->get_primary_key_field()->get_name();
+        $this_model_name                                                 = $this->get_this_model_name();
+        $this_pk_field_name                                              = $this->get_primary_key_field()->get_name();
         $query_params[0][ $this_model_name . "." . $this_pk_field_name ] = $id_or_obj;
         return $related_model->sum($query_params, $field_to_sum);
     }
-
 
 
     /**
@@ -2779,20 +2777,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int | EE_Base_Class $id_or_obj        EE_Base_Class child or its ID
      * @param string              $other_model_name , key in $this->_relatedModels, eg 'Registration', or 'Events'
-     * @param array               $query_params     @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array               $query_params     @see
+     *                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Base_Class
      * @throws EE_Error
      */
     public function get_first_related(EE_Base_Class $id_or_obj, $other_model_name, $query_params)
     {
         $query_params['limit'] = 1;
-        $results = $this->get_all_related($id_or_obj, $other_model_name, $query_params);
+        $results               = $this->get_all_related($id_or_obj, $other_model_name, $query_params);
         if ($results) {
             return array_shift($results);
         }
         return null;
     }
-
 
 
     /**
@@ -2804,7 +2802,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return str_replace("EEM_", "", get_class($this));
     }
-
 
 
     /**
@@ -2821,14 +2818,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
         if (! isset($field_with_model_name) || ! $field_with_model_name) {
-            throw new EE_Error(sprintf(
-                esc_html__("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
-                $this->get_this_model_name()
-            ));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__("There is no EE_Any_Foreign_Model_Name field on model %s", "event_espresso"),
+                    $this->get_this_model_name()
+                )
+            );
         }
         return $field_with_model_name;
     }
-
 
 
     /**
@@ -2858,7 +2856,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $field_n_values = (array) apply_filters('FHEE__EEM_Base__insert__fields_n_values', $field_n_values, $this);
         if ($this->_satisfies_unique_indexes($field_n_values)) {
             $main_table = $this->_get_main_table();
-            $new_id = $this->_insert_into_specific_table($main_table, $field_n_values, false);
+            $new_id     = $this->_insert_into_specific_table($main_table, $field_n_values, false);
             if ($new_id !== false) {
                 foreach ($this->_get_other_tables() as $other_table) {
                     $this->_insert_into_specific_table($other_table, $field_n_values, $new_id);
@@ -2867,8 +2865,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             /**
              * Done just after attempting to insert a new model object
              *
-             * @param EEM_Base   $model           used
-             * @param array      $fields_n_values fields and their values
+             * @param EEM_Base $model           used
+             * @param array    $fields_n_values fields and their values
              * @param int|string the              ID of the newly-inserted model object
              */
             do_action('AHEE__EEM_Base__insert__end', $this, $field_n_values, $new_id);
@@ -2876,7 +2874,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return false;
     }
-
 
 
     /**
@@ -2891,7 +2888,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         foreach ($this->unique_indexes() as $index_name => $index) {
             $uniqueness_where_params = array_intersect_key($field_n_values, $index->fields());
-            if ($this->exists(array($uniqueness_where_params))) {
+            if ($this->exists([$uniqueness_where_params])) {
                 EE_Error::add_error(
                     sprintf(
                         esc_html__(
@@ -2915,7 +2912,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Checks the database for an item that conflicts (ie, if this item were
      * saved to the DB would break some uniqueness requirement, like a primary key
@@ -2929,8 +2925,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                 when finding "conflicts". If true, it's also considered).
      *                                                 Only works for INT primary key,
      *                                                 STRING primary keys cannot be ignored
-     * @throws EE_Error
      * @return EE_Base_Class|array
+     * @throws EE_Error
      */
     public function get_one_conflicting($obj_or_fields_array, $include_primary_key = true)
     {
@@ -2950,7 +2946,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 )
             );
         }
-        $query_params = array();
+        $query_params = [];
         if (
             $this->has_primary_key_field()
             && ($include_primary_key
@@ -2962,16 +2958,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $query_params[0]['OR'][ $this->primary_key_name() ] = $fields_n_values[ $this->primary_key_name() ];
         }
         foreach ($this->unique_indexes() as $unique_index_name => $unique_index) {
-            $uniqueness_where_params = array_intersect_key($fields_n_values, $unique_index->fields());
+            $uniqueness_where_params                              =
+                array_intersect_key($fields_n_values, $unique_index->fields());
             $query_params[0]['OR'][ 'AND*' . $unique_index_name ] = $uniqueness_where_params;
         }
         // if there is nothing to base this search on, then we shouldn't find anything
         if (empty($query_params)) {
-            return array();
+            return [];
         }
         return $this->get_one($query_params);
     }
-
 
 
     /**
@@ -2988,7 +2984,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Wrapper for exists, except ignores default query parameters so we're only considering ID
      *
@@ -2999,15 +2994,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function exists_by_ID($id)
     {
         return $this->exists(
-            array(
+            [
                 'default_where_conditions' => EEM_Base::default_where_conditions_none,
-                array(
+                [
                     $this->primary_key_name() => $id,
-                ),
-            )
+                ],
+            ]
         );
     }
-
 
 
     /**
@@ -3023,16 +3017,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array         $fields_n_values each key should be in field's keys, and value should be an int, string or
      *                                       float
      * @param int           $new_id          for now we assume only int keys
+     * @return int ID of new row inserted, or FALSE on failure
      * @throws EE_Error
      * @global WPDB         $wpdb            only used to get the $wpdb->insert_id after performing an insert
-     * @return int ID of new row inserted, or FALSE on failure
      */
     protected function _insert_into_specific_table(EE_Table_Base $table, $fields_n_values, $new_id = 0)
     {
         global $wpdb;
-        $insertion_col_n_values = array();
-        $format_for_insertion = array();
-        $fields_on_table = $this->_get_fields_for_table($table->get_table_alias());
+        $insertion_col_n_values = [];
+        $format_for_insertion   = [];
+        $fields_on_table        = $this->_get_fields_for_table($table->get_table_alias());
         foreach ($fields_on_table as $field_name => $field_obj) {
             // check if its an auto-incrementing column, in which case we should just leave it to do its autoincrement thing
             if ($field_obj->is_auto_increment()) {
@@ -3042,19 +3036,21 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // if the value we want to assign it to is NULL, just don't mention it for the insertion
             if ($prepared_value !== null) {
                 $insertion_col_n_values[ $field_obj->get_table_column() ] = $prepared_value;
-                $format_for_insertion[] = $field_obj->get_wpdb_data_type();
+                $format_for_insertion[]                                   = $field_obj->get_wpdb_data_type();
             }
         }
         if ($table instanceof EE_Secondary_Table && $new_id) {
             // its not the main table, so we should have already saved the main table's PK which we just inserted
             // so add the fk to the main table as a column
             $insertion_col_n_values[ $table->get_fk_on_table() ] = $new_id;
-            $format_for_insertion[] = '%d';// yes right now we're only allowing these foreign keys to be INTs
+            $format_for_insertion[]                              =
+                '%d';// yes right now we're only allowing these foreign keys to be INTs
         }
+
         // insert the new entry
         $result = $this->_do_wpdb_query(
             'insert',
-            array($table->get_table_name(), $insertion_col_n_values, $format_for_insertion)
+            [$table->get_table_name(), $insertion_col_n_values, $format_for_insertion]
         );
         if ($result === false) {
             return false;
@@ -3074,7 +3070,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Prepare the $field_obj 's value in $fields_n_values for use in the database.
      * If the field doesn't allow NULL, try to use its default. (If it doesn't allow NULL,
@@ -3087,22 +3082,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function _prepare_value_or_use_default($field_obj, $fields_n_values)
     {
+        $field_name = $field_obj->get_name();
         // if this field doesn't allow nullable, don't allow it
-        if (
-            ! $field_obj->is_nullable()
-            && (
-                ! isset($fields_n_values[ $field_obj->get_name() ])
-                || $fields_n_values[ $field_obj->get_name() ] === null
-            )
-        ) {
-            $fields_n_values[ $field_obj->get_name() ] = $field_obj->get_default_value();
+        if (! $field_obj->is_nullable() && ! isset($fields_n_values[ $field_name ])) {
+            $fields_n_values[ $field_name ] = $field_obj->get_default_value();
         }
-        $unprepared_value = isset($fields_n_values[ $field_obj->get_name() ])
-            ? $fields_n_values[ $field_obj->get_name() ]
-            : null;
+        $unprepared_value = $fields_n_values[ $field_name ] ?? null;
         return $this->_prepare_value_for_use_in_db($unprepared_value, $field_obj);
     }
-
 
 
     /**
@@ -3119,7 +3106,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     private function _prepare_value_for_use_in_db($value, $field)
     {
-        if ($field && $field instanceof EE_Model_Field_Base) {
+        if ($field instanceof EE_Model_Field_Base) {
             // phpcs:disable PSR2.ControlStructures.SwitchDeclaration.TerminatingComment
             switch ($this->_values_already_prepared_by_model_object) {
                 /** @noinspection PhpMissingBreakStatementInspection */
@@ -3130,16 +3117,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 case self::prepared_by_model_object:
                     /** @noinspection SuspiciousAssignmentsInspection */
                     $value = $field->prepare_for_use_in_db($value);
-                    // no break
+                // no break
                 case self::prepared_for_use_in_db:
                     // leave the value alone
             }
-            return $value;
             // phpcs:enable
         }
         return $value;
     }
-
 
 
     /**
@@ -3155,12 +3140,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 return $table;
             }
         }
-        throw new EE_Error(sprintf(esc_html__(
-            'There are no main tables on %s. They should be added to _tables array in the constructor',
-            'event_espresso'
-        ), get_class($this)));
+        throw new EE_Error(
+            sprintf(
+                esc_html__(
+                    'There are no main tables on %s. They should be added to _tables array in the constructor',
+                    'event_espresso'
+                ),
+                get_class($this)
+            )
+        );
     }
-
 
 
     /**
@@ -3174,7 +3163,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_get_main_table()->get_table_name();
     }
-
 
 
     /**
@@ -3191,7 +3179,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * get_table_obj_by_alias
      * returns table name given it's alias
@@ -3205,7 +3192,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the tables of type EE_Other_Table from EEM_CPT_Basel_Model::_tables
      *
@@ -3213,7 +3199,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function _get_other_tables()
     {
-        $other_tables = array();
+        $other_tables = [];
         foreach ($this->_tables as $table_alias => $table) {
             if ($table instanceof EE_Secondary_Table) {
                 $other_tables[ $table_alias ] = $table;
@@ -3221,7 +3207,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $other_tables;
     }
-
 
 
     /**
@@ -3236,7 +3221,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Recurses through all the where parameters, and finds all the related models we'll need
      * to complete this query. Eg, given where parameters like array('EVT_ID'=>3) from within Event model, we won't
@@ -3244,7 +3228,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Registration model. If it were array('Registrations.Transactions.Payments.PAY_ID'=>3), then we'd need the
      * related Registration, Transaction, and Payment models.
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
      */
@@ -3303,11 +3288,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * For extracting related models from WHERE (0), HAVING (having), ORDER BY (order_by) or forced joins (force_join)
      *
-     * @param array                       $sub_query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
+     * @param array                       $sub_query_params @see
+     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @throws EE_Error
@@ -3331,17 +3316,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 // indicate needed joins. Eg, array('NOT'=>array('Registration.TXN_ID'=>23)). In this case, we tried
                 // extracting models out of the 'NOT', which obviously wasn't successful, and then we recurse into the value
                 // of array('Registration.TXN_ID'=>23)
-                $query_param_sans_stars = $this->_remove_stars_and_anything_after_from_condition_query_param_key($param);
+                $query_param_sans_stars =
+                    $this->_remove_stars_and_anything_after_from_condition_query_param_key($param);
                 if (in_array($query_param_sans_stars, $this->_logic_query_param_keys, true)) {
                     if (! is_array($possibly_array_of_params)) {
-                        throw new EE_Error(sprintf(
-                            esc_html__(
-                                "You used a special where query param %s, but the value isn't an array of where query params, it's just %s'. It should be an array, eg array('EVT_ID'=>23,'OR'=>array('Venue.VNU_ID'=>32,'Venue.VNU_name'=>'monkey_land'))",
-                                "event_espresso"
-                            ),
-                            $param,
-                            $possibly_array_of_params
-                        ));
+                        throw new EE_Error(
+                            sprintf(
+                                esc_html__(
+                                    "You used a special where query param %s, but the value isn't an array of where query params, it's just %s'. It should be an array, eg array('EVT_ID'=>23,'OR'=>array('Venue.VNU_ID'=>32,'Venue.VNU_name'=>'monkey_land'))",
+                                    "event_espresso"
+                                ),
+                                $param,
+                                $possibly_array_of_params
+                            )
+                        );
                     }
                     $this->_extract_related_models_from_sub_params_array_keys(
                         $possibly_array_of_params,
@@ -3350,18 +3338,24 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     );
                 } elseif (
                     $query_param_type === 0 // ie WHERE
-                          && is_array($possibly_array_of_params)
-                          && isset($possibly_array_of_params[2])
-                          && $possibly_array_of_params[2] == true
+                    && is_array($possibly_array_of_params)
+                    && isset($possibly_array_of_params[2])
+                    && $possibly_array_of_params[2] == true
                 ) {
                     // then $possible_array_of_params looks something like array('<','DTT_sold',true)
                     // indicating that $possible_array_of_params[1] is actually a field name,
                     // from which we should extract query parameters!
                     if (! isset($possibly_array_of_params[0], $possibly_array_of_params[1])) {
-                        throw new EE_Error(sprintf(esc_html__(
-                            "Improperly formed query parameter %s. It should be numerically indexed like array('<','DTT_sold',true); but you provided %s",
-                            "event_espresso"
-                        ), $query_param_type, implode(",", $possibly_array_of_params)));
+                        throw new EE_Error(
+                            sprintf(
+                                esc_html__(
+                                    "Improperly formed query parameter %s. It should be numerically indexed like array('<','DTT_sold',true); but you provided %s",
+                                    "event_espresso"
+                                ),
+                                $query_param_type,
+                                implode(",", $possibly_array_of_params)
+                            )
+                        );
                     }
                     $this->_extract_related_model_info_from_query_param(
                         $possibly_array_of_params[1],
@@ -3375,12 +3369,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * For extracting related models from forced_joins, where the array values contain the info about what
      * models to join with. Eg an array like array('Attendee','Price.Price_Type');
      *
-     * @param array                       $sub_query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array                       $sub_query_params @see
+     *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
      * @throws EE_Error
@@ -3393,10 +3387,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     ) {
         if (! empty($sub_query_params)) {
             if (! is_array($sub_query_params)) {
-                throw new EE_Error(sprintf(
-                    esc_html__("Query parameter %s should be an array, but it isn't.", "event_espresso"),
-                    $sub_query_params
-                ));
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__("Query parameter %s should be an array, but it isn't.", "event_espresso"),
+                        $sub_query_params
+                    )
+                );
             }
             foreach ($sub_query_params as $param) {
                 // $param could be simply 'EVT_ID', or it could be 'Registrations.REG_ID', or even 'Registrations.Transactions.Payments.PAY_amount'
@@ -3419,7 +3415,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * before we know what joins to perform. However, we need to know what data types correspond to which fields on
      * other models before we can finalize the where clause SQL.
      *
-     * @param array $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array $query_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @return EE_Model_Query_Info_Carrier
      * @throws ModelConfigurationException
@@ -3438,9 +3435,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
-        $query_params[0] = isset($query_params[0]) ? $query_params[0] : array();
+        $query_params[0] = isset($query_params[0]) ? $query_params[0] : [];
         // first check if we should alter the query to account for caps or not
         // because the caps might require us to do extra joins
         if (isset($query_params['caps']) && $query_params['caps'] !== 'none') {
@@ -3455,10 +3452,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if (isset($query_params['exclude_protected']) && $query_params['exclude_protected'] === true) {
             $where_param_key_for_password = $this->modelChainAndPassword();
             // only include if related to a cpt where no password has been set
-            $query_params[0]['OR*nopassword'] = array(
-                $where_param_key_for_password => '',
-                $where_param_key_for_password . '*' => array('IS_NULL')
-            );
+            $query_params[0]['OR*nopassword'] = [
+                $where_param_key_for_password       => '',
+                $where_param_key_for_password . '*' => ['IS_NULL'],
+            ];
         }
         $query_object = $this->_extract_related_models_from_query($query_params);
         // verify where_query_params has NO numeric indexes.... that's simply not how you use it!
@@ -3553,9 +3550,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     'order_by'
                 );
                 // assume it's an array of fields to order by
-                $order_array = array();
+                $order_array = [];
                 foreach ($query_params['order_by'] as $field_name_to_order_by => $order) {
-                    $order = $this->_extract_order($order);
+                    $order         = $this->_extract_order($order);
                     $order_array[] = $this->_deduce_column_name_from_query_param($field_name_to_order_by) . SP . $order;
                 }
                 $query_object->set_order_by_sql(" ORDER BY " . implode(",", $order_array));
@@ -3581,14 +3578,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             && ! empty($query_params['order'])
         ) {
             $pk_field = $this->get_primary_key_field();
-            $order = $this->_extract_order($query_params['order']);
+            $order    = $this->_extract_order($query_params['order']);
             $query_object->set_order_by_sql(" ORDER BY " . $pk_field->get_qualified_column() . SP . $order);
         }
         // set group by
         if (array_key_exists('group_by', $query_params)) {
             if (is_array($query_params['group_by'])) {
                 // it's an array, so assume we'll be grouping by a bunch of stuff
-                $group_by_array = array();
+                $group_by_array = [];
                 foreach ($query_params['group_by'] as $field_name_to_group_by) {
                     $group_by_array[] = $this->_deduce_column_name_from_query_param($field_name_to_group_by);
                 }
@@ -3628,20 +3625,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the where conditions that should be imposed on the query based on the
      * context (eg reading frontend, backend, edit or delete).
      *
      * @param string $context one of EEM_Base::valid_cap_contexts()
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
      */
     public function caps_where_conditions($context = self::caps_read)
     {
         EEM_Base::verify_is_valid_cap_context($context);
-        $cap_where_conditions = array();
-        $cap_restrictions = $this->caps_missing($context);
+        $cap_where_conditions = [];
+        $cap_restrictions     = $this->caps_missing($context);
         /**
          * @var $cap_restrictions EE_Default_Where_Conditions[]
          */
@@ -3659,7 +3656,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $cap_restrictions
         );
     }
-
 
 
     /**
@@ -3688,7 +3684,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Looks at all the models which are included in this query, and asks each
      * for their universal_where_params, and returns them in the same format as $query_params[0] (where),
@@ -3703,27 +3698,31 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                                  not for this primary model. 'all', the default,
      *                                                                  means default where conditions will apply as
      *                                                                  normal
-     * @param array                       $where_query_params           @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array                       $where_query_params           @see
+     *                                                                  https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _get_default_where_conditions_for_models_in_query(
         EE_Model_Query_Info_Carrier $query_info_carrier,
-        $use_default_where_conditions = EEM_Base::default_where_conditions_all,
-        $where_query_params = array()
+                                    $use_default_where_conditions = EEM_Base::default_where_conditions_all,
+                                    $where_query_params = []
     ) {
         $allowed_used_default_where_conditions_values = EEM_Base::valid_default_where_conditions();
         if (! in_array($use_default_where_conditions, $allowed_used_default_where_conditions_values)) {
-            throw new EE_Error(sprintf(
-                esc_html__(
-                    "You passed an invalid value to the query parameter 'default_where_conditions' of '%s'. Allowed values are %s",
-                    "event_espresso"
-                ),
-                $use_default_where_conditions,
-                implode(", ", $allowed_used_default_where_conditions_values)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "You passed an invalid value to the query parameter 'default_where_conditions' of '%s'. Allowed values are %s",
+                        "event_espresso"
+                    ),
+                    $use_default_where_conditions,
+                    implode(", ", $allowed_used_default_where_conditions_values)
+                )
+            );
         }
-        $universal_query_params = array();
+        $universal_query_params = [];
         if ($this->_should_use_default_where_conditions($use_default_where_conditions, true)) {
             $universal_query_params = $this->_get_default_where_conditions();
         } elseif ($this->_should_use_minimum_where_conditions($use_default_where_conditions, true)) {
@@ -3732,14 +3731,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         foreach ($query_info_carrier->get_model_names_included() as $model_relation_path => $model_name) {
             $related_model = $this->get_related_model_obj($model_name);
             if ($this->_should_use_default_where_conditions($use_default_where_conditions, false)) {
-                $related_model_universal_where_params = $related_model->_get_default_where_conditions($model_relation_path);
+                $related_model_universal_where_params =
+                    $related_model->_get_default_where_conditions($model_relation_path);
             } elseif ($this->_should_use_minimum_where_conditions($use_default_where_conditions, false)) {
-                $related_model_universal_where_params = $related_model->_get_minimum_where_conditions($model_relation_path);
+                $related_model_universal_where_params =
+                    $related_model->_get_minimum_where_conditions($model_relation_path);
             } else {
                 // we don't want to add full or even minimum default where conditions from this model, so just continue
                 continue;
             }
-            $overrides = $this->_override_defaults_or_make_null_friendly(
+            $overrides              = $this->_override_defaults_or_make_null_friendly(
                 $related_model_universal_where_params,
                 $where_query_params,
                 $related_model,
@@ -3754,7 +3755,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Determines whether or not we should use default where conditions for the model in question
      * (this model, or other related models).
@@ -3762,6 +3762,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * this model only, or to use minimum where conditions on all other models and normal where conditions on this one.
      * We should use default where conditions on related models when they requested to use default where conditions
      * on all models, or specifically just on other related models
+     *
      * @param      $default_where_conditions_value
      * @param bool $for_this_model false means this is for OTHER related models
      * @return bool
@@ -3772,11 +3773,11 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_all,
                            EEM_Base::default_where_conditions_this_only,
                            EEM_Base::default_where_conditions_minimum_others,
-                       ),
+                       ],
                        true
                    )
                )
@@ -3784,14 +3785,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    ! $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_all,
                            EEM_Base::default_where_conditions_others_only,
-                       ),
+                       ],
                        true
                    )
                );
     }
+
 
     /**
      * Determines whether or not we should use default minimum conditions for the model in question
@@ -3800,6 +3802,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * where conditions.
      * We should use minimum where conditions on related models if they requested to use minimum where conditions
      * on this model or others
+     *
      * @param      $default_where_conditions_value
      * @param bool $for_this_model false means this is for OTHER related models
      * @return bool
@@ -3814,10 +3817,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                    ! $for_this_model
                    && in_array(
                        $default_where_conditions_value,
-                       array(
+                       [
                            EEM_Base::default_where_conditions_minimum_others,
                            EEM_Base::default_where_conditions_minimum_all,
-                       ),
+                       ],
                        true
                    )
                );
@@ -3834,7 +3837,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array    $provided_where_conditions
      * @param EEM_Base $model
      * @param string   $model_relation_path like 'Transaction.Payment.'
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @throws EE_Error
      */
     private function _override_defaults_or_make_null_friendly(
@@ -3843,9 +3847,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $model,
         $model_relation_path
     ) {
-        $null_friendly_where_conditions = array();
-        $none_overridden = true;
-        $or_condition_key_for_defaults = 'OR*' . get_class($model);
+        $null_friendly_where_conditions = [];
+        $none_overridden                = true;
+        $or_condition_key_for_defaults  = 'OR*' . get_class($model);
         foreach ($default_where_conditions as $key => $val) {
             if (isset($provided_where_conditions[ $key ])) {
                 $none_overridden = false;
@@ -3856,15 +3860,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         if ($none_overridden && $default_where_conditions) {
             if ($model->has_primary_key_field()) {
                 $null_friendly_where_conditions[ $or_condition_key_for_defaults ][ $model_relation_path
-                                                                                . "."
-                                                                                . $model->primary_key_name() ] = array('IS NULL');
+                                                                                   . "."
+                                                                                   . $model->primary_key_name() ] =
+                    ['IS NULL'];
             }/*else{
                 //@todo NO PK, use other defaults
             }*/
         }
         return $null_friendly_where_conditions;
     }
-
 
 
     /**
@@ -3874,16 +3878,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * NOT array('Event_CPT.post_type'=>'esp_event').
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     private function _get_default_where_conditions($model_relation_path = '')
     {
         if ($this->_ignore_where_strategy) {
-            return array();
+            return [];
         }
         return $this->_default_where_conditions_strategy->get_default_where_conditions($model_relation_path);
     }
-
 
 
     /**
@@ -3894,16 +3898,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Similar to _get_default_where_conditions
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
-     * @return array @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @return array @see
+     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      */
     protected function _get_minimum_where_conditions($model_relation_path = '')
     {
         if ($this->_ignore_where_strategy) {
-            return array();
+            return [];
         }
         return $this->_minimum_where_conditions_strategy->get_default_where_conditions($model_relation_path);
     }
-
 
 
     /**
@@ -3921,14 +3925,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $model_query_info->get_model_names_included() as $model_relation_chain => $name_of_other_model_included
         ) {
             $other_model_included = $this->get_related_model_obj($name_of_other_model_included);
-            $other_model_selects = $other_model_included->_get_columns_to_select_for_this_model($model_relation_chain);
+            $other_model_selects  = $other_model_included->_get_columns_to_select_for_this_model($model_relation_chain);
             foreach ($other_model_selects as $key => $value) {
                 $selects[] = $value;
             }
         }
         return implode(", ", $selects);
     }
-
 
 
     /**
@@ -3940,12 +3943,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _get_columns_to_select_for_this_model($model_relation_chain = '')
     {
-        $fields = $this->field_settings();
-        $selects = array();
-        $table_alias_with_model_relation_chain_prefix = EE_Model_Parser::extract_table_alias_model_relation_chain_prefix(
-            $model_relation_chain,
-            $this->get_this_model_name()
-        );
+        $fields                                       = $this->field_settings();
+        $selects                                      = [];
+        $table_alias_with_model_relation_chain_prefix =
+            EE_Model_Parser::extract_table_alias_model_relation_chain_prefix(
+                $model_relation_chain,
+                $this->get_this_model_name()
+            );
         foreach ($fields as $field_obj) {
             $selects[] = $table_alias_with_model_relation_chain_prefix
                          . $field_obj->get_table_alias()
@@ -3973,7 +3977,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Given a $query_param like 'Registration.Transaction.TXN_ID', pops off 'Registration.',
      * gets the join statement for it; gets the data types for it; and passes the remaining 'Transaction.TXN_ID'
@@ -3983,15 +3986,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param null|string                 $original_query_param
      * @param string                      $query_param          like Registration.Transaction.TXN_ID
      * @param EE_Model_Query_Info_Carrier $passed_in_query_info
-     * @param    string                   $query_param_type     like Registration.Transaction.TXN_ID
+     * @param string                      $query_param_type     like Registration.Transaction.TXN_ID
      *                                                          or 'PAY_ID'. Otherwise, we don't expect there to be a
      *                                                          column name. We only want model names, eg 'Event.Venue'
      *                                                          or 'Registration's
      * @param string                      $original_query_param what it originally was (eg
      *                                                          Registration.Transaction.TXN_ID). If null, we assume it
      *                                                          matches $query_param
-     * @throws EE_Error
      * @return void only modifies the EEM_Related_Model_Info_Carrier passed into it
+     * @throws EE_Error
      */
     private function _extract_related_model_info_from_query_param(
         $query_param,
@@ -4097,22 +4100,24 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Extracts any possible join model information from the provided possible_join_string.
-     * This method will read the provided $possible_join_string value and determine if there are any possible model join
+     * This method will read the provided $possible_join_string value and determine if there are any possible model
+     * join
      * parts that should be added to the query.
      *
      * @param EE_Model_Query_Info_Carrier $query_info_carrier
      * @param string                      $possible_join_string  Such as Registration.REG_ID, or Registration
      * @param null|string                 $original_query_param
      * @param string                      $query_parameter_type  The type for the source of the $possible_join_string
-     *                                                           ('where', 'order_by', 'group_by', 'custom_selects' etc.)
+     *                                                           ('where', 'order_by', 'group_by', 'custom_selects'
+     *                                                           etc.)
      * @return bool  returns true if a join was added and false if not.
      * @throws EE_Error
      */
     private function extractJoinModelFromQueryParams(
         EE_Model_Query_Info_Carrier $query_info_carrier,
-        $possible_join_string,
-        $original_query_param,
-        $query_parameter_type
+                                    $possible_join_string,
+                                    $original_query_param,
+                                    $query_parameter_type
     ) {
         foreach ($this->_model_relations as $valid_related_model_name => $relation_obj) {
             if (strpos($possible_join_string, $valid_related_model_name . ".") === 0) {
@@ -4158,6 +4163,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Extracts related models from Custom Selects and sets up any joins for those related models.
+     *
      * @param EE_Model_Query_Info_Carrier $query_info_carrier
      * @throws EE_Error
      */
@@ -4181,7 +4187,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             }
         }
     }
-
 
 
     /**
@@ -4208,21 +4213,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         EE_Model_Query_Info_Carrier $passed_in_query_info,
         $original_query_param
     ) {
-        $relation_obj = $this->related_settings_for($model_name);
+        $relation_obj         = $this->related_settings_for($model_name);
         $model_relation_chain = EE_Model_Parser::extract_model_relation_chain($model_name, $original_query_param);
         // check if the relation is HABTM, because then we're essentially doing two joins
         // If so, join first to the JOIN table, and add its data types, and then continue as normal
         if ($relation_obj instanceof EE_HABTM_Relation) {
             $join_model_obj = $relation_obj->get_join_model();
             // replace the model specified with the join model for this relation chain, whi
-            $relation_chain_to_join_model = EE_Model_Parser::replace_model_name_with_join_model_name_in_model_relation_chain(
-                $model_name,
-                $join_model_obj->get_this_model_name(),
-                $model_relation_chain
-            );
+            $relation_chain_to_join_model =
+                EE_Model_Parser::replace_model_name_with_join_model_name_in_model_relation_chain(
+                    $model_name,
+                    $join_model_obj->get_this_model_name(),
+                    $model_relation_chain
+                );
             $passed_in_query_info->merge(
                 new EE_Model_Query_Info_Carrier(
-                    array($relation_chain_to_join_model => $join_model_obj->get_this_model_name()),
+                    [$relation_chain_to_join_model => $join_model_obj->get_this_model_name()],
                     $relation_obj->get_join_to_intermediate_model_statement($relation_chain_to_join_model)
                 )
             );
@@ -4230,18 +4236,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // now just join to the other table pointed to by the relation object, and add its data types
         $passed_in_query_info->merge(
             new EE_Model_Query_Info_Carrier(
-                array($model_relation_chain => $model_name),
+                [$model_relation_chain => $model_name],
                 $relation_obj->get_join_statement($model_relation_chain)
             )
         );
     }
 
 
-
     /**
      * Constructs SQL for where clause, like "WHERE Event.ID = 23 AND Transaction.amount > 100" etc.
      *
-     * @param array $where_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array $where_params @see
+     *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @return string of SQL
      * @throws EE_Error
      */
@@ -4253,7 +4259,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return '';
     }
-
 
 
     /**
@@ -4278,14 +4283,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Used for creating nested WHERE conditions. Eg "WHERE ! (Event.ID = 3 OR ( Event_Meta.meta_key = 'bob' AND
      * Event_Meta.meta_value = 'foo'))"
      *
-     * @param array  $where_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @param array  $where_params @see
+     *                             https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @param string $glue         joins each subclause together. Should really only be " AND " or " OR "...
      * @throws EE_Error
      * @return string of SQL
      */
     private function _construct_condition_clause_recursive($where_params, $glue = ' AND')
     {
-        $where_clauses = array();
+        $where_clauses = [];
         foreach ($where_params as $query_param => $op_and_value_or_sub_condition) {
             $query_param = $this->_remove_stars_and_anything_after_from_condition_query_param_key($query_param);
             if (in_array($query_param, $this->_logic_query_param_keys, true)) {
@@ -4294,27 +4300,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     case 'NOT':
                         $where_clauses[] = "! ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               $glue
-                                           )
+                                $op_and_value_or_sub_condition,
+                                $glue
+                            )
                                            . ")";
                         break;
                     case 'and':
                     case 'AND':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               ' AND '
-                                           )
+                                $op_and_value_or_sub_condition,
+                                ' AND '
+                            )
                                            . ")";
                         break;
                     case 'or':
                     case 'OR':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                               $op_and_value_or_sub_condition,
-                                               ' OR '
-                                           )
+                                $op_and_value_or_sub_condition,
+                                ' OR '
+                            )
                                            . ")";
                         break;
                 }
@@ -4325,27 +4331,31 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     if ($this->_custom_selections instanceof CustomSelects) {
                         $field_obj = $this->_custom_selections->getDataTypeForAlias($query_param);
                     } else {
-                        throw new EE_Error(sprintf(esc_html__(
-                            "%s is neither a valid model field name, nor a custom selection",
-                            "event_espresso"
-                        ), $query_param));
+                        throw new EE_Error(
+                            sprintf(
+                                esc_html__(
+                                    "%s is neither a valid model field name, nor a custom selection",
+                                    "event_espresso"
+                                ),
+                                $query_param
+                            )
+                        );
                     }
                 }
                 $op_and_value_sql = $this->_construct_op_and_value($op_and_value_or_sub_condition, $field_obj);
-                $where_clauses[] = $this->_deduce_column_name_from_query_param($query_param) . SP . $op_and_value_sql;
+                $where_clauses[]  = $this->_deduce_column_name_from_query_param($query_param) . SP . $op_and_value_sql;
             }
         }
         return $where_clauses ? implode($glue, $where_clauses) : '';
     }
 
 
-
     /**
      * Takes the input parameter and extract the table name (alias) and column name
      *
      * @param string $query_param like Registration.Transaction.TXN_ID, Event.Datetime.start_time, or REG_ID
-     * @throws EE_Error
      * @return string table alias and column name for SQL, eg "Transaction.TXN_ID"
+     * @throws EE_Error
      */
     private function _deduce_column_name_from_query_param($query_param)
     {
@@ -4381,7 +4391,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Removes the * and anything after it from the condition query param key. It is useful to add the * to condition
      * query param keys (eg, 'OR*', 'EVT_ID') in order for the array keys to still be unique, so that they don't get
@@ -4402,21 +4411,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * creates the SQL for the operator and the value in a WHERE clause, eg "< 23" or "LIKE '%monkey%'"
      *
-     * @param                            mixed      array | string    $op_and_value
+     * @param mixed      array | string    $op_and_value
      * @param EE_Model_Field_Base|string $field_obj . If string, should be one of EEM_Base::_valid_wpdb_data_types
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     private function _construct_op_and_value($op_and_value, $field_obj)
     {
         if (is_array($op_and_value)) {
             $operator = isset($op_and_value[0]) ? $this->_prepare_operator_for_sql($op_and_value[0]) : null;
             if (! $operator) {
-                $php_array_like_string = array();
+                $php_array_like_string = [];
                 foreach ($op_and_value as $key => $value) {
                     $php_array_like_string[] = "$key=>$value";
                 }
@@ -4433,7 +4441,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $value = isset($op_and_value[1]) ? $op_and_value[1] : null;
         } else {
             $operator = '=';
-            $value = $op_and_value;
+            $value    = $op_and_value;
         }
         // check to see if the value is actually another field
         if (is_array($op_and_value) && isset($op_and_value[2]) && $op_and_value[2] == true) {
@@ -4521,7 +4529,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Creates the operands to be used in a BETWEEN query, eg "'2014-12-31 20:23:33' AND '2015-01-23 12:32:54'"
      *
@@ -4533,7 +4540,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _construct_between_value($values, $field_obj)
     {
-        $cleaned_values = array();
+        $cleaned_values = [];
         foreach ($values as $value) {
             $cleaned_values[] = $this->_wpdb_prepare_using_field($value, $field_obj);
         }
@@ -4570,21 +4577,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // but unfortunately that's invalid SQL. So instead we return a string which we KNOW will evaluate to be the empty set
         // which is effectively equivalent to returning "()". We don't return "(0)" because that only works for auto-incrementing columns
         if (empty($prepped)) {
-            $all_fields = $this->field_settings();
-            $first_field    = reset($all_fields);
-            $main_table = $this->_get_main_table();
-            $prepped[]  = "SELECT {$first_field->get_table_column()} FROM {$main_table->get_table_name()} WHERE FALSE";
+            $all_fields  = $this->field_settings();
+            $first_field = reset($all_fields);
+            $main_table  = $this->_get_main_table();
+            $prepped[]   = "SELECT {$first_field->get_table_column()} FROM {$main_table->get_table_name()} WHERE FALSE";
         }
         return '(' . implode(',', $prepped) . ')';
     }
 
 
-
     /**
      * @param mixed                      $value
      * @param EE_Model_Field_Base|string $field_obj if string it should be a wpdb data type like '%d'
-     * @throws EE_Error
      * @return false|null|string
+     * @throws EE_Error
      */
     private function _wpdb_prepare_using_field($value, $field_obj)
     {
@@ -4609,13 +4615,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Takes the input parameter and finds the model field that it indicates.
      *
      * @param string $query_param_name like Registration.Transaction.TXN_ID, Event.Datetime.start_time, or REG_ID
-     * @throws EE_Error
      * @return EE_Model_Field_Base
+     * @throws EE_Error
      */
     protected function _deduce_field_from_query_param($query_param_name)
     {
@@ -4623,20 +4628,25 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         // which will help us find the database table and column
         $query_param_parts = explode(".", $query_param_name);
         if (empty($query_param_parts)) {
-            throw new EE_Error(sprintf(esc_html__(
-                "_extract_column_name is empty when trying to extract column and table name from %s",
-                'event_espresso'
-            ), $query_param_name));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "_extract_column_name is empty when trying to extract column and table name from %s",
+                        'event_espresso'
+                    ),
+                    $query_param_name
+                )
+            );
         }
-        $number_of_parts = count($query_param_parts);
+        $number_of_parts       = count($query_param_parts);
         $last_query_param_part = $query_param_parts[ count($query_param_parts) - 1 ];
         if ($number_of_parts === 1) {
             $field_name = $last_query_param_part;
-            $model_obj = $this;
+            $model_obj  = $this;
         } else {// $number_of_parts >= 2
             // the last part is the column name, and there are only 2parts. therefore...
             $field_name = $last_query_param_part;
-            $model_obj = $this->get_related_model_obj($query_param_parts[ $number_of_parts - 2 ]);
+            $model_obj  = $this->get_related_model_obj($query_param_parts[ $number_of_parts - 2 ]);
         }
         try {
             return $model_obj->field_settings_for($field_name);
@@ -4646,19 +4656,18 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Given a field's name (ie, a key in $this->field_settings()), uses the EE_Model_Field object to get the table's
      * alias and column which corresponds to it
      *
      * @param string $field_name
-     * @throws EE_Error
      * @return string
+     * @throws EE_Error
      */
     public function _get_qualified_column_for_field($field_name)
     {
         $all_fields = $this->field_settings();
-        $field = isset($all_fields[ $field_name ]) ? $all_fields[ $field_name ] : false;
+        $field      = isset($all_fields[ $field_name ]) ? $all_fields[ $field_name ] : false;
         if ($field) {
             return $field->get_qualified_column();
         }
@@ -4673,7 +4682,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             )
         );
     }
-
 
 
     /**
@@ -4719,9 +4727,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                            Also, when querying from the venue model and selecting fields from
      *                                            the ticket model, you should provide the string 'Event.Datetime',
      *                                            indicating you need to join the venue model to the event model,
-     *                                            to the datetime model, in order to find its relation to the ticket model.
-     *                                            This string is used to deduce the prefix that gets added onto the
-     *                                            models' tables qualified columns
+     *                                            to the datetime model, in order to find its relation to the ticket
+     *                                            model. This string is used to deduce the prefix that gets added onto
+     *                                            the models' tables qualified columns
      * @param bool   $return_string               if true, will return a string with qualified column names separated
      *                                            by ', ' if false, will simply return a numerically indexed array of
      *                                            qualified column names
@@ -4729,14 +4737,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function get_qualified_columns_for_all_fields($model_relation_chain = '', $return_string = true)
     {
-        $table_prefix = str_replace('.', '__', $model_relation_chain) . (empty($model_relation_chain) ? '' : '__');
-        $qualified_columns = array();
+        $table_prefix      = str_replace('.', '__', $model_relation_chain) . (empty($model_relation_chain) ? '' : '__');
+        $qualified_columns = [];
         foreach ($this->field_settings() as $field_name => $field) {
             $qualified_columns[] = $table_prefix . $field->get_qualified_column();
         }
         return $return_string ? implode(', ', $qualified_columns) : $qualified_columns;
     }
-
 
 
     /**
@@ -4745,8 +4752,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * its setup so the select query will be setup on and just doing the special select join off of the primary table
      * (as that is typically where the limits would be set).
      *
-     * @param  string       $table_alias The table the select is being built for
-     * @param  mixed|string $limit       The limit for this select
+     * @param string       $table_alias The table the select is being built for
+     * @param mixed|string $limit       The limit for this select
      * @return string                The final select join element for the query.
      */
     public function _construct_limit_join_select($table_alias, $limit)
@@ -4767,7 +4774,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Constructs the internal join if there are multiple tables, or simply the table's name and alias
      * Eg "wp_post AS Event" or "wp_post AS Event INNER JOIN wp_postmeta Event_Meta ON Event.ID = Event_Meta.post_id"
@@ -4781,7 +4787,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $SQL .= $this->_construct_internal_join_to_table_with_alias($this->_get_main_table()->get_table_alias());
         return $SQL;
     }
-
 
 
     /**
@@ -4799,7 +4804,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _construct_internal_join_to_table_with_alias($alias_prefixed)
     {
-        $SQL = '';
+        $SQL               = '';
         $alias_sans_prefix = EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($alias_prefixed);
         foreach ($this->_tables as $table_obj) {
             if ($table_obj instanceof EE_Secondary_Table) {// table is secondary table
@@ -4818,7 +4823,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets an array for storing all the data types on the next-to-be-executed-query.
      * This should be a growing array of keys being table-columns (eg 'EVT_ID' and 'Event.EVT_ID'), and values being
@@ -4828,7 +4832,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function _get_data_types()
     {
-        $data_types = array();
+        $data_types = [];
         foreach ($this->field_settings() as $field_obj) {
             // $data_types[$field_obj->get_table_column()] = $field_obj->get_wpdb_data_type();
             /** @var $field_obj EE_Model_Field_Base */
@@ -4838,26 +4842,30 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the model object given the relation's name / model's name (eg, 'Event', 'Registration',etc. Always singular)
      *
      * @param string $model_name
-     * @throws EE_Error
      * @return EEM_Base
+     * @throws EE_Error
      */
     public function get_related_model_obj($model_name)
     {
         $model_classname = "EEM_" . $model_name;
         if (! class_exists($model_classname)) {
-            throw new EE_Error(sprintf(esc_html__(
-                "You specified a related model named %s in your query. No such model exists, if it did, it would have the classname %s",
-                'event_espresso'
-            ), $model_name, $model_classname));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "You specified a related model named %s in your query. No such model exists, if it did, it would have the classname %s",
+                        'event_espresso'
+                    ),
+                    $model_name,
+                    $model_classname
+                )
+            );
         }
         return call_user_func($model_classname . "::instance");
     }
-
 
 
     /**
@@ -4871,7 +4879,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all related models that this model BELONGS TO. Handy to know sometimes
      * because without THOSE models, this model probably doesn't have much purpose.
@@ -4881,7 +4888,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function belongs_to_relations()
     {
-        $belongs_to_relations = array();
+        $belongs_to_relations = [];
         foreach ($this->relation_settings() as $model_name => $relation_obj) {
             if ($relation_obj instanceof EE_Belongs_To_Relation) {
                 $belongs_to_relations[ $model_name ] = $relation_obj;
@@ -4891,13 +4898,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns the specified EE_Model_Relation, or throws an exception
      *
      * @param string $relation_name name of relation, key in $this->_relatedModels
-     * @throws EE_Error
      * @return EE_Model_Relation_Base
+     * @throws EE_Error
      */
     public function related_settings_for($relation_name)
     {
@@ -4919,29 +4925,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * A convenience method for getting a specific field's settings, instead of getting all field settings for all
      * fields
      *
-     * @param string $fieldName
+     * @param string  $fieldName
      * @param boolean $include_db_only_fields
-     * @throws EE_Error
      * @return EE_Model_Field_Base
+     * @throws EE_Error
      */
     public function field_settings_for($fieldName, $include_db_only_fields = true)
     {
         $fieldSettings = $this->field_settings($include_db_only_fields);
         if (! array_key_exists($fieldName, $fieldSettings)) {
-            throw new EE_Error(sprintf(
-                esc_html__("There is no field/column '%s' on '%s'", 'event_espresso'),
-                $fieldName,
-                get_class($this)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__("There is no field/column '%s' on '%s'", 'event_espresso'),
+                    $fieldName,
+                    get_class($this)
+                )
+            );
         }
         return $fieldSettings[ $fieldName ];
     }
-
 
 
     /**
@@ -4960,7 +4966,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns whether or not this model has a relation to the specified model
      *
@@ -4977,7 +4982,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * gets the field object of type 'primary_key' from the fieldsSettings attribute.
      * Eg, on EE_Answer that would be ANS_ID field object
@@ -4989,7 +4993,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $field_obj instanceof EE_Primary_Key_Field_Base ? true : false;
     }
-
 
 
     /**
@@ -5009,15 +5012,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
             }
             if (! $this->_primary_key_field instanceof EE_Primary_Key_Field_Base) {
-                throw new EE_Error(sprintf(
-                    esc_html__("There is no Primary Key defined on model %s", 'event_espresso'),
-                    get_class($this)
-                ));
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__("There is no Primary Key defined on model %s", 'event_espresso'),
+                        get_class($this)
+                    )
+                );
             }
         }
         return $this->_primary_key_field;
     }
-
 
 
     /**
@@ -5040,7 +5044,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Finds the first field of type $field_class_name.
      *
@@ -5057,7 +5060,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return null;
     }
-
 
 
     /**
@@ -5080,15 +5082,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 }
             }
             if (! isset($this->_cache_foreign_key_to_fields[ $model_name ])) {
-                throw new EE_Error(sprintf(esc_html__(
-                    "There is no foreign key field pointing to model %s on model %s",
-                    'event_espresso'
-                ), $model_name, get_class($this)));
+                throw new EE_Error(
+                    sprintf(
+                        esc_html__(
+                            "There is no foreign key field pointing to model %s on model %s",
+                            'event_espresso'
+                        ),
+                        $model_name,
+                        get_class($this)
+                    )
+                );
             }
         }
         return $this->_cache_foreign_key_to_fields[ $model_name ];
     }
-
 
 
     /**
@@ -5101,10 +5108,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function get_table_for_alias($table_alias)
     {
-        $table_alias_sans_model_relation_chain_prefix = EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($table_alias);
+        $table_alias_sans_model_relation_chain_prefix =
+            EE_Model_Parser::remove_table_alias_model_relation_chain_prefix($table_alias);
         return $this->_tables[ $table_alias_sans_model_relation_chain_prefix ]->get_table_name();
     }
-
 
 
     /**
@@ -5118,7 +5125,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         if ($include_db_only_fields) {
             if ($this->_cached_fields === null) {
-                $this->_cached_fields = array();
+                $this->_cached_fields = [];
                 foreach ($this->_fields as $fields_corresponding_to_table) {
                     foreach ($fields_corresponding_to_table as $field_name => $field_obj) {
                         $this->_cached_fields[ $field_name ] = $field_obj;
@@ -5128,7 +5135,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             return $this->_cached_fields;
         }
         if ($this->_cached_fields_non_db_only === null) {
-            $this->_cached_fields_non_db_only = array();
+            $this->_cached_fields_non_db_only = [];
             foreach ($this->_fields as $fields_corresponding_to_table) {
                 foreach ($fields_corresponding_to_table as $field_name => $field_obj) {
                     /** @var $field_obj EE_Model_Field_Base */
@@ -5142,29 +5149,28 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      *        cycle though array of attendees and create objects out of each item
      *
      * @access        private
-     * @param        array $rows of results of $wpdb->get_results($query,ARRAY_A)
+     * @param array $rows        of results of $wpdb->get_results($query,ARRAY_A)
      * @return \EE_Base_Class[] array keys are primary keys (if there is a primary key on the model. if not,
      *                           numerically indexed)
      * @throws EE_Error
      */
-    protected function _create_objects($rows = array())
+    protected function _create_objects($rows = [])
     {
-        $array_of_objects = array();
+        $array_of_objects = [];
         if (empty($rows)) {
-            return array();
+            return [];
         }
         $count_if_model_has_no_primary_key = 0;
-        $has_primary_key = $this->has_primary_key_field();
-        $primary_key_field = $has_primary_key ? $this->get_primary_key_field() : null;
+        $has_primary_key                   = $this->has_primary_key_field();
+        $primary_key_field                 = $has_primary_key ? $this->get_primary_key_field() : null;
         foreach ((array) $rows as $row) {
             if (empty($row)) {
                 // wp did its weird thing where it returns an array like array(0=>null), which is totally not helpful...
-                return array();
+                return [];
             }
             // check if we've already set this object in the results array,
             // in which case there's no need to process it further (again)
@@ -5191,7 +5197,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // set the timezone on the instantiated objects
             $classInstance->set_timezone($this->_timezone);
             // make sure if there is any timezone setting present that we set the timezone for the object
-            $key = $has_primary_key ? $classInstance->ID() : $count_if_model_has_no_primary_key++;
+            $key                      = $has_primary_key ? $classInstance->ID() : $count_if_model_has_no_primary_key++;
             $array_of_objects[ $key ] = $classInstance;
             // also, for all the relations of type BelongsTo, see if we can cache
             // those related models
@@ -5201,7 +5207,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             foreach ($this->_model_relations as $modelName => $relation_obj) {
                 if ($relation_obj instanceof EE_Belongs_To_Relation) {
                     // check if this model's INFO is present. If so, cache it on the model
-                    $other_model = $relation_obj->get_other_model();
+                    $other_model           = $relation_obj->get_other_model();
                     $other_model_obj_maybe = $other_model->instantiate_class_from_array_or_object($row);
                     // if we managed to make a model object from the results, cache it on the main model object
                     if ($other_model_obj_maybe) {
@@ -5233,7 +5239,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function getValuesForCustomSelectAliasesFromResults(array $db_results_row)
     {
-        $results = array();
+        $results = [];
         if ($this->_custom_selections instanceof CustomSelects) {
             foreach ($this->_custom_selections->columnAliases() as $alias) {
                 if (isset($db_results_row[ $alias ])) {
@@ -5250,6 +5256,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * This will set the value for the given alias
+     *
      * @param string $value
      * @param string $datatype (one of %d, %s, %f)
      * @return int|string|float (int for %d, string for %s, float for %f)
@@ -5274,20 +5281,24 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * object (as set in the model_field!).
      *
      * @return EE_Base_Class single EE_Base_Class object with default values for the properties.
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function create_default_object()
+    public function create_default_object(): EE_Base_Class
     {
-        $this_model_fields_and_values = array();
+        $this_model_fields_and_values = [];
         // setup the row using default values;
         foreach ($this->field_settings() as $field_name => $field_obj) {
             $this_model_fields_and_values[ $field_name ] = $field_obj->get_default_value();
         }
-        $className = $this->_get_class_name();
-        $classInstance = EE_Registry::instance()
-                                    ->load_class($className, array($this_model_fields_and_values), false, false);
-        return $classInstance;
+        $className     = $this->_get_class_name();
+        return EE_Registry::instance()->load_class(
+            $className,
+            [$this_model_fields_and_values],
+            false,
+            false
+        );
     }
-
 
 
     /**
@@ -5327,7 +5338,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 $classInstance = EE_Registry::instance()
                                             ->load_class(
                                                 $className,
-                                                array($this_model_fields_n_values, $this->_timezone),
+                                                [$this_model_fields_n_values, $this->_timezone],
                                                 true,
                                                 false
                                             );
@@ -5338,14 +5349,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $classInstance = EE_Registry::instance()
                                         ->load_class(
                                             $className,
-                                            array($this_model_fields_n_values, $this->_timezone),
+                                            [$this_model_fields_n_values, $this->_timezone],
                                             true,
                                             false
                                         );
         }
         return $classInstance;
     }
-
 
 
     /**
@@ -5361,7 +5371,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * add_to_entity_map
      * Adds the object to the model's entity mappings
@@ -5373,26 +5382,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Note: The map is indexed by whatever the current blog id is set (via EEM_Base::$_model_query_blog_id).  This is
      * so on multisite, the entity map is specific to the query being done for a specific site.
      *
-     * @param    EE_Base_Class $object
-     * @throws EE_Error
+     * @param EE_Base_Class $object
      * @return \EE_Base_Class
+     * @throws EE_Error
      */
     public function add_to_entity_map(EE_Base_Class $object)
     {
         $className = $this->_get_class_name();
         if (! $object instanceof $className) {
-            throw new EE_Error(sprintf(
-                esc_html__("You tried adding a %s to a mapping of %ss", "event_espresso"),
-                is_object($object) ? get_class($object) : $object,
-                $className
-            ));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__("You tried adding a %s to a mapping of %ss", "event_espresso"),
+                    is_object($object) ? get_class($object) : $object,
+                    $className
+                )
+            );
         }
         /** @var $object EE_Base_Class */
         if (! $object->ID()) {
-            throw new EE_Error(sprintf(esc_html__(
-                "You tried storing a model object with NO ID in the %s entity mapper.",
-                "event_espresso"
-            ), get_class($this)));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "You tried storing a model object with NO ID in the %s entity mapper.",
+                        "event_espresso"
+                    ),
+                    get_class($this)
+                )
+            );
         }
         // double check it's not already there
         $classInstance = $this->get_from_entity_map($object->ID());
@@ -5402,7 +5418,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $object->ID() ] = $object;
         return $object;
     }
-
 
 
     /**
@@ -5415,7 +5430,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     public function clear_entity_map($id = null)
     {
         if (empty($id)) {
-            $this->_entity_map[ EEM_Base::$_model_query_blog_id ] = array();
+            $this->_entity_map[ EEM_Base::$_model_query_blog_id ] = [];
             return true;
         }
         if (isset($this->_entity_map[ EEM_Base::$_model_query_blog_id ][ $id ])) {
@@ -5424,7 +5439,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return false;
     }
-
 
 
     /**
@@ -5441,7 +5455,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * _deduce_fields_n_values_from_cols_n_values
      * Given an array where keys are column (or column alias) names and values,
@@ -5452,7 +5465,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values)
     {
-        $this_model_fields_n_values = array();
+        $this_model_fields_n_values = [];
         foreach ($this->get_tables() as $table_alias => $table_obj) {
             $table_pk_value = $this->_get_column_value_with_table_alias_or_not(
                 $cols_n_values,
@@ -5464,7 +5477,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 foreach ($this->_get_fields_for_table($table_alias) as $field_name => $field_obj) {
                     if (! $field_obj->is_db_only_field()) {
                         // prepare field as if its coming from db
-                        $prepared_value = $field_obj->prepare_for_set($field_obj->get_default_value());
+                        $prepared_value                            =
+                            $field_obj->prepare_for_set($field_obj->get_default_value());
                         $this_model_fields_n_values[ $field_name ] = $field_obj->prepare_for_use_in_db($prepared_value);
                     }
                 }
@@ -5541,7 +5555,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         $obj_in_map = $this->get_from_entity_map($id);
         if ($obj_in_map) {
             $wpdb_results = $this->_get_all_wpdb_results(
-                array(array($this->get_primary_key_field()->get_name() => $id), 'limit' => 1)
+                [[$this->get_primary_key_field()->get_name() => $id], 'limit' => 1]
             );
             if ($wpdb_results && is_array($wpdb_results)) {
                 $one_row = reset($wpdb_results);
@@ -5558,7 +5572,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $this->get_one_by_ID($id);
     }
-
 
 
     /**
@@ -5596,7 +5609,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the EE class that corresponds to this model. Eg, for EEM_Answer that
      * would be EE_Answer.To import that class, you'd just add ".class.php" to the name, like so
@@ -5608,7 +5620,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return "EE_" . $this->get_this_model_name();
     }
-
 
 
     /**
@@ -5632,7 +5643,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Very handy general function to allow for plugins to extend any child of EE_TempBase.
      * If a method is called on a child of EE_TempBase that doesn't exist, this function is called
@@ -5653,13 +5663,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $methodName name of method which was called on a child of EE_TempBase, but which
      * @param array  $args       array of original arguments passed to the function
-     * @throws EE_Error
      * @return mixed whatever the plugin which calls add_filter decides
+     * @throws EE_Error
      */
     public function __call($methodName, $args)
     {
         $className = get_class($this);
-        $tagName = "FHEE__{$className}__{$methodName}";
+        $tagName   = "FHEE__{$className}__{$methodName}";
         if (! has_filter($tagName)) {
             throw new EE_Error(
                 sprintf(
@@ -5678,7 +5688,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Ensures $base_class_obj_or_id is of the EE_Base_Class child that corresponds ot this model.
      * If not, assumes its an ID, and uses $this->get_one_by_ID() to get the EE_Base_Class.
@@ -5689,8 +5698,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                       or object's ID
      * @param boolean                  $ensure_is_in_db      if set, we will also verify this model object
      *                                                       exists in the database. If it does not, we add it
-     * @throws EE_Error
      * @return EE_Base_Class
+     * @throws EE_Error
      */
     public function ensure_is_obj($base_class_obj_or_id, $ensure_is_in_db = false)
     {
@@ -5736,7 +5745,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Similar to ensure_is_obj(), this method makes sure $base_class_obj_or_id
      * is a value of the this model's primary key. If it's an EE_Base_Class child,
@@ -5759,19 +5767,20 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             // assume its a string representation of the object
             $id = $base_class_obj_or_id;
         } else {
-            throw new EE_Error(sprintf(
-                esc_html__(
-                    "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
-                    'event_espresso'
-                ),
-                $base_class_obj_or_id,
-                $this->_get_class_name(),
-                print_r($base_class_obj_or_id, true)
-            ));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "'%s' is neither an object of type %s, nor an ID! Its full value is '%s'",
+                        'event_espresso'
+                    ),
+                    $base_class_obj_or_id,
+                    $this->_get_class_name(),
+                    print_r($base_class_obj_or_id, true)
+                )
+            );
         }
         return $id;
     }
-
 
 
     /**
@@ -5798,7 +5807,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Read comments for assume_values_already_prepared_by_model_object()
      *
@@ -5808,7 +5816,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_values_already_prepared_by_model_object;
     }
-
 
 
     /**
@@ -5822,7 +5829,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets all the Unique Indexes on this model
      *
@@ -5830,7 +5836,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function unique_indexes()
     {
-        $unique_indexes = array();
+        $unique_indexes = [];
         foreach ($this->_indexes as $name => $index) {
             if ($index instanceof EE_Unique_Index) {
                 $unique_indexes [ $name ] = $index;
@@ -5838,7 +5844,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $unique_indexes;
     }
-
 
 
     /**
@@ -5857,9 +5862,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 return $index->fields();
             }
         }
-        return array($this->primary_key_name() => $this->get_primary_key_field());
+        return [$this->primary_key_name() => $this->get_primary_key_field()];
     }
-
 
 
     /**
@@ -5884,20 +5888,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the field values from the primary key string
      *
-     * @see EEM_Base::get_combined_primary_key_fields() and EEM_Base::get_index_primary_key_string()
      * @param string $index_primary_key_string
      * @return null|array
      * @throws EE_Error
+     * @see EEM_Base::get_combined_primary_key_fields() and EEM_Base::get_index_primary_key_string()
      */
     public function parse_index_primary_key_string($index_primary_key_string)
     {
         $key_fields = $this->get_combined_primary_key_fields();
         // check all of them are in the $id
-        $key_vals_in_combined_pk = array();
+        $key_vals_in_combined_pk = [];
         parse_str($index_primary_key_string, $key_vals_in_combined_pk);
         foreach ($key_fields as $key_field_name => $field_obj) {
             if (! isset($key_vals_in_combined_pk[ $key_field_name ])) {
@@ -5906,7 +5909,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $key_vals_in_combined_pk;
     }
-
 
 
     /**
@@ -5929,28 +5931,33 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Finds all model objects in the DB that appear to be a copy of $model_object_or_attributes_array.
      * We consider something to be a copy if all the attributes match (except the ID, of course).
      *
      * @param array|EE_Base_Class $model_object_or_attributes_array If its an array, it's field-value pairs
-     * @param array               $query_params @see https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
+     * @param array               $query_params                     @see
+     *                                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
      * @return \EE_Base_Class[] Array keys are object IDs (if there is a primary key on the model. if not, numerically
      *                                                              indexed)
      */
-    public function get_all_copies($model_object_or_attributes_array, $query_params = array())
+    public function get_all_copies($model_object_or_attributes_array, $query_params = [])
     {
         if ($model_object_or_attributes_array instanceof EE_Base_Class) {
             $attributes_array = $model_object_or_attributes_array->model_field_array();
         } elseif (is_array($model_object_or_attributes_array)) {
             $attributes_array = $model_object_or_attributes_array;
         } else {
-            throw new EE_Error(sprintf(esc_html__(
-                "get_all_copies should be provided with either a model object or an array of field-value-pairs, but was given %s",
-                "event_espresso"
-            ), $model_object_or_attributes_array));
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "get_all_copies should be provided with either a model object or an array of field-value-pairs, but was given %s",
+                        "event_espresso"
+                    ),
+                    $model_object_or_attributes_array
+                )
+            );
         }
         // even copies obviously won't have the same ID, so remove the primary key
         // from the WHERE conditions for finding copies (if there is a primary key, of course)
@@ -5966,16 +5973,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the first copy we find. See get_all_copies for more details
      *
-     * @param       mixed EE_Base_Class | array        $model_object_or_attributes_array
+     * @param mixed EE_Base_Class | array        $model_object_or_attributes_array
      * @param array $query_params
      * @return EE_Base_Class
      * @throws EE_Error
      */
-    public function get_one_copy($model_object_or_attributes_array, $query_params = array())
+    public function get_one_copy($model_object_or_attributes_array, $query_params = [])
     {
         if (! is_array($query_params)) {
             EE_Error::doing_it_wrong(
@@ -5986,16 +5992,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 ),
                 '4.6.0'
             );
-            $query_params = array();
+            $query_params = [];
         }
         $query_params['limit'] = 1;
-        $copies = $this->get_all_copies($model_object_or_attributes_array, $query_params);
+        $copies                = $this->get_all_copies($model_object_or_attributes_array, $query_params);
         if (is_array($copies)) {
             return array_shift($copies);
         }
         return null;
     }
-
 
 
     /**
@@ -6009,13 +6014,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function update_by_ID($fields_n_values, $id)
     {
-        $query_params = array(
-            0                          => array($this->get_primary_key_field()->get_name() => $id),
+        $query_params = [
+            [
+                $this->get_primary_key_field()->get_name() => $id
+            ],
             'default_where_conditions' => EEM_Base::default_where_conditions_others_only,
-        );
+        ];
         return $this->update($fields_n_values, $query_params);
     }
-
 
 
     /**
@@ -6027,8 +6033,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     private function _prepare_operator_for_sql($operator_supplied)
     {
-        $sql_operator = isset($this->_valid_operators[ $operator_supplied ]) ? $this->_valid_operators[ $operator_supplied ]
-            : null;
+        $sql_operator = $this->_valid_operators[ $operator_supplied ] ?? null;
         if ($sql_operator) {
             return $sql_operator;
         }
@@ -6045,9 +6050,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the valid operators
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_operators()
@@ -6056,9 +6061,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Gets the between-style operators (take 2 arguments).
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_between_style_operators()
@@ -6069,8 +6074,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "like"-style operators (take a single argument, but it may contain wildcards)
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_like_style_operators()
@@ -6081,8 +6088,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "in"-style operators
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_in_style_operators()
@@ -6093,8 +6102,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets the "null"-style operators (accept no arguments)
+     *
      * @return array keys are accepted strings, values are the SQL they are converted to
      */
     public function valid_null_style_operators()
@@ -6105,6 +6116,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         );
     }
 
+
     /**
      * Gets an array where keys are the primary keys and values are their 'names'
      * (as determined by the model object's name() function, which is often overridden)
@@ -6113,16 +6125,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @return string[]
      * @throws EE_Error
      */
-    public function get_all_names($query_params = array())
+    public function get_all_names($query_params = [])
     {
-        $objs = $this->get_all($query_params);
-        $names = array();
+        $objs  = $this->get_all($query_params);
+        $names = [];
         foreach ($objs as $obj) {
             $names[ $obj->ID() ] = $obj->name();
         }
         return $names;
     }
-
 
 
     /**
@@ -6149,7 +6160,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 );
             }
         }
-        $IDs = array();
+        $IDs = [];
         foreach ($model_objects as $model_object) {
             $id = $model_object->ID();
             if (! $id) {
@@ -6174,7 +6185,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Returns the string used in capabilities relating to this model. If there
      * are no capabilities that relate to this model returns false
@@ -6187,16 +6197,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
-     * Returns the capability-restrictions array (@see EEM_Base::_cap_restrictions).
-     * If $context is provided (which should be set to one of EEM_Base::valid_cap_contexts())
-     * only returns the cap restrictions array in that context (ie, the array
-     * at that key)
+     * Returns the capability-restrictions array (@param string $context
      *
-     * @param string $context
      * @return EE_Default_Where_Conditions[] indexed by associated capability
      * @throws EE_Error
+     * @see EEM_Base::_cap_restrictions).
+     *      If $context is provided (which should be set to one of EEM_Base::valid_cap_contexts())
+     *      only returns the cap restrictions array in that context (ie, the array
+     *      at that key)
+     *
      */
     public function cap_restrictions($context = EEM_Base::caps_read)
     {
@@ -6222,7 +6232,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Indicating whether or not this model thinks its a wp core model
      *
@@ -6232,7 +6241,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_wp_core_model;
     }
-
 
 
     /**
@@ -6245,7 +6253,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public function caps_missing($context = EEM_Base::caps_read)
     {
-        $missing_caps = array();
+        $missing_caps     = [];
         $cap_restrictions = $this->cap_restrictions($context);
         foreach ($cap_restrictions as $cap => $restriction_if_no_cap) {
             if (
@@ -6257,7 +6265,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         return $missing_caps;
     }
-
 
 
     /**
@@ -6274,7 +6281,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
             $this
         );
     }
-
 
 
     /**
@@ -6295,13 +6301,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         throw new EE_Error(
             sprintf(
-                esc_html__('Cannot find capability restrictions for context "%1$s", allowed values are:%2$s', 'event_espresso'),
+                esc_html__(
+                    'Cannot find capability restrictions for context "%1$s", allowed values are:%2$s',
+                    'event_espresso'
+                ),
                 $context,
                 implode(',', array_keys($this->cap_contexts_to_cap_action_map()))
             )
         );
     }
-
 
 
     /**
@@ -6311,14 +6319,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public static function valid_cap_contexts()
     {
-        return apply_filters('FHEE__EEM_Base__valid_cap_contexts', array(
+        return apply_filters('FHEE__EEM_Base__valid_cap_contexts', [
             self::caps_read,
             self::caps_read_admin,
             self::caps_edit,
             self::caps_delete,
-        ));
+        ]);
     }
-
 
 
     /**
@@ -6328,17 +6335,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     public static function valid_default_where_conditions()
     {
-        return array(
+        return [
             EEM_Base::default_where_conditions_all,
             EEM_Base::default_where_conditions_this_only,
             EEM_Base::default_where_conditions_others_only,
             EEM_Base::default_where_conditions_minimum_all,
             EEM_Base::default_where_conditions_minimum_others,
-            EEM_Base::default_where_conditions_none
-        );
+            EEM_Base::default_where_conditions_none,
+        ];
     }
 
     // public static function default_where_conditions_full
+
+
     /**
      * Verifies $context is one of EEM_Base::valid_cap_contexts(), if not it throws an exception
      *
@@ -6366,18 +6375,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     }
 
 
-
     /**
      * Clears all the models field caches. This is only useful when a sub-class
      * might have added a field or something and these caches might be invalidated
      */
     protected function _invalidate_field_caches()
     {
-        $this->_cache_foreign_key_to_fields = array();
-        $this->_cached_fields = null;
-        $this->_cached_fields_non_db_only = null;
+        $this->_cache_foreign_key_to_fields = [];
+        $this->_cached_fields               = null;
+        $this->_cached_fields_non_db_only   = null;
     }
-
 
 
     /**
@@ -6390,7 +6397,6 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
     {
         return $this->_logic_query_param_keys;
     }
-
 
 
     /**
@@ -6414,25 +6420,29 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return false;
     }
 
+
     /**
      * Returns true if this model has a password field on it (regardless of whether that password field has any content)
-     * @since 4.9.74.p
+     *
      * @return boolean
+     * @since 4.9.74.p
      */
     public function hasPassword()
     {
         // if we don't yet know if there's a password field, find out and remember it for next time.
         if ($this->has_password_field === null) {
-            $password_field = $this->getPasswordField();
+            $password_field           = $this->getPasswordField();
             $this->has_password_field = $password_field instanceof EE_Password_Field ? true : false;
         }
         return $this->has_password_field;
     }
 
+
     /**
      * Returns the password field on this model, if there is one
-     * @since 4.9.74.p
+     *
      * @return EE_Password_Field|null
+     * @since 4.9.74.p
      */
     public function getPasswordField()
     {
@@ -6448,14 +6458,15 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Returns the list of field (as EE_Model_Field_Bases) that are protected by the password
-     * @since 4.9.74.p
+     *
      * @return EE_Model_Field_Base[]
      * @throws EE_Error
+     * @since 4.9.74.p
      */
     public function getPasswordProtectedFields()
     {
         $password_field = $this->getPasswordField();
-        $fields = array();
+        $fields         = [];
         if ($password_field instanceof EE_Password_Field) {
             $field_names = $password_field->protectedFields();
             foreach ($field_names as $field_name) {
@@ -6468,8 +6479,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
     /**
      * Checks if the current user can perform the requested action on this model
-     * @since 4.9.74.p
-     * @param string $cap_to_check one of the array keys from _cap_contexts_to_cap_action_map
+     *
+     * @param string              $cap_to_check one of the array keys from _cap_contexts_to_cap_action_map
      * @param EE_Base_Class|array $model_obj_or_fields_n_values
      * @return bool
      * @throws EE_Error
@@ -6478,18 +6489,22 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      * @throws UnexpectedEntityException
+     * @since 4.9.74.p
      */
     public function currentUserCan($cap_to_check, $model_obj_or_fields_n_values)
     {
         if ($model_obj_or_fields_n_values instanceof EE_Base_Class) {
             $model_obj_or_fields_n_values = $model_obj_or_fields_n_values->model_field_array();
         }
-        if (!is_array($model_obj_or_fields_n_values)) {
+        if (! is_array($model_obj_or_fields_n_values)) {
             throw new UnexpectedEntityException(
                 $model_obj_or_fields_n_values,
                 'EE_Base_Class',
                 sprintf(
-                    esc_html__('%1$s must be passed an `EE_Base_Class or an array of fields names with their values. You passed in something different.', 'event_espresso'),
+                    esc_html__(
+                        '%1$s must be passed an `EE_Base_Class or an array of fields names with their values. You passed in something different.',
+                        'event_espresso'
+                    ),
                     __FUNCTION__
                 )
             );
@@ -6497,18 +6512,19 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return $this->exists(
             $this->alter_query_params_to_restrict_by_ID(
                 $this->get_index_primary_key_string($model_obj_or_fields_n_values),
-                array(
+                [
                     'default_where_conditions' => 'none',
                     'caps'                     => $cap_to_check,
-                )
+                ]
             )
         );
     }
 
+
     /**
      * Returns the query param where conditions key to the password affecting this model.
      * Eg on EEM_Event this would just be "password", on EEM_Datetime this would be "Event.password", etc.
-     * @since 4.9.74.p
+     *
      * @return null|string
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -6516,6 +6532,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidInterfaceException
      * @throws ModelConfigurationException
      * @throws ReflectionException
+     * @since 4.9.74.p
      */
     public function modelChainAndPassword()
     {
@@ -6562,11 +6579,13 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         return ($this->model_chain_to_password ? $this->model_chain_to_password . '.' : '') . $password_field_name;
     }
 
+
     /**
      * Returns true if there is a password on a related model which restricts access to some of this model's rows,
      * or if this model itself has a password affecting access to some of its other fields.
-     * @since 4.9.74.p
+     *
      * @return boolean
+     * @since 4.9.74.p
      */
     public function restrictedByRelatedModelPassword()
     {

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -5284,7 +5284,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function create_default_object(): EE_Base_Class
+    public function create_default_object()
     {
         $this_model_fields_and_values = [];
         // setup the row using default values;

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -3706,8 +3706,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     private function _get_default_where_conditions_for_models_in_query(
         EE_Model_Query_Info_Carrier $query_info_carrier,
-                                    $use_default_where_conditions = EEM_Base::default_where_conditions_all,
-                                    $where_query_params = []
+        $use_default_where_conditions = EEM_Base::default_where_conditions_all,
+        $where_query_params = []
     ) {
         $allowed_used_default_where_conditions_values = EEM_Base::valid_default_where_conditions();
         if (! in_array($use_default_where_conditions, $allowed_used_default_where_conditions_values)) {
@@ -4115,9 +4115,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      */
     private function extractJoinModelFromQueryParams(
         EE_Model_Query_Info_Carrier $query_info_carrier,
-                                    $possible_join_string,
-                                    $original_query_param,
-                                    $query_parameter_type
+        $possible_join_string,
+        $original_query_param,
+        $query_parameter_type
     ) {
         foreach ($this->_model_relations as $valid_related_model_name => $relation_obj) {
             if (strpos($possible_join_string, $valid_related_model_name . ".") === 0) {
@@ -4300,27 +4300,27 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                     case 'NOT':
                         $where_clauses[] = "! ("
                                            . $this->_construct_condition_clause_recursive(
-                                $op_and_value_or_sub_condition,
-                                $glue
-                            )
+                                               $op_and_value_or_sub_condition,
+                                               $glue
+                                           )
                                            . ")";
                         break;
                     case 'and':
                     case 'AND':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                $op_and_value_or_sub_condition,
-                                ' AND '
-                            )
+                                               $op_and_value_or_sub_condition,
+                                               ' AND '
+                                           )
                                            . ")";
                         break;
                     case 'or':
                     case 'OR':
                         $where_clauses[] = " ("
                                            . $this->_construct_condition_clause_recursive(
-                                $op_and_value_or_sub_condition,
-                                ' OR '
-                            )
+                                               $op_and_value_or_sub_condition,
+                                               ' OR '
+                                           )
                                            . ")";
                         break;
                 }

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -5448,8 +5448,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param array $cols_n_values
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function deduce_fields_n_values_from_cols_n_values($cols_n_values)
+    public function deduce_fields_n_values_from_cols_n_values(array $cols_n_values): array
     {
         return $this->_deduce_fields_n_values_from_cols_n_values($cols_n_values);
     }
@@ -5460,10 +5462,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Given an array where keys are column (or column alias) names and values,
      * returns an array of their corresponding field names and database values
      *
-     * @param string $cols_n_values
+     * @param array $cols_n_values
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values)
+    protected function _deduce_fields_n_values_from_cols_n_values(array $cols_n_values): array
     {
         $this_model_fields_n_values = [];
         foreach ($this->get_tables() as $table_alias => $table_obj) {
@@ -5477,8 +5481,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
                 foreach ($this->_get_fields_for_table($table_alias) as $field_name => $field_obj) {
                     if (! $field_obj->is_db_only_field()) {
                         // prepare field as if its coming from db
-                        $prepared_value                            =
-                            $field_obj->prepare_for_set($field_obj->get_default_value());
+                        $prepared_value = $field_obj->prepare_for_set($field_obj->get_default_value());
                         $this_model_fields_n_values[ $field_name ] = $field_obj->prepare_for_use_in_db($prepared_value);
                     }
                 }
@@ -5500,14 +5503,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
 
     /**
-     * @param $cols_n_values
+     * @param array $cols_n_values
      * @param $qualified_column
      * @param $regular_column
      * @return null
      * @throws EE_Error
      * @throws ReflectionException
      */
-    protected function _get_column_value_with_table_alias_or_not($cols_n_values, $qualified_column, $regular_column)
+    protected function _get_column_value_with_table_alias_or_not(array $cols_n_values, $qualified_column, $regular_column)
     {
         $value = null;
         // ask the field what it think it's table_name.column_name should be, and call it the "qualified column"

--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -87,7 +87,8 @@ class EEM_Event extends EEM_CPT_Base
                 ),
             )
         );
-        self::$_default_reg_status = empty(self::$_default_reg_status) ? EEM_Registration::status_id_pending_payment
+        self::$_default_reg_status = empty(self::$_default_reg_status)
+            ? EEM_Registration::status_id_pending_payment
             : self::$_default_reg_status;
         $this->_tables = array(
             'Event_CPT'  => new EE_Primary_Table('posts', 'ID'),
@@ -222,7 +223,7 @@ class EEM_Event extends EEM_CPT_Base
                 'EVT_additional_limit'            => new EE_Integer_Field(
                     'EVT_additional_limit',
                     esc_html__('Limit of Additional Registrations on Same Transaction', 'event_espresso'),
-                    true,
+                    false,
                     self::$_default_additional_limit
                 ),
                 'EVT_default_registration_status' => new EE_Enum_Text_Field(
@@ -336,7 +337,7 @@ class EEM_Event extends EEM_CPT_Base
             self::$_instance->_fields['Event_Meta']['EVT_additional_limit'] = new EE_Integer_Field(
                 'EVT_additional_limit',
                 esc_html__('Limit of Additional Registrations on Same Transaction', 'event_espresso'),
-                true,
+                false,
                 self::$_default_additional_limit
             );
             self::$_instance->_fields['Event_Meta']['EVT_additional_limit']->_construct_finalize(

--- a/core/domain/services/event/EventSpacesCalculator.php
+++ b/core/domain/services/event/EventSpacesCalculator.php
@@ -95,12 +95,12 @@ class EventSpacesCalculator
     private $debug = false; // true false
 
     /**
-     * @var null|int $spaces_remaining
+     * @var int|float|null $spaces_remaining
      */
     private $spaces_remaining;
 
     /**
-     * @var null|int $total_spaces_available
+     * @var int|float|null $total_spaces_available
      */
     private $total_spaces_available;
 
@@ -274,7 +274,7 @@ class EventSpacesCalculator
     /**
      * calculate spaces remaining based on "saleable" tickets
      *
-     * @return int
+     * @return int|float
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
@@ -283,7 +283,7 @@ class EventSpacesCalculator
      * @throws InvalidArgumentException
      * @throws ReflectionException
      */
-    public function spacesRemaining(): int
+    public function spacesRemaining()
     {
         if ($this->debug) {
             EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
@@ -292,14 +292,14 @@ class EventSpacesCalculator
             $this->initialize();
             $this->spaces_remaining = $this->calculate();
         }
-        return (int) $this->spaces_remaining;
+        return $this->spaces_remaining;
     }
 
 
     /**
      * calculates total available spaces for an event with no regard for sold tickets
      *
-     * @return int
+     * @return int|float
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
@@ -308,7 +308,7 @@ class EventSpacesCalculator
      * @throws InvalidArgumentException
      * @throws ReflectionException
      */
-    public function totalSpacesAvailable(): int
+    public function totalSpacesAvailable()
     {
         if ($this->debug) {
             EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
@@ -317,7 +317,7 @@ class EventSpacesCalculator
             $this->initialize();
             $this->total_spaces_available = $this->calculate(false);
         }
-        return (int) $this->total_spaces_available;
+        return $this->total_spaces_available;
     }
 
 
@@ -404,9 +404,9 @@ class EventSpacesCalculator
      * performs calculations on initialized data
      *
      * @param bool $consider_sold
-     * @return int
+     * @return int|float
      */
-    private function calculate(bool $consider_sold = true): int
+    private function calculate(bool $consider_sold = true)
     {
         if ($this->debug) {
             EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
@@ -426,7 +426,7 @@ class EventSpacesCalculator
             EEH_Debug_Tools::printr($this->tickets_sold, '$this->tickets_sold', __FILE__, __LINE__);
             EEH_Debug_Tools::printr($spaces_remaining, '$spaces_remaining', __FILE__, __LINE__);
         }
-        return (int) $spaces_remaining;
+        return $spaces_remaining;
     }
 
 
@@ -545,17 +545,17 @@ class EventSpacesCalculator
 
     /**
      * @param string $datetime_identifier
-     * @param int    $reg_limit
+     * @param int|float $reg_limit
      * @param string $ticket_identifier
-     * @param int    $spaces_allocated
-     * @return int
+     * @param int|float $spaces_allocated
+     * @return int|float
      */
     private function calculateAvailableSpacesForTicket(
         string $datetime_identifier,
-        int $reg_limit,
+        $reg_limit,
         string $ticket_identifier,
-        int $spaces_allocated
-    ): int {
+        $spaces_allocated
+    ) {
         // make sure ticket quantity is set
         $ticket_quantity = $this->ticket_quantities[ $ticket_identifier ] ?? 0;
         if ($this->debug) {
@@ -624,12 +624,12 @@ class EventSpacesCalculator
      * @param string $datetime_identifier
      * @param string $ticket_identifier
      * @param bool   $at_capacity
-     * @param int    $ticket_quantity
+     * @param int|float $ticket_quantity
      */
     private function adjustDatetimes(
         string $datetime_identifier,
         string $ticket_identifier,
-        int $ticket_quantity,
+        $ticket_quantity,
         bool $at_capacity
     ) {
         /** @var array $datetime_tickets */
@@ -711,15 +711,15 @@ class EventSpacesCalculator
 
 
     /**
-     * @param string   $datetime_identifier
-     * @param string   $ticket_identifier
-     * @param int|null $ticket_quantity
+     * @param string $datetime_identifier
+     * @param string $ticket_identifier
+     * @param int|float $ticket_quantity
      * @return bool
      */
     private function adjustDatetimeSpaces(
         string $datetime_identifier,
         string $ticket_identifier,
-        ?int $ticket_quantity = 0
+        $ticket_quantity = 0
     ): bool {
         // does datetime have spaces available?
         // and does the supplied ticket have access to this datetime ?

--- a/core/domain/services/event/EventSpacesCalculator.php
+++ b/core/domain/services/event/EventSpacesCalculator.php
@@ -7,10 +7,12 @@ use EE_Datetime;
 use EE_Error;
 use EE_Event;
 use EE_Ticket;
+use EEH_Debug_Tools;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use InvalidArgumentException;
+use ReflectionException;
 
 /**
  * Class EventSpacesCalculator
@@ -38,54 +40,54 @@ class EventSpacesCalculator
     /**
      * @var EE_Ticket[] $active_tickets
      */
-    private $active_tickets = array();
+    private $active_tickets = [];
 
     /**
      * @var EE_Datetime[] $datetimes
      */
-    private $datetimes = array();
+    private $datetimes = [];
 
     /**
      * Array of Ticket IDs grouped by Datetime
      *
      * @var array $datetimes
      */
-    private $datetime_tickets = array();
+    private $datetime_tickets = [];
 
     /**
      * Max spaces for each Datetime (reg limit - previous sold)
      *
      * @var array $datetime_spaces
      */
-    private $datetime_spaces = array();
+    private $datetime_spaces = [];
 
     /**
      * Array of Datetime IDs grouped by Ticket
      *
      * @var array[] $ticket_datetimes
      */
-    private $ticket_datetimes = array();
+    private $ticket_datetimes = [];
 
     /**
      * maximum ticket quantities for each ticket (adjusted for reg limit)
      *
      * @var array $ticket_quantities
      */
-    private $ticket_quantities = array();
+    private $ticket_quantities = [];
 
     /**
      * total quantity of sold and reserved for each ticket
      *
      * @var array $tickets_sold
      */
-    private $tickets_sold = array();
+    private $tickets_sold = [];
 
     /**
      * total spaces available across all datetimes
      *
      * @var array $total_spaces
      */
-    private $total_spaces = array();
+    private $total_spaces = [];
 
     /**
      * @var boolean $debug
@@ -109,15 +111,16 @@ class EventSpacesCalculator
      * @param EE_Event $event
      * @param array    $datetime_query_params
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function __construct(EE_Event $event, array $datetime_query_params = array())
+    public function __construct(EE_Event $event, array $datetime_query_params = [])
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 1);
-            \EEH_Debug_Tools::printr((string) $event->ID(), 'For event', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 1);
+            EEH_Debug_Tools::printr((string) $event->ID(), 'For event', __FILE__, __LINE__);
         }
-        $this->event = $event;
-        $this->datetime_query_params = $datetime_query_params + array('order_by' => array('DTT_reg_limit' => 'ASC'));
+        $this->event                 = $event;
+        $this->datetime_query_params = $datetime_query_params + ['order_by' => ['DTT_reg_limit' => 'ASC']];
         $this->setHooks();
     }
 
@@ -127,14 +130,14 @@ class EventSpacesCalculator
      */
     private function setHooks()
     {
-        add_action('AHEE__EE_Ticket__increase_sold', array($this, 'clearResults'));
-        add_action('AHEE__EE_Ticket__decrease_sold', array($this, 'clearResults'));
-        add_action('AHEE__EE_Datetime__increase_sold', array($this, 'clearResults'));
-        add_action('AHEE__EE_Datetime__decrease_sold', array($this, 'clearResults'));
-        add_action('AHEE__EE_Ticket__increase_reserved', array($this, 'clearResults'));
-        add_action('AHEE__EE_Ticket__decrease_reserved', array($this, 'clearResults'));
-        add_action('AHEE__EE_Datetime__increase_reserved', array($this, 'clearResults'));
-        add_action('AHEE__EE_Datetime__decrease_reserved', array($this, 'clearResults'));
+        add_action('AHEE__EE_Ticket__increase_sold', [$this, 'clearResults']);
+        add_action('AHEE__EE_Ticket__decrease_sold', [$this, 'clearResults']);
+        add_action('AHEE__EE_Datetime__increase_sold', [$this, 'clearResults']);
+        add_action('AHEE__EE_Datetime__decrease_sold', [$this, 'clearResults']);
+        add_action('AHEE__EE_Ticket__increase_reserved', [$this, 'clearResults']);
+        add_action('AHEE__EE_Ticket__decrease_reserved', [$this, 'clearResults']);
+        add_action('AHEE__EE_Datetime__increase_reserved', [$this, 'clearResults']);
+        add_action('AHEE__EE_Datetime__decrease_reserved', [$this, 'clearResults']);
     }
 
 
@@ -144,9 +147,9 @@ class EventSpacesCalculator
     public function clearResults()
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 1);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 1);
         }
-        $this->spaces_remaining = null;
+        $this->spaces_remaining       = null;
         $this->total_spaces_available = null;
     }
 
@@ -157,15 +160,16 @@ class EventSpacesCalculator
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
-    public function getActiveTickets()
+    public function getActiveTickets(): array
     {
         if (empty($this->active_tickets)) {
             $this->active_tickets = $this->event->tickets(
-                array(
-                    array('TKT_deleted' => false),
-                    'order_by' => array('TKT_qty' => 'ASC'),
-                )
+                [
+                    ['TKT_deleted' => false],
+                    'order_by' => ['TKT_qty' => 'ASC'],
+                ]
             );
         }
         return $this->active_tickets;
@@ -177,8 +181,9 @@ class EventSpacesCalculator
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
+     * @throws ReflectionException
      */
-    public function setActiveTickets(array $active_tickets = array())
+    public function setActiveTickets(array $active_tickets = [])
     {
         if (! empty($active_tickets)) {
             foreach ($active_tickets as $active_ticket) {
@@ -206,6 +211,7 @@ class EventSpacesCalculator
      * @throws DomainException
      * @throws EE_Error
      * @throws UnexpectedEntityException
+     * @throws ReflectionException
      */
     private function validateTicket($ticket)
     {
@@ -235,7 +241,7 @@ class EventSpacesCalculator
     /**
      * @return EE_Datetime[]
      */
-    public function getDatetimes()
+    public function getDatetimes(): array
     {
         return $this->datetimes;
     }
@@ -245,6 +251,7 @@ class EventSpacesCalculator
      * @param EE_Datetime $datetime
      * @throws EE_Error
      * @throws DomainException
+     * @throws ReflectionException
      */
     public function setDatetime(EE_Datetime $datetime)
     {
@@ -267,48 +274,50 @@ class EventSpacesCalculator
     /**
      * calculate spaces remaining based on "saleable" tickets
      *
-     * @return float|int
+     * @return int
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
-    public function spacesRemaining()
+    public function spacesRemaining(): int
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
         }
         if ($this->spaces_remaining === null) {
             $this->initialize();
             $this->spaces_remaining = $this->calculate();
         }
-        return $this->spaces_remaining;
+        return (int) $this->spaces_remaining;
     }
 
 
     /**
      * calculates total available spaces for an event with no regard for sold tickets
      *
-     * @return int|float
+     * @return int
      * @throws EE_Error
      * @throws DomainException
      * @throws UnexpectedEntityException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
-    public function totalSpacesAvailable()
+    public function totalSpacesAvailable(): int
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
         }
         if ($this->total_spaces_available === null) {
             $this->initialize();
             $this->total_spaces_available = $this->calculate(false);
         }
-        return $this->total_spaces_available;
+        return (int) $this->total_spaces_available;
     }
 
 
@@ -326,19 +335,20 @@ class EventSpacesCalculator
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     private function initialize()
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
         }
-        $this->datetime_tickets = array();
-        $this->datetime_spaces = array();
-        $this->ticket_datetimes = array();
-        $this->ticket_quantities = array();
-        $this->tickets_sold = array();
-        $this->total_spaces = array();
-        $active_tickets = $this->getActiveTickets();
+        $this->datetime_tickets  = [];
+        $this->datetime_spaces   = [];
+        $this->ticket_datetimes  = [];
+        $this->ticket_quantities = [];
+        $this->tickets_sold      = [];
+        $this->total_spaces      = [];
+        $active_tickets          = $this->getActiveTickets();
         if (! empty($active_tickets)) {
             foreach ($active_tickets as $ticket) {
                 $this->validateTicket($ticket);
@@ -354,7 +364,7 @@ class EventSpacesCalculator
                     // save all datetimes
                     $this->setDatetime($datetime);
                     $datetime_identifier = "D{$datetime->ID()}";
-                    $reg_limit = $datetime->reg_limit();
+                    $reg_limit           = $datetime->reg_limit();
                     // ticket quantity can not exceed datetime reg limit
                     $max_tickets = min($max_tickets, $reg_limit);
                     // as described earlier, because we need to be able to constantly adjust numbers for things,
@@ -383,9 +393,9 @@ class EventSpacesCalculator
             $this->datetime_tickets
         );
         if ($this->debug) {
-            \EEH_Debug_Tools::printr($this->datetime_spaces, 'datetime_spaces', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr($this->datetime_tickets, 'datetime_tickets', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr($this->ticket_quantities, 'ticket_quantities', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->datetime_spaces, 'datetime_spaces', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->datetime_tickets, 'datetime_tickets', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->ticket_quantities, 'ticket_quantities', __FILE__, __LINE__);
         }
     }
 
@@ -394,13 +404,13 @@ class EventSpacesCalculator
      * performs calculations on initialized data
      *
      * @param bool $consider_sold
-     * @return int|float
+     * @return int
      */
-    private function calculate($consider_sold = true)
+    private function calculate(bool $consider_sold = true): int
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
-            \EEH_Debug_Tools::printr($consider_sold, '$consider_sold', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
+            EEH_Debug_Tools::printr($consider_sold, '$consider_sold', __FILE__, __LINE__);
         }
         if ($consider_sold) {
             // subtract amounts sold from all ticket quantities and datetime spaces
@@ -412,11 +422,11 @@ class EventSpacesCalculator
         // total spaces available is just the sum of the spaces available for each datetime
         $spaces_remaining = array_sum($this->total_spaces);
         if ($this->debug) {
-            \EEH_Debug_Tools::printr($this->total_spaces, '$this->total_spaces', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr($this->tickets_sold, '$this->tickets_sold', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr($spaces_remaining, '$spaces_remaining', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->total_spaces, '$this->total_spaces', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->tickets_sold, '$this->tickets_sold', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($spaces_remaining, '$spaces_remaining', __FILE__, __LINE__);
         }
-        return $spaces_remaining;
+        return (int) $spaces_remaining;
     }
 
 
@@ -426,7 +436,7 @@ class EventSpacesCalculator
     private function adjustTicketQuantitiesDueToSales()
     {
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
+            EEH_Debug_Tools::printr(__FUNCTION__, __CLASS__, __FILE__, __LINE__, 2);
         }
         foreach ($this->tickets_sold as $ticket_identifier => $tickets_sold) {
             if (isset($this->ticket_quantities[ $ticket_identifier ])) {
@@ -437,8 +447,8 @@ class EventSpacesCalculator
                     0
                 );
                 if ($this->debug) {
-                    \EEH_Debug_Tools::printr(
-                        "{$tickets_sold} sales for ticket {$ticket_identifier} ",
+                    EEH_Debug_Tools::printr(
+                        "$tickets_sold sales for ticket $ticket_identifier ",
                         'subtracting',
                         __FILE__,
                         __LINE__
@@ -458,8 +468,8 @@ class EventSpacesCalculator
                             0
                         );
                         if ($this->debug) {
-                            \EEH_Debug_Tools::printr(
-                                "{$tickets_sold} sales for datetime {$ticket_datetime} ",
+                            EEH_Debug_Tools::printr(
+                                "$tickets_sold sales for datetime $ticket_datetime ",
                                 'subtracting',
                                 __FILE__,
                                 __LINE__
@@ -476,30 +486,28 @@ class EventSpacesCalculator
      * @param string $datetime_identifier
      * @param array  $tickets
      */
-    private function trackAvailableSpacesForDatetimes($datetime_identifier, array $tickets)
+    private function trackAvailableSpacesForDatetimes(string $datetime_identifier, array $tickets)
     {
         // make sure a reg limit is set for the datetime
-        $reg_limit = isset($this->datetime_spaces[ $datetime_identifier ])
-            ? $this->datetime_spaces[ $datetime_identifier ]
-            : 0;
+        $reg_limit = $this->datetime_spaces[ $datetime_identifier ] ?? 0;
         // and bail if it is not
         if (! $reg_limit) {
             if ($this->debug) {
-                \EEH_Debug_Tools::printr('AT CAPACITY', " . {$datetime_identifier}", __FILE__, __LINE__);
+                EEH_Debug_Tools::printr('AT CAPACITY', " . $datetime_identifier", __FILE__, __LINE__);
             }
             return;
         }
         if ($this->debug) {
-            \EEH_Debug_Tools::printr($datetime_identifier, '* $datetime_identifier', __FILE__, __LINE__, 1);
-            \EEH_Debug_Tools::printr(
-                "{$reg_limit}",
+            EEH_Debug_Tools::printr($datetime_identifier, '* $datetime_identifier', __FILE__, __LINE__, 1);
+            EEH_Debug_Tools::printr(
+                "$reg_limit",
                 'REG LIMIT',
                 __FILE__,
                 __LINE__
             );
         }
         // number of allocated spaces always starts at zero
-        $spaces_allocated = 0;
+        $spaces_allocated                           = 0;
         $this->total_spaces[ $datetime_identifier ] = 0;
         foreach ($tickets as $ticket_identifier) {
             $spaces_allocated = $this->calculateAvailableSpacesForTicket(
@@ -515,22 +523,22 @@ class EventSpacesCalculator
             // track any non-zero values
             $this->total_spaces[ $datetime_identifier ] += $spaces_allocated;
             if ($this->debug) {
-                \EEH_Debug_Tools::printr((string) $spaces_allocated, ' . $spaces_allocated: ', __FILE__, __LINE__);
+                EEH_Debug_Tools::printr((string) $spaces_allocated, ' . $spaces_allocated: ', __FILE__, __LINE__);
             }
         } else {
             if ($this->debug) {
-                \EEH_Debug_Tools::printr(' ', ' . NO TICKETS AVAILABLE FOR DATETIME', __FILE__, __LINE__);
+                EEH_Debug_Tools::printr(' ', ' . NO TICKETS AVAILABLE FOR DATETIME', __FILE__, __LINE__);
             }
         }
         if ($this->debug) {
-            \EEH_Debug_Tools::printr(
+            EEH_Debug_Tools::printr(
                 $this->total_spaces[ $datetime_identifier ],
                 '$total_spaces',
                 __FILE__,
                 __LINE__
             );
-            \EEH_Debug_Tools::printr($this->ticket_quantities, '$ticket_quantities', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr($this->datetime_spaces, 'datetime_spaces', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->ticket_quantities, '$ticket_quantities', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr($this->datetime_spaces, 'datetime_spaces', __FILE__, __LINE__);
         }
     }
 
@@ -543,19 +551,17 @@ class EventSpacesCalculator
      * @return int
      */
     private function calculateAvailableSpacesForTicket(
-        $datetime_identifier,
-        $reg_limit,
-        $ticket_identifier,
-        $spaces_allocated
-    ) {
+        string $datetime_identifier,
+        int $reg_limit,
+        string $ticket_identifier,
+        int $spaces_allocated
+    ): int {
         // make sure ticket quantity is set
-        $ticket_quantity = isset($this->ticket_quantities[ $ticket_identifier ])
-            ? $this->ticket_quantities[ $ticket_identifier ]
-            : 0;
+        $ticket_quantity = $this->ticket_quantities[ $ticket_identifier ] ?? 0;
         if ($this->debug) {
-            \EEH_Debug_Tools::printr("{$spaces_allocated}", '$spaces_allocated', __FILE__, __LINE__);
-            \EEH_Debug_Tools::printr(
-                "{$ticket_quantity}",
+            EEH_Debug_Tools::printr("$spaces_allocated", '$spaces_allocated', __FILE__, __LINE__);
+            EEH_Debug_Tools::printr(
+                "$ticket_quantity",
                 "ticket $ticket_identifier quantity: ",
                 __FILE__,
                 __LINE__,
@@ -564,7 +570,7 @@ class EventSpacesCalculator
         }
         if ($ticket_quantity) {
             if ($this->debug) {
-                \EEH_Debug_Tools::printr(
+                EEH_Debug_Tools::printr(
                     ($spaces_allocated <= $reg_limit)
                         ? 'true'
                         : 'false',
@@ -583,17 +589,17 @@ class EventSpacesCalculator
                 $this->ticket_quantities[ $ticket_identifier ] -= $ticket_quantity;
                 // and increment spaces allocated for this datetime
                 $spaces_allocated += $ticket_quantity;
-                $at_capacity = $spaces_allocated >= $reg_limit;
+                $at_capacity      = $spaces_allocated >= $reg_limit;
                 if ($this->debug) {
-                    \EEH_Debug_Tools::printr(
-                        "{$ticket_quantity} {$ticket_identifier} tickets",
+                    EEH_Debug_Tools::printr(
+                        "$ticket_quantity $ticket_identifier tickets",
                         ' > > allocate ',
                         __FILE__,
                         __LINE__,
                         3
                     );
                     if ($at_capacity) {
-                        \EEH_Debug_Tools::printr('AT CAPACITY', " . {$datetime_identifier}", __FILE__, __LINE__, 3);
+                        EEH_Debug_Tools::printr('AT CAPACITY', " . $datetime_identifier", __FILE__, __LINE__, 3);
                     }
                 }
                 // now adjust all other datetimes that allow access to this ticket
@@ -621,10 +627,10 @@ class EventSpacesCalculator
      * @param int    $ticket_quantity
      */
     private function adjustDatetimes(
-        $datetime_identifier,
-        $ticket_identifier,
-        $ticket_quantity,
-        $at_capacity
+        string $datetime_identifier,
+        string $ticket_identifier,
+        int $ticket_quantity,
+        bool $at_capacity
     ) {
         /** @var array $datetime_tickets */
         foreach ($this->datetime_tickets as $datetime_ID => $datetime_tickets) {
@@ -648,7 +654,7 @@ class EventSpacesCalculator
                     && $this->ticket_quantities[ $datetime_ticket ] > 0
                 ) {
                     if ($this->debug) {
-                        \EEH_Debug_Tools::printr(
+                        EEH_Debug_Tools::printr(
                             $datetime_ticket,
                             ' . . . adjust ticket quantities for',
                             __FILE__,
@@ -663,11 +669,11 @@ class EventSpacesCalculator
                     // don't let ticket quantity go below zero
                     $this->ticket_quantities[ $datetime_ticket ] = max($new_quantity, 0);
                     if ($this->debug) {
-                        \EEH_Debug_Tools::printr(
+                        EEH_Debug_Tools::printr(
                             $at_capacity
-                                ? "0 because Datetime {$datetime_identifier} is at capacity"
+                                ? "0 because Datetime $datetime_identifier is at capacity"
                                 : "{$this->ticket_quantities[ $datetime_ticket ]}",
-                            " . . . . {$datetime_ticket} quantity set to ",
+                            " . . . . $datetime_ticket quantity set to ",
                             __FILE__,
                             __LINE__
                         );
@@ -680,7 +686,7 @@ class EventSpacesCalculator
                         && is_array($this->ticket_datetimes[ $datetime_ticket ])
                     ) {
                         if ($this->debug) {
-                            \EEH_Debug_Tools::printr(
+                            EEH_Debug_Tools::printr(
                                 $datetime_ticket,
                                 ' . . adjust other Datetimes for',
                                 __FILE__,
@@ -703,8 +709,18 @@ class EventSpacesCalculator
         }
     }
 
-    private function adjustDatetimeSpaces($datetime_identifier, $ticket_identifier, $ticket_quantity = 0)
-    {
+
+    /**
+     * @param string   $datetime_identifier
+     * @param string   $ticket_identifier
+     * @param int|null $ticket_quantity
+     * @return bool
+     */
+    private function adjustDatetimeSpaces(
+        string $datetime_identifier,
+        string $ticket_identifier,
+        ?int $ticket_quantity = 0
+    ): bool {
         // does datetime have spaces available?
         // and does the supplied ticket have access to this datetime ?
         if (
@@ -713,10 +729,10 @@ class EventSpacesCalculator
             && in_array($ticket_identifier, $this->datetime_tickets[ $datetime_identifier ], true)
         ) {
             if ($this->debug) {
-                \EEH_Debug_Tools::printr($datetime_identifier, ' . . adjust Datetime Spaces for', __FILE__, __LINE__);
-                \EEH_Debug_Tools::printr(
+                EEH_Debug_Tools::printr($datetime_identifier, ' . . adjust Datetime Spaces for', __FILE__, __LINE__);
+                EEH_Debug_Tools::printr(
                     "{$this->datetime_spaces[ $datetime_identifier ]}",
-                    " . . current  {$datetime_identifier} spaces available",
+                    " . . current  $datetime_identifier spaces available",
                     __FILE__,
                     __LINE__
                 );
@@ -729,9 +745,9 @@ class EventSpacesCalculator
                 0
             );
             if ($this->debug) {
-                \EEH_Debug_Tools::printr(
-                    "{$ticket_quantity}",
-                    " . . . {$datetime_identifier} capacity reduced by",
+                EEH_Debug_Tools::printr(
+                    "$ticket_quantity",
+                    " . . . $datetime_identifier capacity reduced by",
                     __FILE__,
                     __LINE__
                 );

--- a/core/domain/services/graphql/types/Event.php
+++ b/core/domain/services/graphql/types/Event.php
@@ -42,191 +42,189 @@ class Event extends TypeBase
      */
     public function getFields(): array
     {
-        $fields = [
-            new GraphQLField(
-                'allowDonations',
-                'Boolean',
-                'donations',
-                esc_html__('Accept Donations?', 'event_espresso')
-            ),
-            new GraphQLField(
-                'allowOverflow',
-                'Boolean',
-                'allow_overflow',
-                esc_html__('Enable Wait List for Event', 'event_espresso')
-            ),
-            new GraphQLField(
-                'altRegPage',
-                'String',
-                'external_url',
-                esc_html__('URL of Event Page if hosted elsewhere', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'cacheId',
-                ['non_null' => 'String'],
-                null,
-                esc_html__('The cache ID of the object.', 'event_espresso')
-            ),
-            new GraphQLField(
-                'created',
-                'String',
-                'created',
-                esc_html__('Date/Time Event Created', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'dbId',
-                ['non_null' => 'Int'],
-                'ID',
-                esc_html__('The event ID.', 'event_espresso')
-            ),
-            new GraphQLField(
-                'defaultRegStatus',
-                $this->namespace . 'RegistrationStatusEnum',
-                'default_registration_status',
-                esc_html__('Default Event Registration Status', 'event_espresso')
-            ),
-            new GraphQLField(
-                'description',
-                'String',
-                'description',
-                esc_html__('Event Description', 'event_espresso')
-            ),
-            new GraphQLField(
-                'displayDescription',
-                'Boolean',
-                'display_description',
-                esc_html__('Display Description Flag', 'event_espresso')
-            ),
-            new GraphQLField(
-                'displayTicketSelector',
-                'Boolean',
-                'display_ticket_selector',
-                esc_html__('Display Ticket Selector Flag', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isActive',
-                'Boolean',
-                'is_active',
-                esc_html__('Flag indicating event is active', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isCancelled',
-                'Boolean',
-                'is_cancelled',
-                esc_html__('Flag indicating whether the event is marked as cancelled', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isExpired',
-                'Boolean',
-                'is_expired',
-                esc_html__('Flag indicating event is expired or not', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isInactive',
-                'Boolean',
-                'is_inactive',
-                esc_html__('Flag indicating event is inactive', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isPostponed',
-                'Boolean',
-                'is_postponed',
-                esc_html__('Flag indicating whether the event is marked as postponed', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'isSoldOut',
-                'Boolean',
-                'is_sold_out',
-                esc_html__(
-                    'Flag indicating whether the tickets sold for the event, met or exceed the registration limit',
-                    'event_espresso'
-                )
-            ),
-            new GraphQLOutputField(
-                'isUpcoming',
-                'Boolean',
-                'is_upcoming',
-                esc_html__('Whether the event is upcoming', 'event_espresso')
-            ),
-            new GraphQLInputField(
-                'manager',
-                'String',
-                null,
-                esc_html__('Globally unique event ID for the event manager', 'event_espresso')
-            ),
-            new GraphQLOutputField(
-                'manager',
-                'User',
-                null,
-                esc_html__('Event Manager', 'event_espresso')
-            ),
-            new GraphQLField(
-                'maxRegistrations',
-                'Int',
-                'additional_limit',
-                esc_html__('Limit of Additional Registrations on Same Transaction', 'event_espresso')
-            ),
-            new GraphQLField(
-                'memberOnly',
-                'Boolean',
-                'member_only',
-                esc_html__('Member-Only Event Flag', 'event_espresso')
-            ),
-            new GraphQLField(
-                'name',
-                'String',
-                'name',
-                esc_html__('Event Name', 'event_espresso')
-            ),
-            new GraphQLField(
-                'order',
-                'Int',
-                'order',
-                esc_html__('Event Menu Order', 'event_espresso')
-            ),
-            new GraphQLField(
-                'phoneNumber',
-                'String',
-                'phone',
-                esc_html__('Event Phone Number', 'event_espresso')
-            ),
-            new GraphQLField(
-                'shortDescription',
-                'String',
-                'short_description',
-                esc_html__('Event Short Description', 'event_espresso')
-            ),
-            new GraphQLField(
-                'timezoneString',
-                'String',
-                'timezone_string',
-                esc_html__('Timezone (name) for Event times', 'event_espresso')
-            ),
-            new GraphQLField(
-                'visibleOn',
-                'String',
-                'visible_on',
-                esc_html__('Event Visible Date', 'event_espresso')
-            ),
-            new GraphQLField(
-                'venue',
-                'String',
-                null,
-                esc_html__('Event venue ID', 'event_espresso'),
-                null,
-                function (EE_Event $source) {
-                    $venue_ID = $source->venue_ID();
-                    return $venue_ID
-                    // Since venue is a CPT, $type will be 'post'
-                    ? Relay::toGlobalId('post', $venue_ID)
-                    : null;
-                }
-            ),
-        ];
-
         return apply_filters(
             'FHEE__EventEspresso_core_domain_services_graphql_types__event_fields',
-            $fields,
+            [
+                new GraphQLField(
+                    'allowDonations',
+                    'Boolean',
+                    'donations',
+                    esc_html__('Accept Donations?', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'allowOverflow',
+                    'Boolean',
+                    'allow_overflow',
+                    esc_html__('Enable Wait List for Event', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'altRegPage',
+                    'String',
+                    'external_url',
+                    esc_html__('URL of Event Page if hosted elsewhere', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'cacheId',
+                    ['non_null' => 'String'],
+                    null,
+                    esc_html__('The cache ID of the object.', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'created',
+                    'String',
+                    'created',
+                    esc_html__('Date/Time Event Created', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'dbId',
+                    ['non_null' => 'Int'],
+                    'ID',
+                    esc_html__('The event ID.', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'defaultRegStatus',
+                    $this->namespace . 'RegistrationStatusEnum',
+                    'default_registration_status',
+                    esc_html__('Default Event Registration Status', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'description',
+                    'String',
+                    'description',
+                    esc_html__('Event Description', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'displayDescription',
+                    'Boolean',
+                    'display_description',
+                    esc_html__('Display Description Flag', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'displayTicketSelector',
+                    'Boolean',
+                    'display_ticket_selector',
+                    esc_html__('Display Ticket Selector Flag', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isActive',
+                    'Boolean',
+                    'is_active',
+                    esc_html__('Flag indicating event is active', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isCancelled',
+                    'Boolean',
+                    'is_cancelled',
+                    esc_html__('Flag indicating whether the event is marked as cancelled', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isExpired',
+                    'Boolean',
+                    'is_expired',
+                    esc_html__('Flag indicating event is expired or not', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isInactive',
+                    'Boolean',
+                    'is_inactive',
+                    esc_html__('Flag indicating event is inactive', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isPostponed',
+                    'Boolean',
+                    'is_postponed',
+                    esc_html__('Flag indicating whether the event is marked as postponed', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'isSoldOut',
+                    'Boolean',
+                    'is_sold_out',
+                    esc_html__(
+                        'Flag indicating whether the tickets sold for the event, met or exceed the registration limit',
+                        'event_espresso'
+                    )
+                ),
+                new GraphQLOutputField(
+                    'isUpcoming',
+                    'Boolean',
+                    'is_upcoming',
+                    esc_html__('Whether the event is upcoming', 'event_espresso')
+                ),
+                new GraphQLInputField(
+                    'manager',
+                    'String',
+                    null,
+                    esc_html__('Globally unique event ID for the event manager', 'event_espresso')
+                ),
+                new GraphQLOutputField(
+                    'manager',
+                    'User',
+                    null,
+                    esc_html__('Event Manager', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'maxRegistrations',
+                    'Int',
+                    'additional_limit',
+                    esc_html__('Limit of Additional Registrations on Same Transaction', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'memberOnly',
+                    'Boolean',
+                    'member_only',
+                    esc_html__('Member-Only Event Flag', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'name',
+                    'String',
+                    'name',
+                    esc_html__('Event Name', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'order',
+                    'Int',
+                    'order',
+                    esc_html__('Event Menu Order', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'phoneNumber',
+                    'String',
+                    'phone',
+                    esc_html__('Event Phone Number', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'shortDescription',
+                    'String',
+                    'short_description',
+                    esc_html__('Event Short Description', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'timezoneString',
+                    'String',
+                    'timezone_string',
+                    esc_html__('Timezone (name) for Event times', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'visibleOn',
+                    'String',
+                    'visible_on',
+                    esc_html__('Event Visible Date', 'event_espresso')
+                ),
+                new GraphQLField(
+                    'venue',
+                    'String',
+                    null,
+                    esc_html__('Event venue ID', 'event_espresso'),
+                    null,
+                    function (EE_Event $source) {
+                        $venue_ID = $source->venue_ID();
+                        return $venue_ID
+                            // Since venue is a CPT, $type will be 'post'
+                            ? Relay::toGlobalId('post', $venue_ID)
+                            : null;
+                    }
+                ),
+            ],
             $this->name,
             $this->model
         );


### PR DESCRIPTION
This PR:

this was a really tricky issue to figure out and was beginning to drive me bonkers (but why drive when you're in walking distance)
I assumed that the problem was either caused by some unwanted code running, or some wanted code NOT running.
Turns out the issue was the database schema allowing null values if nothing was set, and since the legacy code for the reg options doesn't run if using the Barista plugin with the new EDTR, the value would get blanked out right within the db.

- fixes #3893
- changes the 4.12 DMS so that the event meta table schema no longer allows null values for the additional limit field
- does a BUNCH of formatting and code cleanup (it's what I do when I'm poking around in code)