### PR TITLE
Fix iFrame JS issue from cafe

### DIFF
--- a/core/libraries/iframe_display/Iframe.php
+++ b/core/libraries/iframe_display/Iframe.php
@@ -280,7 +280,7 @@ class Iframe
             ! empty($utm_content) ? array('utm_content' => $utm_content) : array()
         );
         EE_System::do_not_cache();
-        echo wp_kses($this->getTemplate(), AllowedTags::getWithFullTags());
+        echo $this->getTemplate();
         exit;
     }
 

--- a/core/libraries/iframe_display/iframe_wrapper.template.php
+++ b/core/libraries/iframe_display/iframe_wrapper.template.php
@@ -33,7 +33,7 @@ use EventEspresso\core\services\request\sanitizers\AttributesSanitizer;
     <link rel="stylesheet" type="text/css" href="<?php echo esc_url_raw($url); ?>">
         <?php endforeach; ?>
             <script type="text/javascript">
-                <?php echo esc_js($eei18n); ?>
+                <?php echo $eei18n; ?>
             </script>
         <?php foreach ($header_js as $key => $url) :?>
             <?php $header_attributes = isset($header_js_attributes[ $key ]) ? $header_js_attributes[ $key ] : ''; ?>


### PR DESCRIPTION
Fixes an issue with JS escaping on iFrame outputs.

For context see: https://github.com/eventespresso/cafe/pull/196