### PR TITLE
Fix Ticket Editor

### DIFF
--- a/core/admin/EE_Admin_Hooks.core.php
+++ b/core/admin/EE_Admin_Hooks.core.php
@@ -221,8 +221,10 @@ abstract class EE_Admin_Hooks extends EE_Base
         $this->_adminpage_obj = $admin_page;
         $this->request        = LoaderFactory::getLoader()->getShared(RequestInterface::class);
         $this->_req_data      = $this->request->requestParams();
+        $page = $this->request->getRequestParam('page');
+        $current_page = $this->request->getRequestParam('current_page', $page);
         // first let's verify we're on the right page
-        if ($this->request->getRequestParam('page') !== $this->_adminpage_obj->page_slug) {
+        if ($current_page !== $this->_adminpage_obj->page_slug) {
             return;
         }
         $this->_set_defaults();


### PR DESCRIPTION
dunno _**WHY**_ this is like this, but when submitting the event editor during an update, the current admin page is detected using a request param named `current_page`, but when viewing the page normally, it is detected using a request param named `page`.  This PR detects both of those params and runs the required logic.

This was causing ticket prices on new tickets added to new events via the legacy editor to get wiped out