### PR TITLE
$this->datetimes_for_event should not be filled with array

### DIFF
--- a/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
+++ b/caffeinated/admin/extend/registrations/EE_Event_Registrations_List_Table.class.php
@@ -199,7 +199,7 @@ class EE_Event_Registrations_List_Table extends EE_Admin_List_Table
         $this->_hidden_columns   = [];
         $this->event              = EEM_Event::instance()->get_one_by_ID($this->event_id);
         if ($this->event instanceof EE_Event) {
-            $this->datetimes_for_event = $this->event->datetimes_ordered();
+            $this->datetimes_for_event = DatetimesForEventCheckIn::fromEvent($this->event);
         }
     }
 


### PR DESCRIPTION
<!-- 
PLEASE READ THIS:
Thank you for your pull request.
Comment blocks like this get removed upon submission.
Please answer the following questions with as much detail as possible
-->

## Problem this Pull Request solves
When filtering registrations on an event an error is thrown cause the $datetimes_for_event is filled with an array instead of a DatetimesForEventCheckIn.
<!-- describe the use case or issue -->


## How has this been tested
<!-- 
- steps required to test this pull request
- pull requests with automated tests are preferred. 
-->
Steps to reproduce error:
- Go to Admin -> Event Espresso -> Registrations.
- Select Event Check-in
- Select an Event in the Filters and press Filter.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
