### PR TITLE
Fixed default context of new message template.

### DIFF
--- a/core/helpers/EEH_MSG_Template.helper.php
+++ b/core/helpers/EEH_MSG_Template.helper.php
@@ -1166,7 +1166,7 @@ class EEH_MSG_Template
             $new_message_template->set('MTP_ID', 0);
             $new_message_template->set('GRP_ID', $new_mtg->ID()); // relation
             $new_message_template->save();
-            if (empty($success['MTP_context'])) {
+            if (empty($success['MTP_context']) && $new_message_template->get('MTP_context') !== 'admin') {
                 $success['MTP_context'] = $new_message_template->get('MTP_context');
             }
         }

--- a/core/libraries/messages/EE_messenger.lib.php
+++ b/core/libraries/messages/EE_messenger.lib.php
@@ -557,11 +557,14 @@ abstract class EE_messenger extends EE_Messages_Base
                 }
                 // if there is no $default_value then we set it as the global
                 $default_value = empty($default_value) ? $mtpgID : $default_value;
+                $c_config = $mtpg->contexts_config();
+                $edit_context = key(array_slice($c_config, -1));
                 $edit_url_query_args = [
                     'page' => 'espresso_messages',
                     'action' => 'edit_message_template',
                     'id' => $default_value,
-                    'evt_id' => $event_id
+                    'evt_id' => $event_id,
+                    'context' => $edit_context,
                 ];
                 $edit_url = EEH_URL::add_query_args_and_nonce($edit_url_query_args, admin_url('admin.php'));
                 $create_url_query_args = [

--- a/core/services/request/sanitizers/AllowedTags.php
+++ b/core/services/request/sanitizers/AllowedTags.php
@@ -25,6 +25,10 @@ class AllowedTags
         'align'             => 1,
         'aria-*'            => 1,
         'autocomplete'      => 1,
+        'bgcolor'           => 1,
+        'border'            => 1,
+        'cellpadding'       => 1,
+        'cellspacing'       => 1,
         'checked'           => 1,
         'class'             => 1,
         'cols'              => 1,
@@ -43,14 +47,19 @@ class AllowedTags
         'itemtype'          => 1,
         'label'             => 1,
         'lang'              => 1,
+        'leftmargin'        => 1,
+        'marginheight'      => 1,
+        'marginwidth'       => 1,
         'max'               => 1,
         'maxlength'         => 1,
+        'media'             => 1,
         'method'            => 1,
         'min'               => 1,
         'multiple'          => 1,
         'name'              => 1,
         'novalidate'        => 1,
         'placeholder'       => 1,
+        'property'          => 1,
         'readonly'          => 1,
         'rel'               => 1,
         'required'          => 1,
@@ -63,19 +72,10 @@ class AllowedTags
         'tabindex'          => 1,
         'target'            => 1,
         'title'             => 1,
+        'topmargin'         => 1,
         'type'              => 1,
         'value'             => 1,
         'width'             => 1,
-        'topmargin'         => 1,
-        'leftmargin'        => 1,
-        'marginheight'      => 1,
-        'marginwidth'       => 1,
-        'property'          => 1,
-        'bgcolor'           => 1,
-        'media'             => 1,
-        'cellpadding'       => 1,
-        'cellspacing'       => 1,
-        'border'            => 1,
     ];
 
 
@@ -281,6 +281,7 @@ class AllowedTags
         }
         return AllowedTags::$allowed_with_script_and_style_tags;
     }
+
 
     /**
      * @return array[]


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/3234 issue.

This fix sets the default context to anything rather admin so immediately after creating a new custom message, the admin will see the template in primary attendee, attendee, purchaser, or registrant context.

Just click **Create Custom** button on **Messages** -> **Default Message Template** menu.

<img width="947" alt="Screen Shot 2022-06-20 at 19 14 01" src="https://user-images.githubusercontent.com/29144542/174627015-c9e2a16e-23e4-450d-9f01-1a6c7f727166.png">
