### PR TITLE
Save Post Title & Desc From EDTR When Saving New Events

### DIFF
--- a/admin_pages/events/Events_Admin_Page.core.php
+++ b/admin_pages/events/Events_Admin_Page.core.php
@@ -1075,6 +1075,9 @@ class Events_Admin_Page extends EE_Admin_Page_CPT
             $event_values['EVT_external_URL'] = $this->request->getRequestParam('externalURL');
             $event_values['EVT_phone']        = $this->request->getRequestParam('event_phone');
             $event_values['EVT_display_desc'] = $this->request->getRequestParam('display_desc', false, 'bool');
+        } elseif ($post instanceof WP_Post) {
+            $event_values['EVT_name'] = $post->post_title;
+            $event_values['EVT_desc'] = $post->post_content;
         }
         // update event
         $success = $this->_event_model()->update_by_ID($event_values, $post_id);


### PR DESCRIPTION
This PR:

- partially fixes #3893 
- ensures that the post title and description are passed along to the event model when updating/inserting a new event

from chat:

The event description mutation callback has a debounce wrapper, so there is... a 5 second delay (?) or so before it sends its GQL request. If you submit the post before that has fired, then it will be blank on the next page load

so I think we may have to do the following:
- add a listener for the main editor submit button
- grab the event desc from the GQL data
- add that to the regular form data being submitted

but as always i am open to other ideas