### PR TITLE
Missing Message Type & Messenger Parameters

### DIFF
--- a/core/libraries/messages/EE_messenger.lib.php
+++ b/core/libraries/messages/EE_messenger.lib.php
@@ -567,7 +567,9 @@ abstract class EE_messenger extends EE_Messages_Base
                 $create_url_query_args = [
                     'page' => 'espresso_messages',
                     'action' => 'add_new_message_template',
-                    'GRP_ID' => $default_value
+                    'GRP_ID' => $default_value,
+                    'message_type' => $mtpg->message_type(),
+                    'messenger' => $this->name
                 ];
                 $create_url = EEH_URL::add_query_args_and_nonce($create_url_query_args, admin_url('admin.php'));
                 $st_args['mt_name'] = ucwords($mtp_obj->label['singular']);


### PR DESCRIPTION
While checking https://github.com/eventespresso/event-espresso-core/issues/3234 issue, I found that the **Create New Custom** button in the **Notifications** meta-box of event editor throws following error.

An EE_Error exception was thrown!   code: Messages_Admin_Page - add_message_template - 1308
"Sorry, but we can't create new templates because we're missing the messenger or message type"
click to view backtrace and class/method details
/Users/hossein/Projects/ee/wp-content/plugins/event-espresso-core/admin_pages/messages/Messages_Admin_Page.core.php   ( line no: 1308 )

You can see this error only if you try to open the link in a new tab / window.

<img width="1040" alt="Screen Shot 2022-06-20 at 17 21 23" src="https://user-images.githubusercontent.com/29144542/174605645-63dccb0c-296c-46ca-b23b-9dc73070f018.png">


This PR fixed this issue.