### PR TITLE
Kses - Part 15

### DIFF
--- a/core/libraries/form_sections/base/EE_Form_Section_Base.form.php
+++ b/core/libraries/form_sections/base/EE_Form_Section_Base.form.php
@@ -384,7 +384,7 @@ abstract class EE_Form_Section_Base
         $html .= ' action="' . $this->action() . '"';
         $html .= ' method="' . $this->method() . '"';
         $html .= ' name="' . $this->name() . '"';
-        $html .= ' '.$other_attributes . '>';
+        $html .= ' ' . $other_attributes . '>';
         return $html;
     }
 

--- a/core/libraries/form_sections/base/EE_Form_Section_Base.form.php
+++ b/core/libraries/form_sections/base/EE_Form_Section_Base.form.php
@@ -384,7 +384,7 @@ abstract class EE_Form_Section_Base
         $html .= ' action="' . $this->action() . '"';
         $html .= ' method="' . $this->method() . '"';
         $html .= ' name="' . $this->name() . '"';
-        $html .= $other_attributes . '>';
+        $html .= ' '.$other_attributes . '>';
         return $html;
     }
 

--- a/core/libraries/form_sections/form_handlers/FormHandler.php
+++ b/core/libraries/form_sections/form_handlers/FormHandler.php
@@ -590,7 +590,7 @@ abstract class FormHandler implements FormHandlerInterface
             || $form_config === FormHandler::ADD_FORM_TAGS_ONLY
         ) {
             $additional_props = $this->requiresMultipartEnctype()
-                ? 'enctype="multipart/form-data"'
+                ? ' enctype="multipart/form-data"'
                 : '';
             $form_html .= $this->form()->form_open(
                 $this->formAction(),


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/3905 issue.

It was due to lack of one `space` character between the attributes. We had no space between **name** and **enctype** attributes so both get removed by `wp_kses` function.