### PR TITLE
Add Feature Flag for PluginUpdateEngineChecker Class

### DIFF
--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1114,34 +1114,37 @@ class EE_Register_Addon implements EEI_Plugin_API
      */
     public static function load_pue_update()
     {
+        // PUE client existence
+        if (! is_readable(EE_THIRD_PARTY . 'pue/pue-client.php')) return;
+
         // load PUE client
         require_once EE_THIRD_PARTY . 'pue/pue-client.php';
         $license_server = defined('PUE_UPDATES_ENDPOINT') ? PUE_UPDATES_ENDPOINT : 'https://eventespresso.com';
         // cycle thru settings
         foreach (self::$_settings as $settings) {
-            if (! empty($settings['pue_options'])) {
-                // initiate the class and start the plugin update engine!
-                new PluginUpdateEngineChecker(
-                    // host file URL
-                    $license_server,
-                    // plugin slug(s)
-                    array(
-                        'premium'    => array('p' => $settings['pue_options']['pue_plugin_slug']),
-                        'prerelease' => array('beta' => $settings['pue_options']['pue_plugin_slug'] . '-pr'),
-                    ),
-                    // options
-                    array(
-                        'apikey'            => EE_Registry::instance()->NET_CFG->core->site_license_key,
-                        'lang_domain'       => 'event_espresso',
-                        'checkPeriod'       => $settings['pue_options']['checkPeriod'],
-                        'option_key'        => 'ee_site_license_key',
-                        'options_page_slug' => 'event_espresso',
-                        'plugin_basename'   => $settings['pue_options']['plugin_basename'],
-                        // if use_wp_update is TRUE it means you want FREE versions of the plugin to be updated from WP
-                        'use_wp_update'     => $settings['pue_options']['use_wp_update'],
-                    )
-                );
-            }
+            if (empty($settings['pue_options'])) continue;
+
+            // initiate the class and start the plugin update engine!
+            new PluginUpdateEngineChecker(
+                // host file URL
+                $license_server,
+                // plugin slug(s)
+                array(
+                    'premium'    => array('p' => $settings['pue_options']['pue_plugin_slug']),
+                    'prerelease' => array('beta' => $settings['pue_options']['pue_plugin_slug'] . '-pr'),
+                ),
+                // options
+                array(
+                    'apikey'            => EE_Registry::instance()->NET_CFG->core->site_license_key,
+                    'lang_domain'       => 'event_espresso',
+                    'checkPeriod'       => $settings['pue_options']['checkPeriod'],
+                    'option_key'        => 'ee_site_license_key',
+                    'options_page_slug' => 'event_espresso',
+                    'plugin_basename'   => $settings['pue_options']['plugin_basename'],
+                    // if use_wp_update is TRUE it means you want FREE versions of the plugin to be updated from WP
+                    'use_wp_update'     => $settings['pue_options']['use_wp_update'],
+                )
+            );
         }
     }
 

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1118,7 +1118,6 @@ class EE_Register_Addon implements EEI_Plugin_API
         if (! is_readable(EE_THIRD_PARTY . 'pue/pue-client.php')) {
             return;
         }
-
         // load PUE client
         require_once EE_THIRD_PARTY . 'pue/pue-client.php';
         $license_server = defined('PUE_UPDATES_ENDPOINT') ? PUE_UPDATES_ENDPOINT : 'https://eventespresso.com';
@@ -1127,7 +1126,6 @@ class EE_Register_Addon implements EEI_Plugin_API
             if (empty($settings['pue_options'])) {
                 continue;
             }
-
             // initiate the class and start the plugin update engine!
             new PluginUpdateEngineChecker(
                 // host file URL

--- a/core/libraries/plugin_api/EE_Register_Addon.lib.php
+++ b/core/libraries/plugin_api/EE_Register_Addon.lib.php
@@ -1115,14 +1115,18 @@ class EE_Register_Addon implements EEI_Plugin_API
     public static function load_pue_update()
     {
         // PUE client existence
-        if (! is_readable(EE_THIRD_PARTY . 'pue/pue-client.php')) return;
+        if (! is_readable(EE_THIRD_PARTY . 'pue/pue-client.php')) {
+            return;
+        }
 
         // load PUE client
         require_once EE_THIRD_PARTY . 'pue/pue-client.php';
         $license_server = defined('PUE_UPDATES_ENDPOINT') ? PUE_UPDATES_ENDPOINT : 'https://eventespresso.com';
         // cycle thru settings
         foreach (self::$_settings as $settings) {
-            if (empty($settings['pue_options'])) continue;
+            if (empty($settings['pue_options'])) {
+                continue;
+            }
 
             // initiate the class and start the plugin update engine!
             new PluginUpdateEngineChecker(

--- a/core/services/licensing/LicenseService.php
+++ b/core/services/licensing/LicenseService.php
@@ -4,7 +4,6 @@ namespace EventEspresso\core\services\licensing;
 
 use EventEspresso\core\domain\services\pue\Stats;
 use EventEspresso\core\domain\services\pue\Config;
-use PluginUpdateEngineChecker;
 
 /**
  * LicenseService
@@ -64,7 +63,7 @@ class LicenseService
                 'turn_on_notices_saved' => true,
             );
             // initiate the class and start the plugin update engine!
-            new PluginUpdateEngineChecker(
+            new \PluginUpdateEngineChecker(
                 $this->config->hostServerUrl(),
                 $this->config->pluginSlug(),
                 $options


### PR DESCRIPTION
Related to https://github.com/eventespresso/event-espresso-core/issues/3973 issue.

Moved the `PluginUpdateEngineChecker` usage behind the file existence and readable check to run it safely only whenever the file exists so we can safely remove it from `decaf` version.