### PR TITLE
Use `aria-label`s Instead of `title` for List Table Actions

### DIFF
--- a/admin_pages/about/templates/credits.template.php
+++ b/admin_pages/about/templates/credits.template.php
@@ -92,7 +92,7 @@
             'For every major release we want to recognize the people who contributed to the release via a GitHub pull request. Want to see your name listed here? %sWhen you submit a pull request that gets included in a major release%s, we\'ll add your name here linked to your GitHub profile.',
             'event_espresso'
         ),
-        '<a href="https://github.com/eventespresso/event-espresso-core" title="Contribute to Event Espresso by making a pull request via GitHub" target="_blank">',
+        '<a href="https://github.com/eventespresso/event-espresso-core" aria-label="Contribute to Event Espresso by making a pull request via GitHub" target="_blank">',
         '</a>'
     );
     ?>

--- a/admin_pages/about/templates/reviews.template.php
+++ b/admin_pages/about/templates/reviews.template.php
@@ -43,7 +43,7 @@
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/sock2me/"
-                               title="View sock2me's profile"
+                               aria-label="View sock2me's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -57,7 +57,7 @@
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/sock2me/"
-                               title="View sock2me's profile"
+                               aria-label="View sock2me's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >
@@ -104,7 +104,7 @@
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/ivycat/"
-                               title="View ivycat's profile"
+                               aria-label="View ivycat's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -118,7 +118,7 @@
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/ivycat/"
-                               title="View ivycat's profile"
+                               aria-label="View ivycat's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >
@@ -167,7 +167,7 @@
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/amandaleigh/"
-                               title="View amandaleigh's profile"
+                               aria-label="View amandaleigh's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -182,7 +182,7 @@
                             <br>
                             <a
                                 href="https://wordpress.org/support/users/amandaleigh/"
-                                title="View amandaleigh's profile"
+                                aria-label="View amandaleigh's profile"
                                 class="bbp-author-name"
                                 rel="nofollow"
                             >
@@ -242,7 +242,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/birchfinch/"
-                               title="View Bryan's profile"
+                               aria-label="View Bryan's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -256,7 +256,7 @@ if (! defined('EE_CAF_URL')) {
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/birchfinch/"
-                               title="View Bryan's profile"
+                               aria-label="View Bryan's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >
@@ -303,7 +303,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/elainewildash/"
-                               title="View elaine.wildash's profile"
+                               aria-label="View elaine.wildash's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -317,7 +317,7 @@ if (! defined('EE_CAF_URL')) {
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/elainewildash/"
-                               title="View elaine.wildash's profile"
+                               aria-label="View elaine.wildash's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >
@@ -359,7 +359,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/rhj4/"
-                               title="View rhj4's profile"
+                               aria-label="View rhj4's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -373,7 +373,7 @@ if (! defined('EE_CAF_URL')) {
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/rhj4/"
-                               title="View rhj4's profile"
+                               aria-label="View rhj4's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >
@@ -432,7 +432,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/wooninjas/"
-                               title="View Wooninjas's profile"
+                               aria-label="View Wooninjas's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -447,7 +447,7 @@ if (! defined('EE_CAF_URL')) {
                             <br>
                             <a
                                 href="https://wordpress.org/support/users/wooninjas/"
-                                title="View Wooninjas's profile"
+                                aria-label="View Wooninjas's profile"
                                 class="bbp-author-name"
                                 rel="nofollow"
                             >
@@ -485,7 +485,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/johnmacek/"
-                               title="View johnmacek's profile"
+                               aria-label="View johnmacek's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -500,7 +500,7 @@ if (! defined('EE_CAF_URL')) {
                             <br>
                             <a
                                 href="https://wordpress.org/support/users/johnmacek/"
-                                title="View johnmacek's profile"
+                                aria-label="View johnmacek's profile"
                                 class="bbp-author-name"
                                 rel="nofollow"
                             >
@@ -538,7 +538,7 @@ if (! defined('EE_CAF_URL')) {
                     <div class="review-topic-content">
                         <p class="review-user-nicename">
                             <a href="https://wordpress.org/support/users/10bradders10/"
-                               title="View 10bradders10's profile"
+                               aria-label="View 10bradders10's profile"
                                class="bbp-author-avatar"
                                rel="nofollow"
                             >
@@ -552,7 +552,7 @@ if (! defined('EE_CAF_URL')) {
                             </a>
                             <br>
                             <a href="https://wordpress.org/support/users/10bradders10/"
-                               title="View 10bradders10's profile"
+                               aria-label="View 10bradders10's profile"
                                class="bbp-author-name"
                                rel="nofollow"
                             >

--- a/admin_pages/events/Event_Categories_Admin_List_Table.class.php
+++ b/admin_pages/events/Event_Categories_Admin_List_Table.class.php
@@ -86,7 +86,7 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
     {
         $category_name = $item->get_first_related('Term')->get('name');
         $content       = $item->get('term_id');
-        $content       .= '  <span class="show-on-mobile-view-only">' . $category_name . '</span>';
+        $content       .= ' <span class="show-on-mobile-view-only">' . $category_name . '</span>';
         return $content;
     }
 

--- a/admin_pages/events/Event_Categories_Admin_List_Table.class.php
+++ b/admin_pages/events/Event_Categories_Admin_List_Table.class.php
@@ -2,67 +2,65 @@
 
 /**
  * Event_Categories_Admin_List_Table
- *
  * Class for preparing the table listing all the event categories
- *
  * note: anywhere there are no php docs it is because the docs are available in the parent class.
  *
  * @package         Event_Categories_Admin_List_Table
  * @subpackage      includes/core/admin/events/Event_Category_Admin_List_Table.class.php
  * @author          Darren Ethier
- *
- * ------------------------------------------------------------------------
  */
 class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
 {
-    public function __construct($admin_page)
-    {
-        parent::__construct($admin_page);
-    }
+    /**
+     * @var Events_Admin_Page $_admin_page
+     */
+    protected $_admin_page;
 
 
+    /**
+     * @throws EE_Error
+     */
     protected function _setup_data()
     {
-        $this->_data = $this->_admin_page->get_categories($this->_per_page, $this->_current_page);
+        $this->_data           = $this->_admin_page->get_categories($this->_per_page, $this->_current_page);
         $this->_all_data_count = EEM_Term_Taxonomy::instance()->count(
-            array(array('taxonomy' => 'espresso_event_categories'))
+            [['taxonomy' => 'espresso_event_categories']]
         );
     }
 
 
     protected function _set_properties()
     {
-        $this->_wp_list_args = array(
+        $this->_wp_list_args = [
             'singular' => esc_html__('event category', 'event_espresso'),
             'plural'   => esc_html__('event categories', 'event_espresso'),
             'ajax'     => true, // for now,
             'screen'   => $this->_admin_page->get_current_screen()->id,
-        );
+        ];
 
-        $this->_columns = array(
+        $this->_columns = [
             'cb'        => '<input type="checkbox" />',
             'id'        => esc_html__('ID', 'event_espresso'),
             'name'      => esc_html__('Name', 'event_espresso'),
             'shortcode' => esc_html__('Shortcode', 'event_espresso'),
             'count'     => esc_html__('Events', 'event_espresso'),
-        );
+        ];
 
-        $this->_sortable_columns = array(
-            'id'    => array('Term.term_id' => true),
-            'name'  => array('Term.slug' => false),
-            'count' => array('term_count' => false),
-        );
+        $this->_sortable_columns = [
+            'id'    => ['Term.term_id' => true],
+            'name'  => ['Term.slug' => false],
+            'count' => ['term_count' => false],
+        ];
 
         $this->_primary_column = 'id';
 
-        $this->_hidden_columns = array();
+        $this->_hidden_columns = [];
     }
 
 
-    // not needed
     protected function _get_table_filters()
     {
-        return array();
+        return [];
     }
 
 
@@ -78,63 +76,80 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-    public function column_id($item)
+    /**
+     * @param EE_Term $item
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_id(EE_Term $item)
     {
-        $content = $item->get('term_id');
-        $content .= '  <span class="show-on-mobile-view-only">' . $item->get_first_related('Term')->get(
-            'name'
-        ) . '</span>';
+        $category_name = $item->get_first_related('Term')->get('name');
+        $content       = $item->get('term_id');
+        $content       .= '  <span class="show-on-mobile-view-only">' . $category_name . '</span>';
         return $content;
     }
 
 
-    public function column_name($item)
+    /**
+     * @param EE_Term $item
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_name(EE_Term $item)
     {
-        $edit_query_args = array(
+        $edit_query_args = [
             'action'     => 'edit_category',
             'EVT_CAT_ID' => $item->get('term_id'),
-        );
+        ];
 
-        $delete_query_args = array(
+        $delete_query_args = [
             'action'     => 'delete_category',
             'EVT_CAT_ID' => $item->get('term_id'),
-        );
+        ];
 
-        $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EVENTS_ADMIN_URL);
+        $edit_link   = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EVENTS_ADMIN_URL);
         $delete_link = EE_Admin_Page::add_query_args_and_nonce($delete_query_args, EVENTS_ADMIN_URL);
+        $view_link   = get_term_link($item->get('term_id'));
 
         $term_name = $item->get_first_related('Term')->get('name');
 
-        $actions['edit'] = '<a href="' . $edit_link . '" aria-label="' . sprintf(
-			/* translators: The name of the event category */
-			esc_attr__(
-				'Edit Category (%s)',
-				'event_espresso'
-			),
-			$term_name
-		) . '">' . esc_html__('Edit', 'event_espresso') . '</a>';
+        $edit_category_label = sprintf(
+            /* translators: The name of the event category */
+            esc_attr__(
+                'Edit Category (%s)',
+                'event_espresso'
+            ),
+            $term_name
+        );
+        $actions['edit']     = '
+            <a href="' . $edit_link . '" aria-label="' . $edit_category_label . '">
+                ' . esc_html__('Edit', 'event_espresso') . '
+            </a>';
 
-        $actions['delete'] = '<a href="' . $delete_link . '" aria-label="' . sprintf(
+        $delete_category_label = sprintf(
             /* translators: The name of the event category */
             esc_attr__(
                 'Delete Category (%s)',
                 'event_espresso'
             ),
             $term_name
-        ) . '">' . esc_html__('Delete', 'event_espresso') . '</a>';
-
-        $actions['view'] = sprintf(
-            '<a href="%s" aria-label="%s">%s</a>',
-            get_term_link($item->get('term_id')),
-            esc_attr(
-                sprintf(
-                    /* translators: %s: event category name */
-                    esc_html__('View &#8220;%s&#8221; archive', 'event_espresso'),
-                    $item->get_first_related('Term')->get('name')
-                )
-            ),
-            esc_html__('View', 'event_espresso')
         );
+        $actions['delete']     = '
+            <a href="' . $delete_link . '" aria-label="' . $delete_category_label . '">
+                ' . esc_html__('Delete', 'event_espresso') . '
+            </a>';
+
+        $view_category_label = sprintf(
+            /* translators: %s: event category name */
+            esc_html__('View &#8220;%s&#8221; archive', 'event_espresso'),
+            $item->get_first_related('Term')->get('name')
+        );
+        $actions['view']     = '
+            <a href="' . $view_link . '" aria-label="' . $view_category_label . '">
+                ' . esc_html__('View', 'event_espresso') . '
+            </a>';
 
         $content = '<strong><a class="row-title" href="' . $edit_link . '">' . $term_name . '</a></strong>';
         $content .= $this->row_actions($actions);
@@ -142,21 +157,33 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-    public function column_shortcode($item)
+    /**
+     * @param EE_Term $item
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_shortcode(EE_Term $item)
     {
-        $content = '[ESPRESSO_EVENTS category_slug=' . $item->get_first_related('Term')->get('slug') . ']';
-        return $content;
+        return '[ESPRESSO_EVENTS category_slug=' . $item->get_first_related('Term')->get('slug') . ']';
     }
 
 
-    public function column_count($item)
+    /**
+     * @param EE_Term $item
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_count(EE_Term $item)
     {
-        $e_args = array(
-            'action'  => 'default',
-            'EVT_CAT' => $item->get_first_related('Term')->ID(),
+        $category_url = EE_Admin_Page::add_query_args_and_nonce(
+            [
+                'action'  => 'default',
+                'EVT_CAT' => $item->get_first_related('Term')->ID(),
+            ],
+            EVENTS_ADMIN_URL
         );
-        $e_link = EE_Admin_Page::add_query_args_and_nonce($e_args, EVENTS_ADMIN_URL);
-        $content = '<a href="' . $e_link . '">' . $item->get('term_count') . '</a>';
-        return $content;
+        return '<a href="' . $category_url . '">' . $item->get('term_count') . '</a>';
     }
 }

--- a/admin_pages/events/Event_Categories_Admin_List_Table.class.php
+++ b/admin_pages/events/Event_Categories_Admin_List_Table.class.php
@@ -77,12 +77,12 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
 
 
     /**
-     * @param EE_Term $item
+     * @param EE_Term_Taxonomy $item
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function column_id(EE_Term $item)
+    public function column_id(EE_Term_Taxonomy $item)
     {
         $category_name = $item->get_first_related('Term')->get('name');
         $content       = $item->get('term_id');
@@ -92,12 +92,12 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
 
 
     /**
-     * @param EE_Term $item
+     * @param EE_Term_Taxonomy $item
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function column_name(EE_Term $item)
+    public function column_name(EE_Term_Taxonomy $item)
     {
         $edit_query_args = [
             'action'     => 'edit_category',
@@ -158,24 +158,24 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
 
 
     /**
-     * @param EE_Term $item
+     * @param EE_Term_Taxonomy $item
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function column_shortcode(EE_Term $item)
+    public function column_shortcode(EE_Term_Taxonomy $item)
     {
         return '[ESPRESSO_EVENTS category_slug=' . $item->get_first_related('Term')->get('slug') . ']';
     }
 
 
     /**
-     * @param EE_Term $item
+     * @param EE_Term_Taxonomy $item
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function column_count(EE_Term $item)
+    public function column_count(EE_Term_Taxonomy $item)
     {
         $category_url = EE_Admin_Page::add_query_args_and_nonce(
             [

--- a/admin_pages/events/Event_Categories_Admin_List_Table.class.php
+++ b/admin_pages/events/Event_Categories_Admin_List_Table.class.php
@@ -103,16 +103,24 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
         $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EVENTS_ADMIN_URL);
         $delete_link = EE_Admin_Page::add_query_args_and_nonce($delete_query_args, EVENTS_ADMIN_URL);
 
-        $actions = array(
-            'edit' => '<a href="' . $edit_link . '" aria-label="' . esc_attr__(
-                'Edit Category',
-                'event_espresso'
-            ) . '">' . esc_html__('Edit', 'event_espresso') . '</a>',
-        );
+        $term_name = $item->get_first_related('Term')->get('name');
 
-        $actions['delete'] = '<a href="' . $delete_link . '" aria-label="' . esc_attr__(
-            'Delete Category',
-            'event_espresso'
+        $actions['edit'] = '<a href="' . $edit_link . '" aria-label="' . sprintf(
+			/* translators: The name of the event category */
+			esc_attr__(
+				'Edit Category (%s)',
+				'event_espresso'
+			),
+			$term_name
+		) . '">' . esc_html__('Edit', 'event_espresso') . '</a>';
+
+        $actions['delete'] = '<a href="' . $delete_link . '" aria-label="' . sprintf(
+            /* translators: The name of the event category */
+            esc_attr__(
+                'Delete Category (%s)',
+                'event_espresso'
+            ),
+            $term_name
         ) . '">' . esc_html__('Delete', 'event_espresso') . '</a>';
 
         $actions['view'] = sprintf(
@@ -128,9 +136,7 @@ class Event_Categories_Admin_List_Table extends EE_Admin_List_Table
             esc_html__('View', 'event_espresso')
         );
 
-        $content = '<strong><a class="row-title" href="' . $edit_link . '">' . $item->get_first_related('Term')->get(
-            'name'
-        ) . '</a></strong>';
+        $content = '<strong><a class="row-title" href="' . $edit_link . '">' . $term_name . '</a></strong>';
         $content .= $this->row_actions($actions);
         return $content;
     }

--- a/admin_pages/events/Events_Admin_List_Table.class.php
+++ b/admin_pages/events/Events_Admin_List_Table.class.php
@@ -233,7 +233,10 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             );
             $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EVENTS_ADMIN_URL);
             $actions['edit'] = '<a href="' . $edit_link . '"'
-                               . ' title="' . esc_attr__('Edit Event', 'event_espresso') . '">'
+                               . ' aria-label="'
+                               /* Translators: The name of the event */
+                               . sprintf(esc_attr__('Edit Event (%s)', 'event_espresso'), $item->name())
+                               . '">'
                                . esc_html__('Edit', 'event_espresso')
                                . '</a>';
         }
@@ -254,7 +257,13 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             );
             $attendees_link = EE_Admin_Page::add_query_args_and_nonce($attendees_query_args, REG_ADMIN_URL);
             $actions['attendees'] = '<a href="' . $attendees_link . '"'
-                                    . ' title="' . esc_attr__('View Registrations', 'event_espresso') . '">'
+                                    . ' aria-label="'
+                                    . sprintf(
+                                        /* Translators: The name of the event */
+                                        esc_attr__('View Registrations for the event: %s', 'event_espresso'),
+                                        $item->name()
+                                    )
+                                    . '">'
                                     . esc_html__('Registrations', 'event_espresso')
                                     . '</a>';
         }
@@ -308,7 +317,10 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
         }
         $view_link = get_permalink($item->ID());
         $actions['view'] = '<a href="' . $view_link . '"'
-                           . ' title="' . esc_attr__('View Event', 'event_espresso') . '">'
+                           . ' aria-label="'
+                           /* Translators: The name of the event */
+                           . sprintf(esc_attr__('View Event (%s)', 'event_espresso'), $item->name())
+                           . '">'
                            . esc_html__('View', 'event_espresso')
                            . '</a>';
         if ($item->get('status') === 'trash') {
@@ -320,7 +332,15 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
                 )
             ) {
                 $actions['restore_from_trash'] = '<a href="' . $restore_event_link . '"'
-                                                 . ' title="' . esc_attr__('Restore from Trash', 'event_espresso')
+                                                 . ' aria-label="'
+                                                 . sprintf(
+                                                     /* Translators: The name of the event */
+                                                     esc_attr__(
+                                                         'Restore from Trash the event: %s',
+                                                         'event_espresso'
+                                                     ),
+                                                     $item->name()
+                                                 )
                                                  . '">'
                                                  . esc_html__('Restore from Trash', 'event_espresso')
                                                  . '</a>';
@@ -333,7 +353,13 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
                 )
             ) {
                 $actions['delete'] = '<a href="' . $delete_event_link . '"'
-                                     . ' title="' . esc_attr__('Delete Permanently', 'event_espresso') . '">'
+                                     . ' aria-label="'
+                                     . sprintf(
+                                         /* Translators: The name of the event. */
+                                         esc_attr__('Delete Permanently the event: %s', 'event_espresso'),
+                                         $item->name()
+                                     )
+                                     . '">'
                                      . esc_html__('Delete Permanently', 'event_espresso')
                                      . '</a>';
             }
@@ -346,7 +372,13 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
                 )
             ) {
                 $actions['move to trash'] = '<a href="' . $trash_event_link . '"'
-                                            . ' title="' . esc_attr__('Trash Event', 'event_espresso') . '">'
+                                            . ' aria-label="'
+                                            . sprintf(
+                                                /* Translators: The name of the event */
+                                                esc_attr__('Move the event %s to the trash.', 'event_espresso'),
+                                                $item->name()
+                                            )
+                                            . '">'
                                             . esc_html__('Trash', 'event_espresso')
                                             . '</a>';
             }

--- a/admin_pages/events/Events_Admin_List_Table.class.php
+++ b/admin_pages/events/Events_Admin_List_Table.class.php
@@ -404,7 +404,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
         );
         $filter_url = EE_Admin_Page::add_query_args_and_nonce($query_args, EVENTS_ADMIN_URL);
         return $gravatar . '  <a href="' . $filter_url . '"'
-               . ' title="' . esc_attr__('Click to filter events by this author.', 'event_espresso') . '">'
+               . ' aria-label="' . esc_attr__('Click to filter events by this author.', 'event_espresso') . '">'
                . $event_author->display_name
                . '</a>';
     }
@@ -532,7 +532,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
         $action_links = array();
         $view_link = get_permalink($item->ID());
         $action_links[] = '<a href="' . $view_link . '"'
-                          . ' title="' . esc_attr__('View Event', 'event_espresso') . '" target="_blank">';
+                          . ' aria-label="' . esc_attr__('View Event', 'event_espresso') . '" target="_blank">';
         $action_links[] = '<div class="dashicons dashicons-search"></div></a>';
         if (
             EE_Registry::instance()->CAP->current_user_can(
@@ -547,7 +547,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             );
             $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EVENTS_ADMIN_URL);
             $action_links[] = '<a href="' . $edit_link . '"'
-                              . ' title="' . esc_attr__('Edit Event', 'event_espresso') . '">'
+                              . ' aria-label="' . esc_attr__('Edit Event', 'event_espresso') . '">'
                               . '<div class="ee-icon ee-icon-calendar-edit"></div>'
                               . '</a>';
         }
@@ -567,7 +567,7 @@ class Events_Admin_List_Table extends EE_Admin_List_Table
             );
             $attendees_link = EE_Admin_Page::add_query_args_and_nonce($attendees_query_args, REG_ADMIN_URL);
             $action_links[] = '<a href="' . $attendees_link . '"'
-                              . ' title="' . esc_attr__('View Registrants', 'event_espresso') . '">'
+                              . ' aria-label="' . esc_attr__('View Registrants', 'event_espresso') . '">'
                               . '<div class="dashicons dashicons-groups"></div>'
                               . '</a>';
         }

--- a/admin_pages/general_settings/templates/state_details_settings.template.php
+++ b/admin_pages/general_settings/templates/state_details_settings.template.php
@@ -73,7 +73,6 @@
             <input class="STA_abbrev small-text "
                    id='STA_abbrev-XXX'
                    name="STA_abbrev_XXX"
-                   aria-label=""
                    type="text"
                    value=""
             />
@@ -81,7 +80,7 @@
         <td class="general-settings-country-state-input-td">
             <label for="STA_name_XXX"><?php esc_html_e('Name', 'event_espresso'); ?></label>
             <br/>
-            <input id="STA_name-XXX" class="STA_name regular-text " type="text" aria-label="" value="" name="STA_name_XXX">
+            <input id="STA_name-XXX" class="STA_name regular-text " type="text" value="" name="STA_name_XXX">
         </td>
     </tr>
     <tr>

--- a/admin_pages/general_settings/templates/state_details_settings.template.php
+++ b/admin_pages/general_settings/templates/state_details_settings.template.php
@@ -37,7 +37,7 @@
                    id="delete-state-<?php echo absint($STA_ID); ?>-lnk"
                    href="<?php echo esc_url_raw($state['delete_state_url']); ?>"
                    rel="<?php echo esc_attr($STA_ID); ?>"
-                   title="<?php echo sprintf(esc_attr__('Delete State #%d?', 'event_espresso'), $STA_ID); ?>"
+                   aria-label="<?php echo sprintf(esc_attr__('Delete State #%d?', 'event_espresso'), $STA_ID); ?>"
                 >
                 </a>
             </td>
@@ -73,7 +73,7 @@
             <input class="STA_abbrev small-text "
                    id='STA_abbrev-XXX'
                    name="STA_abbrev_XXX"
-                   title=""
+                   aria-label=""
                    type="text"
                    value=""
             />
@@ -81,7 +81,7 @@
         <td class="general-settings-country-state-input-td">
             <label for="STA_name_XXX"><?php esc_html_e('Name', 'event_espresso'); ?></label>
             <br/>
-            <input id="STA_name-XXX" class="STA_name regular-text " type="text" title="" value="" name="STA_name_XXX">
+            <input id="STA_name-XXX" class="STA_name regular-text " type="text" aria-label="" value="" name="STA_name_XXX">
         </td>
     </tr>
     <tr>

--- a/admin_pages/maintenance/templates/migration_options_from_ee3.template.php
+++ b/admin_pages/maintenance/templates/migration_options_from_ee3.template.php
@@ -44,7 +44,7 @@
                                 ),
                                 '<strong>',
                                 '</strong>',
-                                '<a id="migration-risks" class="" title="'
+                                '<a id="migration-risks" class="" aria-label="'
                                 . esc_attr__('click for more details', "event_espresso")
                                 . '">',
                                 '</a>',

--- a/admin_pages/messages/Messages_Template_List_Table.class.php
+++ b/admin_pages/messages/Messages_Template_List_Table.class.php
@@ -353,7 +353,7 @@ class Messages_Template_List_Table extends EE_Admin_List_Table
             );
             $context_array[] = '<a href="' . $edit_link . '"'
                                . ' class="' . "{$item->message_type()}-{$context}-edit-link{$inactive_class}" . '"'
-                               . ' title="' . esc_attr__('Edit Context', 'event_espresso') . '">'
+                               . ' aria-label="' . esc_attr__('Edit Context', 'event_espresso') . '">'
                                . $context_title
                                . '</a>';
         }

--- a/admin_pages/payments/Payment_Log_Admin_List_Table.class.php
+++ b/admin_pages/payments/Payment_Log_Admin_List_Table.class.php
@@ -268,7 +268,7 @@ class Payment_Log_Admin_List_Table extends EE_Admin_List_Table
                 TXN_ADMIN_URL
             );
             return '<a href="' . esc_url_raw($view_txn_lnk_url) . '"  '
-                   . 'title="' . sprintf(
+                   . 'aria-label="' . sprintf(
                        esc_attr__('click to view transaction #%s', 'event_espresso'),
                        $transaction_id
                    ) . '">'

--- a/admin_pages/registration_form/Registration_Form_Questions_Admin_List_Table.class.php
+++ b/admin_pages/registration_form/Registration_Form_Questions_Admin_List_Table.class.php
@@ -126,7 +126,7 @@ class Registration_Form_Questions_Admin_List_Table extends EE_Admin_List_Table
             $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_FORMS_ADMIN_URL);
 
             $actions = array(
-                'edit' => '<a href="' . $edit_link . '" title="' . esc_attr__(
+                'edit' => '<a href="' . $edit_link . '" aria-label="' . esc_attr__(
                     'Edit Event',
                     'event_espresso'
                 ) . '">' . esc_html__('Edit', 'event_espresso') . '</a>',

--- a/admin_pages/registration_form/espresso_events_Registration_Form_Hooks.class.php
+++ b/admin_pages/registration_form/espresso_events_Registration_Form_Hooks.class.php
@@ -171,7 +171,7 @@ class espresso_events_Registration_Form_Hooks extends EE_Admin_Hooks
                              . $checked . ' 
                         />
 						<a href="' . esc_url_raw($edit_link) . '" 
-						    title="' . esc_attr($edit_link_title) . '" 
+						    aria-label="' . esc_attr($edit_link_title) . '" 
 						    target="_blank"
 						    >
 						    ' . $QSG->get('QSG_name') . '

--- a/admin_pages/registrations/EE_Attendee_Contact_List_Table.class.php
+++ b/admin_pages/registrations/EE_Attendee_Contact_List_Table.class.php
@@ -179,7 +179,7 @@ class EE_Attendee_Contact_List_Table extends EE_Admin_List_Table
             'ee_edit_contacts',
             'espresso_registrations_edit_attendee'
         )
-            ? '<a href="' . $edit_lnk_url . '" title="'
+            ? '<a href="' . $edit_lnk_url . '" aria-label="'
               . esc_attr__('Edit Contact', 'event_espresso') . '">'
               . $attendee->lname() . '</a>'
             : $attendee->lname();
@@ -215,7 +215,7 @@ class EE_Attendee_Contact_List_Table extends EE_Admin_List_Table
                 ),
                 REG_ADMIN_URL
             );
-            $actions['edit'] = '<a href="' . $edit_lnk_url . '" title="'
+            $actions['edit'] = '<a href="' . $edit_lnk_url . '" aria-label="'
                                . esc_attr__('Edit Contact', 'event_espresso') . '">'
                                . esc_html__('Edit', 'event_espresso') . '</a>';
         }
@@ -235,7 +235,7 @@ class EE_Attendee_Contact_List_Table extends EE_Admin_List_Table
                     ),
                     REG_ADMIN_URL
                 );
-                $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                $actions['trash'] = '<a href="' . $trash_lnk_url . '" aria-label="'
                                     . esc_attr__('Move Contact to Trash', 'event_espresso')
                                     . '">' . esc_html__('Trash', 'event_espresso') . '</a>';
             }
@@ -254,7 +254,7 @@ class EE_Attendee_Contact_List_Table extends EE_Admin_List_Table
                     ),
                     REG_ADMIN_URL
                 );
-                $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                $actions['restore'] = '<a href="' . $restore_lnk_url . '" aria-label="'
                                       . esc_attr__('Restore Contact', 'event_espresso') . '">'
                                       . esc_html__('Restore', 'event_espresso') . '</a>';
             }
@@ -271,7 +271,7 @@ class EE_Attendee_Contact_List_Table extends EE_Admin_List_Table
             'ee_edit_contacts',
             'espresso_registrations_edit_attendee'
         )
-            ? '<a href="' . $edit_lnk_url . '" title="'
+            ? '<a href="' . $edit_lnk_url . '" aria-label="'
               . esc_attr__('Edit Contact', 'event_espresso') . '">' . $attendee->fname() . '</a>'
             : $attendee->fname();
 

--- a/admin_pages/registrations/EE_Registrations_List_Table.class.php
+++ b/admin_pages/registrations/EE_Registrations_List_Table.class.php
@@ -478,7 +478,7 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
               . $this->_transaction_details['status']
               . '" href="'
               . $view_lnk_url
-              . '" title="'
+              . '" aria-label="'
               . esc_attr($this->_transaction_details['title_attr'])
               . '">'
               . $item->get_i18n_datetime('REG_date')
@@ -521,14 +521,14 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                       . $this->_event_details['status']
                       . '" href="'
                       . $edit_event_url
-                      . '" title="'
+                      . '" aria-label="'
                       . esc_attr($this->_event_details['title_attr'])
                       . '">'
                       . $event_name
                       . '</a>'
                     : $event_name;
             $edit_event_url          = EE_Admin_Page::add_query_args_and_nonce(['event_id' => $EVT_ID], REG_ADMIN_URL);
-            $actions['event_filter'] = '<a href="' . $edit_event_url . '" title="';
+            $actions['event_filter'] = '<a href="' . $edit_event_url . '" aria-label="';
             $actions['event_filter'] .= sprintf(
                 esc_attr__('Filter this list to only show registrations for %s', 'event_espresso'),
                 $event_name
@@ -623,7 +623,7 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
         )
             ? '<a href="'
               . $edit_lnk_url
-              . '" title="'
+              . '" aria-label="'
               . esc_attr__('View Registration Details', 'event_espresso')
               . '">'
               . $attendee_name
@@ -666,7 +666,7 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             );
             $actions['trash'] = '<a href="'
                                 . $trash_lnk_url
-                                . '" title="'
+                                . '" aria-label="'
                                 . esc_attr__('Trash Registration', 'event_espresso')
                                 . '">' . esc_html__('Trash', 'event_espresso') . '</a>';
         } elseif ($this->_view === 'trash') {
@@ -683,11 +683,12 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                     $action,
                     REG_ADMIN_URL
                 );
-                $actions['restore'] = '<a href="'
-                                      . $restore_lnk_url
-                                      . '" title="'
-                                      . esc_attr__('Restore Registration', 'event_espresso') . '">'
-                                      . esc_html__('Restore', 'event_espresso') . '</a>';
+                $actions['restore'] = '
+                    <a href="' . $restore_lnk_url . '" 
+                       aria-label="' . esc_attr__('Restore Registration', 'event_espresso') . '"
+                   >
+                       ' . esc_html__('Restore', 'event_espresso') . '
+                   </a>';
             }
             if (
                 EE_Registry::instance()->CAP->current_user_can(
@@ -701,13 +702,12 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                     $action,
                     REG_ADMIN_URL
                 );
-                $actions['delete'] = '<a href="'
-                                     . $delete_lnk_url
-                                     . '" title="'
-                                     . esc_attr__('Delete Registration Permanently', 'event_espresso')
-                                     . '">'
-                                     . esc_html__('Delete', 'event_espresso')
-                                     . '</a>';
+                $actions['delete'] = '
+                    <a href="' . $delete_lnk_url . '" 
+                       aria-label="' . esc_attr__('Delete Registration Permanently', 'event_espresso') . '"
+                    >
+                        ' . esc_html__('Delete', 'event_espresso') . '
+                    </a>';
             }
         }
         return sprintf('%1$s %2$s', $link, $this->row_actions($actions));
@@ -834,15 +834,14 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                 'espresso_transactions_view_transaction',
                 $item->transaction_ID()
             )
-                ? '<span class="reg-pad-rght"><a class="status-'
-                  . $item->transaction()->status_ID()
-                  . '" href="'
-                  . $view_txn_lnk_url
-                  . '"  title="'
-                  . esc_attr__('View Transaction', 'event_espresso')
-                  . '">'
-                  . $item->transaction()->pretty_total()
-                  . '</a></span>'
+                ? '<span class="reg-pad-rght">
+                    <a class="status-' . $item->transaction()->status_ID() . '" 
+                       href="' . $view_txn_lnk_url . '"  
+                       aria-label="' . esc_attr__('View Transaction', 'event_espresso') . '"
+                    >
+                        ' . $item->transaction()->pretty_total() . '
+                    </a>
+                  </span>'
                 : '<span class="reg-pad-rght">' . $item->transaction()->pretty_total() . '</span>';
         } else {
             return esc_html__("None", "event_espresso");
@@ -881,15 +880,14 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
                     'espresso_transactions_view_transaction',
                     $item->transaction_ID()
                 )
-                    ? '<span class="reg-pad-rght"><a class="status-'
-                      . $transaction->status_ID()
-                      . '" href="'
-                      . $view_txn_lnk_url
-                      . '"  title="'
-                      . esc_attr__('View Transaction', 'event_espresso')
-                      . '">'
-                      . $item->transaction()->pretty_paid()
-                      . '</a><span>'
+                    ? '<span class="reg-pad-rght">
+                        <a class="status-' . $transaction->status_ID() . '" 
+                           href="' . $view_txn_lnk_url . '"  
+                           aria-label="' . esc_attr__('View Transaction', 'event_espresso') . '"
+                        >
+                            ' . $item->transaction()->pretty_paid() . '
+                        </a>
+                       <span>'
                     : '<span class="reg-pad-rght">' . $item->transaction()->pretty_paid() . '</span>';
             }
         }
@@ -931,9 +929,10 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             );
             $actions['view_lnk'] = '
             <li>
-                <a href="' . $view_lnk_url . '" title="'
-                . esc_attr__('View Registration Details', 'event_espresso')
-                . '" class="tiny-text">
+                <a href="' . $view_lnk_url . '" 
+                   aria-label="' . esc_attr__('View Registration Details', 'event_espresso') . '" 
+                   class="tiny-text"
+               >
 				    <div class="dashicons dashicons-clipboard"></div>
 			    </a>
 			</li>';
@@ -955,9 +954,10 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             );
             $actions['edit_lnk'] = '
 			<li>
-                <a href="' . $edit_lnk_url . '" title="'
-                . esc_attr__('Edit Contact Details', 'event_espresso')
-                . '" class="tiny-text">
+			    <a href="' . $edit_lnk_url . '" 
+                   aria-label="' . esc_attr__('Edit Contact Details', 'event_espresso') . '" 
+                   class="tiny-text"
+                >
                     <div class="ee-icon ee-icon-user-edit ee-icon-size-16"></div>
                 </a>
 			</li>';
@@ -981,9 +981,10 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             );
             $actions['resend_reg_lnk'] = '
 			<li>
-			    <a href="' . $resend_reg_lnk_url . '" title="'
-                . esc_attr__('Resend Registration Details', 'event_espresso')
-                . '" class="tiny-text">
+			    <a href="' . $resend_reg_lnk_url . '" 
+			       aria-label="' . esc_attr__('Resend Registration Details', 'event_espresso') . '" 
+			       class="tiny-text"
+                >
 			        <div class="dashicons dashicons-email-alt"></div>
 			    </a>
             </li>';
@@ -1005,9 +1006,10 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
             );
             $actions['view_txn_lnk'] = '
 			<li>
-                <a class="ee-status-color-' . $this->_transaction_details['status']
-                . ' tiny-text" href="' . $view_txn_lnk_url
-                . '"  title="' . $this->_transaction_details['title_attr'] . '">
+                <a class="ee-status-color-' . $this->_transaction_details['status'] . ' tiny-text" 
+                   href="' . $view_txn_lnk_url . '"  
+                   aria-label="' . $this->_transaction_details['title_attr'] . '"
+                >
                     <div class="dashicons dashicons-cart"></div>
                 </a>
 			</li>';
@@ -1021,8 +1023,11 @@ class EE_Registrations_List_Table extends EE_Admin_List_Table
         ) {
             $actions['dl_invoice_lnk'] = '
             <li>
-                <a title="' . esc_attr__('View Transaction Invoice', 'event_espresso')
-                . '" target="_blank" href="' . $item->invoice_url() . '" class="tiny-text">
+                <a aria-label="' . esc_attr__('View Transaction Invoice', 'event_espresso') . '" 
+                   class="tiny-text"
+                   href="' . $item->invoice_url() . '" 
+                   target="_blank" 
+                >
                     <span class="dashicons dashicons-media-spreadsheet ee-icon-size-18"></span>
                 </a>
             </li>';

--- a/admin_pages/registrations/Registrations_Admin_Page.core.php
+++ b/admin_pages/registrations/Registrations_Admin_Page.core.php
@@ -2234,7 +2234,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
 			<tr class="hide-if-no-js">
 				<th> </th>
 				<td class="reg-admin-edit-attendee-question-td">
-					<a class="reg-admin-edit-attendee-question-lnk" href="#" title="'
+					<a class="reg-admin-edit-attendee-question-lnk" href="#" aria-label="'
                . esc_attr__('click to edit question', 'event_espresso')
                . '">
 						<span class="reg-admin-edit-question-group-spn lt-grey-txt">'
@@ -2825,7 +2825,7 @@ class Registrations_Admin_Page extends EE_Admin_Page_CPT
             );
             $edit_event_lnk                     = '<a href="'
                                                   . $edit_event_url
-                                                  . '" title="'
+                                                  . '" aria-label="'
                                                   . esc_attr__('Edit ', 'event_espresso')
                                                   . $this->_reg_event->name()
                                                   . '">'

--- a/admin_pages/registrations/templates/attendee_registrations_main_meta_box.template.php
+++ b/admin_pages/registrations/templates/attendee_registrations_main_meta_box.template.php
@@ -32,7 +32,7 @@
                                 'espresso_events_edit',
                                 $EVT_ID
                             )
-                                ? '<a href="' . esc_url_raw($event_url) . '"  title="'
+                                ? '<a href="' . esc_url_raw($event_url) . '"  aria-label="'
                                   . esc_attr__('Edit Event', 'event_espresso') . '">'
                                   . esc_html($registration->event_name()) . '</a>'
                                 : esc_html($registration->event_name());
@@ -50,7 +50,7 @@
                                 'espresso_registrations_view_registration',
                                 $REG_ID
                             )
-                                ? '<a href="' . esc_url_raw($reg_url) . '" title="'
+                                ? '<a href="' . esc_url_raw($reg_url) . '" aria-label="'
                                   . esc_attr__('View Registration Details', 'event_espresso') . '">'
                                   . esc_html__('View Registration', 'event_espresso') . '</a>'
                                 : $REG_ID;
@@ -67,7 +67,7 @@
                                 'ee_read_transaction',
                                 'espresso_transactions_view_transaction'
                             )
-                                ? '<a href="' . esc_url_raw($txn_url) . '" title="'
+                                ? '<a href="' . esc_url_raw($txn_url) . '" aria-label="'
                                   . esc_attr__('View Transaction Details', 'event_espresso') . '">'
                                   . sprintf(
                                       esc_html__('View Transaction %d', 'event_espresso'),

--- a/admin_pages/registrations/templates/reg_admin_details_main_meta_box_attendees.template.php
+++ b/admin_pages/registrations/templates/reg_admin_details_main_meta_box_attendees.template.php
@@ -32,7 +32,7 @@
                             <td class="jst-left"><?php echo esc_html($attendee['event_name']); ?></td>
                             <td class="jst-left">
                                 <a href="<?php echo esc_url_raw($attendee['att_link']); ?>"
-                                   title="<?php esc_attr_e('View details for this attendee', 'event_espresso'); ?>"
+                                   aria-label="<?php esc_attr_e('View details for this attendee', 'event_espresso'); ?>"
                                 >
                                     <?php echo esc_html($attendee['fname'] . ' ' . $attendee['lname']); ?>
                                 </a>

--- a/admin_pages/registrations/templates/reg_admin_details_side_meta_box_registrant.template.php
+++ b/admin_pages/registrations/templates/reg_admin_details_side_meta_box_registrant.template.php
@@ -64,14 +64,14 @@ $email = sanitize_email($email);
     ) :
         ?>
         <a class="button button-small" href="<?php echo esc_url_raw($att_edit_link); ?>"
-           title="<?php echo esc_attr($att_edit_label); ?>"
+           aria-label="<?php echo esc_attr($att_edit_label); ?>"
         >
             <span class="ee-icon ee-icon-user-edit"></span>
             <?php echo esc_html($att_edit_label); ?>
         </a>
         <?php if (! empty($create_link)) : ?>
         <a class="button button-small" href="<?php echo esc_url_raw($create_link); ?>"
-           title="<?php esc_attr_e(
+           aria-label="<?php esc_attr_e(
                'This registration shares the contact details for the primary registration in this group.  If you\'d like this registration to have its own details, you can do so by clicking this button',
                'event_espresso'
            ); ?>"

--- a/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
+++ b/admin_pages/transactions/EE_Admin_Transactions_List_Table.class.php
@@ -180,7 +180,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
             TXN_ADMIN_URL
         );
         $content = '<a href="' . $view_lnk_url . '"'
-                   . ' title="' . esc_attr__('Go to Transaction Details', 'event_espresso') . '">'
+                   . ' aria-label="' . esc_attr__('Go to Transaction Details', 'event_espresso') . '">'
                    . $transaction->ID()
                    . '</a>';
 
@@ -247,7 +247,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
             TXN_ADMIN_URL
         );
         $txn_date = '<a href="' . $view_lnk_url . '"'
-                    . ' title="'
+                    . ' aria-label="'
                     . esc_attr__('View Transaction Details for TXN #', 'event_espresso') . $transaction->ID() . '">'
                     . $this->_get_txn_timestamp($transaction)
                     . '</a>';
@@ -361,7 +361,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
                 $primary_reg->ID()
             )
                 ? '<a href="' . $edit_lnk_url . '"'
-                  . ' title="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
+                  . ' aria-label="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
                   . $attendee->full_name()
                   . '</a>'
                 : $attendee->full_name();
@@ -439,7 +439,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
                 )
             ) {
                 $actions['filter_by_event'] = '<a href="' . $txn_by_event_lnk . '"'
-                                              . ' title="' . esc_attr__(
+                                              . ' aria-label="' . esc_attr__(
                                                   'Filter transactions by this event',
                                                   'event_espresso'
                                               ) . '">'
@@ -455,7 +455,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
                     $event->ID()
                 )
                     ? '<a href="' . $edit_event_url . '"'
-                      . ' title="'
+                      . ' aria-label="'
                       . sprintf(
                           esc_attr__('Edit Event: %s', 'event_espresso'),
                           $event->get('EVT_name')
@@ -522,7 +522,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
         return '
 			<li>
 				<a href="' . $url . '"'
-               . ' title="' . esc_attr__('View Transaction Details', 'event_espresso') . '" class="tiny-text">
+               . ' aria-label="' . esc_attr__('View Transaction Details', 'event_espresso') . '" class="tiny-text">
 					<span class="dashicons dashicons-cart"></span>
 				</a>
 			</li>';
@@ -548,7 +548,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
             ) {
                 return '
                 <li>
-                    <a title="' . esc_attr__('View Transaction Invoice', 'event_espresso') . '"'
+                    <a aria-label="' . esc_attr__('View Transaction Invoice', 'event_espresso') . '"'
                        . ' target="_blank" href="' . $url . '" class="tiny-text">
                         <span class="dashicons dashicons-media-spreadsheet ee-icon-size-18"></span>
                     </a>
@@ -578,7 +578,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
             ) {
                 return '
 			<li>
-				<a title="' . esc_attr__('View Transaction Receipt', 'event_espresso') . '"'
+				<a aria-label="' . esc_attr__('View Transaction Receipt', 'event_espresso') . '"'
                        . ' target="_blank" href="' . $url . '" class="tiny-text">
 					<span class="dashicons dashicons-media-default ee-icon-size-18"></span>
 				</a>
@@ -618,7 +618,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
                 ? '
 				<li>
 					<a href="' . $url . '"'
-                  . ' title="' . esc_attr__('View Registration Details', 'event_espresso') . '" class="tiny-text">
+                  . ' aria-label="' . esc_attr__('View Registration Details', 'event_espresso') . '" class="tiny-text">
 						<span class="dashicons dashicons-clipboard"></span>
 					</a>
 				</li>'
@@ -665,7 +665,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
             return '
             <li>
                 <a href="' . $url . '"'
-                   . ' title="' . esc_attr__('Send Payment Reminder', 'event_espresso') . '" class="tiny-text">
+                   . ' aria-label="' . esc_attr__('Send Payment Reminder', 'event_espresso') . '" class="tiny-text">
                     <span class="dashicons dashicons-email-alt"></span>
                 </a>
             </li>';
@@ -717,7 +717,7 @@ class EE_Admin_Transactions_List_Table extends EE_Admin_List_Table
         ) {
             return '
             <li>
-                <a title="' . esc_attr__('Make Payment from the Frontend.', 'event_espresso') . '"'
+                <a aria-label="' . esc_attr__('Make Payment from the Frontend.', 'event_espresso') . '"'
                    . ' target="_blank" href="' . $registration->payment_overview_url(true) . '"'
                    . ' class="tiny-text">
                     <span class="dashicons dashicons-money ee-icon-size-18"></span>

--- a/admin_pages/transactions/Transactions_Admin_Page.core.php
+++ b/admin_pages/transactions/Transactions_Admin_Page.core.php
@@ -649,7 +649,7 @@ class Transactions_Admin_Page extends EE_Admin_Page
                     ['action' => 'edit', 'post' => $event->ID()],
                     EVENTS_ADMIN_URL
                 )
-                . '" title="'
+                . '" aria-label="'
                 . esc_attr__('Click to Edit event', 'event_espresso')
                 . '">' . $event->name() . '</a>',
                 '</h3>'

--- a/admin_pages/transactions/templates/txn_admin_details_main_meta_box_attendees.template.php
+++ b/admin_pages/transactions/templates/txn_admin_details_main_meta_box_attendees.template.php
@@ -37,7 +37,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                 );
                                 ?>
                                 <a href="<?php echo esc_url_raw($att_link); ?>"
-                                   title="<?php esc_attr_e('View details for this registrant', 'event_espresso'); ?>"
+                                   aria-label="<?php esc_attr_e('View details for this registrant', 'event_espresso'); ?>"
                                 >
                                     <?php echo esc_html($attendee['attendee']); ?>
                                 </a>

--- a/admin_pages/transactions/templates/txn_admin_details_main_meta_box_txn_details.template.php
+++ b/admin_pages/transactions/templates/txn_admin_details_main_meta_box_txn_details.template.php
@@ -153,7 +153,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                         <li>
                                             <?php if ($can_edit_payments) : ?>
                                                 <a class="txn-admin-payment-action-edit-lnk"
-                                                   title="<?php esc_attr_e('Edit Payment', 'event_espresso'); ?>"
+                                                   aria-label="<?php esc_attr_e('Edit Payment', 'event_espresso'); ?>"
                                                    data-payment-id="<?php echo absint($PAY_ID); ?>"
                                                 >
                                                     <div class="dashicons dashicons-edit" style="margin: 0;"></div>
@@ -163,7 +163,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                         <li>
                                             <?php if ($can_delete_payments) : ?>
                                                 <a class="txn-admin-payment-action-delete-lnk"
-                                                   title="<?php esc_attr_e('Delete Payment', 'event_espresso'); ?>"
+                                                   aria-label="<?php esc_attr_e('Delete Payment', 'event_espresso'); ?>"
                                                    data-payment-id="<?php echo absint($PAY_ID); ?>"
                                                 >
                                                     <div class="dashicons dashicons-trash" style="margin: 0;"></div>
@@ -307,7 +307,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                             <ul class="txn-overview-actions-ul">
                                 <li>
                                     <a class="txn-admin-payment-action-edit-lnk"
-                                       title="<?php esc_attr_e('Edit Payment', 'event_espresso'); ?>"
+                                       aria-label="<?php esc_attr_e('Edit Payment', 'event_espresso'); ?>"
                                        data-payment-id="PAY_ID"
                                     >
                                         <div class="dashicons dashicons-edit" style="margin: 0;"></div>
@@ -315,7 +315,7 @@ use EventEspresso\core\services\request\sanitizers\AllowedTags;
                                 </li>
                                 <li>
                                     <a class="txn-admin-payment-action-delete-lnk"
-                                       title="<?php esc_attr_e('Delete Payment', 'event_espresso'); ?>"
+                                       aria-label="<?php esc_attr_e('Delete Payment', 'event_espresso'); ?>"
                                        data-payment-id="PAY_ID"
                                     >
                                         <div class="dashicons dashicons-trash" style="margin: 0;"></div>

--- a/admin_pages/transactions/templates/txn_admin_details_side_meta_box_registrant.template.php
+++ b/admin_pages/transactions/templates/txn_admin_details_side_meta_box_registrant.template.php
@@ -64,7 +64,7 @@ $prime_reg_email = sanitize_email($prime_reg_email);
     ) : ?>
         <p style="text-align:right;">
             <a class="button button-small" href="<?php echo esc_url_raw($edit_attendee_url); ?>"
-               title="<?php esc_attr_e('View details for this contact.', 'event_espresso'); ?>"
+               aria-label="<?php esc_attr_e('View details for this contact.', 'event_espresso'); ?>"
             >
                 <span class="ee-icon ee-icon-user-edit"></span>
                 <?php esc_html_e('View / Edit this Contact', 'event_espresso'); ?>

--- a/admin_pages/venues/Venue_Categories_Admin_List_Table.class.php
+++ b/admin_pages/venues/Venue_Categories_Admin_List_Table.class.php
@@ -35,7 +35,6 @@ class Venue_Categories_Admin_List_Table extends EE_Admin_List_Table
             'cb'    => '<input type="checkbox" />',
             'id'    => esc_html__('ID', 'event_espresso'),
             'name'  => esc_html__('Name', 'event_espresso'),
-            // 'shortcode' => esc_html__('Shortcode', 'event_espresso'),
             'count' => esc_html__('Venues', 'event_espresso'),
         );
 
@@ -103,7 +102,7 @@ class Venue_Categories_Admin_List_Table extends EE_Admin_List_Table
                     'event_espresso'
                 ),
                 $term_name
-            ) . '">' . __('Edit', 'event_espresso') . '</a>',
+            ) . '">' . esc_html__('Edit', 'event_espresso') . '</a>',
         );
 
 
@@ -114,7 +113,7 @@ class Venue_Categories_Admin_List_Table extends EE_Admin_List_Table
                 'event_espresso'
             ),
             $term_name
-        ) . '">' . __('Delete', 'event_espresso') . '</a>';
+        ) . '">' . esc_html__('Delete', 'event_espresso') . '</a>';
 
         $content = '<strong><a class="row-title" href="' . $edit_link . '">' . $item->get_first_related('Term')->get(
             'name'

--- a/admin_pages/venues/Venue_Categories_Admin_List_Table.class.php
+++ b/admin_pages/venues/Venue_Categories_Admin_List_Table.class.php
@@ -93,18 +93,28 @@ class Venue_Categories_Admin_List_Table extends EE_Admin_List_Table
         $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_VENUES_ADMIN_URL);
         $delete_link = EE_Admin_Page::add_query_args_and_nonce($delete_query_args, EE_VENUES_ADMIN_URL);
 
+        $term_name = $item->get_first_related('Term')->get('name');
+
         $actions = array(
-            'edit' => '<a href="' . $edit_link . '" title="' . esc_attr__(
-                'Edit Category',
-                'event_espresso'
-            ) . '">' . esc_html__('Edit', 'event_espresso') . '</a>',
+            'edit' => '<a href="' . $edit_link . '" aria-label="' . sprintf(
+                /* translators: The name of the venue category */
+                esc_attr__(
+                    'Edit Category (%s)',
+                    'event_espresso'
+                ),
+                $term_name
+            ) . '">' . __('Edit', 'event_espresso') . '</a>',
         );
 
 
-        $actions['delete'] = '<a href="' . $delete_link . '" title="' . esc_attr__(
-            'Delete Category',
-            'event_espresso'
-        ) . '">' . esc_html__('Delete', 'event_espresso') . '</a>';
+        $actions['delete'] = '<a href="' . $delete_link . '" aria-label="' . sprintf(
+            /* translators: The name of the venue category */
+            esc_attr__(
+                'Delete Category (%s)',
+                'event_espresso'
+            ),
+            $term_name
+        ) . '">' . __('Delete', 'event_espresso') . '</a>';
 
         $content = '<strong><a class="row-title" href="' . $edit_link . '">' . $item->get_first_related('Term')->get(
             'name'

--- a/admin_pages/venues/Venues_Admin_List_Table.class.php
+++ b/admin_pages/venues/Venues_Admin_List_Table.class.php
@@ -237,9 +237,11 @@ class Venues_Admin_List_Table extends EE_Admin_List_Table
 
     /**
      * @param EE_Venue $venue
-     * @return int
+     * @return int|string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function column_capacity(EE_Venue $venue): int
+    public function column_capacity(EE_Venue $venue)
     {
         return $venue->capacity();
     }

--- a/admin_pages/venues/Venues_Admin_List_Table.class.php
+++ b/admin_pages/venues/Venues_Admin_List_Table.class.php
@@ -10,11 +10,18 @@
  * @package         Venues_Admin_List_Table
  * @subpackage      includes/core/admin/events/Venues_Admin_List_Table.class.php
  * @author          Darren Ethier
- *
- * ------------------------------------------------------------------------
  */
 class Venues_Admin_List_Table extends EE_Admin_List_Table
 {
+    /**
+     * @var   int
+     */
+    private $related_event_count = 0;
+
+
+    /**
+     * @param $admin_page
+     */
     public function __construct($admin_page)
     {
         parent::__construct($admin_page);
@@ -59,12 +66,20 @@ class Venues_Admin_List_Table extends EE_Admin_List_Table
 
 
     // todo... add _venue_status in here (which we'll define a EE_Admin_CPT_List_Table for common properties)
-    protected function _get_table_filters()
+
+
+    /**
+     * @return array
+     */
+    protected function _get_table_filters(): array
     {
         return array();
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     protected function _add_view_counts()
     {
         $this->_views['all']['count'] = EEM_Venue::instance()->count();
@@ -74,43 +89,62 @@ class Venues_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-    public function column_cb($item)
+    /**
+     * @param EE_Venue|null $venue
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_cb($venue): string
     {
-
-        return $item->count_related('Event') > 0 && $item->get('status') === 'trash'
+        $this->related_event_count = $venue->count_related('Event');
+        return $this->related_event_count > 0 && $venue->status() === 'trash'
             ? '<span class="ee-lock-icon"></span>'
             : sprintf(
                 '<input type="checkbox" name="venue_id[]" value="%s" />',
-                $item->ID()
+                $venue->ID()
             );
     }
 
 
-    public function column_id($item)
+    /**
+     * @param EE_Venue $venue
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_id(EE_Venue $venue): string
     {
-        $content = $item->ID();
-        $content .= '  <span class="show-on-mobile-view-only">' . $item->name() . '</span>';
-        return $content;
+        return $venue->ID() . '  <span class="show-on-mobile-view-only">' . $venue->name() . '</span>';
     }
 
 
-    public function column_name($item)
+    /**
+     * @param EE_Venue $venue
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_name(EE_Venue $venue): string
     {
-        $edit_query_args = array(
-            'action' => 'edit',
-            'post'   => $item->ID(),
+        $edit_link = EE_Admin_Page::add_query_args_and_nonce(
+            [
+                'action' => 'edit',
+                'post'   => $venue->ID(),
+            ],
+            EE_VENUES_ADMIN_URL
         );
 
-        $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_VENUES_ADMIN_URL);
-
         $statuses = EEM_Venue::instance()->get_status_array();
-        $actions = $this->_column_name_action_setup($item);
-        $content = EE_Registry::instance()->CAP->current_user_can('ee_edit_venue', 'espresso_venues_edit', $item->ID())
-            ? '<strong><a class="row-title" href="' . $edit_link . '">' . stripslashes_deep(
-                $item->name()
-            ) . '</a></strong>' : $item->name();
-        $content .= $item->status() == 'draft' ? ' - <span class="post-state">' . $statuses['draft'] . '</span>' : '';
-        $content .= $this->row_actions($actions);
+        $actions = $this->_column_name_action_setup($venue);
+        $content = EE_Registry::instance()->CAP->current_user_can('ee_edit_venue', 'espresso_venues_edit', $venue->ID())
+            ? '
+            <strong>
+                <a class="row-title" href="' . $edit_link . '">' . stripslashes_deep($venue->name()) . '</a>
+            </strong>'
+            : $venue->name();
+        $content .= $venue->status() == 'draft' ? ' - <span class="post-state">' . $statuses['draft'] . '</span>' : '';
+        $content .= $this->row_actions(array_filter($actions));
         return $content;
     }
 
@@ -118,143 +152,148 @@ class Venues_Admin_List_Table extends EE_Admin_List_Table
     /**
      * Used to setup the actions for the Venue name column
      *
-     * @param EE_Venue $item
+     * @param EE_Venue $venue
      * @return array()
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _column_name_action_setup(EE_Venue $item)
+    protected function _column_name_action_setup(EE_Venue $venue): array
     {
-        $actions = array();
-
-        if (EE_Registry::instance()->CAP->current_user_can('ee_edit_venue', 'espresso_venues_edit', $item->ID())) {
-            $edit_query_args = array(
-                'action' => 'edit',
-                'post'   => $item->ID(),
-            );
-            $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_VENUES_ADMIN_URL);
-            $actions['edit'] = '<a href="' . $edit_link . '" title="' . esc_attr__(
-                'Edit Venue',
-                'event_espresso'
-            ) . '">' . esc_html__('Edit', 'event_espresso') . '</a>';
-        }
-
-
-        if (
-            EE_Registry::instance()->CAP->current_user_can(
+        $actions = [];
+        if ($venue->status() === 'trash') {
+            $actions['restore_venue'] = $this->getVenueActionLink(
+                $venue,
+                'restore_venue',
+                esc_html__('Restore from Trash', 'event_espresso'),
+                /* Translators: The name of the venue */
+                esc_attr__('Restore Venue (%s) from Trash', 'event_espresso'),
                 'ee_delete_venue',
-                'espresso_venues_trash_venue',
-                $item->ID()
-            )
-        ) {
-            $trash_event_query_arg = array(
-                'action' => 'trash_venue',
-                'VNU_ID' => $item->ID(),
+                'espresso_venues_restore_venue'
             );
-            $trash_venue_link = EE_Admin_Page::add_query_args_and_nonce($trash_event_query_arg, EE_VENUES_ADMIN_URL);
-        }
-
-        if (
-            EE_Registry::instance()->CAP->current_user_can(
+            if ($this->related_event_count === 0) {
+                $actions['delete_venue'] = $this->getVenueActionLink(
+                    $venue,
+                    'delete_venue',
+                    esc_html__('Delete Permanently', 'event_espresso'),
+                    /* Translators: The name of the venue */
+                    esc_attr__('Permanently Delete Venue (%s)', 'event_espresso'),
+                    'ee_delete_venue',
+                    'espresso_venues_delete_venue'
+                );
+            }
+        } else {
+            $actions['view']        = $this->getVenueActionLink(
+                $venue,
+                'view',
+                esc_html__('View', 'event_espresso'),
+                /* Translators: The name of the venue */
+                esc_attr__('View Venue (%s)', 'event_espresso'),
+                '',
+                '',
+                get_permalink($venue->ID())
+            );
+            $actions['edit']        = $this->getVenueActionLink(
+                $venue,
+                'edit',
+                esc_html__('Edit', 'event_espresso'),
+                /* Translators: The name of the venue */
+                esc_attr__('Edit Venue (%s)', 'event_espresso'),
+                'ee_edit_venue',
+                'espresso_venues_edit'
+            );
+            $actions['trash_venue'] = $this->getVenueActionLink(
+                $venue,
+                'trash_venue',
+                esc_html__('Trash', 'event_espresso'),
+                /* Translators: The name of the venue */
+                esc_attr__('Trash Venue (%s)', 'event_espresso'),
                 'ee_delete_venue',
-                'espresso_venues_restore_venue',
-                $item->ID()
-            )
-        ) {
-            $restore_venue_query_args = array(
-                'action' => 'restore_venue',
-                'VNU_ID' => $item->ID(),
+                'espresso_venues_trash_venue'
             );
-            $restore_venue_link = EE_Admin_Page::add_query_args_and_nonce(
-                $restore_venue_query_args,
-                EE_VENUES_ADMIN_URL
-            );
-        }
-
-        if (
-            EE_Registry::instance()->CAP->current_user_can(
-                'ee_delete_venue',
-                'espresso_venues_delete_venue',
-                $item->ID()
-            )
-        ) {
-            $delete_venue_query_args = array(
-                'action' => 'delete_venue',
-                'VNU_ID' => $item->ID(),
-            );
-            $delete_venue_link = EE_Admin_Page::add_query_args_and_nonce($delete_venue_query_args, EE_VENUES_ADMIN_URL);
-        }
-
-        $view_link = get_permalink($item->ID());
-
-        switch ($item->get('status')) {
-            case 'trash':
-                if (
-                    EE_Registry::instance()->CAP->current_user_can(
-                        'ee_delete_venue',
-                        'espresso_venues_restore_venue',
-                        $item->ID()
-                    )
-                ) {
-                    $actions['restore_from_trash'] = '<a href="' . $restore_venue_link . '" title="' . esc_attr__(
-                        'Restore from Trash',
-                        'event_espresso'
-                    ) . '">' . esc_html__('Restore from Trash', 'event_espresso') . '</a>';
-                }
-                if (
-                    $item->count_related('Event') === 0 && EE_Registry::instance()->CAP->current_user_can(
-                        'ee_delete_venue',
-                        'espresso_venues_delete_venue',
-                        $item->ID()
-                    )
-                ) {
-                    $actions['delete permanently'] = '<a href="' . $delete_venue_link . '" title="' . esc_attr__(
-                        'Delete Permanently',
-                        'event_espresso'
-                    ) . '">' . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
-                }
-                break;
-            default:
-                $actions['view'] = '<a href="' . $view_link . '" title="' . esc_attr__(
-                    'View Venue',
-                    'event_espresso'
-                ) . '">' . esc_html__('View', 'event_espresso') . '</a>';
-                if (
-                    EE_Registry::instance()->CAP->current_user_can(
-                        'ee_delete_venue',
-                        'espresso_venues_trash_venue',
-                        $item->ID()
-                    )
-                ) {
-                    $actions['move to trash'] = '<a href="' . $trash_venue_link . '" title="' . esc_attr__(
-                        'Trash Event',
-                        'event_espresso'
-                    ) . '">' . esc_html__('Trash', 'event_espresso') . '</a>';
-                }
         }
         return $actions;
     }
 
 
-    public function column_address($item)
+    /**
+     * @param EE_Venue $venue
+     * @return string
+     */
+    public function column_address(EE_Venue $venue): string
     {
-        return $item->address();
+        return $venue->address();
     }
 
 
-    public function column_city($item)
+    /**
+     * @param EE_Venue $venue
+     * @return string
+     */
+    public function column_city(EE_Venue $venue): string
     {
-        return $item->city();
+        return $venue->city();
     }
 
 
-    public function column_capacity($item)
+    /**
+     * @param EE_Venue $venue
+     * @return int
+     */
+    public function column_capacity(EE_Venue $venue): int
     {
-        return $item->capacity();
+        return $venue->capacity();
     }
 
 
-    public function column_shortcode($item)
+    /**
+     * @param EE_Venue $venue
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function column_shortcode(EE_Venue $venue): string
     {
-        $content = '[ESPRESSO_VENUE id=' . $item->ID() . ']';
-        return $content;
+        return '[ESPRESSO_VENUE id=' . $venue->ID() . ']';
+    }
+
+
+    /**
+     * @param EE_Venue    $venue
+     * @param string      $action
+     * @param string      $link_text
+     * @param string      $aria_label
+     * @param string      $cap
+     * @param string      $context
+     * @param string|null $action_url
+     * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    public function getVenueActionLink(
+        EE_Venue $venue,
+        string $action,
+        string $link_text,
+        string $aria_label,
+        string $cap,
+        string $context,
+        ?string $action_url = null
+    ): string {
+        if ($cap && ! EE_Registry::instance()->CAP->current_user_can($cap, $context, $venue->ID())) {
+            return '';
+        }
+        $key = $action === 'edit' ? 'post' : 'VNU_ID';
+        // if supplied an $action_url, then use that, otherwise build one using the $action param
+        $action_url = $action_url
+            ?: EE_Admin_Page::add_query_args_and_nonce(
+                [
+                    'action' => $action,
+                    $key     => $venue->ID(),
+                ],
+                EE_VENUES_ADMIN_URL
+            );
+        $aria_label = sprintf($aria_label, $venue->name());
+        return "
+        <a href='$action_url' aria-label='$aria_label'>$link_text</a>";
     }
 }

--- a/admin_pages/venues/Venues_Admin_Page.core.php
+++ b/admin_pages/venues/Venues_Admin_Page.core.php
@@ -104,112 +104,112 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
 
         $this->_page_routes = [
             'default'                    => [
-                'func'       => '_overview_list_table',
+                'func'       => [$this, '_overview_list_table'],
                 'capability' => 'ee_read_venues',
             ],
             'create_new'                 => [
-                'func'       => '_create_new_cpt_item',
+                'func'       => [$this, '_create_new_cpt_item'],
                 'capability' => 'ee_edit_venues',
             ],
             'edit'                       => [
-                'func'       => '_edit_cpt_item',
+                'func'       => [$this, '_edit_cpt_item'],
                 'capability' => 'ee_edit_venue',
                 'obj_id'     => $VNU_ID,
             ],
             'trash_venue'                => [
-                'func'       => '_trash_or_restore_venue',
+                'func'       => [$this, '_trash_or_restore_venue'],
                 'args'       => ['venue_status' => 'trash'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venue',
                 'obj_id'     => $VNU_ID,
             ],
             'trash_venues'               => [
-                'func'       => '_trash_or_restore_venues',
+                'func'       => [$this, '_trash_or_restore_venues'],
                 'args'       => ['venue_status' => 'trash'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venues',
             ],
             'restore_venue'              => [
-                'func'       => '_trash_or_restore_venue',
+                'func'       => [$this, '_trash_or_restore_venue'],
                 'args'       => ['venue_status' => 'draft'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venue',
                 'obj_id'     => $VNU_ID,
             ],
             'restore_venues'             => [
-                'func'       => '_trash_or_restore_venues',
+                'func'       => [$this, '_trash_or_restore_venues'],
                 'args'       => ['venue_status' => 'draft'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venues',
             ],
             'delete_venues'              => [
-                'func'       => '_delete_venues',
+                'func'       => [$this, '_delete_venues'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venues',
             ],
             'delete_venue'               => [
-                'func'       => '_delete_venue',
+                'func'       => [$this, '_delete_venue'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venue',
                 'obj_id'     => $VNU_ID,
             ],
             // settings related
             'google_map_settings'        => [
-                'func'       => '_google_map_settings',
+                'func'       => [$this, '_google_map_settings'],
                 'capability' => 'manage_options',
             ],
             'update_google_map_settings' => [
-                'func'       => '_update_google_map_settings',
+                'func'       => [$this, '_update_google_map_settings'],
                 'capability' => 'manage_options',
                 'noheader'   => true,
             ],
             // venue category tab related
             'add_category'               => [
-                'func'       => '_category_details',
+                'func'       => [$this, '_category_details'],
                 'args'       => ['add'],
                 'capability' => 'ee_edit_venue_category',
             ],
             'edit_category'              => [
-                'func'       => '_category_details',
+                'func'       => [$this, '_category_details'],
                 'args'       => ['edit'],
                 'capability' => 'ee_edit_venue_category',
             ],
             'delete_categories'          => [
-                'func'       => '_delete_categories',
+                'func'       => [$this, '_delete_categories'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venue_category',
             ],
 
             'delete_category' => [
-                'func'       => '_delete_categories',
+                'func'       => [$this, '_delete_categories'],
                 'noheader'   => true,
                 'capability' => 'ee_delete_venue_category',
             ],
 
             'insert_category' => [
-                'func'       => '_insert_or_update_category',
+                'func'       => [$this, '_insert_or_update_category'],
                 'args'       => ['new_category' => true],
                 'noheader'   => true,
                 'capability' => 'ee_edit_venue_category',
             ],
 
             'update_category'   => [
-                'func'       => '_insert_or_update_category',
+                'func'       => [$this, '_insert_or_update_category'],
                 'args'       => ['new_category' => false],
                 'noheader'   => true,
                 'capability' => 'ee_edit_venue_category',
             ],
             'export_categories' => [
-                'func'       => '_categories_export',
+                'func'       => [$this, '_categories_export'],
                 'noheader'   => true,
                 'capability' => 'export',
             ],
             'import_categories' => [
-                'func'       => '_import_categories',
+                'func'       => [$this, '_import_categories'],
                 'capability' => 'import',
             ],
             'category_list'     => [
-                'func'       => '_category_list_table',
+                'func'       => [$this, '_category_list_table'],
                 'capability' => 'ee_manage_venue_categories',
             ],
         ];
@@ -926,7 +926,6 @@ class Venues_Admin_Page extends EE_Admin_Page_CPT
     protected function _trash_or_restore_venue($venue_status = 'trash', $redirect_after = true)
     {
         $VNU_ID = $this->request->getRequestParam('VNU_ID', 0, 'int');
-
         // loop thru venues
         if ($VNU_ID) {
             // clean status

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -247,13 +247,15 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 $this->_admin_base_url
             );
             $title  = esc_attr__('Duplicate Event', 'event_espresso');
-            $return .= '<a href="'
-                       . $href
-                       . '" title="'
-                       . $title
-                       . '" id="ee-duplicate-event-button" class="button button-small"  value="duplicate_event">'
-                       . $title
-                       . '</a>';
+            $return .= '
+                <a href="' . $href . '" 
+                   aria-label="' . $title . '" 
+                   id="ee-duplicate-event-button" 
+                   class="button button-small"
+                   value="duplicate_event"
+                >
+                    ' . $title . '
+                </a>';
         }
         return $return;
     }
@@ -413,12 +415,12 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                 'EVT_ID' => $event->ID(),
             ];
             $reports_link       = EE_Admin_Page::add_query_args_and_nonce($reports_query_args, REG_ADMIN_URL);
-            $action_links[]     = '<a href="'
-                                  . $reports_link
-                                  . '" title="'
-                                  . esc_attr__('View Report', 'event_espresso')
-                                  . '"><div class="dashicons dashicons-chart-bar"></div></a>'
-                                  . "\n\t";
+            $action_links[]     = '
+                <a href="' . $reports_link . '" 
+                   aria-label="' . esc_attr__('View Report', 'event_espresso') . '"
+                >
+                    <div class="dashicons dashicons-chart-bar"></div>
+                </a>' . "\n\t";
         }
         if (EE_Registry::instance()->CAP->current_user_can('ee_read_global_messages', 'view_filtered_messages')) {
             EE_Registry::instance()->load_helper('MSG_Template');

--- a/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
+++ b/caffeinated/admin/extend/events/Extend_Events_Admin_Page.core.php
@@ -420,7 +420,7 @@ class Extend_Events_Admin_Page extends Events_Admin_Page
                    aria-label="' . esc_attr__('View Report', 'event_espresso') . '"
                 >
                     <div class="dashicons dashicons-chart-bar"></div>
-                </a>' . "\n\t";
+                </a>';
         }
         if (EE_Registry::instance()->CAP->current_user_can('ee_read_global_messages', 'view_filtered_messages')) {
             EE_Registry::instance()->load_helper('MSG_Template');

--- a/caffeinated/admin/extend/events/Tickets_List_Table.class.php
+++ b/caffeinated/admin/extend/events/Tickets_List_Table.class.php
@@ -95,7 +95,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'trash_ticket',
                     'TKT_ID' => $item->ID(),
                 ), EVENTS_ADMIN_URL);
-                $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                $actions['trash'] = '<a href="' . $trash_lnk_url . '" aria-label="'
                                     . esc_attr__('Move Ticket to trash', 'event_espresso') . '">'
                                     . esc_html__('Trash', 'event_espresso') . '</a>';
             } else {
@@ -104,7 +104,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'restore_ticket',
                     'TKT_ID' => $item->ID(),
                 ), EVENTS_ADMIN_URL);
-                $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                $actions['restore'] = '<a href="' . $restore_lnk_url . '" aria-label="'
                                       . esc_attr__('Restore Ticket', 'event_espresso') . '">'
                                       . esc_html__('Restore', 'event_espresso') . '</a>';
                 // delete price link
@@ -112,7 +112,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'delete_ticket',
                     'TKT_ID' => $item->ID(),
                 ), EVENTS_ADMIN_URL);
-                $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                $actions['delete'] = '<a href="' . $delete_lnk_url . '" aria-label="'
                                      . esc_attr__('Delete Ticket Permanently', 'event_espresso') . '">'
                                      . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
             }

--- a/caffeinated/admin/extend/events/qtips/EE_Event_Editor_Tips.lib.php
+++ b/caffeinated/admin/extend/events/qtips/EE_Event_Editor_Tips.lib.php
@@ -171,7 +171,7 @@ class EE_Event_Editor_Tips extends EE_Qtip_Config
                        'Clicking the taxable ticket toggle checkbox has enabled taxes for this ticket. What this means is that when a person purchases this ticket, the tax will be applied to all prices on this ticket. You can edit the existing tax price modifier that was setup in Event Espresso by going to  %sDefault Pricing Admin Page%s (labelled "Pricing" in the Event Espresso Menu)',
                        'event_espresso'
                    ),
-                   '<a href="' . $price_admin_link . '" title="' . esc_attr__(
+                   '<a href="' . $price_admin_link . '" aria-label="' . esc_attr__(
                        'Pricing Admin Page',
                        'event_espresso'
                    ) . '">',

--- a/caffeinated/admin/extend/events/templates/event_datetime_metabox_clone_button.template.php
+++ b/caffeinated/admin/extend/events/templates/event_datetime_metabox_clone_button.template.php
@@ -5,7 +5,7 @@
 ?>
 
 <a class='clone-date-time dtm-inp-btn' rel='<?php echo absint($row); ?>'
-   title='<?php esc_attr_e('Clone this Event Date and Time', 'event_espresso'); ?>'
+   aria-label='<?php esc_attr_e('Clone this Event Date and Time', 'event_espresso'); ?>'
    style='position:relative; top:5px; margin:0 0 0 10px; font-size:.9em; cursor:pointer;'>
     <img alt='<?php esc_attr_e('clone', 'event_espresso'); ?>'
          height='16'

--- a/caffeinated/admin/extend/messages/Custom_Messages_Template_List_Table.class.php
+++ b/caffeinated/admin/extend/messages/Custom_Messages_Template_List_Table.class.php
@@ -198,13 +198,12 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
                 $item->ID()
             )
         ) {
-            $actions['trash'] = '<a href="'
-                                . $trash_lnk_url
-                                . '" title="'
-                                . esc_attr__('Move Template Group to Trash', 'event_espresso')
-                                . '">'
-                                . esc_html__('Move to Trash', 'event_espresso')
-                                . '</a>';
+            $actions['trash'] = '
+                <a href="' . $trash_lnk_url . '" 
+                   aria-label="' . esc_attr__('Move Template Group to Trash', 'event_espresso') . '"
+                >
+                    ' . esc_html__('Move to Trash', 'event_espresso') . '
+                </a>';
         } else {
             if (
                 EE_Registry::instance()->CAP->current_user_can(
@@ -213,12 +212,12 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
                     $item->ID()
                 )
             ) {
-                $actions['restore'] = '<a href="'
-                                      . $restore_lnk_url
-                                      . '" title="'
-                                      . esc_attr__('Restore Message Template', 'event_espresso')
-                                      . '">'
-                                      . esc_html__('Restore', 'event_espresso') . '</a>';
+                $actions['restore'] = '
+                    <a href="' . $restore_lnk_url . '" 
+                       aria-label="' . esc_attr__('Restore Message Template', 'event_espresso') . '"
+                    >
+                        ' . esc_html__('Restore', 'event_espresso') . '
+                    </a>';
             }
 
             if (
@@ -229,13 +228,12 @@ class Custom_Messages_Template_List_Table extends Messages_Template_List_Table
                     $item->ID()
                 )
             ) {
-                $actions['delete'] = '<a href="'
-                                     . $delete_lnk_url
-                                     . '" title="'
-                                     . esc_attr__('Delete Template Group Permanently', 'event_espresso')
-                                     . '">'
-                                     . esc_html__('Delete Permanently', 'event_espresso')
-                                     . '</a>';
+                $actions['delete'] = '
+                    <a href="' . $delete_lnk_url . '" 
+                       aria-label="' . esc_attr__('Delete Template Group Permanently', 'event_espresso') . '"
+                    >
+                        ' . esc_html__('Delete Permanently', 'event_espresso') . '
+                    </a>';
             }
         }
         return $actions;

--- a/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
+++ b/caffeinated/admin/extend/registration_form/Extend_Registration_Form_Questions_Admin_List_Table.class.php
@@ -68,7 +68,7 @@ class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_F
             )
         ) {
             $actions = array(
-                'edit' => '<a href="' . $edit_link . '" title="'
+                'edit' => '<a href="' . $edit_link . '" aria-label="'
                           . esc_html__('Edit Question', 'event_espresso') . '">'
                           . esc_html__('Edit', 'event_espresso') . '</a>',
             );
@@ -83,7 +83,7 @@ class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_F
                 $item->ID()
             )
         ) {
-                $actions['delete'] = '<a href="' . $trash_link . '" title="'
+                $actions['delete'] = '<a href="' . $trash_link . '" aria-label="'
                                      . esc_html__('Trash Question', 'event_espresso') . '">'
                                      . esc_html__('Trash', 'event_espresso') . '</a>';
         }
@@ -96,7 +96,7 @@ class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_F
                     $item->ID()
                 )
             ) {
-                $actions['restore'] = '<a href="' . $restore_link . '" title="'
+                $actions['restore'] = '<a href="' . $restore_link . '" aria-label="'
                                       . esc_html__('Restore Question', 'event_espresso') . '">'
                                       . esc_html__('Restore', 'event_espresso') . '</a>';
             }
@@ -108,7 +108,7 @@ class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_F
                     $item->ID()
                 )
             ) {
-                    $actions['delete'] = '<a href="' . $delete_link . '" title="'
+                    $actions['delete'] = '<a href="' . $delete_link . '" aria-label="'
                                          . esc_html__('Delete Question Permanently', 'event_espresso') . '">'
                                          . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
             }
@@ -119,7 +119,7 @@ class Extend_Registration_Form_Questions_Admin_List_Table extends Registration_F
                 'espresso_registration_form_edit_question'
             )
         ) {
-            $actions['duplicate'] = '<a href="' . $duplicate_link . '" title="'
+            $actions['duplicate'] = '<a href="' . $duplicate_link . '" aria-label="'
                                     . esc_html__('Duplicate Question', 'event_espresso') . '">'
                                     . esc_html__('Duplicate', 'event_espresso') . '</a>';
         }

--- a/caffeinated/admin/extend/registration_form/Registration_Form_Question_Groups_Admin_List_Table.class.php
+++ b/caffeinated/admin/extend/registration_form/Registration_Form_Question_Groups_Admin_List_Table.class.php
@@ -185,7 +185,7 @@ class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_T
             )
         ) {
             $actions = array(
-                'edit' => '<a href="' . $edit_link . '" title="'
+                'edit' => '<a href="' . $edit_link . '" aria-label="'
                           . esc_attr__('Edit Question Group', 'event_espresso') . '">'
                           . esc_html__('Edit', 'event_espresso') . '</a>',
             );
@@ -199,7 +199,7 @@ class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_T
                 $item->ID()
             )
         ) {
-            $actions['delete'] = '<a href="' . $trash_link . '" title="'
+            $actions['delete'] = '<a href="' . $trash_link . '" aria-label="'
                                  . esc_attr__('Delete Question Group', 'event_espresso') . '">'
                                  . esc_html__('Trash', 'event_espresso') . '</a>';
         }
@@ -212,7 +212,7 @@ class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_T
                     $item->ID()
                 )
             ) {
-                $actions['restore'] = '<a href="' . $restore_link . '" title="'
+                $actions['restore'] = '<a href="' . $restore_link . '" aria-label="'
                                       . esc_attr__('Restore Question Group', 'event_espresso') . '">'
                                       . esc_html__('Restore', 'event_espresso') . '</a>';
             }
@@ -225,7 +225,7 @@ class Registration_Form_Question_Groups_Admin_List_Table extends EE_Admin_List_T
                     $item->ID()
                 )
             ) {
-                    $actions['delete'] = '<a href="' . $delete_link . '" title="'
+                    $actions['delete'] = '<a href="' . $delete_link . '" aria-label="'
                                          . esc_attr__('Delete Question Group Permanently', 'event_espresso') . '">'
                                          . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
             }

--- a/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
@@ -150,21 +150,21 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
 					<p id="event-question-group-' . $QSG->ID() . '">
 						<input value="' . $QSG->ID() . '"'
                              . ' type="checkbox" name="add_attendee_question_groups[' . $QSG->ID() . ']"' . $checked . ' />
-						<a href="' . $edit_link . '" title="'
-                             . sprintf(
-                                 esc_attr__('Edit %s Group', 'event_espresso'),
-                                 $QSG->get('QSG_name')
-                             )
-                             . '" target="_blank">' . $QSG->get('QSG_name') . '</a>
+						<a href="' . $edit_link . '" 
+						   aria-label="' . sprintf(esc_attr__('Edit %s Group', 'event_espresso'), $QSG->get('QSG_name')) . '" 
+                          target="_blank"
+                        >
+                            ' . $QSG->get('QSG_name') . '
+                        </a>
 					</p>';
                     if ($QSG->ID() === 2) {
                         $html .= '
-					<p id="question-group-requirements-notice-pg" class="important-notice small-text" style="display: none;">'
-                                 . esc_html__(
-                                     'The Personal Information question group is required whenever the Address Information question group is activated.',
-                                     'event_espresso'
-                                 )
-                                 . '</p>';
+					    <p id="question-group-requirements-notice-pg" class="important-notice small-text" style="display: none;">
+					        ' . esc_html__(
+                                'The Personal Information question group is required whenever the Address Information question group is activated.',
+                                'event_espresso'
+                            ) . '
+                        </p>';
                     }
                 }
                 $html .= count($QSGs) > 10 ? '</div>' : '';

--- a/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
+++ b/caffeinated/admin/extend/registration_form/espresso_events_Registration_Form_Hooks_Extend.class.php
@@ -160,10 +160,10 @@ class espresso_events_Registration_Form_Hooks_Extend extends espresso_events_Reg
                     if ($QSG->ID() === 2) {
                         $html .= '
 					    <p id="question-group-requirements-notice-pg" class="important-notice small-text" style="display: none;">
-					        ' . esc_html__(
-                                'The Personal Information question group is required whenever the Address Information question group is activated.',
-                                'event_espresso'
-                            ) . '
+                        ' . esc_html__(
+                            'The Personal Information question group is required whenever the Address Information question group is activated.',
+                            'event_espresso'
+                        ) . '
                         </p>';
                     }
                 }

--- a/caffeinated/admin/extend/registration_form/templates/question_groups_main_meta_box.template.php
+++ b/caffeinated/admin/extend/registration_form/templates/question_groups_main_meta_box.template.php
@@ -209,7 +209,7 @@ $id = ! empty($QST_system) ? '_disabled' : '';
                                     );
                                     $edit_link = EE_Admin_Page::add_query_args_and_nonce($edit_query_args, EE_FORMS_ADMIN_URL);
 
-                                    echo '<a href="' . $edit_link . '" target="_blank" title="' .
+                                    echo '<a href="' . $edit_link . '" target="_blank" aria-label="' .
                                         sprintf(
                                             esc_attr__('Edit %s', 'event_espresso'),
                                             $question->admin_label()

--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -367,7 +367,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         )
             ? '<a href="'
               . $edit_lnk_url
-              . '" title="'
+              . '" aria-label="'
               . esc_attr__('View Registration Details', 'event_espresso')
               . '">'
               . $item->attendee()->full_name()
@@ -393,7 +393,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             'view_registration',
             $item->ID()
         )
-            ? '<a href="' . $link . '" title="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
+            ? '<a href="' . $link . '" aria-label="' . esc_attr__('View Registration Details', 'event_espresso') . '">'
               . $item->reg_code()
               . '</a>'
             : $item->reg_code();
@@ -432,7 +432,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
                     : esc_html__('Checked Out', 'event_espresso');
                 // get timestamp string
                 $timestamp_string   = $last_timestamp->get_datetime('CHK_timestamp');
-                $actions['checkin'] = '<a href="' . $checkin_list_url . '" title="'
+                $actions['checkin'] = '<a href="' . $checkin_list_url . '" aria-label="'
                                       . esc_attr__(
                                           'View this registrant\'s check-ins/checkouts for the datetime',
                                           'event_espresso'
@@ -475,7 +475,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
             $event_label   = EE_Registry::instance()->CAP->current_user_can(
                 'ee_read_checkins',
                 'espresso_registrations_registration_checkins'
-            ) ? '<a href="' . $chkin_lnk_url . '" title="'
+            ) ? '<a href="' . $chkin_lnk_url . '" aria-label="'
                 . esc_attr__(
                     'View Checkins for this Event',
                     'event_espresso'
@@ -540,7 +540,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
                     . $item->transaction()->status_ID()
                     . '" href="'
                     . $view_txn_lnk_url
-                    . '"  title="'
+                    . '"  aria-label="'
                     . esc_attr__('View Transaction', 'event_espresso')
                     . '">
 						'
@@ -580,7 +580,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
                 'espresso_transactions_view_transaction'
             ) ? '<a href="'
                 . $view_txn_url
-                . '" title="'
+                . '" aria-label="'
                 . esc_attr__('View Transaction', 'event_espresso')
                 . '"><span class="reg-pad-rght">'
                 . $txn_total

--- a/caffeinated/admin/extend/registrations/EE_Registration_CheckIn_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Registration_CheckIn_List_Table.class.php
@@ -156,7 +156,7 @@ class EE_Registration_CheckIn_List_Table extends EE_Admin_List_Table
             'ee_delete_checkins',
             'espresso_registrations_delete_checkin_row'
         )
-            ? '<a href="' . $delete_url . '" title="'
+            ? '<a href="' . $delete_url . '" aria-label="'
               . esc_attr__('Click here to delete this check-in record', 'event_espresso') . '">'
               . esc_html__('Delete', 'event_espresso') . '</a>'
             : '';

--- a/caffeinated/admin/extend/registrations/Extend_EE_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/Extend_EE_Registrations_List_Table.class.php
@@ -39,7 +39,7 @@ class Extend_EE_Registrations_List_Table extends EE_Registrations_List_Table
             'espresso_registrations_registration_checkins'
         )
             ? '<a href="' . $check_in_url . '"'
-              . ' title="' . esc_attr__(
+              . ' aria-label="' . esc_attr__(
                   'The Check-In List allows you to easily toggle check-in status for this event',
                   'event_espresso'
               )
@@ -91,7 +91,7 @@ class Extend_EE_Registrations_List_Table extends EE_Registrations_List_Table
                 // close "href"
                 $datetime_string .= '"';
                 // open "title" tag
-                $datetime_string .= ' title="';
+                $datetime_string .= ' aria-label="';
                 // link title text
                 $datetime_string .= esc_attr__('View Checkins for this Event', 'event_espresso');
                 // close "title" tag and end of "a" tag opening
@@ -110,7 +110,7 @@ class Extend_EE_Registrations_List_Table extends EE_Registrations_List_Table
                         array('event_id' => $EVT_ID, 'datetime_id' => $datetime->ID()),
                         REG_ADMIN_URL
                     )
-                                               . '" title="' . sprintf(
+                                               . '" aria-label="' . sprintf(
                                                    esc_attr__(
                                                        'Filter this list to only show registrations for this datetime %s',
                                                        'event_espresso'

--- a/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
+++ b/caffeinated/admin/extend/registrations/Extend_Registrations_Admin_Page.core.php
@@ -863,7 +863,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             : '';
         $attendee_link = ! empty($attendee_link)
             ? '<a href="' . $attendee->get_admin_details_link() . '"'
-              . ' title="' . esc_html__('Click for attendee details', 'event_espresso') . '">'
+              . ' aria-label="' . esc_html__('Click for attendee details', 'event_espresso') . '">'
               . '<span id="checkin-attendee-name">'
               . $attendee_name
               . '</span></a>'
@@ -873,7 +873,7 @@ class Extend_Registrations_Admin_Page extends Registrations_Admin_Page
             : '';
         $event_link = ! empty($event_link)
             ? '<a href="' . $event_link . '"'
-              . ' title="' . esc_html__('Click here to edit event.', 'event_espresso') . '">'
+              . ' aria-label="' . esc_html__('Click here to edit event.', 'event_espresso') . '">'
               . '<span id="checkin-event-name">'
               . $registration->event_name()
               . '</span>'

--- a/caffeinated/admin/new/pricing/Prices_List_Table.class.php
+++ b/caffeinated/admin/new/pricing/Prices_List_Table.class.php
@@ -136,7 +136,7 @@ class Prices_List_Table extends EE_Admin_List_Table
                 'action' => 'edit_price',
                 'id'     => $item->ID(),
             ), PRICING_ADMIN_URL);
-            $actions['edit'] = '<a href="' . $edit_lnk_url . '" title="'
+            $actions['edit'] = '<a href="' . $edit_lnk_url . '" aria-label="'
                                . esc_attr__('Edit Price', 'event_espresso') . '">'
                                . esc_html__('Edit', 'event_espresso') . '</a>';
         }
@@ -146,7 +146,7 @@ class Prices_List_Table extends EE_Admin_List_Table
             'edit_price',
             $item->ID()
         )
-            ? '<a href="' . $edit_lnk_url . '" title="'
+            ? '<a href="' . $edit_lnk_url . '" aria-label="'
               . esc_attr__('Edit Price', 'event_espresso') . '">'
               . stripslashes($item->name()) . '</a>'
             : $item->name();
@@ -166,7 +166,7 @@ class Prices_List_Table extends EE_Admin_List_Table
                         'id'       => $item->ID(),
                         'noheader' => true,
                     ), PRICING_ADMIN_URL);
-                    $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                    $actions['trash'] = '<a href="' . $trash_lnk_url . '" aria-label="'
                                         . esc_attr__('Move Price to Trash', 'event_espresso') . '">'
                                         . esc_html__('Move to Trash', 'event_espresso') . '</a>';
                 }
@@ -184,7 +184,7 @@ class Prices_List_Table extends EE_Admin_List_Table
                         'id'       => $item->ID(),
                         'noheader' => true,
                     ), PRICING_ADMIN_URL);
-                    $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                    $actions['restore'] = '<a href="' . $restore_lnk_url . '" aria-label="'
                                           . esc_attr__('Restore Price', 'event_espresso') . '">'
                                           . esc_html__('Restore', 'event_espresso') . '</a>';
                 }
@@ -202,7 +202,7 @@ class Prices_List_Table extends EE_Admin_List_Table
                         'id'       => $item->ID(),
                         'noheader' => true,
                     ), PRICING_ADMIN_URL);
-                    $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                    $actions['delete'] = '<a href="' . $delete_lnk_url . '" aria-label="'
                                          . esc_attr__('Delete Price Permanently', 'event_espresso') . '">'
                                          . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
                 }

--- a/caffeinated/admin/new/pricing/templates/event_tickets_datetime_edit_row.template.php
+++ b/caffeinated/admin/new/pricing/templates/event_tickets_datetime_edit_row.template.php
@@ -74,7 +74,7 @@
               class="<?php echo esc_attr($trash_icon); ?> clickable" style="<?php echo esc_attr($show_trash); ?>"></span>
         <?php if ($reg_list_url !== '') : ?>
             <a href="<?php echo esc_url_raw($reg_list_url); ?>"
-               title="<?php esc_attr_e('View registrations for this datetime.', 'event_espresso'); ?>"
+               aria-label="<?php esc_attr_e('View registrations for this datetime.', 'event_espresso'); ?>"
                style="text-decoration: none;">
                 <span data-context="datetime" data-datetime-row="<?php echo esc_attr($dtt_row); ?>"
                       class="dashicons dashicons-groups clickable"></span>

--- a/caffeinated/admin/new/tickets/Tickets_List_Table.class.php
+++ b/caffeinated/admin/new/tickets/Tickets_List_Table.class.php
@@ -98,7 +98,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'trash_ticket',
                     'TKT_ID' => $item->ID(),
                 ), TICKETS_ADMIN_URL);
-                $actions['trash'] = '<a href="' . $trash_lnk_url . '" title="'
+                $actions['trash'] = '<a href="' . $trash_lnk_url . '" aria-label="'
                                     . esc_attr__('Move Ticket to trash', 'event_espresso') . '">'
                                     . esc_html__('Trash', 'event_espresso') . '</a>';
             } else {
@@ -107,7 +107,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'restore_ticket',
                     'TKT_ID' => $item->ID(),
                 ), TICKETS_ADMIN_URL);
-                $actions['restore'] = '<a href="' . $restore_lnk_url . '" title="'
+                $actions['restore'] = '<a href="' . $restore_lnk_url . '" aria-label="'
                                       . esc_attr__('Restore Ticket', 'event_espresso') . '">'
                                       . esc_html__('Restore', 'event_espresso') . '</a>';
                 // delete price link
@@ -115,7 +115,7 @@ class Tickets_List_Table extends EE_Admin_List_Table
                     'action' => 'delete_ticket',
                     'TKT_ID' => $item->ID(),
                 ), TICKETS_ADMIN_URL);
-                $actions['delete'] = '<a href="' . $delete_lnk_url . '" title="'
+                $actions['delete'] = '<a href="' . $delete_lnk_url . '" aria-label="'
                                      . esc_attr__('Delete Ticket Permanently', 'event_espresso') . '">'
                                      . esc_html__('Delete Permanently', 'event_espresso') . '</a>';
             }

--- a/core/db_classes/EE_Venue.class.php
+++ b/core/db_classes/EE_Venue.class.php
@@ -254,7 +254,9 @@ class EE_Venue extends EE_CPT_Base implements EEI_Address
     /**
      * Gets capacity
      *
-     * @return int
+     * @return int|string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function capacity()
     {

--- a/core/helpers/EEH_MSG_Template.helper.php
+++ b/core/helpers/EEH_MSG_Template.helper.php
@@ -805,7 +805,7 @@ class EEH_MSG_Template
     {
         $url = EEH_MSG_Template::get_message_action_url($type, $message, $query_params);
         $icon_css = EEH_MSG_Template::get_message_action_icon($type);
-        $title = isset($icon_css['label']) ? 'title="' . $icon_css['label'] . '"' : '';
+        $label = isset($icon_css['label']) ? 'aria-label="' . $icon_css['label'] . '"' : '';
 
         if (empty($url) || empty($icon_css) || ! isset($icon_css['css_class'])) {
             return '';
@@ -821,7 +821,7 @@ class EEH_MSG_Template
             )
         );
 
-        return '<a href="' . $url . '" ' . $title . '><span class="' . esc_attr($icon_css['css_class']) . '"></span></a>';
+        return '<a href="' . $url . '" ' . $label . '><span class="' . esc_attr($icon_css['css_class']) . '"></span></a>';
     }
 
 


### PR DESCRIPTION
this PR:

- changes `title` attributes to `aria-label` for action links on the
    - Events list table
    - Event Category list table
    - Venues list table
    - Venue Category list table