### PR TITLE
Fix basic auth reporting globals when WP Application Passwords authenticate first

### DIFF
--- a/core/third_party_libs/wp-api-basic-auth/basic-auth.php
+++ b/core/third_party_libs/wp-api-basic-auth/basic-auth.php
@@ -24,10 +24,6 @@ function json_basic_auth_handler($user)
     $wp_json_basic_auth_success       = false;
     $wp_json_basic_auth_received_data = false;
 
-    // Don't authenticate twice
-    if (! empty($user)) {
-        return $user;
-    }
     $username = null;
     $password = null;
     //account for issue where some servers remove the PHP auth headers
@@ -52,7 +48,7 @@ function json_basic_auth_handler($user)
         if (empty($header) && isset($_GET['_authorization'])) {
             $header = $_GET['_authorization'];
             //and now remove this special header so it doesn't interfere with other parts of the request
-            unset($_GET['authorization']);
+            unset($_GET['_authorization']);
         }
         //ok if we found the header data ourselves, let's parse it
         if (! empty($header)) {
@@ -68,12 +64,24 @@ function json_basic_auth_handler($user)
         }
     }
 
+    if (isset($username)) {
+        //we have some authorization data, whether or not this plugin ends up using it
+        $wp_json_basic_auth_received_data = true;
+    }
+
+    // Don't authenticate twice. Another 'determine_current_user' callback (e.g. WordPress core's
+    // application password handler, which runs before this one on the same filter) may have
+    // already authenticated the user with the basic auth data found above, so report that the
+    // data was received and that authentication succeeded rather than resetting the globals.
+    if (! empty($user)) {
+        $wp_json_basic_auth_success = $wp_json_basic_auth_received_data;
+        return $user;
+    }
+
     // Check that we're trying to authenticate
     if (! isset($username)) {
         return $user;
     }
-    //we have some authorization data we can try authenticating with
-    $wp_json_basic_auth_received_data = true;
     /**
      * In multi-site, wp_authenticate_spam_check filter is run on authentication. This filter calls
      * get_currentuserinfo which in turn calls the determine_current_user filter. This leads to infinite


### PR DESCRIPTION
## Problem

The EE4 mobile apps call `GET /wp-json/ee/vX/site_info` after login. That endpoint (`core/libraries/rest_api/controllers/config/Read.php::handleRequestSiteInfo`) reports `authentication.received_basic_auth_data` and `insecure_usage_of_basic_auth` by reading the globals `$wp_json_basic_auth_received_data` / `$wp_json_basic_auth_success`, set by `json_basic_auth_handler()` in the bundled Basic Auth plugin (`core/third_party_libs/wp-api-basic-auth/basic-auth.php`, hooked on `determine_current_user` at priority 20).

Since WP 5.6, core's Application Passwords handler (`wp_validate_application_password`) is hooked on the same filter/priority and registers earlier, so it runs first. When a client authenticates with an Application Password in the `Authorization: Basic` header:

1. WP core authenticates the user successfully.
2. `json_basic_auth_handler()` then runs, resets all three globals to null/false, and hits its "Don't authenticate twice" early return **before** it ever looks for Basic auth credentials.
3. Result: `site_info` reports `received_basic_auth_data: false` on a request that was successfully authenticated with Basic auth data.

**Confirmed empirically** (2026-07-08, live EE4 site): the same `Authorization: Basic` header with an application password returns 200 + the full user from `/wp-json/wp/v2/users/me` and full event data from EE endpoints, while `site_info` on the identical request reports `received_basic_auth_data: false`.

### Impact

The false negative tells the EE4 mobile app that header auth is broken, so it permanently switches to the `_authorization` query-string fallback — where Application Passwords **cannot** authenticate (they only work via the Authorization header / `wp_authenticate`'s API-request path). Net effect: Application Password logins are unusable in the mobile app. (The app is also being patched to probe before falling back, but the server-side flag should be truthful regardless.)

## Fix

Restructure `json_basic_auth_handler()`:

1. Move the credential-detection block (`PHP_AUTH_USER`/`PW` → `HTTP_AUTHORIZATION` → `REDIRECT_HTTP_AUTHORIZATION` → `$_GET['_authorization']`, logic unchanged) so it runs **before** the "Don't authenticate twice" early return.
2. Set `$wp_json_basic_auth_received_data = true` whenever credentials were found, regardless of which handler ends up using them.
3. In the "Don't authenticate twice" branch, set `$wp_json_basic_auth_success = $wp_json_basic_auth_received_data;` before returning `$user` — if Basic auth data was present AND the user is already authenticated (e.g. by WP core's Application Passwords), that is a Basic auth success for reporting purposes. These globals are read later in the request by `site_info`, so the assignment is meaningful despite the immediate return, and it keeps `insecure_usage_of_basic_auth` (`$success && ! is_ssl()`) accurate.
4. Fix a 9-year-old typo: `unset($_GET['authorization']);` → `unset($_GET['_authorization']);`. The read of `$_GET['_authorization']` and this unset were introduced together in eb65fd09 (2017-03-01) with the comment "remove this special header so it doesn't interfere"; a plain `authorization` GET key is never read or set anywhere in the repo, so the intended target is unambiguous. The unset is behaviorally inert either way (`WP_REST_Server` builds the request object from `$_GET` before authentication runs, and nothing else in EE core reads `_authorization`), so this part is correctness-only.

Everything else (the `wp_authenticate()` path, spam-check filter juggling, cookie-filter removal, `rest_authentication_errors` passthrough) is byte-identical. If no user was authenticated yet and credentials were found, the function still calls `wp_authenticate()` itself exactly as before.

**Not a security change** — no change to who can authenticate, only to the accuracy of the reporting globals plus the dead-code typo correction.

## Testing

Environment: WP 5.6+ over HTTPS, EE4 active, a user with an Application Password.

1. **The headline before/after (reproduces the mobile-app bug):** `GET /wp-json/ee/v4.8.36/site_info` with `Authorization: Basic base64(user:application-password)` → `authentication.received_basic_auth_data` is now `true` (was `false`).
2. Regression: same request with `Authorization: Basic base64(user:real-wp-password)` (handled by this plugin's own `wp_authenticate` path) → still `true`, user still authenticated.
3. Regression: query-string fallback `GET .../site_info?_authorization=Basic%20<base64>` with a real password → still authenticates, `received_basic_auth_data: true`.
4. No credentials at all → `received_basic_auth_data: false`, no warnings/notices raised.
5. Wrong password in the header → 401/403 via `rest_authentication_errors` as before.
6. Insecure-warning logic: over plain HTTP with valid real-password Basic auth, `insecure_usage_of_basic_auth` is still `true` and the warning text present.
7. `php -l` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
