### PR TITLE
Add a filter to getTickets used for the TicketSelector

### DIFF
--- a/modules/ticket_selector/DisplayTicketSelector.php
+++ b/modules/ticket_selector/DisplayTicketSelector.php
@@ -415,7 +415,13 @@ class DisplayTicketSelector
                 : current_time('timestamp');
             $ticket_query_args[0]['TKT_end_date'] = ['>', $current_time];
         }
-        return EEM_Ticket::instance()->get_all($ticket_query_args);
+
+        return apply_filters(
+            'FHEE__EE_Ticket_Selector__getTickets_tickets',
+            EEM_Ticket::instance()->get_all($ticket_query_args),
+            $ticket_query_args,
+            $this
+        );
     }
 
 


### PR DESCRIPTION
For context, see: https://eventespresso.com/topic/ticket-count-based-on-custom-user-field/?view=all#post-335745

The user wants to limit the TKT qty based on a custom value, I could have filtered just the Qty field but this allows more flexibility overall.

To test this I used this function:

```
add_filter('FHEE__EE_Ticket_Selector__getTickets_tickets', 'tw_filter_ts_tickets', 10, 2);
function tw_filter_ts_tickets($tickets, $query_args) {
	foreach($tickets as $ticket) {
		$ticket->set_max(2);
	}
	return $tickets;
}
```

Which then uses all of the same methods within the class to output as usual, only now the ticket qty is set to 2 in the dropdown. The idea being this could be done on specific tickets based on whatever value you need to pull in within the filter.

Because save() isn't called anywhere within the ticket selector this change only applies when loading,