### PR TITLE
Fix Admin Settings Form Data

### DIFF
--- a/admin_pages/general_settings/General_Settings_Admin_Page.core.php
+++ b/admin_pages/general_settings/General_Settings_Admin_Page.core.php
@@ -68,70 +68,70 @@ class General_Settings_Admin_Page extends EE_Admin_Page
     {
         $this->_page_routes = [
             'critical_pages'                => [
-                'func'       => '_espresso_page_settings',
+                'func'       => [$this, '_espresso_page_settings'],
                 'capability' => 'manage_options',
             ],
             'update_espresso_page_settings' => [
-                'func'       => '_update_espresso_page_settings',
+                'func'       => [$this, '_update_espresso_page_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
             'default'                       => [
-                'func'       => '_your_organization_settings',
+                'func'       => [$this, '_your_organization_settings'],
                 'capability' => 'manage_options',
             ],
 
             'update_your_organization_settings' => [
-                'func'       => '_update_your_organization_settings',
+                'func'       => [$this, '_update_your_organization_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
 
             'admin_option_settings' => [
-                'func'       => '_admin_option_settings',
+                'func'       => [$this, '_admin_option_settings'],
                 'capability' => 'manage_options',
             ],
 
             'update_admin_option_settings' => [
-                'func'       => '_update_admin_option_settings',
+                'func'       => [$this, '_update_admin_option_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
 
             'country_settings' => [
-                'func'       => '_country_settings',
+                'func'       => [$this, '_country_settings'],
                 'capability' => 'manage_options',
             ],
 
             'update_country_settings' => [
-                'func'       => '_update_country_settings',
+                'func'       => [$this, '_update_country_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
 
             'display_country_settings' => [
-                'func'       => 'display_country_settings',
+                'func'       => [$this, 'display_country_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
 
             'add_new_state' => [
-                'func'       => 'add_new_state',
+                'func'       => [$this, 'add_new_state'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
 
             'delete_state'            => [
-                'func'       => 'delete_state',
+                'func'       => [$this, 'delete_state'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
             'privacy_settings'        => [
-                'func'       => 'privacySettings',
+                'func'       => [$this, 'privacySettings'],
                 'capability' => 'manage_options',
             ],
             'update_privacy_settings' => [
-                'func'               => 'updatePrivacySettings',
+                'func'               => [$this, 'updatePrivacySettings'],
                 'capability'         => 'manage_options',
                 'noheader'           => true,
                 'headers_sent_route' => 'privacy_settings',
@@ -543,7 +543,8 @@ class General_Settings_Admin_Page extends EE_Admin_Page
                 $this->request->getRequestParam(
                     $admin_options_settings_form->slug(),
                     [],
-                    DataType::OBJECT // need to change this to ARRAY after min PHP version gets bumped to 7+
+                    DataType::OBJECT, // need to change this to ARRAY after min PHP version gets bumped to 7+
+                    true
                 )
             );
             EE_Registry::instance()->CFG->admin = apply_filters(

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -563,7 +563,7 @@ class EED_Add_New_State extends EED_Module
      */
     public static function filter_checkout_request_params($request_params)
     {
-        foreach ($request_params as $form_section) {
+        foreach ((array) $request_params as $form_section) {
             if (is_array($form_section)) {
                 EED_Add_New_State::unset_new_state_request_params($form_section);
                 EED_Add_New_State::filter_checkout_request_params($form_section);


### PR DESCRIPTION
this PR:

- fixes #3927
- fixes request param data supplied to admin settings form (was not being passed as array)
- makes all route `funcs` callable (enhancement)
- type casts `$request_params` passed to `EED_Add_New_State` as array (just in case)