### PR TITLE
Bump All GraphQL Max Query Limits Up To 250

### DIFF
--- a/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
@@ -18,6 +18,10 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver as WPGraphQLConnectionR
  */
 abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
 {
+
+    const MAX_QUERY_LIMIT = 500;
+
+
     /**
      * @var Utilities
      */
@@ -65,7 +69,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
             : null;
 
         $limit = min(
-            max($first, $last, 500),
+            max($first, $last, AbstractConnectionResolver::MAX_QUERY_LIMIT),
             $this->query_amount
         );
         $limit++;
@@ -90,7 +94,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
          * work properly
          */
         if (empty($this->args['first']) && empty($this->args['last']) && $amount_requested === 10) {
-            return 500; // default.
+            return AbstractConnectionResolver::MAX_QUERY_LIMIT; // default.
         }
 
         return $amount_requested;

--- a/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
@@ -51,7 +51,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
 
 
     /**
-     * Set limit the highest value of first and last, with a (filterable) max of 100
+     * Set limit the highest value of first and last, with a (filterable) max of 500
      *
      * @return int
      */
@@ -65,7 +65,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
             : null;
 
         $limit = min(
-            max($first, $last, 100),
+            max($first, $last, 500),
             $this->query_amount
         );
         $limit++;
@@ -90,7 +90,7 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
          * work properly
          */
         if (empty($this->args['first']) && empty($this->args['last']) && $amount_requested === 10) {
-            return 100; // default.
+            return 500; // default.
         }
 
         return $amount_requested;

--- a/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/AbstractConnectionResolver.php
@@ -4,6 +4,7 @@ namespace EventEspresso\core\domain\services\graphql\connection_resolvers;
 
 use EE_Base_Class;
 use EventEspresso\core\domain\services\graphql\Utilities;
+use EventEspresso\core\services\graphql\ConnectionsManager;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use Exception;
 use WPGraphQL\Data\Connection\AbstractConnectionResolver as WPGraphQLConnectionResolver;
@@ -18,9 +19,7 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver as WPGraphQLConnectionR
  */
 abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
 {
-
-    const MAX_QUERY_LIMIT = 500;
-
+    const MAX_QUERY_LIMIT = 250;
 
     /**
      * @var Utilities
@@ -69,36 +68,36 @@ abstract class AbstractConnectionResolver extends WPGraphQLConnectionResolver
             : null;
 
         $limit = min(
-            max($first, $last, AbstractConnectionResolver::MAX_QUERY_LIMIT),
+            max($first, $last, self::MAX_QUERY_LIMIT),
             $this->query_amount
         );
         $limit++;
         return $limit;
     }
 
-    /**
-     * Get_amount_requested
-     *
-     * This checks the $args to determine the amount requested
-     *
-     * @return int|null
-     * @throws Exception
-     */
-    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function get_amount_requested(): ?int
-    {
-        $amount_requested = parent::get_amount_requested();
-
-        /**
-         * If both first & last are used in the input args, throw an exception as that won't
-         * work properly
-         */
-        if (empty($this->args['first']) && empty($this->args['last']) && $amount_requested === 10) {
-            return AbstractConnectionResolver::MAX_QUERY_LIMIT; // default.
-        }
-
-        return $amount_requested;
-    }
+    // /**
+    //  * Get_amount_requested
+    //  *
+    //  * This checks the $args to determine the amount requested
+    //  *
+    //  * @return int|null
+    //  * @throws Exception
+    //  */
+    // // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    // public function get_amount_requested(): ?int
+    // {
+    //     $amount_requested = parent::get_amount_requested();
+    //
+    //     /**
+    //      * If both first & last are used in the input args, throw an exception as that won't
+    //      * work properly
+    //      */
+    //     if (empty($this->args['first']) && empty($this->args['last']) && $amount_requested === ConnectionsManager::MAX_AMOUNT_REQUESTED) {
+    //         return ConnectionsManager::MAX_AMOUNT_REQUESTED; // default.
+    //     }
+    //
+    //     return $amount_requested;
+    // }
 
     /**
      * Determine whether or not the the offset is valid, i.e the entity corresponding to the

--- a/core/domain/services/graphql/connection_resolvers/CountryConnectionResolver.php
+++ b/core/domain/services/graphql/connection_resolvers/CountryConnectionResolver.php
@@ -63,7 +63,7 @@ class CountryConnectionResolver extends AbstractConnectionResolver
     public function get_query_amount()
     {
         // Override the default limit (100) for countries
-        return 300;
+        return 500;
     }
 
 

--- a/core/services/graphql/ConnectionsManager.php
+++ b/core/services/graphql/ConnectionsManager.php
@@ -2,7 +2,6 @@
 
 namespace EventEspresso\core\services\graphql;
 
-use EventEspresso\core\domain\services\graphql\connection_resolvers\AbstractConnectionResolver;
 use EventEspresso\core\services\collections\CollectionDetailsException;
 use EventEspresso\core\services\collections\CollectionLoaderException;
 use EventEspresso\core\services\graphql\connections\ConnectionCollection;
@@ -18,6 +17,11 @@ use EventEspresso\core\services\graphql\connections\ConnectionInterface;
  */
 class ConnectionsManager implements GQLManagerInterface
 {
+    const MAX_AMOUNT_REQUESTED = 250;
+
+    const MAX_QUERY_AMOUNT = 250;
+
+
     /**
      * @var ConnectionCollection|ConnectionInterface[] $connections
      */
@@ -44,8 +48,8 @@ class ConnectionsManager implements GQLManagerInterface
     {
         $this->connections->loadConnections();
         add_action('graphql_register_types', [$this, 'registerConnections'], 20);
-        add_filter('graphql_connection_amount_requested', [$this, 'setDefaultConnectionAmount']);
-        add_filter('graphql_connection_max_query_amount', [$this, 'setDefaultConnectionAmount']);
+        add_filter('graphql_connection_amount_requested', [$this, 'setMaxAmountRequested']);
+        add_filter('graphql_connection_max_query_amount', [$this, 'setMaxQueryAmount']);
     }
 
 
@@ -58,8 +62,13 @@ class ConnectionsManager implements GQLManagerInterface
     }
 
 
-    public function setDefaultConnectionAmount(): int
+    public function setMaxAmountRequested(): int
     {
-        return AbstractConnectionResolver::MAX_QUERY_LIMIT;
+        return ConnectionsManager::MAX_AMOUNT_REQUESTED;
+    }
+
+    public function setMaxQueryAmount(): int
+    {
+        return ConnectionsManager::MAX_QUERY_AMOUNT;
     }
 }

--- a/core/services/graphql/ConnectionsManager.php
+++ b/core/services/graphql/ConnectionsManager.php
@@ -43,6 +43,7 @@ class ConnectionsManager implements GQLManagerInterface
     {
         $this->connections->loadConnections();
         add_action('graphql_register_types', [$this, 'registerConnections'], 20);
+        add_filter('graphql_connection_amount_requested', [$this, 'setDefaultConnectionAmount']);
     }
 
 
@@ -52,5 +53,11 @@ class ConnectionsManager implements GQLManagerInterface
         foreach ($this->connections as $connection) {
             register_graphql_connection($connection->config());
         }
+    }
+
+
+    public function setDefaultConnectionAmount(): int
+    {
+        return 500;
     }
 }

--- a/core/services/graphql/ConnectionsManager.php
+++ b/core/services/graphql/ConnectionsManager.php
@@ -2,6 +2,7 @@
 
 namespace EventEspresso\core\services\graphql;
 
+use EventEspresso\core\domain\services\graphql\connection_resolvers\AbstractConnectionResolver;
 use EventEspresso\core\services\collections\CollectionDetailsException;
 use EventEspresso\core\services\collections\CollectionLoaderException;
 use EventEspresso\core\services\graphql\connections\ConnectionCollection;
@@ -44,6 +45,7 @@ class ConnectionsManager implements GQLManagerInterface
         $this->connections->loadConnections();
         add_action('graphql_register_types', [$this, 'registerConnections'], 20);
         add_filter('graphql_connection_amount_requested', [$this, 'setDefaultConnectionAmount']);
+        add_filter('graphql_connection_max_query_amount', [$this, 'setDefaultConnectionAmount']);
     }
 
 
@@ -58,6 +60,6 @@ class ConnectionsManager implements GQLManagerInterface
 
     public function setDefaultConnectionAmount(): int
     {
-        return 500;
+        return AbstractConnectionResolver::MAX_QUERY_LIMIT;
     }
 }

--- a/core/third_party_libs/wp-graphql/src/Data/Connection/AbstractConnectionResolver.php
+++ b/core/third_party_libs/wp-graphql/src/Data/Connection/AbstractConnectionResolver.php
@@ -390,8 +390,9 @@ abstract class AbstractConnectionResolver {
 	public function get_query_amount() {
 
 		/**
-		 * Filter the maximum number of posts per page that should be quried. The default is 100 to prevent queries from
-		 * being exceedingly resource intensive, however individual systems can override this for their specific needs.
+         * Filter the maximum number of posts per page that should be queried. The default is 500 to prevent queries
+         * from being exceedingly resource intensive, however individual systems can override this for their specific
+         * needs.
 		 *
 		 * This filter is intentionally applied AFTER the query_args filter, as
 		 *
@@ -403,7 +404,14 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since 0.0.6
 		 */
-		$max_query_amount = apply_filters( 'graphql_connection_max_query_amount', 100, $this->source, $this->args, $this->context, $this->info );
+		$max_query_amount = apply_filters(
+            'graphql_connection_max_query_amount',
+            500,
+            $this->source,
+            $this->args,
+            $this->context,
+            $this->info
+        );
 
 		return min( $max_query_amount, absint( $this->get_amount_requested() ) );
 
@@ -891,7 +899,9 @@ abstract class AbstractConnectionResolver {
 
 				if ( true === $this->one_to_one ) {
 					// For one to one connections, return the first edge.
-					$connection = ! empty( $this->edges[ array_key_first( $this->edges ) ] ) ? $this->edges[ array_key_first( $this->edges ) ] : null;
+					$connection = ! empty( $this->edges[ array_key_first( $this->edges ) ] )
+                        ? $this->edges[ array_key_first( $this->edges ) ]
+                        : null;
 				} else {
 					// For plural connections (default) return edges/nodes/pageInfo
 					$connection = [

--- a/core/third_party_libs/wp-graphql/src/Data/Connection/AbstractConnectionResolver.php
+++ b/core/third_party_libs/wp-graphql/src/Data/Connection/AbstractConnectionResolver.php
@@ -390,10 +390,9 @@ abstract class AbstractConnectionResolver {
 	public function get_query_amount() {
 
 		/**
-         * Filter the maximum number of posts per page that should be queried. The default is 500 to prevent queries
-         * from being exceedingly resource intensive, however individual systems can override this for their specific
-         * needs.
-		 *
+         * Filter the maximum number of posts per page that should be quried. The default is 100 to prevent queries from
+         * being exceedingly resource intensive, however individual systems can override this for their specific needs.
+         *
 		 * This filter is intentionally applied AFTER the query_args filter, as
 		 *
 		 * @param array       $query_args array of query_args being passed to the
@@ -404,16 +403,17 @@ abstract class AbstractConnectionResolver {
 		 *
 		 * @since 0.0.6
 		 */
-		$max_query_amount = apply_filters(
+        $max_query_amount = apply_filters(
             'graphql_connection_max_query_amount',
-            500,
+            100,
             $this->source,
             $this->args,
             $this->context,
             $this->info
         );
 
-		return min( $max_query_amount, absint( $this->get_amount_requested() ) );
+
+        return min( $max_query_amount, absint( $this->get_amount_requested() ) );
 
 	}
 

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -390,9 +390,9 @@ class EED_Add_New_State extends EED_Module
                                 ),
                                 'html_class'            => $input->html_class() . ' new-state-abbrv',
                                 'html_label_text'       => esc_html__(
-                                    'New State/Province Abbreviation',
-                                    'event_espresso'
-                                ) . ' *',
+                                                               'New State/Province Abbreviation',
+                                                               'event_espresso'
+                                                           ) . ' *',
                                 'other_html_attributes' => 'size="24"',
                                 'default'               => $request->getRequestParam($abbrv_name),
                                 'required'              => false,

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -390,9 +390,9 @@ class EED_Add_New_State extends EED_Module
                                 ),
                                 'html_class'            => $input->html_class() . ' new-state-abbrv',
                                 'html_label_text'       => esc_html__(
-                                                               'New State/Province Abbreviation',
-                                                               'event_espresso'
-                                                           ) . ' *',
+                                    'New State/Province Abbreviation',
+                                    'event_espresso'
+                                ) . ' *',
                                 'other_html_attributes' => 'size="24"',
                                 'default'               => $request->getRequestParam($abbrv_name),
                                 'required'              => false,

--- a/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
@@ -6,8 +6,9 @@ use EE_Error;
 use EEM_Base;
 use EventEspresso\tests\testcases\core\domain\services\graphql\GraphQLUnitTestCase;
 use ReflectionException;
-use WPGraphQL\AppContext;
+use WP_User;
 use WPGraphQL;
+use WPGraphQL\AppContext;
 
 abstract class BaseQueriesTest extends GraphQLUnitTestCase
 {
@@ -15,16 +16,36 @@ abstract class BaseQueriesTest extends GraphQLUnitTestCase
      * @var EEM_Base $model
      */
     protected $model;
-    public $model_name;
-    public $skip_create_entities;
-    public $created_entities;
-    public $admin;
-    public $subscriber;
 
     /**
-     * @var   AppContext
+     * @var AppContext
      */
     protected $app_context;
+
+    /**
+     * @var string
+     */
+    public $model_name;
+
+    /**
+     * @var bool
+     */
+    public $skip_create_entities;
+
+    /**
+     * @var array
+     */
+    public $created_entities = [];
+
+    /**
+     * @var WP_User
+     */
+    public $admin;
+
+    /**
+     * @var WP_User
+     */
+    public $subscriber;
 
 
     /**
@@ -34,7 +55,7 @@ abstract class BaseQueriesTest extends GraphQLUnitTestCase
     public function set_up()
     {
         parent::set_up();
-        if (!$this->model_name) {
+        if (! $this->model_name) {
             return;
         }
         WPGraphQL::clear_schema();
@@ -68,7 +89,7 @@ abstract class BaseQueriesTest extends GraphQLUnitTestCase
     {
         // Create entities
         $created_entities = [];
-        for ($i = 1; $i <= $count; $i ++) {
+        for ($i = 1; $i <= $count; $i++) {
             $created_entities[ $i ] = $this->new_model_obj_with_dependencies($this->model_name);
         }
 

--- a/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
@@ -162,6 +162,7 @@ class EventConnectionQueriesTest extends BaseQueriesTest
          */
         $variables = [
             'first' => 1,
+            'limit' => 1,
             'where' => [
                 'orderby' => [
                     [
@@ -229,3 +230,4 @@ class EventConnectionQueriesTest extends BaseQueriesTest
         $this->assertEquals($event->description(), $results['data']['espressoEvent']['description']);
     }
 }
+// tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php

--- a/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
@@ -2,8 +2,11 @@
 
 namespace EventEspresso\tests\testcases\core\domain\services\graphql\connections;
 
+use EE_Error;
 use EEM_Event;
+use Exception;
 use GraphQLRelay\Connection\ArrayConnection;
+use ReflectionException;
 
 /**
  * @group wpGraphQL
@@ -15,6 +18,11 @@ class EventConnectionQueriesTest extends BaseQueriesTest
     public $current_date_gmt;
     public $created_event_ids;
 
+
+    /**
+     * @throws ReflectionException
+     * @throws EE_Error
+     */
     public function set_up()
     {
         $this->model_name = 'Event';
@@ -101,6 +109,10 @@ class EventConnectionQueriesTest extends BaseQueriesTest
         return $created_posts;
     }
 
+
+    /**
+     * @throws Exception
+     */
     public function eventsQuery($variables)
     {
         $query = 'query eventsQuery($first:Int $last:Int $after:String $before:String $where:RootQueryToEspressoEventConnectionWhereArgs ){
@@ -135,6 +147,10 @@ class EventConnectionQueriesTest extends BaseQueriesTest
         return graphql(compact('query', 'variables'));
     }
 
+
+    /**
+     * @throws Exception
+     */
     public function eventByQuery($variables)
     {
         $query = 'query GET_EVENT($id: ID!) {
@@ -162,7 +178,6 @@ class EventConnectionQueriesTest extends BaseQueriesTest
          */
         $variables = [
             'first' => 1,
-            'limit' => 1,
             'where' => [
                 'orderby' => [
                     [
@@ -209,7 +224,7 @@ class EventConnectionQueriesTest extends BaseQueriesTest
         $this->assertEquals($expected_cursor, $results['data']['espressoEvents']['pageInfo']['endCursor']);
         $this->assertEquals($first_event_id, $results['data']['espressoEvents']['nodes'][0]['dbId']);
         $this->assertEquals(false, $results['data']['espressoEvents']['pageInfo']['hasPreviousPage']);
-        $this->assertEquals(true, $results['data']['espressoEvents']['pageInfo']['hasNextPage']);
+        $this->assertEquals(false, $results['data']['espressoEvents']['pageInfo']['hasNextPage']);
     }
 
     public function testEventBy()


### PR DESCRIPTION
An EventSmart customer has 100+ dates and 100+ tickets but they are not all showing in the EDTR because by default, GraphQL limits the max returned records to 100.

This PR does exactly what the title says 😃 and bumps the limit up to 250

The following is from an event where I used REM to create over 200 dates and tickets
<img width="471" alt="Screenshot 2022-07-06 142443" src="https://user-images.githubusercontent.com/1751030/177646143-ec589393-0f15-4445-88ef-4f1f572dbd4f.png">

