### PR TITLE
Add translation 'for' text in name_and_info()

### DIFF
--- a/core/db_classes/EE_Ticket.class.php
+++ b/core/db_classes/EE_Ticket.class.php
@@ -1563,7 +1563,7 @@ class EE_Ticket extends EE_Soft_Delete_Base_Class implements EEI_Line_Item_Objec
         foreach ($this->datetimes() as $datetime) {
             $times[] = $datetime->start_date_and_time();
         }
-        return $this->name() . ' @ ' . implode(', ', $times) . ' for ' . $this->pretty_price();
+        return $this->name() . ' @ ' . implode(', ', $times) . __(' for ', 'event_espresso') . $this->pretty_price();
     }
 
 


### PR DESCRIPTION
<!-- 
PLEASE READ THIS:
Thank you for your pull request.
Comment blocks like this get removed upon submission.
Please answer the following questions with as much detail as possible
-->

## Problem this Pull Request solves
There is no translation for the 'for' label in the ticketname


## How has this been tested
<!-- 
- steps required to test this pull request
- pull requests with automated tests are preferred. 
-->
Create a waitlist and open the dropdown.
![image](https://user-images.githubusercontent.com/8821740/204512212-218f0cf0-887f-4026-8336-5d3a1a55116a.png)


## Checklist

* [X] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [X] User input is adequately validated and sanitized
* [X] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [X] My code is tested.
* [X] My code follows the Event Espresso code style.
* [X] My code has proper inline documentation.
* [X] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
