### PR TITLE
Add span wrapper to the base url

### DIFF
--- a/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
+++ b/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
@@ -58,12 +58,12 @@ $event_archive_url = EEH_Event_View::event_archive_url();
         <td>
             <span class="base-url"><?php echo site_url() . '/ ';?></span>
             <?php echo EEH_Form_Fields::text(
-                          'not_used',
-                          EE_Registry::instance()->CFG->core->event_cpt_slug,
-                          'event_cpt_slug',
-                          'event_cpt_slug',
-                          'regular'
-                      ); ?>
+                'not_used',
+                EE_Registry::instance()->CFG->core->event_cpt_slug,
+                'event_cpt_slug',
+                'event_cpt_slug',
+                'regular'
+            ); ?>
             <p class="description"><?php
                 esc_html_e(
                     'This allows you to configure what slug is used for the url of all event pages.',

--- a/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
+++ b/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
@@ -56,8 +56,10 @@ $event_archive_url = EEH_Event_View::event_archive_url();
             </label>
         </th>
         <td>
-            <?php echo site_url() . '/ '
-                      . EEH_Form_Fields::text(
+            <span class="base-url"><?php 
+                echo site_url() . '/ ';
+            ?></span>
+            <?php echo EEH_Form_Fields::text(
                           'not_used',
                           EE_Registry::instance()->CFG->core->event_cpt_slug,
                           'event_cpt_slug',

--- a/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
+++ b/caffeinated/modules/events_archive_caff/templates/admin-event-list-settings.template.php
@@ -56,9 +56,7 @@ $event_archive_url = EEH_Event_View::event_archive_url();
             </label>
         </th>
         <td>
-            <span class="base-url"><?php 
-                echo site_url() . '/ ';
-            ?></span>
+            <span class="base-url"><?php echo site_url() . '/ ';?></span>
             <?php echo EEH_Form_Fields::text(
                           'not_used',
                           EE_Registry::instance()->CFG->core->event_cpt_slug,


### PR DESCRIPTION
<!-- 
PLEASE READ THIS:
Thank you for your pull request.
Comment blocks like this get removed upon submission.
Please answer the following questions with as much detail as possible
-->

## Problem this Pull Request solves
<!-- describe the use case or issue -->


## How has this been tested
<!-- 
- steps required to test this pull request
- pull requests with automated tests are preferred. 
-->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
