### PR TITLE
Fix missing iCal icon on datetimes

### DIFF
--- a/public/template_tags.php
+++ b/public/template_tags.php
@@ -605,7 +605,7 @@ if (! function_exists('espresso_list_of_event_dates')) {
             <br/>';
         }
         if ($echo) {
-            echo wp_kses($html, AllowedTags::getAllowedTags());
+            echo wp_kses($html, AllowedTags::getWithFormTags());
             return '';
         }
         return $html;


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/ical-download-icon/?view=all

This branch just switches wp_kses to use `getWithFormTags()` to allow for input fields.

Master: https://monosnap.com/file/RIvZiEuls5AzyUPIijui2vIV327qfB

This branch: https://monosnap.com/file/izBbGZvWusP599giwEabrxdFsaqHMz