### PR TITLE
Fix iCal Icon in Upcoming Events Widget

### DIFF
--- a/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
+++ b/widgets/upcoming_events/EEW_Upcoming_Events.widget.php
@@ -329,7 +329,7 @@ class EEW_Upcoming_Events extends EspressoWidget
                 if (! empty($title)) {
                     echo wp_kses($before_title . $title . $after_title, AllowedTags::getAllowedTags());
                 }
-                echo wp_kses($this->widgetContent($post), AllowedTags::getAllowedTags());
+                echo wp_kses($this->widgetContent($post), AllowedTags::getWithFormTags());
                 // After widget (defined by themes).
                 echo wp_kses($after_widget, AllowedTags::getAllowedTags());
             }


### PR DESCRIPTION
Fixes https://github.com/eventespresso/event-espresso-core/issues/3954 issue.

<img width="441" alt="Screen Shot 2022-07-12 at 17 00 50" src="https://user-images.githubusercontent.com/29144542/178490136-daf381de-cac7-46d4-b9e9-8fca05312486.png">
