### PR TITLE
Add Prep Decaf Release Workflow

### DIFF
--- a/.github/workflows/prep-decaf-release.yml
+++ b/.github/workflows/prep-decaf-release.yml
@@ -1,0 +1,25 @@
+name: Prep Decaf Release
+
+on:
+    push:
+        branches: [prep-decaf]
+
+jobs:
+    makepot:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout the commit
+              uses: actions/checkout@v2
+
+            - name: Get decafFilesRemove
+              id: files-to-remove
+              uses: eventespresso/actions/packages/json-prop@main
+              with:
+                  file-path: info.json
+                  prop-path: decafFilesRemove
+                  output-as-json: true
+
+            - name: Remove files/directories
+              uses: eventespresso/actions/packages/remove-files@main
+              with:
+                  paths: ${{ steps.files-to-remove.outputs.value }}


### PR DESCRIPTION
this PR simply adds a new GHA (GitHub Action) workflow named `prep-decaf-release.yml` that deletes all of the files listed under `decafFilesRemove` in the repo `info.json` file