### PR TITLE
PUE Fix - Fix variable name typo

### DIFF
--- a/caffeinated/core/domain/services/pue/RegisterAddonPUE.php
+++ b/caffeinated/core/domain/services/pue/RegisterAddonPUE.php
@@ -52,8 +52,8 @@ class RegisterAddonPUE
     public static function setAddonPueSlug(EE_Addon $addon, string $addon_name)
     {
         // setup the add-on's pue_slug if we have one.
-        if (! empty($addon_api_settings[ $addon_name ]['pue_options']['pue_plugin_slug'])) {
-            $addon->setPueSlug($addon_api_settings[ $addon_name ]['pue_options']['pue_plugin_slug']);
+        if (! empty(RegisterAddonPUE::$addon_api_settings[ $addon_name ]['pue_options']['pue_plugin_slug'])) {
+            $addon->setPueSlug(RegisterAddonPUE::$addon_api_settings[ $addon_name ]['pue_options']['pue_plugin_slug']);
         }
     }
 


### PR DESCRIPTION
Add-ons currently can't update through PUE because of a variable name typo when setting the 'PUE Slug' for each add-on.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
