### PR TITLE
Update CrawlerDetect

### DIFF
--- a/core/services/request/middleware/BotDetector.php
+++ b/core/services/request/middleware/BotDetector.php
@@ -4,7 +4,7 @@ namespace EventEspresso\core\services\request\middleware;
 
 use EventEspresso\core\services\request\RequestInterface;
 use EventEspresso\core\services\request\ResponseInterface;
-use EventEspressoVendor\Jaybizzle\CrawlerDetect\CrawlerDetect;
+use EventEspressoVendor\CrawlerDetect\CrawlerDetect;
 
 /**
  * Class BotDetector
@@ -28,10 +28,12 @@ class BotDetector extends Middleware
         $this->request = $request;
         $this->response = $response;
         /** @var CrawlerDetect $CrawlerDetect */
-        $CrawlerDetect = $this->loader->getShared('EventEspressoVendor\Jaybizzle\CrawlerDetect\CrawlerDetect');
-        // Check and record the user agent of the current 'visitor'
-        $this->request->setIsBot($CrawlerDetect->isCrawler());
-        $this->request->setUserAgent($CrawlerDetect->userAgent());
+        $CrawlerDetect = $this->loader->getShared('EventEspressoVendor\CrawlerDetect\CrawlerDetect');
+        if ($CrawlerDetect instanceof CrawlerDetect) {
+            // Check and record the user agent of the current 'visitor'
+            $this->request->setIsBot($CrawlerDetect->isCrawler());
+            $this->request->setUserAgent($CrawlerDetect->userAgent());
+        }
         $this->response = $this->processRequestStack($this->request, $this->response);
         return $this->response;
     }

--- a/core/third_party_libs/CrawlerDetect/CrawlerDetect.php
+++ b/core/third_party_libs/CrawlerDetect/CrawlerDetect.php
@@ -8,11 +8,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace EventEspressoVendor\Jaybizzle\CrawlerDetect;
+namespace EventEspressoVendor\CrawlerDetect;
 
-use EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures\Headers;
-use EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures\Crawlers;
-use EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures\Exclusions;
+use EventEspressoVendor\CrawlerDetect\Fixtures\Headers;
+use EventEspressoVendor\CrawlerDetect\Fixtures\Crawlers;
+use EventEspressoVendor\CrawlerDetect\Fixtures\Exclusions;
 
 /**
  * Class CrawlerDetect

--- a/core/third_party_libs/CrawlerDetect/Fixtures/AbstractProvider.php
+++ b/core/third_party_libs/CrawlerDetect/Fixtures/AbstractProvider.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures;
+namespace EventEspressoVendor\CrawlerDetect\Fixtures;
 
 /**
  * Class AbstractProvider

--- a/core/third_party_libs/CrawlerDetect/Fixtures/Crawlers.php
+++ b/core/third_party_libs/CrawlerDetect/Fixtures/Crawlers.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures;
+namespace EventEspressoVendor\CrawlerDetect\Fixtures;
 
 /**
  * Class Crawlers

--- a/core/third_party_libs/CrawlerDetect/Fixtures/Exclusions.php
+++ b/core/third_party_libs/CrawlerDetect/Fixtures/Exclusions.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures;
+namespace EventEspressoVendor\CrawlerDetect\Fixtures;
 
 /**
  * Class Exclusions

--- a/core/third_party_libs/CrawlerDetect/Fixtures/Headers.php
+++ b/core/third_party_libs/CrawlerDetect/Fixtures/Headers.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace EventEspressoVendor\Jaybizzle\CrawlerDetect\Fixtures;
+namespace EventEspressoVendor\CrawlerDetect\Fixtures;
 
 /**
  * Class Headers


### PR DESCRIPTION
This PR prepares things so we can remove the third party `CrawlerDetect` lib from decaf, which includes:
- moving `CrawlerDetect` up a single folder (no real reason for doing this)
- add instanceof check to `BotDetector` middleware to protect again golden rule violation

once this gets merged into the `prep-decaf` branch, we can remove the `CrawlerDetect` lib in that branch