### PR TITLE
Add "use_filters" url param to DateTime reg links

### DIFF
--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -1240,7 +1240,11 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
             'reg_list_url'         => $default || ! $datetime->event() instanceof \EE_Event
                 ? ''
                 : EE_Admin_Page::add_query_args_and_nonce(
-                    array('event_id' => $datetime->event()->ID(), 'datetime_id' => $datetime->ID()),
+                    array(
+                        'event_id' => $datetime->event()->ID(),
+                        'datetime_id' => $datetime->ID(),
+                        'use_filters' => true
+                    ),
                     REG_ADMIN_URL
                 ),
         );


### PR DESCRIPTION
Similar to #3940 only these are for the DateTime links:

![image](https://user-images.githubusercontent.com/4345417/178508886-d4f14a22-03a3-4341-8bbf-eba87f7bcc1e.png)



<!-- 
PLEASE READ THIS:
Thank you for your pull request.
Comment blocks like this get removed upon submission.
Please answer the following questions with as much detail as possible
-->

## Problem this Pull Request solves
<!-- describe the use case or issue -->


## How has this been tested
<!-- 
- steps required to test this pull request
- pull requests with automated tests are preferred. 
-->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
* [ ] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
