### PR TITLE
Kses - Part 16

### DIFF
--- a/modules/single_page_checkout/reg_steps/payment_options/payment_options_main.template.php
+++ b/modules/single_page_checkout/reg_steps/payment_options/payment_options_main.template.php
@@ -41,7 +41,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
 <?php echo wp_kses($before_payment_options, AllowedTags::getWithFormTags()); ?>
 
 <div id="methods-of-payment">
-    <?php echo wp_kses($payment_options, AllowedTags::getWithFormTags()); ?>
+    <?php echo wp_kses($payment_options, AllowedTags::getWithFullTags()); ?>
 </div>
 <!-- end #methods-of-payment -->
 


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/3910 issue.

The issue was happened due to a lack of iframe tag in list of allowed tags. Used the `AllowedTags::getWithFullTags()` collection solved the problem.