### PR TITLE
Fix Issue of Escaping Content of Ticket Description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor/
 *.DS_Store
 *.idea
 *.vscode
+tests/.phpunit.result.cache

--- a/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
+++ b/caffeinated/admin/new/pricing/espresso_events_Pricing_Hooks.class.php
@@ -1539,7 +1539,7 @@ class espresso_events_Pricing_Hooks extends EE_Admin_Hooks
                     )
                 ),
             'TKT_ID'                        => $default ? 0 : $ticket->ID(),
-            'TKT_description'               => $default ? '' : $ticket->get_f('TKT_description'),
+            'TKT_description'               => $default ? '' : $ticket->get_raw('TKT_description'),
             'TKT_is_default'                => $default ? 0 : $ticket->is_default(),
             'TKT_required'                  => $default ? 0 : $ticket->required(),
             'TKT_is_default_selector'       => '',


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes https://github.com/eventespresso/event-espresso-core/issues/3963 issue.

## How has this been tested

<img width="643" alt="Screen Shot 2022-07-22 at 17 14 41" src="https://user-images.githubusercontent.com/29144542/180582558-097c56ec-b0f6-4d80-b926-576449dc908f.png">

<img width="508" alt="Screen Shot 2022-07-22 at 17 15 26" src="https://user-images.githubusercontent.com/29144542/180582562-5c6a22c2-764f-4482-915e-992470277927.png">
