### PR TITLE
Fix Command Bus Middleware

### DIFF
--- a/core/services/commands/CommandBus.php
+++ b/core/services/commands/CommandBus.php
@@ -91,8 +91,9 @@ class CommandBus implements CommandBusInterface
                                ->verify($command)
                                ->handle($command);
         };
+        $command_bus_middleware_array = $this->command_bus_middleware;
         // now build the rest of the middleware stack
-        while ($command_bus_middleware = array_pop($this->command_bus_middleware)) {
+        while ($command_bus_middleware = array_pop($command_bus_middleware_array)) {
             if (! $command_bus_middleware instanceof CommandBusMiddlewareInterface) {
                 throw new InvalidCommandBusMiddlewareException($command_bus_middleware);
             }

--- a/core/services/commands/CommandBusInterface.php
+++ b/core/services/commands/CommandBusInterface.php
@@ -15,7 +15,7 @@ interface CommandBusInterface
     public function getCommandHandlerManager();
 
     /**
-     * @param \EventEspresso\core\services\commands\CommandInterface $command
+     * @param CommandInterface $command
      * @return mixed
      */
     public function execute($command);

--- a/core/services/commands/CommandHandlerManager.php
+++ b/core/services/commands/CommandHandlerManager.php
@@ -118,6 +118,7 @@ class CommandHandlerManager implements CommandHandlerManagerInterface
             $handler = $this->command_handlers[ $command_name ];
         } elseif (class_exists($command_handler)) {
             $handler = $this->loader->getShared($command_handler);
+            $this->addCommandHandler($handler, $command_name);
         }
         // if Handler requires an instance of the CommandBus, but that has not yet been set
         if ($handler instanceof CompositeCommandHandler && ! $handler->commandBus() instanceof CommandBusInterface) {

--- a/core/services/commands/CommandRequiresCapCheckInterface.php
+++ b/core/services/commands/CommandRequiresCapCheckInterface.php
@@ -2,6 +2,8 @@
 
 namespace EventEspresso\core\services\commands;
 
+use EventEspresso\core\domain\services\capabilities\CapCheck;
+
 /**
  * Interface CommandRequiresCapCheckInterface
  * this interface is used to identify Command classes
@@ -12,7 +14,7 @@ namespace EventEspresso\core\services\commands;
 interface CommandRequiresCapCheckInterface
 {
     /**
-     * @return \EventEspresso\core\domain\services\capabilities\CapCheck
+     * @return CapCheck
      */
     public function getCapCheck();
 }

--- a/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
+++ b/modules/single_page_checkout/EED_Single_Page_Checkout.module.php
@@ -1078,7 +1078,7 @@ class EED_Single_Page_Checkout extends EED_Module
                         ]
                     );
                     // override capabilities for frontend registrations
-                    if (! is_admin()) {
+                    if ($this->request->isFrontend()) {
                         $CreateRegistrationCommand->setCapCheck(
                             new PublicCapabilities('', 'create_new_registration')
                         );

--- a/modules/single_page_checkout/reg_steps/attendee_information/EE_SPCO_Reg_Step_Attendee_Information.class.php
+++ b/modules/single_page_checkout/reg_steps/attendee_information/EE_SPCO_Reg_Step_Attendee_Information.class.php
@@ -4,7 +4,7 @@ use EventEspresso\core\domain\entities\contexts\Context;
 use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
-use EventEspresso\core\services\commands\attendee\CreateAttendeeCommand;
+use EventEspresso\core\domain\services\commands\attendee\CreateAttendeeCommand;
 use EventEspresso\core\services\loaders\LoaderFactory;
 
 /**


### PR DESCRIPTION
Somehow, when updating FQCNs for commands, my IDE failed to return a result used in SPCO when searching for `EventEspresso\core\services\commands`

This PR:
- updates the import used in the first reg step 
- updates a couple of phpdocs
- used the request class to verify the request type in SPCO when creating registrations

EDIT:
also found a bug in the command bus middleware stack that was preventing middleware from running in composite commands more than once.