### PR TITLE
Copy LoaderFactory changes over from cafe

### DIFF
--- a/core/services/loaders/LoaderFactory.php
+++ b/core/services/loaders/LoaderFactory.php
@@ -3,6 +3,7 @@
 namespace EventEspresso\core\services\loaders;
 
 use EE_Registry;
+use EventEspresso\core\domain\values\FullyQualifiedName;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 use EventEspresso\core\services\collections\LooseCollection;
@@ -90,7 +91,7 @@ class LoaderFactory
         $generator = null,
         ClassInterfaceCache $class_cache = null,
         ObjectIdentifier $object_identifier = null
-    ) {
+    ): LoaderInterface {
         if (
             ! LoaderFactory::$loader instanceof LoaderInterface
             && ($generator instanceof EE_Registry || $generator instanceof CoffeeShop)
@@ -109,5 +110,31 @@ class LoaderFactory
             );
         }
         return LoaderFactory::$loader;
+    }
+
+
+    /**
+     * Used for instantiating a new instance of a class
+     *
+     * @param FullyQualifiedName|string $fqcn
+     * @param array                     $arguments
+     * @return mixed
+     */
+    public static function getNew($fqcn, array $arguments = [])
+    {
+        return LoaderFactory::getLoader()->getNew($fqcn, $arguments);
+    }
+
+
+    /**
+     * Used for getting a shared instance of a class
+     *
+     * @param FullyQualifiedName|string $fqcn
+     * @param array                     $arguments
+     * @return mixed
+     */
+    public static function getShared($fqcn, array $arguments = [])
+    {
+        return LoaderFactory::getLoader()->getShared($fqcn, $arguments);
     }
 }


### PR DESCRIPTION
Hey Brent,

Looks like the changes from #4122 are causing a fatal in core.

Select tickets and submit and it'll fatal with:

`
PHP Fatal error:  Uncaught Error: Call to undefined method EventEspresso\core\services\loaders\LoaderFactory::getNew() in C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\modules\ticket_selector\ProcessTicketSelector.php:205
Stack trace:
#0 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\modules\ticket_selector\EED_Ticket_Selector.module.php(259): EventEspresso\modules\ticket_selector\ProcessTicketSelector->processTicketSelections()
#1 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\core\EE_Module_Request_Router.core.php(240): EED_Ticket_Selector->process_ticket_selections(Object(WP_Query))
#2 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\core\EE_Module_Request_Router.core.php(181): EE_Module_Request_Router->_module_router('EED_Ticket_Sele...', 'process_ticket_...')
#3 C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\core\EE_Front_Controller.core.php(231): EE_Module_Request_Router->resolve_route('ee', 'process_ticket_...')
#4 C:\laragon\www\ee4\wp-includes\class-wp-hook.php(308): EE_Front_Controller->pre_get_posts(Object(WP_Query))
#5 C:\laragon\www\ee4\wp-includes\class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#6 C:\laragon\www\ee4\wp-includes\plugin.php(565): WP_Hook->do_action(Array)
#7 C:\laragon\www\ee4\wp-includes\class-wp-query.php(1833): do_action_ref_array('pre_get_posts', Array)
#8 C:\laragon\www\ee4\wp-includes\class-wp-query.php(3749): WP_Query->get_posts()
#9 C:\laragon\www\ee4\wp-includes\class-wp.php(663): WP_Query->query(Array)
#10 C:\laragon\www\ee4\wp-includes\class-wp.php(783): WP->query_posts()
#11 C:\laragon\www\ee4\wp-includes\functions.php(1332): WP->main('')
#12 C:\laragon\www\ee4\wp-blog-header.php(16): wp()
#13 C:\laragon\www\ee4\index.php(17): require('C:\\laragon\\www\\...')
#14 {main}
  thrown in C:\laragon\www\ee4\wp-content\plugins\event-espresso-core-reg\modules\ticket_selector\ProcessTicketSelector.php on line 205
`

So I copied over the changes to the LoaderFactory into core.